### PR TITLE
Fix trim_right/trim_left deprecation warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,7 @@ fn main() {
 fn commit_info() -> String {
     match (channel(), commit_hash(), commit_date()) {
         (channel, Some(hash), Some(date)) => {
-            format!("{} ({} {})", channel, hash.trim_right(), date)
+            format!("{} ({} {})", channel, hash.trim_end(), date)
         }
         _ => String::new(),
     }

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -367,22 +367,27 @@ fn identify_comment(
     if rest.is_empty() {
         Some(rewritten_first_group)
     } else {
-        identify_comment(rest.trim_start(), block_style, shape, config, is_doc_comment).map(
-            |rest_str| {
-                format!(
-                    "{}\n{}{}{}",
-                    rewritten_first_group,
-                    // insert back the blank line
-                    if has_bare_lines && style.is_line_comment() {
-                        "\n"
-                    } else {
-                        ""
-                    },
-                    shape.indent.to_string(config),
-                    rest_str
-                )
-            },
+        identify_comment(
+            rest.trim_start(),
+            block_style,
+            shape,
+            config,
+            is_doc_comment,
         )
+        .map(|rest_str| {
+            format!(
+                "{}\n{}{}{}",
+                rewritten_first_group,
+                // insert back the blank line
+                if has_bare_lines && style.is_line_comment() {
+                    "\n"
+                } else {
+                    ""
+                },
+                shape.indent.to_string(config),
+                rest_str
+            )
+        })
     }
 }
 

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -291,7 +291,7 @@ fn identify_comment(
         let mut hbl = false;
 
         for line in orig.lines() {
-            let trimmed_line = line.trim_left();
+            let trimmed_line = line.trim_start();
             if trimmed_line.is_empty() {
                 hbl = true;
                 break;
@@ -308,22 +308,22 @@ fn identify_comment(
 
     let (has_bare_lines, first_group_ending) = match style {
         CommentStyle::DoubleSlash | CommentStyle::TripleSlash | CommentStyle::Doc => {
-            let line_start = style.line_start().trim_left();
+            let line_start = style.line_start().trim_start();
             consume_same_line_comments(style, orig, line_start)
         }
         CommentStyle::Custom(opener) => {
-            let trimmed_opener = opener.trim_right();
+            let trimmed_opener = opener.trim_end();
             consume_same_line_comments(style, orig, trimmed_opener)
         }
         // for a block comment, search for the closing symbol
         CommentStyle::DoubleBullet | CommentStyle::SingleBullet | CommentStyle::Exclamation => {
-            let closer = style.closer().trim_left();
+            let closer = style.closer().trim_start();
             let mut closing_symbol_offset = 0;
             let mut hbl = false;
             let mut first = true;
             for line in orig.lines() {
                 closing_symbol_offset += compute_len(&orig[closing_symbol_offset..], line);
-                let mut trimmed_line = line.trim_left();
+                let mut trimmed_line = line.trim_start();
                 if !trimmed_line.starts_with('*')
                     && !trimmed_line.starts_with("//")
                     && !trimmed_line.starts_with("/*")
@@ -333,7 +333,7 @@ fn identify_comment(
 
                 // Remove opener from consideration when searching for closer
                 if first {
-                    let opener = style.opener().trim_right();
+                    let opener = style.opener().trim_end();
                     trimmed_line = &trimmed_line[opener.len()..];
                     first = false;
                 }
@@ -367,7 +367,7 @@ fn identify_comment(
     if rest.is_empty() {
         Some(rewritten_first_group)
     } else {
-        identify_comment(rest.trim_left(), block_style, shape, config, is_doc_comment).map(
+        identify_comment(rest.trim_start(), block_style, shape, config, is_doc_comment).map(
             |rest_str| {
                 format!(
                     "{}\n{}{}{}",
@@ -427,7 +427,7 @@ struct ItemizedBlock {
 impl ItemizedBlock {
     /// Returns true if the line is formatted as an item
     fn is_itemized_line(line: &str) -> bool {
-        let trimmed = line.trim_left();
+        let trimmed = line.trim_start();
         trimmed.starts_with("* ") || trimmed.starts_with("- ")
     }
 
@@ -537,7 +537,7 @@ impl<'a> CommentRewrite<'a> {
         while let Some(line) = iter.next() {
             result.push_str(line);
             result.push_str(match iter.peek() {
-                Some(next_line) if next_line.is_empty() => sep.trim_right(),
+                Some(next_line) if next_line.is_empty() => sep.trim_end(),
                 Some(..) => &sep,
                 None => "",
             });
@@ -757,15 +757,15 @@ fn rewrite_comment_inner(
 ) -> Option<String> {
     let mut rewriter = CommentRewrite::new(orig, block_style, shape, config);
 
-    let line_breaks = count_newlines(orig.trim_right());
+    let line_breaks = count_newlines(orig.trim_end());
     let lines = orig
         .lines()
         .enumerate()
         .map(|(i, mut line)| {
-            line = trim_right_unless_two_whitespaces(line.trim_left(), is_doc_comment);
+            line = trim_end_unless_two_whitespaces(line.trim_start(), is_doc_comment);
             // Drop old closer.
             if i == line_breaks && line.ends_with("*/") && !line.starts_with("//") {
-                line = line[..(line.len() - 2)].trim_right();
+                line = line[..(line.len() - 2)].trim_end();
             }
 
             line
@@ -774,7 +774,7 @@ fn rewrite_comment_inner(
         .map(|(line, has_leading_whitespace)| {
             if orig.starts_with("/*") && line_breaks == 0 {
                 (
-                    line.trim_left(),
+                    line.trim_start(),
                     has_leading_whitespace || config.normalize_comments(),
                 )
             } else {
@@ -794,7 +794,7 @@ fn rewrite_comment_inner(
 const RUSTFMT_CUSTOM_COMMENT_PREFIX: &str = "//#### ";
 
 fn hide_sharp_behind_comment(s: &str) -> Cow<str> {
-    if s.trim_left().starts_with("# ") {
+    if s.trim_start().starts_with("# ") {
         Cow::from(format!("{}{}", RUSTFMT_CUSTOM_COMMENT_PREFIX, s))
     } else {
         Cow::from(s)
@@ -804,9 +804,9 @@ fn hide_sharp_behind_comment(s: &str) -> Cow<str> {
 fn trim_custom_comment_prefix(s: &str) -> String {
     s.lines()
         .map(|line| {
-            let left_trimmed = line.trim_left();
+            let left_trimmed = line.trim_start();
             if left_trimmed.starts_with(RUSTFMT_CUSTOM_COMMENT_PREFIX) {
-                left_trimmed.trim_left_matches(RUSTFMT_CUSTOM_COMMENT_PREFIX)
+                left_trimmed.trim_start_matches(RUSTFMT_CUSTOM_COMMENT_PREFIX)
             } else {
                 line
             }
@@ -866,11 +866,11 @@ pub fn recover_missing_comment_in_span(
 }
 
 /// Trim trailing whitespaces unless they consist of two or more whitespaces.
-fn trim_right_unless_two_whitespaces(s: &str, is_doc_comment: bool) -> &str {
+fn trim_end_unless_two_whitespaces(s: &str, is_doc_comment: bool) -> &str {
     if is_doc_comment && s.ends_with("  ") {
         s
     } else {
-        s.trim_right()
+        s.trim_end()
     }
 }
 
@@ -898,7 +898,7 @@ fn light_rewrite_comment(
                 ""
             };
             // Preserve markdown's double-space line break syntax in doc comment.
-            trim_right_unless_two_whitespaces(left_trimmed, is_doc_comment)
+            trim_end_unless_two_whitespaces(left_trimmed, is_doc_comment)
         })
         .collect();
     lines.join(&format!("\n{}", offset.to_string(config)))
@@ -918,7 +918,7 @@ fn left_trim_comment_line<'a>(line: &'a str, style: &CommentStyle) -> (&'a str, 
         if line.starts_with(opener) {
             (&line[opener.len()..], true)
         } else {
-            (&line[opener.trim_right().len()..], false)
+            (&line[opener.trim_end().len()..], false)
         }
     } else if line.starts_with("/* ")
         || line.starts_with("// ")

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1252,12 +1252,12 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
                         format!(
                             "{}{}",
                             new_indent.to_string(context.config),
-                            line.trim_left()
+                            line.trim_start()
                         )
                     })
                     .collect::<Vec<_>>()
                     .join("\n")
-                    .trim_left(),
+                    .trim_start(),
             );
             return wrap_str(indented_string_lit, context.config.max_width(), shape);
         } else {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -50,7 +50,7 @@ impl<'a> FmtVisitor<'a> {
             Some(ref s) if s.is_empty() => {
                 // Format up to last newline
                 let prev_span = mk_sp(self.last_pos, source!(self, span).lo());
-                let trimmed_snippet = self.snippet(prev_span).trim_right();
+                let trimmed_snippet = self.snippet(prev_span).trim_end();
                 let span_end = self.last_pos + BytePos(trimmed_snippet.len() as u32);
                 self.format_missing(span_end);
                 // We have an excessive newline from the removed import.

--- a/src/items.rs
+++ b/src/items.rs
@@ -1249,7 +1249,7 @@ pub fn format_struct_struct(
     {
         result.push('\n');
         result.push_str(&offset.to_string(context.config));
-        result.push_str(generics_str.trim_left());
+        result.push_str(generics_str.trim_start());
     } else {
         result.push_str(&generics_str);
     }
@@ -1493,7 +1493,7 @@ fn rewrite_type_item<R: Rewrite>(
         result.push_str(suffix);
     } else {
         result.push_str(&indent.to_string_with_newline(context.config));
-        result.push_str(suffix.trim_left());
+        result.push_str(suffix.trim_start());
     }
 
     // 1 = ";"
@@ -1619,7 +1619,7 @@ pub fn rewrite_struct_field(
     let field_str = rewrite_assign_rhs(context, prefix, &*field.ty, shape)?;
     // Remove a leading white-space from `rewrite_assign_rhs()` when rewriting a tuple struct.
     let field_str = if is_prefix_empty {
-        field_str.trim_left()
+        field_str.trim_start()
     } else {
         &field_str
     };
@@ -1986,7 +1986,7 @@ fn rewrite_fn_base(
     let snuggle_angle_bracket = generics_str
         .lines()
         .last()
-        .map_or(false, |l| l.trim_left().len() == 1);
+        .map_or(false, |l| l.trim_start().len() == 1);
 
     // Note that the width and indent don't really matter, we'll re-layout the
     // return type later anyway.

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -177,11 +177,11 @@ impl ListItem {
     pub fn has_single_line_comment(&self) -> bool {
         self.pre_comment
             .as_ref()
-            .map_or(false, |comment| comment.trim_left().starts_with("//"))
+            .map_or(false, |comment| comment.trim_start().starts_with("//"))
             || self
                 .post_comment
                 .as_ref()
-                .map_or(false, |comment| comment.trim_left().starts_with("//"))
+                .map_or(false, |comment| comment.trim_start().starts_with("//"))
     }
 
     pub fn has_comment(&self) -> bool {
@@ -463,7 +463,7 @@ where
                     || comment.trim().len() > width;
 
                 rewrite_comment(
-                    comment.trim_left(),
+                    comment.trim_start(),
                     block_style,
                     comment_shape,
                     formatting.config,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1290,7 +1290,7 @@ impl MacroBranch {
 
         // Indent the body since it is in a block.
         let indent_str = body_indent.to_string(&config);
-        let mut new_body = LineClasses::new(new_body.trim_right())
+        let mut new_body = LineClasses::new(new_body.trim_end())
             .enumerate()
             .fold(
                 (String::new(), true),

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -63,7 +63,7 @@ impl<'a> FmtVisitor<'a> {
     pub fn format_missing_with_indent(&mut self, end: BytePos) {
         let config = self.config;
         self.format_missing_inner(end, |this, last_snippet, snippet| {
-            this.push_str(last_snippet.trim_right());
+            this.push_str(last_snippet.trim_end());
             if last_snippet == snippet && !this.output_at_start() {
                 // No new lines in the snippet.
                 this.push_str("\n");
@@ -75,7 +75,7 @@ impl<'a> FmtVisitor<'a> {
 
     pub fn format_missing_no_indent(&mut self, end: BytePos) {
         self.format_missing_inner(end, |this, last_snippet, _| {
-            this.push_str(last_snippet.trim_right());
+            this.push_str(last_snippet.trim_end());
         })
     }
 

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -184,7 +184,7 @@ where
 {
     let tab_spaces = context.config.tab_spaces();
     let lhs_overhead = match separator_place {
-        SeparatorPlace::Back => shape.used_width() + pp.prefix.len() + pp.infix.trim_right().len(),
+        SeparatorPlace::Back => shape.used_width() + pp.prefix.len() + pp.infix.trim_end().len(),
         SeparatorPlace::Front => shape.used_width(),
     };
     let lhs_shape = Shape {
@@ -238,8 +238,8 @@ where
         }
     };
     let infix = match separator_place {
-        SeparatorPlace::Back => pp.infix.trim_right(),
-        SeparatorPlace::Front => pp.infix.trim_left(),
+        SeparatorPlace::Back => pp.infix.trim_end(),
+        SeparatorPlace::Front => pp.infix.trim_start(),
     };
     if separator_place == SeparatorPlace::Front {
         rhs_shape = rhs_shape.offset_left(infix.len())?;

--- a/src/string.rs
+++ b/src/string.rs
@@ -107,7 +107,7 @@ pub fn rewrite_string<'a>(
             for (i, grapheme) in graphemes[cur_start..].iter().enumerate() {
                 if is_line_feed(grapheme) {
                     // take care of blank lines
-                    result = trim_right_but_line_feed(fmt.trim_end, result);
+                    result = trim_end_but_line_feed(fmt.trim_end, result);
                     result.push_str("\n");
                     if !is_bareline_ok && cur_start + i + 1 < graphemes.len() {
                         result.push_str(&indent_without_newline);
@@ -117,7 +117,7 @@ pub fn rewrite_string<'a>(
                     result.push_str(grapheme);
                 }
             }
-            result = trim_right_but_line_feed(fmt.trim_end, result);
+            result = trim_end_but_line_feed(fmt.trim_end, result);
             break;
         }
 
@@ -138,7 +138,7 @@ pub fn rewrite_string<'a>(
             }
             SnippetState::EndWithLineFeed(line, len) => {
                 if line == "\n" && fmt.trim_end {
-                    result = result.trim_right().to_string();
+                    result = result.trim_end().to_string();
                 }
                 result.push_str(&line);
                 if is_bareline_ok {
@@ -188,11 +188,11 @@ fn detect_url(s: &[&str], index: usize) -> Option<usize> {
 }
 
 /// Trims whitespaces to the right except for the line feed character.
-fn trim_right_but_line_feed(trim_end: bool, result: String) -> String {
+fn trim_end_but_line_feed(trim_end: bool, result: String) -> String {
     let whitespace_except_line_feed = |c: char| c.is_whitespace() && c != '\n';
     if trim_end && result.ends_with(whitespace_except_line_feed) {
         result
-            .trim_right_matches(whitespace_except_line_feed)
+            .trim_end_matches(whitespace_except_line_feed)
             .to_string()
     } else {
         result
@@ -244,7 +244,7 @@ fn break_string(max_chars: usize, trim_end: bool, line_end: &str, input: &[&str]
                 if i <= index_minus_ws {
                     let mut line = &input[0..i].concat()[..];
                     if trim_end {
-                        line = line.trim_right();
+                        line = line.trim_end();
                     }
                     return SnippetState::EndWithLineFeed(format!("{}\n", line), i + 1);
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -399,7 +399,7 @@ where
             "{}\n{}{}",
             args,
             list_shape.indent.to_string(context.config),
-            output.trim_left()
+            output.trim_start()
         ))
     }
 }
@@ -422,7 +422,7 @@ impl Rewrite for ast::WherePredicate {
                 ..
             }) => {
                 let type_str = bounded_ty.rewrite(context, shape)?;
-                let colon = type_bound_colon(context).trim_right();
+                let colon = type_bound_colon(context).trim_end();
                 let lhs = if let Some(lifetime_str) =
                     rewrite_lifetime_param(context, shape, bound_generic_params)
                 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -514,7 +514,7 @@ pub fn remove_trailing_white_spaces(text: &str) -> String {
 /// ```
 pub fn trim_left_preserve_layout(orig: &str, indent: Indent, config: &Config) -> Option<String> {
     let mut lines = LineClasses::new(orig);
-    let first_line = lines.next().map(|(_, s)| s.trim_right().to_owned())?;
+    let first_line = lines.next().map(|(_, s)| s.trim_end().to_owned())?;
     let mut trimmed_lines = Vec::with_capacity(16);
 
     let mut veto_trim = false;

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -141,14 +141,14 @@ pub fn rewrite_with_alignment<T: AlignedItem>(
         );
 
         let snippet = context.snippet(missing_span);
-        if snippet.trim_left().starts_with("//") {
+        if snippet.trim_start().starts_with("//") {
             let offset = snippet.lines().next().map_or(0, |l| l.len());
             // 2 = "," + "\n"
             init_hi + BytePos(offset as u32 + 2)
-        } else if snippet.trim_left().starts_with("/*") {
+        } else if snippet.trim_start().starts_with("/*") {
             let comment_lines = snippet
                 .lines()
-                .position(|line| line.trim_right().ends_with("*/"))
+                .position(|line| line.trim_end().ends_with("*/"))
                 .unwrap_or(0);
 
             let offset = snippet


### PR DESCRIPTION
I saw these in the rustc tool build logs. Should I add a `#![deny(deprecated)]` as well?