### PR TITLE
Fix incorrect documentation for `unstable_features`

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2298,7 +2298,7 @@ Whether to use colored output or not.
 
 ## `unstable_features`
 
-Enable unstable features on stable channel.
+Enable unstable features on the unstable channel.
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`


### PR DESCRIPTION
Fixes #3247

According to the lined PR, the documentation claiming that the unstable features can be enabled in stable is wrong.