### PR TITLE
remove unecessary source test file

### DIFF
--- a/tests/source/issue-3314.rs
+++ b/tests/source/issue-3314.rs
@@ -1,5 +1,0 @@
-/*code
-/*code*/
-if true {
-    println!("1");
-}*/


### PR DESCRIPTION
Introduced in #3318, the files tests/source/issue-3314.rs and tests/target/issue-3314.rs are the same and so only the target is needed.