### PR TITLE
handle field attributes when aligning a struct's fields

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1600,7 +1600,7 @@ pub(crate) fn rewrite_struct_field(
         shape,
         attrs_extendable,
     )?;
-    let overhead = last_line_width(&attr_prefix);
+    let overhead = trimmed_last_line_width(&attr_prefix);
     let lhs_offset = lhs_max_width.saturating_sub(overhead);
     for _ in 0..lhs_offset {
         spacing.push(' ');

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -17,7 +17,9 @@ use crate::rewrite::{Rewrite, RewriteContext};
 use crate::shape::{Indent, Shape};
 use crate::source_map::SpanUtils;
 use crate::spanned::Spanned;
-use crate::utils::{contains_skip, is_attributes_extendable, mk_sp, rewrite_ident};
+use crate::utils::{
+    contains_skip, is_attributes_extendable, mk_sp, rewrite_ident, trimmed_last_line_width,
+};
 
 pub(crate) trait AlignedItem {
     fn skip(&self) -> bool;
@@ -183,13 +185,9 @@ fn struct_field_prefix_max_min_width<T: AlignedItem>(
     fields
         .iter()
         .map(|field| {
-            field.rewrite_prefix(context, shape).and_then(|field_str| {
-                if field_str.contains('\n') {
-                    None
-                } else {
-                    Some(field_str.len())
-                }
-            })
+            field
+                .rewrite_prefix(context, shape)
+                .map(|field_str| trimmed_last_line_width(&field_str))
         })
         .fold_options((0, ::std::usize::MAX), |(max_len, min_len), len| {
             (cmp::max(max_len, len), cmp::min(min_len, len))

--- a/tests/source/issue-2869.rs
+++ b/tests/source/issue-2869.rs
@@ -16,6 +16,11 @@ struct AuditLog1 {
     actor_context_id: Option<String>,
     actor_ip_address: Option<IpAddr>,
     azure_active_directory_event_type: Option<u8>,
+
+    #[serde(rename = "very")]
+    aaaaa: String,
+    #[serde(rename = "cool")]
+    bb: i32,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/tests/source/issue-2869.rs
+++ b/tests/source/issue-2869.rs
@@ -1,0 +1,36 @@
+// rustfmt-struct_field_align_threshold: 50
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct AuditLog1 {
+    creation_time: String,
+    id: String,
+    operation: String,
+    organization_id: String,
+    record_type: u32,
+    result_status: Option<String>,
+    #[serde(rename = "ClientIP")]
+    client_ip: Option<IpAddr>,
+    object_id: String,
+    actor: Option<Vec<IDType>>,
+    actor_context_id: Option<String>,
+    actor_ip_address: Option<IpAddr>,
+    azure_active_directory_event_type: Option<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct AuditLog2 {
+    creation_time: String,
+    id: String,
+    operation: String,
+    organization_id: String,
+    record_type: u32,
+    result_status: Option<String>,
+    client_ip: Option<IpAddr>,
+    object_id: String,
+    actor: Option<Vec<IDType>>,
+    actor_context_id: Option<String>,
+    actor_ip_address: Option<IpAddr>,
+    azure_active_directory_event_type: Option<u8>,
+}

--- a/tests/target/configs/struct_field_align_threshold/20.rs
+++ b/tests/target/configs/struct_field_align_threshold/20.rs
@@ -38,7 +38,7 @@ fn main() {
 pub struct Foo {
     #[rustfmt::skip]
     f :   SomeType, // Comment beside a field
-    f: SomeType, // Comment beside a field
+    f:     SomeType, // Comment beside a field
     // Comment on a field
     #[AnAttribute]
     g:     SomeOtherType,
@@ -323,7 +323,7 @@ fn main() {
         // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
         // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
         // hendrerit. Donec et mollis dolor.
-        first: item(),
+        first:  item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
         // Nam tincidunt congue enim, ut porta lorem lacinia consectetur.
         second: Item,

--- a/tests/target/configs/struct_field_align_threshold/20.rs
+++ b/tests/target/configs/struct_field_align_threshold/20.rs
@@ -41,9 +41,9 @@ pub struct Foo {
     f: SomeType, // Comment beside a field
     // Comment on a field
     #[AnAttribute]
-    g: SomeOtherType,
+    g:     SomeOtherType,
     /// A doc comment on a field
-    h: AThirdType,
+    h:     AThirdType,
     pub i: TypeForPublicField,
 }
 
@@ -66,7 +66,7 @@ struct X {
 pub struct Writebatch<K: Key> {
     #[allow(dead_code)] // only used for holding the internal pointer
     writebatch: RawWritebatch,
-    marker: PhantomData<K>,
+    marker:     PhantomData<K>,
 }
 
 struct Bar;

--- a/tests/target/issue-2869.rs
+++ b/tests/target/issue-2869.rs
@@ -16,6 +16,11 @@ struct AuditLog1 {
     actor_context_id:                  Option<String>,
     actor_ip_address:                  Option<IpAddr>,
     azure_active_directory_event_type: Option<u8>,
+
+    #[serde(rename = "very")]
+    aaaaa: String,
+    #[serde(rename = "cool")]
+    bb:    i32,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/tests/target/issue-2869.rs
+++ b/tests/target/issue-2869.rs
@@ -1,0 +1,36 @@
+// rustfmt-struct_field_align_threshold: 50
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct AuditLog1 {
+    creation_time:                     String,
+    id:                                String,
+    operation:                         String,
+    organization_id:                   String,
+    record_type:                       u32,
+    result_status:                     Option<String>,
+    #[serde(rename = "ClientIP")]
+    client_ip:                         Option<IpAddr>,
+    object_id:                         String,
+    actor:                             Option<Vec<IDType>>,
+    actor_context_id:                  Option<String>,
+    actor_ip_address:                  Option<IpAddr>,
+    azure_active_directory_event_type: Option<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct AuditLog2 {
+    creation_time:                     String,
+    id:                                String,
+    operation:                         String,
+    organization_id:                   String,
+    record_type:                       u32,
+    result_status:                     Option<String>,
+    client_ip:                         Option<IpAddr>,
+    object_id:                         String,
+    actor:                             Option<Vec<IDType>>,
+    actor_context_id:                  Option<String>,
+    actor_ip_address:                  Option<IpAddr>,
+    azure_active_directory_event_type: Option<u8>,
+}


### PR DESCRIPTION
the `items::rewrite_struct_field` method was already handling multiline
field names via `last_line_width`, which was rendered moot by the
previous logic in
`vertical::AlignedItem::struct_field_prefix_max_min_width`.

Close #2869