### PR TITLE
Add a test for #2941.

### DIFF
--- a/tests/target/issue-2941.rs
+++ b/tests/target/issue-2941.rs
@@ -1,0 +1,5 @@
+// rustfmt-wrap_comments: true
+
+//! ```
+//! \
+//! ```


### PR DESCRIPTION
Test that rustfmt won't crash when parsing backslash in doc comment. Close #2941. 