### PR TITLE
Support EmitMode::ModifiedLines with stdin input

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -338,25 +338,6 @@ impl ReportedErrors {
     }
 }
 
-/// A single span of changed lines, with 0 or more removed lines
-/// and a vector of 0 or more inserted lines.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct ModifiedChunk {
-    /// The first to be removed from the original text
-    pub line_number_orig: u32,
-    /// The number of lines which have been replaced
-    pub lines_removed: u32,
-    /// The new lines
-    pub lines: Vec<String>,
-}
-
-/// Set of changed sections of a file.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct ModifiedLines {
-    /// The set of changed chunks.
-    pub chunks: Vec<ModifiedChunk>,
-}
-
 #[derive(Clone, Copy, Debug)]
 enum Timer {
     Disabled,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::config::{
     Range, Verbosity,
 };
 
-pub use crate::rustfmt_diff::make_diff;
+pub use crate::rustfmt_diff::{ModifiedChunk, ModifiedLines};
 
 #[macro_use]
 mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ pub use crate::config::{
     Range, Verbosity,
 };
 
+pub use crate::rustfmt_diff::make_diff;
+
 #[macro_use]
 mod utils;
 

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -122,13 +122,11 @@ impl std::str::FromStr for ModifiedLines {
                 (Some(orig), Some(removed), Some(added)) => (orig, removed, added),
                 _ => return Err(()),
             };
-            eprintln!("{} {} {}", orig, rem, new_lines);
             let (orig, rem, new_lines): (u32, u32, usize) =
                 match (orig.parse(), rem.parse(), new_lines.parse()) {
                     (Ok(a), Ok(b), Ok(c)) => (a, b, c),
                     _ => return Err(()),
                 };
-            eprintln!("{} {} {}", orig, rem, new_lines);
             let lines = lines.by_ref().take(new_lines);
             let lines: Vec<_> = lines.map(ToOwned::to_owned).collect();
             if lines.len() != new_lines {

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -56,8 +56,8 @@ pub struct ModifiedLines {
 impl From<Vec<Mismatch>> for ModifiedLines {
     fn from(mismatches: Vec<Mismatch>) -> ModifiedLines {
         let chunks = mismatches.into_iter().map(|mismatch| {
-            let lines = || mismatch.lines.iter();
-            let num_removed = lines()
+            let lines = mismatch.lines.iter();
+            let num_removed = lines
                 .filter(|line| match line {
                     DiffLine::Resulting(_) => true,
                     _ => false,

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -6,7 +6,7 @@ use syntax::source_map::SourceMap;
 
 use crate::checkstyle::output_checkstyle_file;
 use crate::config::{Config, EmitMode, FileName, Verbosity};
-use crate::rustfmt_diff::{make_diff, output_modified, print_diff};
+use crate::rustfmt_diff::{make_diff, print_diff, ModifiedLines};
 
 #[cfg(test)]
 use crate::formatting::FileRecord;
@@ -107,7 +107,7 @@ where
         EmitMode::ModifiedLines => {
             let mismatch = make_diff(&original_text, formatted_text, 0);
             let has_diff = !mismatch.is_empty();
-            output_modified(out, mismatch);
+            write!(out, "{}", ModifiedLines::from(mismatch))?;
             return Ok(has_diff);
         }
         EmitMode::Checkstyle => {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -9,8 +9,8 @@ use std::process::{Command, Stdio};
 use std::str::Chars;
 
 use crate::config::{Color, Config, EmitMode, FileName, ReportTactic};
-use crate::formatting::{ModifiedChunk, ReportedErrors, SourceFile};
-use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, OutputWriter};
+use crate::formatting::{ReportedErrors, SourceFile};
+use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, ModifiedChunk, OutputWriter};
 use crate::source_file;
 use crate::{FormatReport, Input, Session};
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -9,7 +9,7 @@ use std::process::{Command, Stdio};
 use std::str::Chars;
 
 use crate::config::{Color, Config, EmitMode, FileName, ReportTactic};
-use crate::formatting::{ModifiedChunk, SourceFile};
+use crate::formatting::{ModifiedChunk, ReportedErrors, SourceFile};
 use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, OutputWriter};
 use crate::source_file;
 use crate::{FormatReport, Input, Session};
@@ -288,6 +288,30 @@ fn stdin_parser_panic_caught() {
 
         assert!(session.has_parsing_errors());
     }
+}
+
+/// Ensures that `EmitMode::ModifiedLines` works with input from `stdin`. Useful
+/// when embedding Rustfmt (e.g. inside RLS).
+#[test]
+fn stdin_works_with_modified_lines() {
+    let input = "\nfn\n some( )\n{\n}\nfn main () {}\n";
+    let output = "1 6 2\nfn some() {}\nfn main() {}\n";
+
+    let input = Input::Text(input.to_owned());
+    let mut config = Config::default();
+    config.set().emit_mode(EmitMode::ModifiedLines);
+    let mut buf: Vec<u8> = vec![];
+    {
+        let mut session = Session::new(config, Some(&mut buf));
+        session.format(input).unwrap();
+        let errors = ReportedErrors {
+            has_diff: true,
+            ..Default::default()
+        };
+        assert_eq!(session.errors, errors);
+    }
+    let newline = if cfg!(windows) { "\r\n" } else { "\n" };
+    assert_eq!(buf, output.replace('\n', newline).as_bytes());
 }
 
 #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::Chars;
 
-use crate::config::{Color, Config, EmitMode, FileName, ReportTactic};
+use crate::config::{Color, Config, EmitMode, FileName, NewlineStyle, ReportTactic};
 use crate::formatting::{ReportedErrors, SourceFile};
 use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, ModifiedChunk, OutputWriter};
 use crate::source_file;
@@ -299,6 +299,7 @@ fn stdin_works_with_modified_lines() {
 
     let input = Input::Text(input.to_owned());
     let mut config = Config::default();
+    config.set().newline_style(NewlineStyle::Unix);
     config.set().emit_mode(EmitMode::ModifiedLines);
     let mut buf: Vec<u8> = vec![];
     {
@@ -310,8 +311,7 @@ fn stdin_works_with_modified_lines() {
         };
         assert_eq!(session.errors, errors);
     }
-    let newline = if cfg!(windows) { "\r\n" } else { "\n" };
-    assert_eq!(buf, output.replace('\n', newline).as_bytes());
+    assert_eq!(buf, output.as_bytes());
 }
 
 #[test]


### PR DESCRIPTION
Main motivation is to handle the case where we have an input from stdin and we're mostly interested in a diff rather than whole file and trying to come up with this information ourselves. The `EmitMode::ModifiedLines` should still support writing to a specified `Write` sink - we mostly lacked the information on what was the input text so we ask that the passed `source_map`.

Currently works with https://github.com/Xanewok/rls/tree/rustfmt-modified-lines branch on the RLS side.

related #1173 (although this still has to go through (de)serialization)