### PR TITLE
set the TARGET envar for the stdsimd integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - env: INTEGRATION=rand
     - env: INTEGRATION=rust-clippy
     - env: INTEGRATION=rust-semverver
-    - env: INTEGRATION=stdsimd
+    - env: INTEGRATION=stdsimd TARGET=x86_64-unknown-linux-gnu
     - env: INTEGRATION=tempdir
   allow_failures:
     # Doesn't build - seems to be because of an option


### PR DESCRIPTION
The `stdsimd` crate fails to compile with the following. Setting the TARGET envar fixes the problem.

```
error: custom attribute panicked
   --> crates/core_arch/src/x86/fxsr.rs:102:5
    |
102 |     #[simd_test(enable = "fxsr")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: TARGET environment variable should be set for rustc: NotPresent
```