### PR TITLE
fix Removed indentation after nested comments error

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -321,6 +321,7 @@ fn identify_comment(
         // for a block comment, search for the closing symbol
         CommentStyle::DoubleBullet | CommentStyle::SingleBullet | CommentStyle::Exclamation => {
             let closer = style.closer().trim_start();
+            let mut count = orig.matches(closer).count();
             let mut closing_symbol_offset = 0;
             let mut hbl = false;
             let mut first = true;
@@ -341,7 +342,10 @@ fn identify_comment(
                     first = false;
                 }
                 if trimmed_line.ends_with(closer) {
-                    break;
+                    count -= 1;
+                    if count == 0 {
+                        break;
+                    }
                 }
             }
             (hbl, closing_symbol_offset)

--- a/tests/source/issue-3314.rs
+++ b/tests/source/issue-3314.rs
@@ -1,0 +1,5 @@
+/*code
+/*code*/
+if true {
+    println!("1");
+}*/

--- a/tests/target/issue-3314.rs
+++ b/tests/target/issue-3314.rs
@@ -1,0 +1,5 @@
+/*code
+/*code*/
+if true {
+    println!("1");
+}*/


### PR DESCRIPTION
related: https://github.com/rust-lang/rustfmt/issues/3314