### PR TITLE
add config inline_attribute_width

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2408,6 +2408,27 @@ pub enum Foo {}
 pub enum Foo {}
 ```
 
+## `inline_attribute_width`
+
+Write an item and its attribute on the same line if their combined width is below a threshold
+
+- **Default value**: 0
+- **Possible values**: any positive integer
+- **Stable**: No (tracking issue: #3343)
+
+### Example
+
+#### `0` (default):
+```rust
+#[cfg(feature = "alloc")]
+use core::slice;
+```
+
+#### `50`:
+```rust
+#[cfg(feature = "alloc")] use core::slice;
+```
+
 ## `emit_mode`
 
 Internal option

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -105,6 +105,9 @@ create_config! {
         "Minimum number of blank lines which must be put between items";
     edition: Edition, Edition::Edition2015, true, "The edition of the parser (RFC 2052)";
     version: Version, Version::One, false, "Version of formatting rules";
+    inline_attribute_width: usize, 0, false,
+        "Write an item and its attribute on the same line \
+        if their combined width is below a threshold";
 
     // Options that can change the source code beyond whitespace/blocks (somewhat linty things)
     merge_derives: bool, true, true, "Merge multiple `#[derive(...)]` into a single one";

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -7,7 +7,7 @@ use syntax::source_map::{self, BytePos, Span, DUMMY_SP};
 
 use crate::comment::combine_strs_with_missing_comments;
 use crate::config::lists::*;
-use crate::config::{Edition, IndentStyle, Version};
+use crate::config::{Edition, IndentStyle};
 use crate::lists::{
     definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator,
 };
@@ -250,7 +250,7 @@ impl UseTree {
             let hi = self.span.lo();
             let span = mk_sp(lo, hi);
 
-            let allow_extend = if context.config.version() == Version::Two {
+            let allow_extend = if attrs.len() == 1 {
                 let line_len = attr_str.len() + 1 + use_str.len();
                 !attrs.first().unwrap().is_sugared_doc
                     && context.config.inline_attribute_width() >= line_len

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -83,7 +83,22 @@ fn rewrite_reorderable_item(
         _ => return None,
     };
 
-    combine_strs_with_missing_comments(context, &attrs_str, &item_str, missed_span, shape, false)
+    let allow_extend = if attrs.len() == 1 {
+        let line_len = attrs_str.len() + 1 + item_str.len();
+        !attrs.first().unwrap().is_sugared_doc
+            && context.config.inline_attribute_width() >= line_len
+    } else {
+        false
+    };
+
+    combine_strs_with_missing_comments(
+        context,
+        &attrs_str,
+        &item_str,
+        missed_span,
+        shape,
+        allow_extend,
+    )
 }
 
 /// Rewrite a list of items with reordering. Every item in `items` must have

--- a/tests/source/issue-3343.rs
+++ b/tests/source/issue-3343.rs
@@ -1,0 +1,48 @@
+// rustfmt-inline_attribute_width: 50
+
+#[cfg(feature = "alloc")]
+use core::slice;
+
+#[cfg(feature = "alloc")]
+use total_len_is::_50__;
+
+#[cfg(feature = "alloc")]
+use total_len_is::_51___;
+
+#[cfg(feature = "alloc")]
+extern crate len_is_50_;
+
+#[cfg(feature = "alloc")]
+extern crate len_is_51__;
+
+/// this is a comment to test is_sugared_doc property
+use core::convert;
+
+#[fooooo]
+#[barrrrr]
+use total_len_is_::_51______;
+
+#[cfg(not(all(
+    feature = "std",
+    any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        target_os = "haiku",
+        target_os = "emscripten",
+        target_os = "solaris",
+        target_os = "cloudabi",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "bitrig",
+        target_os = "redox",
+        target_os = "fuchsia",
+        windows,
+        all(target_arch = "wasm32", feature = "stdweb"),
+        all(target_arch = "wasm32", feature = "wasm-bindgen"),
+    )
+)))]
+use core::slice;

--- a/tests/target/issue-3343.rs
+++ b/tests/target/issue-3343.rs
@@ -1,0 +1,45 @@
+// rustfmt-inline_attribute_width: 50
+
+#[cfg(feature = "alloc")] use core::slice;
+
+#[cfg(feature = "alloc")] use total_len_is::_50__;
+
+#[cfg(feature = "alloc")]
+use total_len_is::_51___;
+
+#[cfg(feature = "alloc")] extern crate len_is_50_;
+
+#[cfg(feature = "alloc")]
+extern crate len_is_51__;
+
+/// this is a comment to test is_sugared_doc property
+use core::convert;
+
+#[fooooo]
+#[barrrrr]
+use total_len_is_::_51______;
+
+#[cfg(not(all(
+    feature = "std",
+    any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        target_os = "haiku",
+        target_os = "emscripten",
+        target_os = "solaris",
+        target_os = "cloudabi",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "bitrig",
+        target_os = "redox",
+        target_os = "fuchsia",
+        windows,
+        all(target_arch = "wasm32", feature = "stdweb"),
+        all(target_arch = "wasm32", feature = "wasm-bindgen"),
+    )
+)))]
+use core::slice;


### PR DESCRIPTION
related: https://github.com/rust-lang/rustfmt/issues/3343

If the line width is width within config width, attribute is inline.
I don't want to change default rustfmt behavior, so config default value is 0.