### PR TITLE
cargo-fmt: remove command line validation which did not properly handle the windows environment

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -242,7 +242,9 @@ fn get_targets_root_only(targets: &mut HashSet<Target>) -> Result<(), io::Error>
     let in_workspace_root = workspace_root_path == current_dir;
 
     for package in metadata.packages {
-        if in_workspace_root || PathBuf::from(&package.manifest_path) == current_dir_manifest {
+        if in_workspace_root
+            || PathBuf::from(&package.manifest_path).canonicalize()? == current_dir_manifest
+        {
             for target in package.targets {
                 targets.insert(Target::from_target(&target));
             }

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -54,7 +54,7 @@ fn execute() -> i32 {
 
     // If there is any invalid argument passed to `cargo fmt`, return without formatting.
     let mut is_package_arg = false;
-    for arg in env::args().skip(2).take_while(|a| a != "--") {
+    for arg in env::args().skip(1).take_while(|a| a != "--") {
         if arg.starts_with('-') {
             is_package_arg = arg.starts_with("--package") | arg.starts_with("-p");
         } else if !is_package_arg {

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -54,7 +54,7 @@ fn execute() -> i32 {
 
     // If there is any invalid argument passed to `cargo fmt`, return without formatting.
     let mut is_package_arg = false;
-    for arg in env::args().skip(1).take_while(|a| a != "--") {
+    for arg in env::args().skip(2).take_while(|a| a != "--") {
         if arg.starts_with('-') {
             is_package_arg = arg.starts_with("--package") | arg.starts_with("-p");
         } else if !is_package_arg {


### PR DESCRIPTION
@jakoschiko @chris-morgan Could you give this branch a try ?

Maybe the problem in windows comes from our handling of `env::args()`, where the first item is skipped. That is usually the executable name, but not [always](https://doc.rust-lang.org/std/env/fn.args.html):

> The first element is traditionally the path of the executable, but it can be set to arbitrary text, and may not even exist. This means this property should not be relied upon for security purposes.

Close #2694 