### PR TITLE
DO NOT MERGE. Test case to show broken behavior

### DIFF
--- a/tests/source/configs/hard_tabs/big_tab.rs
+++ b/tests/source/configs/hard_tabs/big_tab.rs
@@ -1,0 +1,9 @@
+// rustfmt-hard_tabs: true
+// rustfmt-tab_spaces: 4
+// Hard tabs
+
+fn lorem() -> usize {
+file
+.aaabbbcc01234567890123456789012345678901234567890123456789()
+.01234567890123456789012345678901234567890123456789()
+}

--- a/tests/source/configs/hard_tabs/small_tab.rs
+++ b/tests/source/configs/hard_tabs/small_tab.rs
@@ -1,0 +1,9 @@
+// rustfmt-hard_tabs: true
+// rustfmt-tab_spaces: 2
+// Hard tabs
+
+fn lorem() -> usize {
+file
+.aaabbbcc01234567890123456789012345678901234567890123456789()
+.01234567890123456789012345678901234567890123456789()
+}

--- a/tests/source/configs/hard_tabs/true.rs
+++ b/tests/source/configs/hard_tabs/true.rs
@@ -2,5 +2,5 @@
 // Hard tabs
 
 fn lorem() -> usize {
-42 // spaces before 42
+42 // tabs before 42
 }

--- a/tests/target/configs/hard_tabs/big_tab.rs
+++ b/tests/target/configs/hard_tabs/big_tab.rs
@@ -1,0 +1,8 @@
+// rustfmt-hard_tabs: true
+// rustfmt-tab_spaces: 4
+// Hard tabs
+
+fn lorem() -> usize {
+	file.aaabbbcc01234567890123456789012345678901234567890123456789()
+		.01234567890123456789012345678901234567890123456789()
+}

--- a/tests/target/configs/hard_tabs/small_tab.rs
+++ b/tests/target/configs/hard_tabs/small_tab.rs
@@ -1,0 +1,9 @@
+// rustfmt-hard_tabs: true
+// rustfmt-tab_spaces: 2
+// Hard tabs
+
+fn lorem() -> usize {
+	file
+		.aaabbbcc01234567890123456789012345678901234567890123456789()
+		.01234567890123456789012345678901234567890123456789()
+}

--- a/tests/target/configs/hard_tabs/true.rs
+++ b/tests/target/configs/hard_tabs/true.rs
@@ -2,5 +2,5 @@
 // Hard tabs
 
 fn lorem() -> usize {
-	42 // spaces before 42
+	42 // tabs before 42
 }


### PR DESCRIPTION
If "tab_spaces" is smaller, rustfmt should try
to put more stuff in one line.

If "tab_spaces" is bigger, rustfmt should try
to put less stuff in one line, instead spreading over multiple lines.

This test shows exactly the opposite behavior.

This isn't a PR, but rather a show case to demonstrate a current bug. I didn't see any other convenient way to show it, reproducibly. Also, having a readily made test can help writing a fix.