### PR TITLE
allow specifying package with -p

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -56,7 +56,7 @@ fn execute() -> i32 {
     let mut is_package_arg = false;
     for arg in env::args().skip(2).take_while(|a| a != "--") {
         if arg.starts_with('-') {
-            is_package_arg = arg.starts_with("--package");
+            is_package_arg = arg.starts_with("--package") | arg.starts_with("-p");
         } else if !is_package_arg {
             print_usage_to_stderr(&opts, &format!("Invalid argument: `{}`.", arg));
             return FAILURE;


### PR DESCRIPTION
currently `cargo fmt -p blah` is rejected but `cargo fmt --package blah` is allowed. both should be allowed