### PR TITLE
Catch possible tokenizer panics

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -73,7 +73,12 @@ fn format_project<T: FormatHandler>(
     let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
     let mut parse_session = make_parse_sess(source_map.clone(), config);
     let mut report = FormatReport::new();
-    let krate = parse_crate(input, &parse_session, config, &mut report)?;
+    let krate = match parse_crate(input, &parse_session, config, &mut report) {
+        Ok(krate) => krate,
+        // Surface parse error via Session (errors are merged there from report)
+        Err(ErrorKind::ParseError) => return Ok(report),
+        Err(e) => return Err(e),
+    };
     timer = timer.done_parsing();
 
     // Suppress error output if we have to do any further parsing.

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -289,6 +289,18 @@ fn stdin_formatting_smoke_test() {
 }
 
 #[test]
+fn stdin_parser_panic_caught() {
+    // https://github.com/rust-lang/rustfmt/issues/3239
+    for text in ["{", "}"].iter().cloned().map(String::from) {
+        let mut buf = vec![];
+        let mut session = Session::new(Default::default(), Some(&mut buf));
+        let _ = session.format(Input::Text(text));
+
+        assert!(session.has_parsing_errors());
+    }
+}
+
+#[test]
 fn stdin_disable_all_formatting_test() {
     match option_env!("CFG_RELEASE_CHANNEL") {
         None | Some("nightly") => {}


### PR DESCRIPTION
When using `new_parser_from_source_str` sometimes it can panic on incomplete input (e.g. bare `}`), so here we use the `Result`-returning `maybe_new_parser_from_source_str` variant to catch possible errors and diagnostics to emit later.

Closes #3239 

related #753 
cc @topecongiro 