### PR TITLE
Unicode text wrapping in comments and string literals.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,8 @@ dependencies = [
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode_categories 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -749,6 +751,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +903,7 @@ dependencies = [
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode_categories 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ rustc-ap-syntax = "306.0.0"
 rustc-ap-syntax_pos = "306.0.0"
 failure = "0.1.1"
 bytecount = "0.4"
+unicode-width = "0.1.5"
+unicode_categories = "0.1.1"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,9 @@ extern crate serde_json;
 extern crate syntax;
 extern crate syntax_pos;
 extern crate toml;
+extern crate unicode_categories;
 extern crate unicode_segmentation;
+extern crate unicode_width;
 
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -431,7 +431,8 @@ impl<'a> Context<'a> {
         };
 
         if let Some(rewrite) = rewrite {
-            let rewrite_first_line = Some(rewrite[..first_line_width(&rewrite)].to_owned());
+            // splitn(2, *).next().unwrap() is always safe.
+            let rewrite_first_line = Some(rewrite.splitn(2, '\n').next().unwrap().to_owned());
             last_list_item.item = rewrite_first_line;
             Some(rewrite)
         } else {

--- a/tests/source/comment6.rs
+++ b/tests/source/comment6.rs
@@ -1,0 +1,10 @@
+// rustfmt-wrap_comments: true
+
+// Pendant la nuit du 9 mars 1860, les nuages, se confondant avec la mer, limitaient à quelques brasses la portée de la vue.
+// Sur cette mer démontée, dont les lames déferlaient en projetant des lueurs livides, un léger bâtiment fuyait presque à sec de toile.
+
+pub mod foo {}
+
+// ゆく河の流れは絶えずして、しかももとの水にあらず。淀みに浮かぶうたかたは、かつ消えかつ結びて、久しくとどまりたるためしなし。世の中にある人とすみかと、またかくのごとし。
+
+pub mod bar {}

--- a/tests/source/string_punctuation.rs
+++ b/tests/source/string_punctuation.rs
@@ -4,4 +4,6 @@ fn main() {
     println!("ThisIsAReallyLongStringWithNoSpaces.It_should_prefer_to_break_onpunctuation:Likethisssssssssssss");
     format!("{}__{}__{}ItShouldOnlyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyNoticeSemicolonsPeriodsColonsAndCommasAndResortToMid-CharBreaksAfterPunctuation{}{}",x,y,z,a,b);
     println!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaalhijalfhiigjapdighjapdigjapdighdapighapdighpaidhg;adopgihadoguaadbadgad,qeoihapethae8t0aet8haetadbjtaeg;ooeouthaoeutgadlgajduabgoiuadogabudogubaodugbadgadgadga;adoughaoeugbaouea");
+    println!("sentuhaesnuthaesnutheasunteahusnaethuseantuihaesntdiastnidaetnuhaideuhsenathe。WeShouldSupportNonAsciiPunctuations§ensuhatheasunteahsuneathusneathuasnuhaesnuhaesnuaethusnaetuheasnuth");
+    println!("ThisIsASampleOfCJKString.祇園精舍の鐘の声、諸行無常の響きあり。娑羅双樹の花の色、盛者必衰の理をあらはす。奢れる人も久しからず、ただ春の夜の夢のごとし。猛き者もつひにはほろびぬ、ひとへに風の前の塵に同じ。");
 }

--- a/tests/target/comment6.rs
+++ b/tests/target/comment6.rs
@@ -1,0 +1,14 @@
+// rustfmt-wrap_comments: true
+
+// Pendant la nuit du 9 mars 1860, les nuages, se confondant avec la mer,
+// limitaient à quelques brasses la portée de la vue. Sur cette mer démontée,
+// dont les lames déferlaient en projetant des lueurs livides, un léger bâtiment
+// fuyait presque à sec de toile.
+
+pub mod foo {}
+
+// ゆく河の流れは絶えずして、しかももとの水にあらず。淀みに浮かぶうたかたは、
+// かつ消えかつ結びて、久しくとどまりたるためしなし。世の中にある人とすみかと、
+// またかくのごとし。
+
+pub mod bar {}

--- a/tests/target/string_punctuation.rs
+++ b/tests/target/string_punctuation.rs
@@ -11,4 +11,14 @@ fn main() {
          adopgihadoguaadbadgad,qeoihapethae8t0aet8haetadbjtaeg;\
          ooeouthaoeutgadlgajduabgoiuadogabudogubaodugbadgadgadga;adoughaoeugbaouea"
     );
+    println!(
+        "sentuhaesnuthaesnutheasunteahusnaethuseantuihaesntdiastnidaetnuhaideuhsenathe。\
+         WeShouldSupportNonAsciiPunctuations§\
+         ensuhatheasunteahsuneathusneathuasnuhaesnuhaesnuaethusnaetuheasnuth"
+    );
+    println!(
+        "ThisIsASampleOfCJKString.祇園精舍の鐘の声、諸行無常の響きあり。娑羅双樹の花の色、\
+         盛者必衰の理をあらはす。奢れる人も久しからず、ただ春の夜の夢のごとし。\
+         猛き者もつひにはほろびぬ、ひとへに風の前の塵に同じ。"
+    );
 }


### PR DESCRIPTION
This PR includes several fixes related to #3235 .

Clearing the terminology: Replaced some identifier's "chars" into "width".

Introduce unicode_width crate, which implements UAX#11: Replaced some of the `str::len()` calls into this unicode width method calls to support characters occupying != 1 width (e.g. CJK, combined chars).

Introduce unicode_categories crate just to make `is_punctuation()` method unicode supported: Without this CJK strings almost cannot be wrapped because it does not include whitespaces, and the old `is_punctuation()` method was only supporting ASCII delimiters.
But by this fix we may over-detect the punctuation characters. For example, do we really want to insert newline after like "§" or "¶"? I'm not sure.
I believe the next step is to support UAX#14, which is defining the line-breaking algorithm. Then we can completely solve this punctuation issue.