### PR TITLE
Remove a trivial redundant code.

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1301,7 +1301,7 @@ impl<'a> Iterator for LineClasses<'a> {
 
         let start_class = match self.base.peek() {
             Some((kind, _)) => *kind,
-            None => FullCodeCharKind::Normal,
+            None => unreachable!(),
         };
 
         while let Some((kind, c)) = self.base.next() {


### PR DESCRIPTION
self.base.peek().is_none() case is already caught by the line above.