### PR TITLE
exit integration test successfully if the crate build failed before applying rustfmt

### DIFF
--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -43,7 +43,7 @@ function check_fmt_with_lib_tests {
 function check_fmt_base {
     local test_args="$1"
     local build=$(cargo test $test_args 2>&1)
-    if [[ "$build" =~ "build failed" ]]; then
+    if [[ "$build" =~ "build failed" ]] || [[ "$build" =~ "test result: FAILED." ]]; then
           return 0
     fi
     touch rustfmt.toml

--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -42,8 +42,8 @@ function check_fmt_with_lib_tests {
 
 function check_fmt_base {
     local test_args="$1"
-    cargo test $test_args
-    if [[ $? != 0 ]]; then
+    local build=$(cargo test $test_args 2>&1)
+    if [[ "$build" =~ "build failed" ]]; then
           return 0
     fi
     touch rustfmt.toml

--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -39,17 +39,17 @@ mod test {
 
     #[test]
     fn test_ignore_path_set() {
-        let config = Config::from_toml(
-            "ignore = [
-            \"foo.rs\",
-            \"bar_dir/*\",
-        ]",
-        )
-        .unwrap();
-        let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
+        match option_env!("CFG_RELEASE_CHANNEL") {
+            // this test requires nightly
+            None | Some("nightly") => {
+                let config = Config::from_toml(r#"ignore = ["foo.rs", "bar_dir/*"]"#).unwrap();
+                let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
 
-        assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/foo.rs"))));
-        assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz.rs"))));
-        assert!(!ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/bar.rs"))));
+                assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/foo.rs"))));
+                assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz.rs"))));
+                assert!(!ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/bar.rs"))));
+            }
+            _ => (),
+        };
     }
 }


### PR DESCRIPTION
The `cargo test --all` command failed and exited the main process with a
SIGINT. Trapping the signal or trying to get the code of a subshell
didn't work.

Close #2724