### PR TITLE
fix line numbering in missed spans and handle file_lines in edge cases

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use syntax::source_map::{BytePos, Pos, Span};
 
 use crate::comment::{rewrite_comment, CodeCharKind, CommentCodeSlices};
+use crate::config::file_lines::FileLines;
 use crate::config::{EmitMode, FileName};
 use crate::shape::{Indent, Shape};
 use crate::source_map::LineRangeUtils;
@@ -156,7 +157,7 @@ impl<'a> FmtVisitor<'a> {
     fn write_snippet_inner<F>(
         &mut self,
         big_snippet: &str,
-        big_diff: usize,
+        mut big_diff: usize,
         old_snippet: &str,
         span: Span,
         process_last_snippet: F,
@@ -175,16 +176,36 @@ impl<'a> FmtVisitor<'a> {
             _ => Cow::from(old_snippet),
         };
 
+        // if the snippet starts with a new line, then information about the lines needs to be
+        // adjusted since it is off by 1.
+        let snippet = if snippet.starts_with('\n') {
+            // this takes into account the blank_lines_* options
+            self.push_vertical_spaces(1);
+            // include the newline character into the big_diff
+            big_diff += 1;
+            status.cur_line += 1;
+            &snippet[1..]
+        } else {
+            snippet
+        };
+
+        let slice_within_file_lines_range = |file_lines: FileLines, cur_line, s| -> (usize, bool) {
+            let newline_count = count_newlines(s);
+            let within_file_lines_range = file_lines.contains_range(
+                file_name,
+                cur_line,
+                // if a newline character is at the end of the slice, then the number of newlines
+                // needs to be decreased by 1 so that the range checked against the file_lines is
+                // the visual range one would expect.
+                cur_line + newline_count - if s.ends_with('\n') { 1 } else { 0 },
+            );
+            (newline_count, within_file_lines_range)
+        };
         for (kind, offset, subslice) in CommentCodeSlices::new(snippet) {
             debug!("{:?}: {:?}", kind, subslice);
 
-            let newline_count = count_newlines(subslice);
-            let within_file_lines_range = self.config.file_lines().contains_range(
-                file_name,
-                status.cur_line,
-                status.cur_line + newline_count,
-            );
-
+            let (newline_count, within_file_lines_range) =
+                slice_within_file_lines_range(self.config.file_lines(), status.cur_line, subslice);
             if CodeCharKind::Comment == kind && within_file_lines_range {
                 // 1: comment.
                 self.process_comment(
@@ -205,7 +226,15 @@ impl<'a> FmtVisitor<'a> {
             }
         }
 
-        process_last_snippet(self, &snippet[status.line_start..], snippet);
+        let last_snippet = &snippet[status.line_start..];
+        let (_, within_file_lines_range) =
+            slice_within_file_lines_range(self.config.file_lines(), status.cur_line, last_snippet);
+        if within_file_lines_range {
+            process_last_snippet(self, last_snippet, snippet);
+        } else {
+            // just append what's left
+            self.push_str(last_snippet);
+        }
     }
 
     fn process_comment(

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -71,6 +71,7 @@ impl<'a> SpanUtils for SnippetProvider<'a> {
 
 impl LineRangeUtils for SourceMap {
     fn lookup_line_range(&self, span: Span) -> LineRange {
+        let snippet = self.span_to_snippet(span).unwrap_or(String::new());
         let lo = self.lookup_line(span.lo()).unwrap();
         let hi = self.lookup_line(span.hi()).unwrap();
 
@@ -80,11 +81,14 @@ impl LineRangeUtils for SourceMap {
             lo, hi
         );
 
+        // in case the span starts with a newline, the line range is off by 1 without the
+        // adjustment below
+        let offset = 1 + if snippet.starts_with('\n') { 1 } else { 0 };
         // Line numbers start at 1
         LineRange {
             file: lo.sf.clone(),
-            lo: lo.line + 1,
-            hi: hi.line + 1,
+            lo: lo.line + offset,
+            hi: hi.line + offset,
         }
     }
 }

--- a/tests/target/issue-3442.rs
+++ b/tests/target/issue-3442.rs
@@ -1,0 +1,10 @@
+// rustfmt-file_lines: [{"file":"tests/target/issue-3442.rs","range":[5,5]},{"file":"tests/target/issue-3442.rs","range":[8,8]}]
+
+extern crate alpha; // comment 1
+extern crate beta; // comment 2
+#[allow(aaa)] // comment 3
+#[macro_use]
+extern crate gamma;
+#[allow(bbb)] // comment 4
+#[macro_use]
+extern crate lazy_static;


### PR DESCRIPTION
- a leading/trailing newline character in missed spans was throwing off the
  start/end of ranges used to compare against file_lines
- fix handling of file_lines when closing a block

Close #3442