### PR TITLE
Prioritize single_line_fn and empty_item_single_line over brace_style

### DIFF
--- a/tests/source/issue-2835.rs
+++ b/tests/source/issue-2835.rs
@@ -1,0 +1,7 @@
+// rustfmt-brace_style: AlwaysNextLine
+// rustfmt-fn_single_line: true
+
+fn lorem() -> i32
+{
+    42
+}

--- a/tests/target/configs/brace_style/item_always_next_line.rs
+++ b/tests/target/configs/brace_style/item_always_next_line.rs
@@ -21,7 +21,5 @@ where
 mod tests
 {
     #[test]
-    fn it_works()
-    {
-    }
+    fn it_works() {}
 }

--- a/tests/target/fn-custom-7.rs
+++ b/tests/target/fn-custom-7.rs
@@ -30,11 +30,7 @@ fn foo(
 
 trait Test
 {
-    fn foo(a: u8)
-    {
-    }
+    fn foo(a: u8) {}
 
-    fn bar(a: u8) -> String
-    {
-    }
+    fn bar(a: u8) -> String {}
 }

--- a/tests/target/issue-2835.rs
+++ b/tests/target/issue-2835.rs
@@ -1,0 +1,4 @@
+// rustfmt-brace_style: AlwaysNextLine
+// rustfmt-fn_single_line: true
+
+fn lorem() -> i32 { 42 }


### PR DESCRIPTION
When either one of these two options are set to `true`, each should take
precedence over the brace_style option.

This commit does not introduce any formatting change to the default
configuration, so no version gate is required.

Closes #2835.