### PR TITLE
Add a path to the parent dir of rustfmt.toml as a prefix to paths in ignore

### DIFF
--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -141,7 +141,7 @@ macro_rules! create_config {
                 ConfigWasSet(self)
             }
 
-            fn fill_from_parsed_config(mut self, parsed: PartialConfig) -> Config {
+            fn fill_from_parsed_config(mut self, parsed: PartialConfig, dir: &Path) -> Config {
             $(
                 if let Some(val) = parsed.$i {
                     if self.$i.3 {
@@ -160,6 +160,7 @@ macro_rules! create_config {
             )+
                 self.set_heuristics();
                 self.set_license_template();
+                self.set_ignore(dir);
                 self
             }
 
@@ -286,6 +287,9 @@ macro_rules! create_config {
                 }
             }
 
+            fn set_ignore(&mut self, dir: &Path) {
+                self.ignore.2.add_prefix(dir);
+            }
 
             /// Returns `true` if the config key was explicitly set and is the default value.
             pub fn is_default(&self, key: &str) -> bool {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -190,7 +190,8 @@ impl Config {
         let mut file = File::open(&file_path)?;
         let mut toml = String::new();
         file.read_to_string(&mut toml)?;
-        Config::from_toml(&toml).map_err(|err| Error::new(ErrorKind::InvalidData, err))
+        Config::from_toml(&toml, file_path.parent().unwrap())
+            .map_err(|err| Error::new(ErrorKind::InvalidData, err))
     }
 
     /// Resolves the config for input in `dir`.
@@ -252,7 +253,7 @@ impl Config {
         }
     }
 
-    pub(crate) fn from_toml(toml: &str) -> Result<Config, String> {
+    pub(crate) fn from_toml(toml: &str, dir: &Path) -> Result<Config, String> {
         let parsed: ::toml::Value = toml
             .parse()
             .map_err(|e| format!("Could not parse TOML: {}", e))?;
@@ -271,7 +272,7 @@ impl Config {
                 if !err.is_empty() {
                     eprint!("{}", err);
                 }
-                Ok(Config::default().fill_from_parsed_config(parsed_config))
+                Ok(Config::default().fill_from_parsed_config(parsed_config, dir))
             }
             Err(e) => {
                 err.push_str("Error: Decoding config file failed:\n");
@@ -425,7 +426,7 @@ mod test {
 
     #[test]
     fn test_was_set() {
-        let config = Config::from_toml("hard_tabs = true").unwrap();
+        let config = Config::from_toml("hard_tabs = true", Path::new("")).unwrap();
 
         assert_eq!(config.was_set().hard_tabs(), true);
         assert_eq!(config.was_set().verbose(), false);

--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use ignore::{self, gitignore};
 
 use crate::config::{FileName, IgnoreList};
@@ -10,7 +8,7 @@ pub struct IgnorePathSet {
 
 impl IgnorePathSet {
     pub fn from_ignore_list(ignore_list: &IgnoreList) -> Result<Self, ignore::Error> {
-        let mut ignore_builder = gitignore::GitignoreBuilder::new(PathBuf::from(""));
+        let mut ignore_builder = gitignore::GitignoreBuilder::new(ignore_list.rustfmt_toml_path());
 
         for ignore_path in ignore_list {
             ignore_builder.add_line(None, ignore_path.to_str().unwrap())?;

--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -1,5 +1,6 @@
-use ignore::{self, gitignore};
 use std::path::PathBuf;
+
+use ignore::{self, gitignore};
 
 use crate::config::{FileName, IgnoreList};
 
@@ -33,16 +34,19 @@ impl IgnorePathSet {
 
 #[cfg(test)]
 mod test {
+    use std::path::{Path, PathBuf};
+
     use crate::config::{Config, FileName};
     use crate::ignore_path::IgnorePathSet;
-    use std::path::PathBuf;
 
     #[test]
     fn test_ignore_path_set() {
         match option_env!("CFG_RELEASE_CHANNEL") {
             // this test requires nightly
             None | Some("nightly") => {
-                let config = Config::from_toml(r#"ignore = ["foo.rs", "bar_dir/*"]"#).unwrap();
+                let config =
+                    Config::from_toml(r#"ignore = ["foo.rs", "bar_dir/*"]"#, Path::new(""))
+                        .unwrap();
                 let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
 
                 assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/foo.rs"))));

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -564,7 +564,7 @@ fn get_config(config_file: Option<&Path>) -> Config {
         .read_to_string(&mut def_config)
         .expect("Couldn't read config");
 
-    Config::from_toml(&def_config).expect("invalid TOML")
+    Config::from_toml(&def_config, Path::new("tests/config/")).expect("invalid TOML")
 }
 
 // Reads significant comments of the form: `// rustfmt-key: value` into a hash map.


### PR DESCRIPTION
Paths users specify in `ignore` configuraiton option is relative to the
directory which contains the rustfmt.toml file. When processing the ignore paths
internally, rustfmt should add a path to the directory as a  prefix since
RealPath passed from libsyntax is a full path.

Closes #3521.