### PR TITLE
Use annotate-snippets for emitting errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "argon2rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +708,7 @@ dependencies = [
 name = "rustfmt-nightly"
 version = "1.2.0"
 dependencies = [
+ "annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -920,6 +937,8 @@ dependencies = [
 
 [metadata]
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+"checksum annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8bcdcd5b291ce85a78f2b9d082a8de9676c12b1840d386d67bc5eea6f9d2b4e"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ bytecount = "0.5"
 unicode-width = "0.1.5"
 unicode_categories = "0.1.1"
 dirs = "1.0.4"
+annotate-snippets = { version = "0.5.0", features = ["ansi_term"] }
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -310,21 +310,10 @@ fn format_and_emit_report<T: Write>(session: &mut Session<'_, T>, input: Input) 
     match session.format(input) {
         Ok(report) => {
             if report.has_warnings() {
-                let enable_colors = match term::stderr() {
-                    Some(ref mut t)
-                        if session.config.color().use_colored_tty()
-                            && t.supports_color()
-                            && t.supports_attr(term::Attr::Bold) =>
-                    {
-                        true
-                    }
-                    _ => false,
-                };
-
                 eprintln!(
                     "{}",
                     FormatReportFormatterBuilder::new(&report)
-                        .enable_colors(enable_colors)
+                        .enable_colors(should_print_with_colors(session))
                         .build()
                 );
             }
@@ -333,6 +322,19 @@ fn format_and_emit_report<T: Write>(session: &mut Session<'_, T>, input: Input) 
             eprintln!("Error writing files: {}", msg);
             session.add_operational_error();
         }
+    }
+}
+
+fn should_print_with_colors<T: Write>(session: &mut Session<'_, T>) -> bool {
+    match term::stderr() {
+        Some(ref mut t)
+            if session.config.color().use_colored_tty()
+                && t.supports_color()
+                && t.supports_attr(term::Attr::Bold) =>
+        {
+            true
+        }
+        _ => false,
     }
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -327,7 +327,7 @@ fn format_and_emit_report<T: Write>(session: &mut Session<'_, T>, input: Input) 
 
 fn should_print_with_colors<T: Write>(session: &mut Session<'_, T>) -> bool {
     match term::stderr() {
-        Some(ref mut t)
+        Some(ref t)
             if session.config.color().use_colored_tty()
                 && t.supports_color()
                 && t.supports_attr(term::Attr::Bold) =>

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -16,7 +16,7 @@ use getopts::{Matches, Options};
 
 use crate::rustfmt::{
     load_config, CliOptions, Color, Config, Edition, EmitMode, ErrorKind, FileLines, FileName,
-    Input, ReportFormatterBuilder, Session, Verbosity,
+    FormatReportFormatterBuilder, Input, Session, Verbosity,
 };
 
 fn main() {
@@ -323,7 +323,7 @@ fn format_and_emit_report<T: Write>(session: &mut Session<'_, T>, input: Input) 
 
                 eprintln!(
                     "{}",
-                    ReportFormatterBuilder::new(&report)
+                    FormatReportFormatterBuilder::new(&report)
                         .enable_colors(enable_colors)
                         .build()
                 );

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -1,0 +1,127 @@
+use crate::config::FileName;
+use crate::formatting::FormattingError;
+use crate::{ErrorKind, FormatReport};
+use annotate_snippets::display_list::DisplayList;
+use annotate_snippets::formatter::DisplayListFormatter;
+use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use std::fmt::{self, Display};
+
+pub struct ReportFormatterBuilder<'a> {
+    report: &'a FormatReport,
+    enable_colors: bool,
+}
+
+impl<'a> ReportFormatterBuilder<'a> {
+    pub fn new(report: &'a FormatReport) -> Self {
+        Self {
+            report,
+            enable_colors: false,
+        }
+    }
+
+    pub fn enable_colors(self, enable_colors: bool) -> Self {
+        Self {
+            enable_colors,
+            ..self
+        }
+    }
+
+    pub fn build(self) -> ReportFormatter<'a> {
+        ReportFormatter {
+            report: self.report,
+            enable_colors: self.enable_colors,
+        }
+    }
+}
+
+pub struct ReportFormatter<'a> {
+    report: &'a FormatReport,
+    enable_colors: bool,
+}
+
+impl<'a> Display for ReportFormatter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let formatter = DisplayListFormatter::new(self.enable_colors);
+        let errors_by_file = &self.report.internal.borrow().0;
+
+        for (file, errors) in errors_by_file {
+            for error in errors {
+                let snippet = formatting_error_to_snippet(file, error);
+                writeln!(f, "{}", formatter.format(&DisplayList::from(snippet)))?;
+                writeln!(f, "")?;
+            }
+        }
+
+        if !errors_by_file.is_empty() {
+            let snippet = Snippet {
+                title: Some(Annotation {
+                    id: None,
+                    label: Some(format!(
+                        "rustfmt may have failed to format. See previous {} errors.",
+                        self.report.warning_count()
+                    )),
+                    annotation_type: AnnotationType::Warning,
+                }),
+                footer: Vec::new(),
+                slices: Vec::new(),
+            };
+            writeln!(f, "{}", formatter.format(&DisplayList::from(snippet)))?;
+        }
+
+        Ok(())
+    }
+}
+
+fn formatting_error_to_snippet(file: &FileName, error: &FormattingError) -> Snippet {
+    let (space_len, target_len) = error.format_len();
+    let annotation_type = error_kind_to_snippet_annotation_type(&error.kind);
+    let slice_annotations = if target_len > 0 {
+        vec![SourceAnnotation {
+            range: (space_len, space_len + target_len),
+            label: String::new(),
+            annotation_type: AnnotationType::Error,
+        }]
+    } else {
+        Vec::new()
+    };
+
+    let title_annotation_id = if error.is_internal() {
+        Some("internal".to_string())
+    } else {
+        None
+    };
+
+    Snippet {
+        title: Some(Annotation {
+            id: title_annotation_id,
+            label: Some(format!("{}", error.kind)),
+            annotation_type,
+        }),
+        footer: vec![Annotation {
+            id: None,
+            label: Some(error.msg_suffix().to_string()),
+            annotation_type: AnnotationType::Note,
+        }],
+        slices: vec![Slice {
+            source: error.line_buffer.clone(),
+            line_start: error.line,
+            origin: Some(format!("{}:{}", file, error.line)),
+            fold: false,
+            annotations: slice_annotations,
+        }],
+    }
+}
+
+fn error_kind_to_snippet_annotation_type(error_kind: &ErrorKind) -> AnnotationType {
+    match error_kind {
+        ErrorKind::LineOverflow(..)
+        | ErrorKind::TrailingWhitespace
+        | ErrorKind::IoError(_)
+        | ErrorKind::ParseError
+        | ErrorKind::LostComment
+        | ErrorKind::LicenseCheck
+        | ErrorKind::BadAttr
+        | ErrorKind::VersionMismatch => AnnotationType::Error,
+        ErrorKind::BadIssue(_) | ErrorKind::DeprecatedAttr => AnnotationType::Warning,
+    }
+}

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -54,8 +54,7 @@ impl<'a> Display for FormatReportFormatter<'a> {
         for (file, errors) in errors_by_file {
             for error in errors {
                 let snippet = formatting_error_to_snippet(file, error);
-                writeln!(f, "{}", formatter.format(&DisplayList::from(snippet)))?;
-                writeln!(f, "")?;
+                writeln!(f, "{}\n", formatter.format(&DisplayList::from(snippet)))?;
             }
         }
 

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -6,12 +6,14 @@ use annotate_snippets::formatter::DisplayListFormatter;
 use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
 use std::fmt::{self, Display};
 
+/// A builder for [`FormatReportFormatter`].
 pub struct FormatReportFormatterBuilder<'a> {
     report: &'a FormatReport,
     enable_colors: bool,
 }
 
 impl<'a> FormatReportFormatterBuilder<'a> {
+    /// Creates a new [`FormatReportFormatterBuilder`].
     pub fn new(report: &'a FormatReport) -> Self {
         Self {
             report,
@@ -19,6 +21,7 @@ impl<'a> FormatReportFormatterBuilder<'a> {
         }
     }
 
+    /// Enables colors and formatting in the output.
     pub fn enable_colors(self, enable_colors: bool) -> Self {
         Self {
             enable_colors,
@@ -26,6 +29,7 @@ impl<'a> FormatReportFormatterBuilder<'a> {
         }
     }
 
+    /// Creates a new [`FormatReportFormatter`] from the settings in this builder.
     pub fn build(self) -> FormatReportFormatter<'a> {
         FormatReportFormatter {
             report: self.report,
@@ -34,6 +38,9 @@ impl<'a> FormatReportFormatterBuilder<'a> {
     }
 }
 
+/// Formats the warnings/errors in a [`FormatReport`].
+///
+/// Can be created using a [`FormatReportFormatterBuilder`].
 pub struct FormatReportFormatter<'a> {
     report: &'a FormatReport,
     enable_colors: bool,

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -73,7 +73,7 @@ fn formatting_failure_snippet(warning_count: usize) -> Snippet {
         title: Some(Annotation {
             id: None,
             label: Some(format!(
-                "rustfmt may have failed to format. See previous {} errors.",
+                "rustfmt has failed to format. See previous {} errors.",
                 warning_count
             )),
             annotation_type: AnnotationType::Warning,

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -166,6 +166,7 @@ fn error_kind_to_snippet_annotation_type(error_kind: &ErrorKind) -> AnnotationTy
         | ErrorKind::LostComment
         | ErrorKind::LicenseCheck
         | ErrorKind::BadAttr
+        | ErrorKind::InvalidGlobPattern(_)
         | ErrorKind::VersionMismatch => AnnotationType::Error,
         ErrorKind::BadIssue(_) | ErrorKind::DeprecatedAttr => AnnotationType::Warning,
     }

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -6,12 +6,12 @@ use annotate_snippets::formatter::DisplayListFormatter;
 use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
 use std::fmt::{self, Display};
 
-pub struct ReportFormatterBuilder<'a> {
+pub struct FormatReportFormatterBuilder<'a> {
     report: &'a FormatReport,
     enable_colors: bool,
 }
 
-impl<'a> ReportFormatterBuilder<'a> {
+impl<'a> FormatReportFormatterBuilder<'a> {
     pub fn new(report: &'a FormatReport) -> Self {
         Self {
             report,
@@ -26,20 +26,20 @@ impl<'a> ReportFormatterBuilder<'a> {
         }
     }
 
-    pub fn build(self) -> ReportFormatter<'a> {
-        ReportFormatter {
+    pub fn build(self) -> FormatReportFormatter<'a> {
+        FormatReportFormatter {
             report: self.report,
             enable_colors: self.enable_colors,
         }
     }
 }
 
-pub struct ReportFormatter<'a> {
+pub struct FormatReportFormatter<'a> {
     report: &'a FormatReport,
     enable_colors: bool,
 }
 
-impl<'a> Display for ReportFormatter<'a> {
+impl<'a> Display for FormatReportFormatter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let formatter = DisplayListFormatter::new(self.enable_colors);
         let errors_by_file = &self.report.internal.borrow().0;

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -79,9 +79,7 @@ fn formatting_failure_snippet(warning_count: usize) -> Snippet {
 fn formatting_error_to_snippet(file: &FileName, error: &FormattingError) -> Snippet {
     let slices = vec![snippet_code_slice(file, error)];
     let title = Some(snippet_title(error));
-    let footer = snippet_footer(error)
-        .map(|footer| vec![footer])
-        .unwrap_or_default();
+    let footer = snippet_footer(error).into_iter().collect();
 
     Snippet {
         title,
@@ -115,9 +113,7 @@ fn snippet_footer(error: &FormattingError) -> Option<Annotation> {
 }
 
 fn snippet_code_slice(file: &FileName, error: &FormattingError) -> Slice {
-    let annotations = slice_annotation(error)
-        .map(|annotation| vec![annotation])
-        .unwrap_or_default();
+    let annotations = slice_annotation(error).into_iter().collect();
     let origin = Some(format!("{}:{}", file, error.line));
     let source = error.line_buffer.clone();
 

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -269,15 +269,14 @@ impl FormattingError {
         }
     }
 
-    pub(crate) fn msg_prefix(&self) -> &str {
+    pub(crate) fn is_internal(&self) -> bool {
         match self.kind {
             ErrorKind::LineOverflow(..)
             | ErrorKind::TrailingWhitespace
             | ErrorKind::IoError(_)
             | ErrorKind::ParseError
-            | ErrorKind::LostComment => "internal error:",
-            ErrorKind::LicenseCheck | ErrorKind::BadAttr | ErrorKind::VersionMismatch => "error:",
-            ErrorKind::BadIssue(_) | ErrorKind::DeprecatedAttr => "warning:",
+            | ErrorKind::LostComment => true,
+            _ => false,
         }
     }
 

--- a/src/git-rustfmt/main.rs
+++ b/src/git-rustfmt/main.rs
@@ -11,7 +11,7 @@ use env_logger;
 use getopts::{Matches, Options};
 use rustfmt_nightly as rustfmt;
 
-use crate::rustfmt::{load_config, CliOptions, Input, Session};
+use crate::rustfmt::{load_config, CliOptions, Input, ReportFormatterBuilder, Session};
 
 fn prune_files(files: Vec<&str>) -> Vec<&str> {
     let prefixes: Vec<_> = files
@@ -67,7 +67,7 @@ fn fmt_files(files: &[&str]) -> i32 {
     for file in files {
         let report = session.format(Input::File(PathBuf::from(file))).unwrap();
         if report.has_warnings() {
-            eprintln!("{}", report);
+            eprintln!("{}", ReportFormatterBuilder::new(&report).build());
         }
         if !session.has_no_errors() {
             exit_code = 1;

--- a/src/git-rustfmt/main.rs
+++ b/src/git-rustfmt/main.rs
@@ -11,7 +11,7 @@ use env_logger;
 use getopts::{Matches, Options};
 use rustfmt_nightly as rustfmt;
 
-use crate::rustfmt::{load_config, CliOptions, Input, ReportFormatterBuilder, Session};
+use crate::rustfmt::{load_config, CliOptions, FormatReportFormatterBuilder, Input, Session};
 
 fn prune_files(files: Vec<&str>) -> Vec<&str> {
     let prefixes: Vec<_> = files
@@ -67,7 +67,7 @@ fn fmt_files(files: &[&str]) -> i32 {
     for file in files {
         let report = session.format(Input::File(PathBuf::from(file))).unwrap();
         if report.has_warnings() {
-            eprintln!("{}", ReportFormatterBuilder::new(&report).build());
+            eprintln!("{}", FormatReportFormatterBuilder::new(&report).build());
         }
         if !session.has_no_errors() {
             exit_code = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::config::{
     Range, Verbosity,
 };
 
-pub use crate::format_report_formatter::{ReportFormatter, ReportFormatterBuilder};
+pub use crate::format_report_formatter::{FormatReportFormatter, FormatReportFormatterBuilder};
 
 pub use crate::rustfmt_diff::{ModifiedChunk, ModifiedLines};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl FormattedSnippet {
 
 /// Reports on any issues that occurred during a run of Rustfmt.
 ///
-/// Can be reported to the user via its `Display` implementation or `print_fancy`.
+/// Can be reported to the user using the `Display` impl on [`FormatReportFormatter`].
 #[derive(Clone)]
 pub struct FormatReport {
     // Maps stringified file paths to their associated formatting errors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate serde_derive;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt;
 use std::io::{self, Write};
 use std::mem;
 use std::panic;
@@ -238,6 +239,32 @@ impl FormatReport {
     /// Whether any warnings or errors are present in the report.
     pub fn has_warnings(&self) -> bool {
         self.internal.borrow().1.has_formatting_errors
+    }
+
+    /// Print the report to a terminal using colours and potentially other
+    /// fancy output.
+    #[deprecated(note = "Use FormatReportFormatter with colors enabled instead")]
+    pub fn fancy_print(
+        &self,
+        mut t: Box<dyn term::Terminal<Output = io::Stderr>>,
+    ) -> Result<(), term::Error> {
+        writeln!(
+            t,
+            "{}",
+            FormatReportFormatterBuilder::new(&self)
+                .enable_colors(true)
+                .build()
+        )?;
+        Ok(())
+    }
+}
+
+#[deprecated(note = "Use FormatReportFormatter instead")]
+impl fmt::Display for FormatReport {
+    // Prints all the formatting errors.
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(fmt, "{}", FormatReportFormatterBuilder::new(&self).build())?;
+        Ok(())
     }
 }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -13,7 +13,7 @@ use crate::config::{Color, Config, EmitMode, FileName, NewlineStyle, ReportTacti
 use crate::formatting::{ReportedErrors, SourceFile};
 use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, ModifiedChunk, OutputWriter};
 use crate::source_file;
-use crate::{FormatReport, Input, Session};
+use crate::{FormatReport, Input, ReportFormatterBuilder, Session};
 
 const DIFF_CONTEXT_SIZE: usize = 3;
 const CONFIGURATIONS_FILE_NAME: &str = "Configurations.md";
@@ -299,7 +299,7 @@ fn self_tests() {
     assert_eq!(fails, 0, "{} self tests failed", fails);
 
     for format_report in reports {
-        println!("{}", format_report);
+        println!("{}", ReportFormatterBuilder::new(&format_report).build());
         warnings += format_report.warning_count();
     }
 
@@ -427,7 +427,7 @@ fn check_files(files: Vec<PathBuf>, opt_config: &Option<PathBuf>) -> (Vec<Format
 
         match idempotent_check(&file_name, &opt_config) {
             Ok(ref report) if report.has_warnings() => {
-                print!("{}", report);
+                print!("{}", ReportFormatterBuilder::new(&report).build());
                 fails += 1;
             }
             Ok(report) => reports.push(report),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -13,7 +13,7 @@ use crate::config::{Color, Config, EmitMode, FileName, NewlineStyle, ReportTacti
 use crate::formatting::{ReportedErrors, SourceFile};
 use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, ModifiedChunk, OutputWriter};
 use crate::source_file;
-use crate::{FormatReport, Input, ReportFormatterBuilder, Session};
+use crate::{FormatReport, Input, FormatReportFormatterBuilder, Session};
 
 const DIFF_CONTEXT_SIZE: usize = 3;
 const CONFIGURATIONS_FILE_NAME: &str = "Configurations.md";
@@ -299,7 +299,7 @@ fn self_tests() {
     assert_eq!(fails, 0, "{} self tests failed", fails);
 
     for format_report in reports {
-        println!("{}", ReportFormatterBuilder::new(&format_report).build());
+        println!("{}", FormatReportFormatterBuilder::new(&format_report).build());
         warnings += format_report.warning_count();
     }
 
@@ -427,7 +427,7 @@ fn check_files(files: Vec<PathBuf>, opt_config: &Option<PathBuf>) -> (Vec<Format
 
         match idempotent_check(&file_name, &opt_config) {
             Ok(ref report) if report.has_warnings() => {
-                print!("{}", ReportFormatterBuilder::new(&report).build());
+                print!("{}", FormatReportFormatterBuilder::new(&report).build());
                 fails += 1;
             }
             Ok(report) => reports.push(report),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -13,7 +13,7 @@ use crate::config::{Color, Config, EmitMode, FileName, NewlineStyle, ReportTacti
 use crate::formatting::{ReportedErrors, SourceFile};
 use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, ModifiedChunk, OutputWriter};
 use crate::source_file;
-use crate::{FormatReport, Input, FormatReportFormatterBuilder, Session};
+use crate::{FormatReport, FormatReportFormatterBuilder, Input, Session};
 
 const DIFF_CONTEXT_SIZE: usize = 3;
 const CONFIGURATIONS_FILE_NAME: &str = "Configurations.md";
@@ -299,7 +299,10 @@ fn self_tests() {
     assert_eq!(fails, 0, "{} self tests failed", fails);
 
     for format_report in reports {
-        println!("{}", FormatReportFormatterBuilder::new(&format_report).build());
+        println!(
+            "{}",
+            FormatReportFormatterBuilder::new(&format_report).build()
+        );
         warnings += format_report.warning_count();
     }
 


### PR DESCRIPTION
Resolves #2729.

There are a couple of things that I'm not sure if I did them correctly:

- `annotate-snippets` doesn't have an "internal error" annotation type. I'm currently printing "internal" as the annotation id (where the error id usually is in `rustc`):
    <img width="600" alt="Screenshot 2019-04-13 at 21 49 49" src="https://user-images.githubusercontent.com/4602612/56084644-11b79680-5e36-11e9-89f5-50072d54c053.png">
- Does `rustfmt` have any guarantees about the public API when used as a library? Because I removed `fancy_print` and the `Display` impl from `FormatReport` both of which were `pub`.
- Is there a particular reason that "warning" was previously printed in red? It is now printed in yellow:
   <img width="300" alt="Screenshot 2019-04-13 at 21 54 41" src="https://user-images.githubusercontent.com/4602612/56084683-dcf80f00-5e36-11e9-8e68-ecdc592b7875.png">


     