### PR TITLE
lists: Detect block comment by starting from the end.

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -566,14 +566,9 @@ where
 
 pub fn extract_pre_comment(pre_snippet: &str) -> (Option<String>, ListItemCommentStyle) {
     let trimmed_pre_snippet = pre_snippet.trim();
+    let has_block_comment = trimmed_pre_snippet.ends_with("*/");
     let has_single_line_comment = trimmed_pre_snippet.starts_with("//");
-    let has_block_comment = trimmed_pre_snippet.starts_with("/*");
-    if has_single_line_comment {
-        (
-            Some(trimmed_pre_snippet.to_owned()),
-            ListItemCommentStyle::DifferentLine,
-        )
-    } else if has_block_comment {
+    if has_block_comment {
         let comment_end = pre_snippet.chars().rev().position(|c| c == '/').unwrap();
         if pre_snippet
             .chars()
@@ -591,6 +586,11 @@ pub fn extract_pre_comment(pre_snippet: &str) -> (Option<String>, ListItemCommen
                 ListItemCommentStyle::SameLine,
             )
         }
+    } else if has_single_line_comment {
+        (
+            Some(trimmed_pre_snippet.to_owned()),
+            ListItemCommentStyle::DifferentLine,
+        )
     } else {
         (None, ListItemCommentStyle::None)
     }

--- a/tests/source/expr-block.rs
+++ b/tests/source/expr-block.rs
@@ -280,6 +280,21 @@ fn issue_1862() {
     )
 }
 
+fn issue_3025() {
+    foo(
+        // This describes the argument below.
+        /* bar = */ None ,
+        // This describes the argument below.
+        something_something,
+        // This describes the argument below. */
+        None ,
+        // This describes the argument below.
+        /* This comment waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay too long to be kept on the same line */ None ,
+        // This describes the argument below.
+        /* com */ this_last_arg_is_tooooooooooooooooooooooooooooooooo_long_to_be_kept_with_the_pre_comment ,
+    )
+}
+
 fn issue_1878() {
     let channel: &str = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(2, &self))?;
 }

--- a/tests/target/expr-block.rs
+++ b/tests/target/expr-block.rs
@@ -281,6 +281,23 @@ fn issue_1862() {
     )
 }
 
+fn issue_3025() {
+    foo(
+        // This describes the argument below.
+        /* bar = */ None,
+        // This describes the argument below.
+        something_something,
+        // This describes the argument below. */
+        None,
+        // This describes the argument below.
+        /* This comment waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay too long to be kept on the same line */
+        None,
+        // This describes the argument below.
+        /* com */
+        this_last_arg_is_tooooooooooooooooooooooooooooooooo_long_to_be_kept_with_the_pre_comment,
+    )
+}
+
 fn issue_1878() {
     let channel: &str = seq
         .next_element()?


### PR DESCRIPTION
The issue with the current code is that comments are collapsed, so comments like
the one from the test end up in a string like:

```
"// this is a single line comment\n/* block = */"
```

I chose to fix it by detecting whether we're in a block comment starting from
the end instead, and tested a single-line comment ended in `*/` just for sanity,
ensuring line breaks are not removed in that case, which would break the
formatting.

The right fix eventually is probably to lex the comments properly, but this does
the work for now, I guess :)

Fixes #3025