### PR TITLE
fix Comma in comment causes no formatting

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -612,7 +612,7 @@ pub fn extract_post_comment(
         post_snippet[1..].trim_matches(white_space)
     } else if post_snippet.starts_with(separator) {
         post_snippet[separator.len()..].trim_matches(white_space)
-    } else if post_snippet.ends_with(',') {
+    } else if post_snippet.ends_with(',') && !post_snippet.trim().starts_with("//") {
         post_snippet[..(post_snippet.len() - 1)].trim_matches(white_space)
     } else {
         post_snippet

--- a/tests/source/issue-3532.rs
+++ b/tests/source/issue-3532.rs
@@ -1,0 +1,7 @@
+fn foo(a: T) {
+    match a {
+1 => {}
+    0 => {}
+    // _ => panic!("doesn't format!"),
+    }
+}

--- a/tests/target/issue-3532.rs
+++ b/tests/target/issue-3532.rs
@@ -1,0 +1,6 @@
+fn foo(a: T) {
+    match a {
+        1 => {}
+        0 => {} // _ => panic!("doesn't format!"),
+    }
+}


### PR DESCRIPTION
fix: #3532 

this issue causes internal error like below

```
rchaser53nombp:rustfmt rchaser53$ cargo run --bin rustfmt -- issue-3532.rs
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/rustfmt issue-3532.rs`
error[internal]: not formatted because a comment would be lost
 --> /Users/rchaser53/Desktop/rustfmt/issue-3532.rs:2
  |
2 |     match a {
  |
  = note: set `error_on_unformatted = false` to suppress the warning against comments or string literals

warning: rustfmt has failed to format. See previous 1 errors.
```