### PR TITLE
transition to Rust 2018

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,9 +35,7 @@ fn main() {
 // (git not installed or if this is not a git repository) just return an empty string.
 fn commit_info() -> String {
     match (channel(), commit_hash(), commit_date()) {
-        (channel, Some(hash), Some(date)) => {
-            format!("{} ({} {})", channel, hash.trim_end(), date)
-        }
+        (channel, Some(hash), Some(date)) => format!("{} ({} {})", channel, hash.trim_end(), date),
         _ => String::new(),
     }
 }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -10,19 +10,19 @@
 
 //! Format attributes and meta items.
 
-use comment::{contains_comment, rewrite_doc_comment, CommentStyle};
-use config::lists::*;
-use config::IndentStyle;
-use expr::rewrite_literal;
-use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
-use overflow;
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use types::{rewrite_path, PathContext};
-use utils::{count_newlines, mk_sp};
-
 use syntax::ast;
 use syntax::source_map::{BytePos, Span, DUMMY_SP};
+
+use crate::comment::{contains_comment, rewrite_doc_comment, CommentStyle};
+use crate::config::lists::*;
+use crate::config::IndentStyle;
+use crate::expr::rewrite_literal;
+use crate::lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
+use crate::overflow;
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::types::{rewrite_path, PathContext};
+use crate::utils::{count_newlines, mk_sp};
 
 /// Returns attributes on the given statement.
 pub fn get_attrs_from_stmt(stmt: &ast::Stmt) -> &[ast::Attribute] {
@@ -216,7 +216,7 @@ impl Rewrite for ast::MetaItem {
             }
             ast::MetaItemKind::List(ref list) => {
                 let path = rewrite_path(context, PathContext::Type, None, &self.ident, shape)?;
-                let has_trailing_comma = ::expr::span_ends_with_comma(context, self.span);
+                let has_trailing_comma = crate::expr::span_ends_with_comma(context, self.span);
                 overflow::rewrite_with_parens(
                     context,
                     &path,
@@ -383,7 +383,7 @@ impl<'a> Rewrite for [ast::Attribute] {
                 if let Some(missing_span) = missing_span {
                     let snippet = context.snippet(missing_span);
                     let (mla, mlb) = has_newlines_before_after_comment(snippet);
-                    let comment = ::comment::recover_missing_comment_in_span(
+                    let comment = crate::comment::recover_missing_comment_in_span(
                         missing_span,
                         shape.with_max_width(context.config),
                         context,
@@ -418,7 +418,7 @@ impl<'a> Rewrite for [ast::Attribute] {
                     .get(derives.len())
                     .map(|next| mk_sp(attrs[derives.len() - 1].span.hi(), next.span.lo()));
                 if let Some(missing_span) = missing_span {
-                    let comment = ::comment::recover_missing_comment_in_span(
+                    let comment = crate::comment::recover_missing_comment_in_span(
                         missing_span,
                         shape.with_max_width(context.config),
                         context,
@@ -451,7 +451,7 @@ impl<'a> Rewrite for [ast::Attribute] {
                 .get(1)
                 .map(|next| mk_sp(attrs[0].span.hi(), next.span.lo()));
             if let Some(missing_span) = missing_span {
-                let comment = ::comment::recover_missing_comment_in_span(
+                let comment = crate::comment::recover_missing_comment_in_span(
                     missing_span,
                     shape.with_max_width(context.config),
                     context,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -24,7 +24,7 @@ use failure::err_msg;
 
 use getopts::{Matches, Options};
 
-use rustfmt::{
+use crate::rustfmt::{
     load_config, CliOptions, Color, Config, Edition, EmitMode, ErrorKind, FileLines, FileName,
     Input, Session, Verbosity,
 };

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -65,24 +65,24 @@
 //!            .qux
 //! ```
 
-use comment::{rewrite_comment, CharClasses, FullCodeCharKind, RichChar};
-use config::IndentStyle;
-use expr::rewrite_call;
-use lists::extract_pre_comment;
-use macros::convert_try_mac;
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use source_map::SpanUtils;
-use utils::{
-    self, first_line_width, last_line_extendable, last_line_width, mk_sp, rewrite_ident,
-    trimmed_last_line_width, wrap_str,
-};
-
 use std::borrow::Cow;
 use std::cmp::min;
 
 use syntax::source_map::{BytePos, Span};
 use syntax::{ast, ptr};
+
+use crate::comment::{rewrite_comment, CharClasses, FullCodeCharKind, RichChar};
+use crate::config::IndentStyle;
+use crate::expr::rewrite_call;
+use crate::lists::extract_pre_comment;
+use crate::macros::convert_try_mac;
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::source_map::SpanUtils;
+use crate::utils::{
+    self, first_line_width, last_line_extendable, last_line_width, mk_sp, rewrite_ident,
+    trimmed_last_line_width, wrap_str,
+};
 
 pub fn rewrite_chain(expr: &ast::Expr, context: &RewriteContext, shape: Shape) -> Option<String> {
     let chain = Chain::from_ast(expr, context);

--- a/src/checkstyle.rs
+++ b/src/checkstyle.rs
@@ -11,7 +11,7 @@
 use std::io::{self, Write};
 use std::path::Path;
 
-use rustfmt_diff::{DiffLine, Mismatch};
+use crate::rustfmt_diff::{DiffLine, Mismatch};
 
 /// The checkstyle header - should be emitted before the output of Rustfmt.
 ///

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -8,19 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use config::lists::*;
 use syntax::parse::classify;
 use syntax::source_map::Span;
 use syntax::{ast, ptr};
 
-use expr::{block_contains_comment, is_simple_block, is_unsafe_block, rewrite_cond};
-use items::{span_hi_for_arg, span_lo_for_arg};
-use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
-use overflow::OverflowableItem;
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use source_map::SpanUtils;
-use utils::{last_line_width, left_most_sub_expr, stmt_expr, NodeIdExt};
+use crate::config::lists::*;
+use crate::expr::{block_contains_comment, is_simple_block, is_unsafe_block, rewrite_cond};
+use crate::items::{span_hi_for_arg, span_lo_for_arg};
+use crate::lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
+use crate::overflow::OverflowableItem;
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::source_map::SpanUtils;
+use crate::utils::{last_line_width, left_most_sub_expr, stmt_expr, NodeIdExt};
 
 // This module is pretty messy because of the rules around closures and blocks:
 // FIXME - the below is probably no longer true in full.
@@ -159,7 +159,8 @@ fn rewrite_closure_with_block(
         span: body.span,
         recovered: false,
     };
-    let block = ::expr::rewrite_block_with_visitor(context, "", &block, None, None, shape, false)?;
+    let block =
+        crate::expr::rewrite_block_with_visitor(context, "", &block, None, None, shape, false)?;
     Some(format!("{} {}", prefix, block))
 }
 

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -15,14 +15,14 @@ use std::{self, borrow::Cow, iter};
 use itertools::{multipeek, MultiPeek};
 use syntax::source_map::Span;
 
-use config::Config;
-use rewrite::RewriteContext;
-use shape::{Indent, Shape};
-use string::{rewrite_string, StringFormat};
-use utils::{
+use crate::config::Config;
+use crate::rewrite::RewriteContext;
+use crate::shape::{Indent, Shape};
+use crate::string::{rewrite_string, StringFormat};
+use crate::utils::{
     count_newlines, first_line_width, last_line_width, trim_left_preserve_layout, unicode_str_width,
 };
-use {ErrorKind, FormattingError};
+use crate::{ErrorKind, FormattingError};
 
 fn is_custom_comment(comment: &str) -> bool {
     if !comment.starts_with("//") {
@@ -657,7 +657,7 @@ impl<'a> CommentRewrite<'a> {
                     _ => {
                         let mut config = self.fmt.config.clone();
                         config.set().wrap_comments(false);
-                        match ::format_code_block(&self.code_block_buffer, &config) {
+                        match crate::format_code_block(&self.code_block_buffer, &config) {
                             Some(ref s) => trim_custom_comment_prefix(&s.snippet),
                             None => trim_custom_comment_prefix(&self.code_block_buffer),
                         }
@@ -1672,7 +1672,7 @@ fn remove_comment_header(comment: &str) -> &str {
 #[cfg(test)]
 mod test {
     use super::*;
-    use shape::{Indent, Shape};
+    use crate::shape::{Indent, Shape};
 
     #[test]
     fn char_classes() {
@@ -1733,11 +1733,11 @@ mod test {
     #[test]
     #[rustfmt::skip]
     fn format_doc_comments() {
-        let mut wrap_normalize_config: ::config::Config = Default::default();
+        let mut wrap_normalize_config: crate::config::Config = Default::default();
         wrap_normalize_config.set().wrap_comments(true);
         wrap_normalize_config.set().normalize_comments(true);
 
-        let mut wrap_config: ::config::Config = Default::default();
+        let mut wrap_config: crate::config::Config = Default::default();
         wrap_config.set().wrap_comments(true);
 
         let comment = rewrite_comment(" //test",

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use config::file_lines::FileLines;
-use config::options::{IgnoreList, WidthHeuristics};
+use crate::config::file_lines::FileLines;
+use crate::config::options::{IgnoreList, WidthHeuristics};
 
 /// Trait for types that can be used in `Config`.
 pub trait ConfigType: Sized {

--- a/src/config/lists.rs
+++ b/src/config/lists.rs
@@ -10,8 +10,8 @@
 
 //! Configuration options related to rewriting a list.
 
-use config::config_type::ConfigType;
-use config::IndentStyle;
+use crate::config::config_type::ConfigType;
+use crate::config::IndentStyle;
 
 /// The definitive formatting tactic for lists.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use regex::Regex;
 use std::cell::Cell;
 use std::default::Default;
 use std::fs::File;
@@ -16,10 +15,12 @@ use std::io::{Error, ErrorKind, Read};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use config::config_type::ConfigType;
-pub use config::file_lines::{FileLines, FileName, Range};
-pub use config::lists::*;
-pub use config::options::*;
+use regex::Regex;
+
+use crate::config::config_type::ConfigType;
+pub use crate::config::file_lines::{FileLines, FileName, Range};
+pub use crate::config::lists::*;
+pub use crate::config::options::*;
 
 #[macro_use]
 pub mod config_type;

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use config::config_type::ConfigType;
-use config::lists::*;
-use config::{Config, FileName};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 use atty;
 
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use crate::config::config_type::ConfigType;
+use crate::config::lists::*;
+use crate::config::{Config, FileName};
 
 /// Macro that will stringify the enum variants or a provided textual repr
 #[macro_export]
@@ -169,7 +169,7 @@ impl NewlineStyle {
     /// If the style is set to `Auto` and `raw_input_text` contains no
     /// newlines, the `Native` style will be used.
     pub(crate) fn apply(self, formatted_text: &mut String, raw_input_text: &str) {
-        use NewlineStyle::*;
+        use crate::NewlineStyle::*;
         let mut style = self;
         if style == Auto {
             style = Self::auto_detect(raw_input_text);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -11,40 +11,40 @@
 use std::borrow::Cow;
 use std::cmp::min;
 
-use config::lists::*;
 use syntax::parse::token::DelimToken;
 use syntax::source_map::{BytePos, SourceMap, Span};
 use syntax::{ast, ptr};
 
-use chains::rewrite_chain;
-use closures;
-use comment::{
+use crate::chains::rewrite_chain;
+use crate::closures;
+use crate::comment::{
     combine_strs_with_missing_comments, contains_comment, recover_comment_removed, rewrite_comment,
     rewrite_missing_comment, CharClasses, FindUncommented,
 };
-use config::{Config, ControlBraceStyle, IndentStyle, Version};
-use lists::{
+use crate::config::lists::*;
+use crate::config::{Config, ControlBraceStyle, IndentStyle, Version};
+use crate::lists::{
     definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting, struct_lit_shape,
     struct_lit_tactic, write_list, ListFormatting, ListItem, Separator,
 };
-use macros::{rewrite_macro, MacroPosition};
-use matches::rewrite_match;
-use overflow::{self, IntoOverflowableItem, OverflowableItem};
-use pairs::{rewrite_all_pairs, rewrite_pair, PairParts};
-use patterns::is_short_pattern;
-use rewrite::{Rewrite, RewriteContext};
-use shape::{Indent, Shape};
-use source_map::{LineRangeUtils, SpanUtils};
-use spanned::Spanned;
-use string::{rewrite_string, StringFormat};
-use types::{rewrite_path, PathContext};
-use utils::{
+use crate::macros::{rewrite_macro, MacroPosition};
+use crate::matches::rewrite_match;
+use crate::overflow::{self, IntoOverflowableItem, OverflowableItem};
+use crate::pairs::{rewrite_all_pairs, rewrite_pair, PairParts};
+use crate::patterns::is_short_pattern;
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::{Indent, Shape};
+use crate::source_map::{LineRangeUtils, SpanUtils};
+use crate::spanned::Spanned;
+use crate::string::{rewrite_string, StringFormat};
+use crate::types::{rewrite_path, PathContext};
+use crate::utils::{
     colon_spaces, contains_skip, count_newlines, first_line_ends_with, inner_attributes,
     last_line_extendable, last_line_width, mk_sp, outer_attributes, ptr_vec_to_ref_vec,
     semicolon_for_expr, semicolon_for_stmt, wrap_str,
 };
-use vertical::rewrite_with_alignment;
-use visitor::FmtVisitor;
+use crate::vertical::rewrite_with_alignment;
+use crate::visitor::FmtVisitor;
 
 impl Rewrite for ast::Expr {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -12,11 +12,11 @@ use syntax::errors::{DiagnosticBuilder, Handler};
 use syntax::parse::{self, ParseSess};
 use syntax::source_map::{FilePathMapping, SourceMap, Span};
 
-use comment::{CharClasses, FullCodeCharKind};
-use config::{Config, FileName, Verbosity};
-use issues::BadIssueSeeker;
-use visitor::{FmtVisitor, SnippetProvider};
-use {modules, source_file, ErrorKind, FormatReport, Input, Session};
+use crate::comment::{CharClasses, FullCodeCharKind};
+use crate::config::{Config, FileName, Verbosity};
+use crate::issues::BadIssueSeeker;
+use crate::visitor::{FmtVisitor, SnippetProvider};
+use crate::{modules, source_file, ErrorKind, FormatReport, Input, Session};
 
 // A map of the files of a crate, with their new content
 pub(crate) type SourceFile = Vec<FileRecord>;
@@ -157,7 +157,7 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
 
         debug_assert_eq!(
             visitor.line_number,
-            ::utils::count_newlines(&visitor.buffer)
+            crate::utils::count_newlines(&visitor.buffer)
         );
 
         // For some reason, the source_map does not include terminating

--- a/src/git-rustfmt/main.rs
+++ b/src/git-rustfmt/main.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 
 use getopts::{Matches, Options};
 
-use rustfmt::{load_config, CliOptions, Input, Session};
+use crate::rustfmt::{load_config, CliOptions, Input, Session};
 
 fn prune_files(files: Vec<&str>) -> Vec<&str> {
     let prefixes: Vec<_> = files

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -8,24 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::fmt;
 
-use config::lists::*;
 use syntax::ast::{self, UseTreeKind};
 use syntax::source_map::{self, BytePos, Span, DUMMY_SP};
 
-use comment::combine_strs_with_missing_comments;
-use config::{Edition, IndentStyle};
-use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator};
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use source_map::SpanUtils;
-use spanned::Spanned;
-use utils::{is_same_visibility, mk_sp, rewrite_ident};
-use visitor::FmtVisitor;
-
-use std::borrow::Cow;
-use std::fmt;
+use crate::comment::combine_strs_with_missing_comments;
+use crate::config::lists::*;
+use crate::config::{Edition, IndentStyle};
+use crate::lists::{
+    definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator,
+};
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::source_map::SpanUtils;
+use crate::spanned::Spanned;
+use crate::utils::{is_same_visibility, mk_sp, rewrite_ident};
+use crate::visitor::FmtVisitor;
 
 /// Returns a name imported by a `use` declaration. e.g. returns `Ordering`
 /// for `std::cmp::Ordering` and `self` for `std::cmp::self`.
@@ -242,7 +243,7 @@ impl UseTree {
     // Rewrite use tree with `use ` and a trailing `;`.
     pub fn rewrite_top_level(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
         let vis = self.visibility.as_ref().map_or(Cow::from(""), |vis| {
-            ::utils::format_visibility(context, &vis)
+            crate::utils::format_visibility(context, &vis)
         });
         let use_str = self
             .rewrite(context, shape.offset_left(vis.len())?)

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-use config::ReportTactic;
+use crate::config::ReportTactic;
 
 const TO_DO_CHARS: &[char] = &['t', 'o', 'd', 'o'];
 const FIX_ME_CHARS: &[char] = &['f', 'i', 'x', 'm', 'e'];

--- a/src/items.rs
+++ b/src/items.rs
@@ -13,32 +13,34 @@
 use std::borrow::Cow;
 use std::cmp::{min, Ordering};
 
-use config::lists::*;
 use regex::Regex;
 use rustc_target::spec::abi;
 use syntax::source_map::{self, BytePos, Span};
 use syntax::visit;
 use syntax::{ast, ptr, symbol};
 
-use comment::{
+use crate::comment::{
     combine_strs_with_missing_comments, contains_comment, recover_comment_removed,
     recover_missing_comment_in_span, rewrite_missing_comment, FindUncommented,
 };
-use config::{BraceStyle, Config, Density, IndentStyle, Version};
-use expr::{
+use crate::config::lists::*;
+use crate::config::{BraceStyle, Config, Density, IndentStyle, Version};
+use crate::expr::{
     format_expr, is_empty_block, is_simple_block_stmt, rewrite_assign_rhs, rewrite_assign_rhs_with,
     ExprType, RhsTactics,
 };
-use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator};
-use macros::{rewrite_macro, MacroPosition};
-use overflow;
-use rewrite::{Rewrite, RewriteContext};
-use shape::{Indent, Shape};
-use source_map::{LineRangeUtils, SpanUtils};
-use spanned::Spanned;
-use utils::*;
-use vertical::rewrite_with_alignment;
-use visitor::FmtVisitor;
+use crate::lists::{
+    definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator,
+};
+use crate::macros::{rewrite_macro, MacroPosition};
+use crate::overflow;
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::{Indent, Shape};
+use crate::source_map::{LineRangeUtils, SpanUtils};
+use crate::spanned::Spanned;
+use crate::utils::*;
+use crate::vertical::rewrite_with_alignment;
+use crate::visitor::FmtVisitor;
 
 const DEFAULT_VISIBILITY: ast::Visibility = source_map::Spanned {
     node: ast::VisibilityKind::Inherited,
@@ -621,7 +623,7 @@ impl<'a> FmtVisitor<'a> {
                 self.buffer.clear();
             }
             // type -> existential -> const -> macro -> method
-            use ast::ImplItemKind::*;
+            use crate::ast::ImplItemKind::*;
             fn need_empty_line(a: &ast::ImplItemKind, b: &ast::ImplItemKind) -> bool {
                 match (a, b) {
                     (Type(..), Type(..))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,15 +42,16 @@ use std::mem;
 use std::panic;
 use std::path::PathBuf;
 use std::rc::Rc;
+
+use failure::Fail;
 use syntax::ast;
 
-use comment::LineClasses;
-use failure::Fail;
-use formatting::{FormatErrorMap, FormattingError, ReportedErrors, SourceFile};
-use issues::Issue;
-use shape::Indent;
+use crate::comment::LineClasses;
+use crate::formatting::{FormatErrorMap, FormattingError, ReportedErrors, SourceFile};
+use crate::issues::Issue;
+use crate::shape::Indent;
 
-pub use config::{
+pub use crate::config::{
     load_config, CliOptions, Color, Config, Edition, EmitMode, FileLines, FileName, NewlineStyle,
     Range, Verbosity,
 };

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -13,15 +13,15 @@
 use std::cmp;
 use std::iter::Peekable;
 
-use config::lists::*;
 use syntax::source_map::BytePos;
 
-use comment::{find_comment_end, rewrite_comment, FindUncommented};
-use config::{Config, IndentStyle};
-use rewrite::RewriteContext;
-use shape::{Indent, Shape};
-use utils::{count_newlines, first_line_width, last_line_width, mk_sp, starts_with_newline};
-use visitor::SnippetProvider;
+use crate::comment::{find_comment_end, rewrite_comment, FindUncommented};
+use crate::config::lists::*;
+use crate::config::{Config, IndentStyle};
+use crate::rewrite::RewriteContext;
+use crate::shape::{Indent, Shape};
+use crate::utils::{count_newlines, first_line_width, last_line_width, mk_sp, starts_with_newline};
+use crate::visitor::SnippetProvider;
 
 pub struct ListFormatting<'a> {
     tactic: DefinitiveListTactic,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -21,7 +21,6 @@
 
 use std::collections::HashMap;
 
-use config::lists::*;
 use syntax::parse::new_parser_from_tts;
 use syntax::parse::parser::Parser;
 use syntax::parse::token::{BinOpToken, DelimToken, Token};
@@ -32,19 +31,22 @@ use syntax::tokenstream::{Cursor, ThinTokenStream, TokenStream, TokenTree};
 use syntax::ThinVec;
 use syntax::{ast, parse, ptr};
 
-use comment::{contains_comment, CharClasses, FindUncommented, FullCodeCharKind, LineClasses};
-use expr::rewrite_array;
-use lists::{itemize_list, write_list, ListFormatting};
-use overflow;
-use rewrite::{Rewrite, RewriteContext};
-use shape::{Indent, Shape};
-use source_map::SpanUtils;
-use spanned::Spanned;
-use utils::{
+use crate::comment::{
+    contains_comment, CharClasses, FindUncommented, FullCodeCharKind, LineClasses,
+};
+use crate::config::lists::*;
+use crate::expr::rewrite_array;
+use crate::lists::{itemize_list, write_list, ListFormatting};
+use crate::overflow;
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::{Indent, Shape};
+use crate::source_map::SpanUtils;
+use crate::spanned::Spanned;
+use crate::utils::{
     format_visibility, is_empty_line, mk_sp, remove_trailing_white_spaces, rewrite_ident,
     trim_left_preserve_layout, wrap_str, NodeIdExt,
 };
-use visitor::FmtVisitor;
+use crate::visitor::FmtVisitor;
 
 const FORCED_BRACKET_MACROS: &[&str] = &["vec!"];
 
@@ -75,7 +77,7 @@ impl MacroArg {
 
 impl Rewrite for ast::Item {
     fn rewrite(&self, context: &RewriteContext, shape: Shape) -> Option<String> {
-        let mut visitor = ::visitor::FmtVisitor::from_context(context);
+        let mut visitor = crate::visitor::FmtVisitor::from_context(context);
         visitor.block_indent = shape.indent;
         visitor.last_pos = self.span().lo();
         visitor.visit_item(self);
@@ -1271,12 +1273,12 @@ impl MacroBranch {
         config.set().max_width(new_width);
 
         // First try to format as items, then as statements.
-        let new_body_snippet = match ::format_snippet(&body_str, &config) {
+        let new_body_snippet = match crate::format_snippet(&body_str, &config) {
             Some(new_body) => new_body,
             None => {
                 let new_width = new_width + config.tab_spaces();
                 config.set().max_width(new_width);
-                match ::format_code_block(&body_str, &config) {
+                match crate::format_code_block(&body_str, &config) {
                     Some(new_body) => new_body,
                     None => return None,
                 }
@@ -1374,7 +1376,7 @@ fn format_lazy_static(context: &RewriteContext, shape: Shape, ts: &TokenStream) 
 
     while parser.token != Token::Eof {
         // Parse a `lazy_static!` item.
-        let vis = ::utils::format_visibility(context, &parse_or!(parse_visibility, false));
+        let vis = crate::utils::format_visibility(context, &parse_or!(parse_visibility, false));
         parser.eat_keyword(symbol::keywords::Static);
         parser.eat_keyword(symbol::keywords::Ref);
         let id = parse_or!(parse_ident);
@@ -1392,7 +1394,7 @@ fn format_lazy_static(context: &RewriteContext, shape: Shape, ts: &TokenStream) 
             id,
             ty.rewrite(context, nested_shape)?
         ));
-        result.push_str(&::expr::rewrite_assign_rhs(
+        result.push_str(&crate::expr::rewrite_assign_rhs(
             context,
             stmt,
             &*expr,

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -12,22 +12,22 @@
 
 use std::iter::repeat;
 
-use config::lists::*;
 use syntax::source_map::{BytePos, Span};
 use syntax::{ast, ptr};
 
-use comment::{combine_strs_with_missing_comments, rewrite_comment};
-use config::{Config, ControlBraceStyle, IndentStyle, Version};
-use expr::{
+use crate::comment::{combine_strs_with_missing_comments, rewrite_comment};
+use crate::config::lists::*;
+use crate::config::{Config, ControlBraceStyle, IndentStyle, Version};
+use crate::expr::{
     format_expr, is_empty_block, is_simple_block, is_unsafe_block, prefer_next_line, rewrite_cond,
     rewrite_multiple_patterns, ExprType, RhsTactics,
 };
-use lists::{itemize_list, write_list, ListFormatting};
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use source_map::SpanUtils;
-use spanned::Spanned;
-use utils::{
+use crate::lists::{itemize_list, write_list, ListFormatting};
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::source_map::SpanUtils;
+use crate::spanned::Spanned;
+use crate::utils::{
     contains_skip, extra_offset, first_line_width, inner_attributes, last_line_extendable, mk_sp,
     ptr_vec_to_ref_vec, semicolon_for_expr, trimmed_last_line_width,
 };

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -12,12 +12,12 @@ use std::borrow::Cow;
 
 use syntax::source_map::{BytePos, Pos, Span};
 
-use comment::{rewrite_comment, CodeCharKind, CommentCodeSlices};
-use config::{EmitMode, FileName};
-use shape::{Indent, Shape};
-use source_map::LineRangeUtils;
-use utils::{count_newlines, last_line_width, mk_sp};
-use visitor::FmtVisitor;
+use crate::comment::{rewrite_comment, CodeCharKind, CommentCodeSlices};
+use crate::config::{EmitMode, FileName};
+use crate::shape::{Indent, Shape};
+use crate::source_map::LineRangeUtils;
+use crate::utils::{count_newlines, last_line_width, mk_sp};
+use crate::visitor::FmtVisitor;
 
 struct SnippetStatus {
     /// An offset to the current line from the beginning of the original snippet.

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -17,8 +17,8 @@ use syntax::parse::{parser, DirectoryOwnership};
 use syntax::source_map;
 use syntax_pos::symbol::Symbol;
 
-use config::FileName;
-use utils::contains_skip;
+use crate::config::FileName;
+use crate::utils::contains_skip;
 
 /// List all the files containing modules of a crate.
 /// If a file is used twice in a crate, it appears only once.

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -10,28 +10,30 @@
 
 //! Rewrite a list some items with overflow.
 
-use config::lists::*;
-use config::Version;
+use std::cmp::min;
+
 use syntax::parse::token::DelimToken;
 use syntax::source_map::Span;
 use syntax::{ast, ptr};
 
-use closures;
-use expr::{
+use crate::closures;
+use crate::config::lists::*;
+use crate::config::Version;
+use crate::expr::{
     can_be_overflowed_expr, is_every_expr_simple, is_method_call, is_nested_call, is_simple_expr,
     rewrite_cond,
 };
-use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator};
-use macros::MacroArg;
-use patterns::{can_be_overflowed_pat, TuplePatField};
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use source_map::SpanUtils;
-use spanned::Spanned;
-use types::{can_be_overflowed_type, SegmentParam};
-use utils::{count_newlines, extra_offset, first_line_width, last_line_width, mk_sp};
-
-use std::cmp::min;
+use crate::lists::{
+    definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator,
+};
+use crate::macros::MacroArg;
+use crate::patterns::{can_be_overflowed_pat, TuplePatField};
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::source_map::SpanUtils;
+use crate::spanned::Spanned;
+use crate::types::{can_be_overflowed_type, SegmentParam};
+use crate::utils::{count_newlines, extra_offset, first_line_width, last_line_width, mk_sp};
 
 const SHORT_ITEM_THRESHOLD: usize = 10;
 
@@ -544,7 +546,7 @@ impl<'a> Context<'a> {
                     && self.one_line_width != 0
                     && !list_items[0].has_comment()
                     && !list_items[0].inner_as_ref().contains('\n')
-                    && ::lists::total_item_width(&list_items[0]) <= self.one_line_width
+                    && crate::lists::total_item_width(&list_items[0]) <= self.one_line_width
                 {
                     tactic = DefinitiveListTactic::Horizontal;
                 } else {

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -10,11 +10,13 @@
 
 use syntax::ast;
 
-use config::lists::*;
-use config::IndentStyle;
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use utils::{first_line_width, is_single_line, last_line_width, trimmed_last_line_width, wrap_str};
+use crate::config::lists::*;
+use crate::config::IndentStyle;
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::utils::{
+    first_line_width, is_single_line, last_line_width, trimmed_last_line_width, wrap_str,
+};
 
 /// Sigils that decorate a binop pair.
 #[derive(new, Clone, Copy)]

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -8,26 +8,26 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use config::lists::*;
 use syntax::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax};
 use syntax::ptr;
 use syntax::source_map::{self, BytePos, Span};
 
-use comment::FindUncommented;
-use expr::{can_be_overflowed_expr, rewrite_unary_prefix, wrap_struct_field};
-use lists::{
+use crate::comment::FindUncommented;
+use crate::config::lists::*;
+use crate::expr::{can_be_overflowed_expr, rewrite_unary_prefix, wrap_struct_field};
+use crate::lists::{
     itemize_list, shape_for_tactic, struct_lit_formatting, struct_lit_shape, struct_lit_tactic,
     write_list,
 };
-use macros::{rewrite_macro, MacroPosition};
-use overflow;
-use pairs::{rewrite_pair, PairParts};
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use source_map::SpanUtils;
-use spanned::Spanned;
-use types::{rewrite_path, PathContext};
-use utils::{format_mutability, mk_sp, rewrite_ident};
+use crate::macros::{rewrite_macro, MacroPosition};
+use crate::overflow;
+use crate::pairs::{rewrite_pair, PairParts};
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::source_map::SpanUtils;
+use crate::spanned::Spanned;
+use crate::types::{rewrite_path, PathContext};
+use crate::utils::{format_mutability, mk_sp, rewrite_ident};
 
 /// Returns true if the given pattern is short. A short pattern is defined by the following grammar:
 ///

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -16,22 +16,22 @@
 
 // FIXME(#2455): Reorder trait items.
 
-use config::Config;
+use std::cmp::{Ord, Ordering};
+
 use syntax::{ast, attr, source_map::Span};
 
-use attr::filter_inline_attrs;
-use comment::combine_strs_with_missing_comments;
-use imports::{merge_use_trees, UseTree};
-use items::{is_mod_decl, rewrite_extern_crate, rewrite_mod};
-use lists::{itemize_list, write_list, ListFormatting, ListItem};
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use source_map::LineRangeUtils;
-use spanned::Spanned;
-use utils::{contains_skip, mk_sp};
-use visitor::FmtVisitor;
-
-use std::cmp::{Ord, Ordering};
+use crate::attr::filter_inline_attrs;
+use crate::comment::combine_strs_with_missing_comments;
+use crate::config::Config;
+use crate::imports::{merge_use_trees, UseTree};
+use crate::items::{is_mod_decl, rewrite_extern_crate, rewrite_mod};
+use crate::lists::{itemize_list, write_list, ListFormatting, ListItem};
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::source_map::LineRangeUtils;
+use crate::spanned::Spanned;
+use crate::utils::{contains_skip, mk_sp};
+use crate::visitor::FmtVisitor;
 
 /// Choose the ordering between the given two items.
 fn compare_items(a: &ast::Item, b: &ast::Item) -> Ordering {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -10,16 +10,16 @@
 
 // A generic trait to abstract the rewriting of an element (of the AST).
 
+use std::cell::RefCell;
+
 use syntax::parse::ParseSess;
 use syntax::ptr;
 use syntax::source_map::{SourceMap, Span};
 
-use config::{Config, IndentStyle};
-use shape::Shape;
-use visitor::SnippetProvider;
-use FormatReport;
-
-use std::cell::RefCell;
+use crate::config::{Config, IndentStyle};
+use crate::shape::Shape;
+use crate::visitor::SnippetProvider;
+use crate::FormatReport;
 
 pub trait Rewrite {
     /// Rewrite self into shape.

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -8,11 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use config::{Color, Config, Verbosity};
-use diff;
 use std::collections::VecDeque;
 use std::io;
 use std::io::Write;
+
+use diff;
+
+use crate::config::{Color, Config, Verbosity};
 
 #[derive(Debug, PartialEq)]
 pub enum DiffLine {

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 use std::cmp::min;
 use std::ops::{Add, Sub};
 
-use Config;
+use crate::Config;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Indent {

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -11,12 +11,12 @@
 use std::fs;
 use std::io::{self, Write};
 
-use checkstyle::output_checkstyle_file;
-use config::{Config, EmitMode, FileName, Verbosity};
-use rustfmt_diff::{make_diff, output_modified, print_diff};
+use crate::checkstyle::output_checkstyle_file;
+use crate::config::{Config, EmitMode, FileName, Verbosity};
+use crate::rustfmt_diff::{make_diff, output_modified, print_diff};
 
 #[cfg(test)]
-use formatting::FileRecord;
+use crate::formatting::FileRecord;
 
 // Append a newline to the end of each file.
 pub fn append_newline(s: &mut String) {
@@ -33,13 +33,13 @@ where
     T: Write,
 {
     if config.emit_mode() == EmitMode::Checkstyle {
-        write!(out, "{}", ::checkstyle::header())?;
+        write!(out, "{}", crate::checkstyle::header())?;
     }
     for &(ref filename, ref text) in source_file {
         write_file(text, filename, out, config)?;
     }
     if config.emit_mode() == EmitMode::Checkstyle {
-        write!(out, "{}", ::checkstyle::footer())?;
+        write!(out, "{}", crate::checkstyle::footer())?;
     }
 
     Ok(())

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -11,11 +11,11 @@
 //! This module contains utilities that work with the `SourceMap` from `libsyntax`/`syntex_syntax`.
 //! This includes extension traits and methods for looking up spans and line ranges for AST nodes.
 
-use config::file_lines::LineRange;
 use syntax::source_map::{BytePos, SourceMap, Span};
-use visitor::SnippetProvider;
 
-use comment::FindUncommented;
+use crate::comment::FindUncommented;
+use crate::config::file_lines::LineRange;
+use crate::visitor::SnippetProvider;
 
 pub trait SpanUtils {
     fn span_after(&self, original: Span, needle: &str) -> BytePos;

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -8,15 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::cmp::max;
+
 use syntax::{
     ast, ptr,
     source_map::{self, Span},
 };
 
-use macros::MacroArg;
-use utils::{mk_sp, outer_attributes};
-
-use std::cmp::max;
+use crate::macros::MacroArg;
+use crate::utils::{mk_sp, outer_attributes};
 
 /// Spanned returns a span including attributes, if available.
 pub trait Spanned {
@@ -116,7 +116,7 @@ impl Spanned for ast::Arm {
 
 impl Spanned for ast::Arg {
     fn span(&self) -> Span {
-        if ::items::is_named_arg(self) {
+        if crate::items::is_named_arg(self) {
             mk_sp(self.pat.span.lo(), self.ty.span.hi())
         } else {
             self.ty.span

--- a/src/string.rs
+++ b/src/string.rs
@@ -14,9 +14,9 @@ use regex::Regex;
 use unicode_categories::UnicodeCategories;
 use unicode_segmentation::UnicodeSegmentation;
 
-use config::Config;
-use shape::Shape;
-use utils::{unicode_str_width, wrap_str};
+use crate::config::Config;
+use crate::shape::Shape;
+use crate::utils::{unicode_str_width, wrap_str};
 
 const MIN_STRING: usize = 10;
 
@@ -362,8 +362,8 @@ fn graphemes_width(graphemes: &[&str]) -> usize {
 #[cfg(test)]
 mod test {
     use super::{break_string, detect_url, rewrite_string, SnippetState, StringFormat};
-    use config::Config;
-    use shape::{Indent, Shape};
+    use crate::config::Config;
+    use crate::shape::{Indent, Shape};
     use unicode_segmentation::UnicodeSegmentation;
 
     #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -18,11 +18,11 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::Chars;
 
-use config::{Color, Config, EmitMode, FileName, ReportTactic};
-use formatting::{ModifiedChunk, SourceFile};
-use rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, OutputWriter};
-use source_file;
-use {FormatReport, Input, Session};
+use crate::config::{Color, Config, EmitMode, FileName, ReportTactic};
+use crate::formatting::{ModifiedChunk, SourceFile};
+use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, OutputWriter};
+use crate::source_file;
+use crate::{FormatReport, Input, Session};
 
 const DIFF_CONTEXT_SIZE: usize = 3;
 const CONFIGURATIONS_FILE_NAME: &str = "Configurations.md";
@@ -145,7 +145,9 @@ fn modified_test() {
     let filename = "tests/writemode/source/modified.rs";
     let mut data = Vec::new();
     let mut config = Config::default();
-    config.set().emit_mode(::config::EmitMode::ModifiedLines);
+    config
+        .set()
+        .emit_mode(crate::config::EmitMode::ModifiedLines);
 
     {
         let mut session = Session::new(config, Some(&mut data));

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,22 +11,22 @@
 use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
-use config::lists::*;
 use syntax::ast::{self, FunctionRetTy, Mutability};
 use syntax::source_map::{self, BytePos, Span};
 use syntax::symbol::keywords;
 
-use config::{IndentStyle, TypeDensity};
-use expr::{rewrite_assign_rhs, rewrite_tuple, rewrite_unary_prefix};
-use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
-use macros::{rewrite_macro, MacroPosition};
-use overflow;
-use pairs::{rewrite_pair, PairParts};
-use rewrite::{Rewrite, RewriteContext};
-use shape::Shape;
-use source_map::SpanUtils;
-use spanned::Spanned;
-use utils::{
+use crate::config::lists::*;
+use crate::config::{IndentStyle, TypeDensity};
+use crate::expr::{rewrite_assign_rhs, rewrite_tuple, rewrite_unary_prefix};
+use crate::lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
+use crate::macros::{rewrite_macro, MacroPosition};
+use crate::overflow;
+use crate::pairs::{rewrite_pair, PairParts};
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::Shape;
+use crate::source_map::SpanUtils;
+use crate::spanned::Spanned;
+use crate::utils::{
     colon_spaces, extra_offset, first_line_width, format_abi, format_mutability,
     last_line_extendable, last_line_width, mk_sp, rewrite_ident,
 };
@@ -706,7 +706,7 @@ fn rewrite_bare_fn(
         result.push_str("> ");
     }
 
-    result.push_str(::utils::format_unsafety(bare_fn.unsafety));
+    result.push_str(crate::utils::format_unsafety(bare_fn.unsafety));
 
     result.push_str(&format_abi(
         bare_fn.abi,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,13 +20,12 @@ use syntax::ast::{
 use syntax::ptr;
 use syntax::source_map::{BytePos, Span, NO_EXPANSION};
 use syntax_pos::Mark;
-
-use comment::{filter_normal_code, CharClasses, FullCodeCharKind, LineClasses};
-use config::{Config, Version};
-use rewrite::RewriteContext;
-use shape::{Indent, Shape};
-
 use unicode_width::UnicodeWidthStr;
+
+use crate::comment::{filter_normal_code, CharClasses, FullCodeCharKind, LineClasses};
+use crate::config::{Config, Version};
+use crate::rewrite::RewriteContext;
+use crate::shape::{Indent, Shape};
 
 pub const DEPR_SKIP_ANNOTATION: &str = "rustfmt_skip";
 pub const SKIP_ANNOTATION: &str = "rustfmt::skip";

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -12,19 +12,21 @@
 
 use std::cmp;
 
-use config::lists::*;
 use syntax::ast;
 use syntax::source_map::{BytePos, Span};
 
-use comment::{combine_strs_with_missing_comments, contains_comment};
-use expr::rewrite_field;
-use items::{rewrite_struct_field, rewrite_struct_field_prefix};
-use lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator};
-use rewrite::{Rewrite, RewriteContext};
-use shape::{Indent, Shape};
-use source_map::SpanUtils;
-use spanned::Spanned;
-use utils::{contains_skip, is_attributes_extendable, mk_sp, rewrite_ident};
+use crate::comment::{combine_strs_with_missing_comments, contains_comment};
+use crate::config::lists::*;
+use crate::expr::rewrite_field;
+use crate::items::{rewrite_struct_field, rewrite_struct_field_prefix};
+use crate::lists::{
+    definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator,
+};
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::{Indent, Shape};
+use crate::source_map::SpanUtils;
+use crate::spanned::Spanned;
+use crate::utils::{contains_skip, is_attributes_extendable, mk_sp, rewrite_ident};
 
 pub trait AlignedItem {
     fn skip(&self) -> bool;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -8,32 +8,32 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::cell::RefCell;
+
 use syntax::attr::HasAttrs;
 use syntax::parse::ParseSess;
 use syntax::source_map::{self, BytePos, Pos, SourceMap, Span};
 use syntax::{ast, visit};
 
-use attr::*;
-use comment::{CodeCharKind, CommentCodeSlices, FindUncommented};
-use config::{BraceStyle, Config};
-use items::{
+use crate::attr::*;
+use crate::comment::{CodeCharKind, CommentCodeSlices, FindUncommented};
+use crate::config::{BraceStyle, Config};
+use crate::items::{
     format_impl, format_trait, format_trait_alias, is_mod_decl, is_use_item,
     rewrite_associated_impl_type, rewrite_associated_type, rewrite_existential_impl_type,
     rewrite_existential_type, rewrite_extern_crate, rewrite_type_alias, FnSig, StaticParts,
     StructParts,
 };
-use macros::{rewrite_macro, rewrite_macro_def, MacroPosition};
-use rewrite::{Rewrite, RewriteContext};
-use shape::{Indent, Shape};
-use source_map::{LineRangeUtils, SpanUtils};
-use spanned::Spanned;
-use utils::{
+use crate::macros::{rewrite_macro, rewrite_macro_def, MacroPosition};
+use crate::rewrite::{Rewrite, RewriteContext};
+use crate::shape::{Indent, Shape};
+use crate::source_map::{LineRangeUtils, SpanUtils};
+use crate::spanned::Spanned;
+use crate::utils::{
     self, contains_skip, count_newlines, inner_attributes, mk_sp, ptr_vec_to_ref_vec,
     rewrite_ident, DEPR_SKIP_ANNOTATION,
 };
-use {ErrorKind, FormatReport, FormattingError};
-
-use std::cell::RefCell;
+use crate::{ErrorKind, FormatReport, FormattingError};
 
 /// Creates a string slice corresponding to the specified span.
 pub struct SnippetProvider<'a> {


### PR DESCRIPTION
This fixes issue #3315 

1. Run `cargo fix --edition`
2. Sort import groups (`std::` -> 3rd party -> `crate::`)
3. `cargo build && cargo test`