### PR TITLE
Enable overflow_delimited_expr for structs

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1346,6 +1346,7 @@ pub fn can_be_overflowed_expr(
         ast::ExprKind::Match(..) => {
             (context.use_block_indent() && args_len == 1)
                 || (context.config.indent_style() == IndentStyle::Visual && args_len > 1)
+                || context.config.overflow_delimited_expr()
         }
         ast::ExprKind::If(..)
         | ast::ExprKind::IfLet(..)

--- a/tests/source/match_overflow_expr.rs
+++ b/tests/source/match_overflow_expr.rs
@@ -1,0 +1,53 @@
+// rustfmt-overflow_delimited_expr: true
+
+fn main() {
+    println!(
+        "Foobar: {}",
+        match "input" {
+            "a" => "",
+            "b" => "",
+            "c" => "",
+            "d" => "",
+            "e" => "",
+            "f" => "",
+            "g" => "",
+            "h" => "",
+            "i" => "",
+            "j" => "",
+            "k" => "",
+            "l" => "",
+            "m" => "",
+            "n" => "",
+            "o" => "",
+            "p" => "",
+            "q" => "",
+            "r" => "Rust",
+        }
+    );
+}
+
+fn main() {
+    println!(
+        "Very Long Input String Which Makes It Impossible To Fit On The Same Line: {}",
+        match "input" {
+            "a" => "",
+            "b" => "",
+            "c" => "",
+            "d" => "",
+            "e" => "",
+            "f" => "",
+            "g" => "",
+            "h" => "",
+            "i" => "",
+            "j" => "",
+            "k" => "",
+            "l" => "",
+            "m" => "",
+            "n" => "",
+            "o" => "",
+            "p" => "",
+            "q" => "",
+            "r" => "Rust",
+        }
+    );
+}

--- a/tests/target/match_overflow_expr.rs
+++ b/tests/target/match_overflow_expr.rs
@@ -1,0 +1,50 @@
+// rustfmt-overflow_delimited_expr: true
+
+fn main() {
+    println!("Foobar: {}", match "input" {
+        "a" => "",
+        "b" => "",
+        "c" => "",
+        "d" => "",
+        "e" => "",
+        "f" => "",
+        "g" => "",
+        "h" => "",
+        "i" => "",
+        "j" => "",
+        "k" => "",
+        "l" => "",
+        "m" => "",
+        "n" => "",
+        "o" => "",
+        "p" => "",
+        "q" => "",
+        "r" => "Rust",
+    });
+}
+
+fn main() {
+    println!(
+        "Very Long Input String Which Makes It Impossible To Fit On The Same Line: {}",
+        match "input" {
+            "a" => "",
+            "b" => "",
+            "c" => "",
+            "d" => "",
+            "e" => "",
+            "f" => "",
+            "g" => "",
+            "h" => "",
+            "i" => "",
+            "j" => "",
+            "k" => "",
+            "l" => "",
+            "m" => "",
+            "n" => "",
+            "o" => "",
+            "p" => "",
+            "q" => "",
+            "r" => "Rust",
+        }
+    );
+}


### PR DESCRIPTION
I've tried looking into the issue I've opened and noticed that it seems
quite trivial to resolve it.

I'm not sure if there are any issues with this, since this almost seems
too trivial to be correct, but I've tried adding some test cases which
seem to be functioning and do not fail.

Please let me know if there's anything that needs to be fixed.

This fixes https://github.com/rust-lang/rustfmt/issues/3482.