### PR TITLE
fix "internal error: left behind trailing whitespace" with long lines

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1037,8 +1037,7 @@ Format string literals where necessary
 
 ```rust
 fn main() {
-    let lorem =
-        "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit amet consectetur adipiscing";
+    let lorem = "ipsum dolor sit amet consectetur adipiscing elit lorem ipsum dolor sit amet consectetur adipiscing";
 }
 ```
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -22,7 +22,7 @@ use comment::{
     combine_strs_with_missing_comments, contains_comment, recover_comment_removed, rewrite_comment,
     rewrite_missing_comment, CharClasses, FindUncommented,
 };
-use config::{Config, ControlBraceStyle, IndentStyle};
+use config::{Config, ControlBraceStyle, IndentStyle, Version};
 use lists::{
     definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting, struct_lit_shape,
     struct_lit_tactic, write_list, ListFormatting, ListItem, Separator,
@@ -1264,7 +1264,11 @@ fn rewrite_string_lit(context: &RewriteContext, span: Span, shape: Shape) -> Opt
                     .join("\n")
                     .trim_start(),
             );
-            return wrap_str(indented_string_lit, context.config.max_width(), shape);
+            return if context.config.version() == Version::Two {
+                Some(indented_string_lit)
+            } else {
+                wrap_str(indented_string_lit, context.config.max_width(), shape)
+            };
         } else {
             return wrap_str(string_lit.to_owned(), context.config.max_width(), shape);
         }

--- a/tests/source/configs/indent_style/block_trailing_comma_call/one.rs
+++ b/tests/source/configs/indent_style/block_trailing_comma_call/one.rs
@@ -1,0 +1,9 @@
+// rustfmt-version: One
+// rustfmt-error_on_line_overflow: false
+// rustfmt-indent_style: Block
+
+// rustfmt should not add trailing comma when rewriting macro. See #1528.
+fn a() {
+    panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
+    foo(a, oooptoptoptoptptooptoptoptoptptooptoptoptoptptoptoptoptoptpt());
+}

--- a/tests/source/configs/indent_style/block_trailing_comma_call/two.rs
+++ b/tests/source/configs/indent_style/block_trailing_comma_call/two.rs
@@ -1,0 +1,9 @@
+// rustfmt-version: Two
+// rustfmt-error_on_line_overflow: false
+// rustfmt-indent_style: Block
+
+// rustfmt should not add trailing comma when rewriting macro. See #1528.
+fn a() {
+    panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
+    foo(a, oooptoptoptoptptooptoptoptoptptooptoptoptoptptoptoptoptoptpt());
+}

--- a/tests/source/issue-2179/one.rs
+++ b/tests/source/issue-2179/one.rs
@@ -1,3 +1,4 @@
+// rustfmt-version: One
 // rustfmt-error_on_line_overflow: false
 
 fn issue_2179() {

--- a/tests/source/issue-2179/two.rs
+++ b/tests/source/issue-2179/two.rs
@@ -1,0 +1,36 @@
+// rustfmt-version: Two
+// rustfmt-error_on_line_overflow: false
+
+fn issue_2179() {
+    let (opts, rustflags, clear_env_rust_log) =
+        {
+            // We mustn't lock configuration for the whole build process
+            let rls_config = rls_config.lock().unwrap();
+
+            let opts = CargoOptions::new(&rls_config);
+            trace!("Cargo compilation options:\n{:?}", opts);
+            let rustflags = prepare_cargo_rustflags(&rls_config);
+
+            // Warn about invalid specified bin target or package depending on current mode
+            // TODO: Return client notifications along with diagnostics to inform the user
+            if !rls_config.workspace_mode {
+                let cur_pkg_targets = ws.current().unwrap().targets();
+
+                if let &Some(ref build_bin) = rls_config.build_bin.as_ref() {
+                    let mut bins = cur_pkg_targets.iter().filter(|x| x.is_bin());
+                    if let None = bins.find(|x| x.name() == build_bin) {
+                        warn!("cargo - couldn't find binary `{}` specified in `build_bin` configuration", build_bin);
+                    }
+                }
+            } else {
+                for package in &opts.package {
+                    if let None = ws.members().find(|x| x.name() == package) {
+                        warn!("cargo - couldn't find member package `{}` specified in `analyze_package` configuration", package);
+                    }
+                }
+            }
+
+            (opts, rustflags, rls_config.clear_env_rust_log)
+        };
+
+}

--- a/tests/source/issue-3295/two.rs
+++ b/tests/source/issue-3295/two.rs
@@ -1,0 +1,13 @@
+// rustfmt-version: Two
+pub enum TestEnum {
+    a,
+    b,
+}
+
+fn the_test(input: TestEnum) {
+    match input {
+        TestEnum::a => String::from("aaa"),
+        TestEnum::b => String::from("this is a very very very very very very very very very very very very very very very ong string"),
+        
+    };
+}

--- a/tests/target/configs/indent_style/block_trailing_comma_call/one.rs
+++ b/tests/target/configs/indent_style/block_trailing_comma_call/one.rs
@@ -1,8 +1,12 @@
+// rustfmt-version: One
 // rustfmt-error_on_line_overflow: false
 // rustfmt-indent_style: Block
 
 // rustfmt should not add trailing comma when rewriting macro. See #1528.
 fn a() {
     panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
-    foo(a, oooptoptoptoptptooptoptoptoptptooptoptoptoptptoptoptoptoptpt());
+    foo(
+        a,
+        oooptoptoptoptptooptoptoptoptptooptoptoptoptptoptoptoptoptpt(),
+    );
 }

--- a/tests/target/configs/indent_style/block_trailing_comma_call/two.rs
+++ b/tests/target/configs/indent_style/block_trailing_comma_call/two.rs
@@ -1,9 +1,12 @@
+// rustfmt-version: Two
 // rustfmt-error_on_line_overflow: false
 // rustfmt-indent_style: Block
 
 // rustfmt should not add trailing comma when rewriting macro. See #1528.
 fn a() {
-    panic!("this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:");
+    panic!(
+        "this is a long string that goes past the maximum line length causing rustfmt to insert a comma here:"
+    );
     foo(
         a,
         oooptoptoptoptptooptoptoptoptptooptoptoptoptptoptoptoptoptpt(),

--- a/tests/target/issue-2179/one.rs
+++ b/tests/target/issue-2179/one.rs
@@ -1,3 +1,4 @@
+// rustfmt-version: One
 // rustfmt-error_on_line_overflow: false
 
 fn issue_2179() {

--- a/tests/target/issue-2179/two.rs
+++ b/tests/target/issue-2179/two.rs
@@ -1,0 +1,40 @@
+// rustfmt-version: Two
+// rustfmt-error_on_line_overflow: false
+
+fn issue_2179() {
+    let (opts, rustflags, clear_env_rust_log) = {
+        // We mustn't lock configuration for the whole build process
+        let rls_config = rls_config.lock().unwrap();
+
+        let opts = CargoOptions::new(&rls_config);
+        trace!("Cargo compilation options:\n{:?}", opts);
+        let rustflags = prepare_cargo_rustflags(&rls_config);
+
+        // Warn about invalid specified bin target or package depending on current mode
+        // TODO: Return client notifications along with diagnostics to inform the user
+        if !rls_config.workspace_mode {
+            let cur_pkg_targets = ws.current().unwrap().targets();
+
+            if let &Some(ref build_bin) = rls_config.build_bin.as_ref() {
+                let mut bins = cur_pkg_targets.iter().filter(|x| x.is_bin());
+                if let None = bins.find(|x| x.name() == build_bin) {
+                    warn!(
+                        "cargo - couldn't find binary `{}` specified in `build_bin` configuration",
+                        build_bin
+                    );
+                }
+            }
+        } else {
+            for package in &opts.package {
+                if let None = ws.members().find(|x| x.name() == package) {
+                    warn!(
+                        "cargo - couldn't find member package `{}` specified in `analyze_package` configuration",
+                        package
+                    );
+                }
+            }
+        }
+
+        (opts, rustflags, rls_config.clear_env_rust_log)
+    };
+}

--- a/tests/target/issue-3295/two.rs
+++ b/tests/target/issue-3295/two.rs
@@ -1,0 +1,14 @@
+// rustfmt-version: Two
+pub enum TestEnum {
+    a,
+    b,
+}
+
+fn the_test(input: TestEnum) {
+    match input {
+        TestEnum::a => String::from("aaa"),
+        TestEnum::b => String::from(
+            "this is a very very very very very very very very very very very very very very very ong string",
+        ),
+    };
+}


### PR DESCRIPTION
related: https://github.com/rust-lang/rustfmt/issues/3295

I don't have the confidence this PR.
But this fixs #3295 at least.