### PR TITLE
Stabilize disable_all_formatting

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -605,7 +605,7 @@ Don't reformat anything
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
-- **Stable**: No (tracking issue: #3388)
+- **Stable**: Yes
 
 ## `error_on_line_overflow`
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -124,7 +124,7 @@ create_config! {
         "Require a specific version of rustfmt";
     unstable_features: bool, false, false,
             "Enables unstable features. Only available on nightly channel";
-    disable_all_formatting: bool, false, false, "Don't reformat anything";
+    disable_all_formatting: bool, false, true, "Don't reformat anything";
     skip_children: bool, false, false, "Don't reformat out of line modules";
     hide_parse_errors: bool, false, false, "Hide errors from the parser";
     error_on_line_overflow: bool, false, false, "Error if unable to get all lines within max_width";

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -97,7 +97,11 @@ fn verify_config_used(path: &Path, config_name: &str) {
                     .lines()
                     .map(|l| l.unwrap())
                     .take_while(|l| l.starts_with("//"))
-                    .any(|l| l.starts_with(&format!("// rustfmt-{}", config_name))),
+                    .any(|l| {
+                        let option_name = format!("// rustfmt-{}", config_name);
+                        let skip_name = "// skip-option-check";
+                        l.starts_with(&option_name) || l.starts_with(&skip_name)
+                    }),
                 format!(
                     "config option file {} does not contain expected config name",
                     path.display()

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -23,6 +23,10 @@ const SKIP_FILE_WHITE_LIST: &[&str] = &[
     // We want to make sure that the `skip_children` is correctly working,
     // so we do not want to test this file directly.
     "configs/skip_children/foo/mod.rs",
+    "configs/disable_all_formatting/true_mod/mod.rs",
+    "configs/disable_all_formatting/false_mod/mod.rs",
+    "configs/disable_all_formatting/no_entry_false.rs",
+    "configs/disable_all_formatting/no_entry_true.rs",
     "issue-3434/no_entry.rs",
 ];
 

--- a/tests/source/configs/disable_all_formatting/false.rs
+++ b/tests/source/configs/disable_all_formatting/false.rs
@@ -1,6 +1,8 @@
 // rustfmt-disable_all_formatting: false
 // Disable all formatting
 
+mod no_entry_false;
+mod false_mod;
 fn main() {
     if lorem{println!("ipsum!");}else{println!("dolor!");}
 }

--- a/tests/source/configs/disable_all_formatting/false_mod/mod.rs
+++ b/tests/source/configs/disable_all_formatting/false_mod/mod.rs
@@ -1,0 +1,4 @@
+// skip-option-check
+fn bar() {
+    if lorem{println!("ipsum!");}else{println!("dolor!");}
+}

--- a/tests/source/configs/disable_all_formatting/no_entry_false.rs
+++ b/tests/source/configs/disable_all_formatting/no_entry_false.rs
@@ -1,0 +1,4 @@
+// skip-option-check
+fn foo() {
+    if lorem{println!("ipsum!");}else{println!("dolor!");}
+}

--- a/tests/source/configs/disable_all_formatting/no_entry_true.rs
+++ b/tests/source/configs/disable_all_formatting/no_entry_true.rs
@@ -1,0 +1,4 @@
+// skip-option-check
+fn foo() {
+    iflorem{println!("ipsum!");}else{println!("dolor!");}
+}

--- a/tests/source/configs/disable_all_formatting/true.rs
+++ b/tests/source/configs/disable_all_formatting/true.rs
@@ -1,6 +1,8 @@
 // rustfmt-disable_all_formatting: true
 // Disable all formatting
 
+mod true_mod;
+mod no_entry_true;
 fn main() {
     iflorem{println!("ipsum!");}else{println!("dolor!");}
 }

--- a/tests/source/configs/disable_all_formatting/true_mod/mod.rs
+++ b/tests/source/configs/disable_all_formatting/true_mod/mod.rs
@@ -1,0 +1,4 @@
+// skip-option-check
+fn bar() {
+    iflorem{println!("ipsum!");}else{println!("dolor!");}
+}

--- a/tests/target/configs/disable_all_formatting/false.rs
+++ b/tests/target/configs/disable_all_formatting/false.rs
@@ -1,6 +1,8 @@
 // rustfmt-disable_all_formatting: false
 // Disable all formatting
 
+mod false_mod;
+mod no_entry_false;
 fn main() {
     if lorem {
         println!("ipsum!");

--- a/tests/target/configs/disable_all_formatting/false_mod/mod.rs
+++ b/tests/target/configs/disable_all_formatting/false_mod/mod.rs
@@ -1,0 +1,8 @@
+// skip-option-check
+fn bar() {
+    if lorem {
+        println!("ipsum!");
+    } else {
+        println!("dolor!");
+    }
+}

--- a/tests/target/configs/disable_all_formatting/no_entry_false.rs
+++ b/tests/target/configs/disable_all_formatting/no_entry_false.rs
@@ -1,0 +1,8 @@
+// skip-option-check
+fn foo() {
+    if lorem {
+        println!("ipsum!");
+    } else {
+        println!("dolor!");
+    }
+}

--- a/tests/target/configs/disable_all_formatting/no_entry_true.rs
+++ b/tests/target/configs/disable_all_formatting/no_entry_true.rs
@@ -1,0 +1,4 @@
+// skip-option-check
+fn foo() {
+    if lorem{println!("ipsum!");}else{println!("dolor!");}
+}

--- a/tests/target/configs/disable_all_formatting/true.rs
+++ b/tests/target/configs/disable_all_formatting/true.rs
@@ -1,6 +1,8 @@
 // rustfmt-disable_all_formatting: true
 // Disable all formatting
 
+mod no_entry_true;
+mod true_mod;
 fn main() {
     if lorem{println!("ipsum!");}else{println!("dolor!");}
 }

--- a/tests/target/configs/disable_all_formatting/true_mod/mod.rs
+++ b/tests/target/configs/disable_all_formatting/true_mod/mod.rs
@@ -1,0 +1,4 @@
+// skip-option-check
+fn bar() {
+    iflorem{println!("ipsum!");}else{println!("dolor!");}
+}


### PR DESCRIPTION
related: https://github.com/rust-lang/rustfmt/issues/3197, https://github.com/rust-lang/rustfmt/issues/3388

This options is a very simple and no bugs are reported.
So I think this options can be stabilized only tests addition.