### PR TITLE
Clarify version gate used for #3229

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -91,6 +91,31 @@ Please try to avoid leaving `TODO`s in the code. There are a few around, but I
 wish there weren't. You can leave `FIXME`s, preferably with an issue number.
 
 
+### Version-gate formatting changes
+
+A change that introduces a different code-formatting should be gated on the
+`version` configuration. This is to ensure the formatting of the current major
+release is preserved, while allowing fixes to be implemented for the next
+release.
+
+This is done by conditionally guarding the change like so:
+
+```rust
+if config.version() == Version::One { // if the current major release is 1.x
+    // current formatting
+} else {
+    // new formatting
+}
+```
+
+This allows the user to apply the next formatting explicitly via the
+configuration, while being stable by default.
+
+When the next major release is done, the code block of the previous formatting
+can be deleted, e.g., the first block in the example above when going from `1.x`
+to `2.x`.
+
+
 ### A quick tour of Rustfmt
 
 Rustfmt is basically a pretty printer - that is, its mode of operation is to

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -413,12 +413,15 @@ fn rewrite_match_body(
             } else {
                 ""
             };
-            let semicolon =
-                if context.config.version() == Version::Two && semicolon_for_expr(context, body) {
+            let semicolon = if context.config.version() == Version::One {
+                ""
+            } else {
+                if semicolon_for_expr(context, body) {
                     ";"
                 } else {
                     ""
-                };
+                }
+            };
             ("{", format!("{}{}}}{}", semicolon, indent_str, comma))
         } else {
             ("", String::from(","))


### PR DESCRIPTION
Related to #3229 

In response to https://github.com/rust-lang/rustfmt/issues/2877#issuecomment-448460946, this PR is to make the version-gate a bit more clear, although I got a `E0317` compile error on what I proposed (which is nice!).
Although the change is a bit verbose for what it does, I think it makes the future gate-cleaning easier: just keep what is in the `else` block. @topecongiro Up to you if it's better ;o)

I also profited and added a section to the contributing file about version-gates.