### PR TITLE
Fix issue #3265

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1304,7 +1304,13 @@ impl<'a> Iterator for LineClasses<'a> {
             None => FullCodeCharKind::Normal,
         };
 
-        while let Some((kind, c)) = self.base.next() {
+        while let Some((kind, mut c)) = self.base.next() {
+            // If \r\n newline appears, consume one more character.
+            // Then do the same process with the single \n case.
+            if c == '\r' && self.base.peek().map_or(false, |(_, c2)| *c2 == '\n') {
+                self.base.next();
+                c = '\n';
+            }
             if c == '\n' {
                 self.kind = match (start_class, kind) {
                     (FullCodeCharKind::Normal, FullCodeCharKind::InString) => {

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1304,13 +1304,7 @@ impl<'a> Iterator for LineClasses<'a> {
             None => FullCodeCharKind::Normal,
         };
 
-        while let Some((kind, mut c)) = self.base.next() {
-            // If \r\n newline appears, consume one more character.
-            // Then do the same process with the single \n case.
-            if c == '\r' && self.base.peek().map_or(false, |(_, c2)| *c2 == '\n') {
-                self.base.next();
-                c = '\n';
-            }
+        while let Some((kind, c)) = self.base.next() {
             if c == '\n' {
                 self.kind = match (start_class, kind) {
                     (FullCodeCharKind::Normal, FullCodeCharKind::InString) => {
@@ -1325,6 +1319,11 @@ impl<'a> Iterator for LineClasses<'a> {
             } else {
                 line.push(c);
             }
+        }
+
+        // Workaround for CRLF newline.
+        if line.ends_with('\r') {
+            line.pop();
         }
 
         Some((self.kind, line))

--- a/tests/source/issue-3265.rs
+++ b/tests/source/issue-3265.rs
@@ -1,0 +1,14 @@
+// rustfmt-newline_style: Windows
+#[cfg(test)]
+mod test {
+    summary_test! {
+        tokenize_recipe_interpolation_eol,
+    "foo: # some comment
+ {{hello}}
+",
+    "foo: \
+ {{hello}} \
+{{ahah}}",
+        "N:#$>^{N}$<.",
+      }
+}

--- a/tests/target/issue-3265.rs
+++ b/tests/target/issue-3265.rs
@@ -1,0 +1,14 @@
+// rustfmt-newline_style: Windows
+#[cfg(test)]
+mod test {
+    summary_test! {
+        tokenize_recipe_interpolation_eol,
+    "foo: # some comment
+ {{hello}}
+",
+    "foo: \
+    {{hello}} \
+    {{ahah}}",
+        "N:#$>^{N}$<.",
+      }
+}


### PR DESCRIPTION
In Windows, the "multiple \\
line text" format in macro was not well formatted. PL #3028 was fixing this for single LF newline environment, but not for CRLF environment.

The cause was something like this:
rewrite_macro_inner() function calls trim_left_preserve_layout() function, and it is using LineClasses iterator to split lines. But LineClasses splits the text into line only using LF, so CR remains at the end of the lines.
This CR was preventing the parser to detect '\\' at the end-of-line, because CR is always existing at the end-of-line.