### PR TITLE
WIP: Don't create `self` imports with `merge_imports`

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -578,7 +578,8 @@ impl UseTree {
             .path
             .clone()
             .iter_mut()
-            .zip(other.path.clone().into_iter())
+            .take(self.path.len() - 1)
+            .zip(other.path.clone().into_iter().take(other.path.len() - 1))
         {
             if *a == b {
                 new_path.push(b);

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -989,9 +989,9 @@ mod test {
         }
 
         test_merge!(["a::b::{c, d}", "a::b::{e, f}"], ["a::b::{c, d, e, f}"]);
-        test_merge!(["a::b::c", "a::b"], ["a::b::{self, c}"]);
+        test_merge!(["a::b::c", "a::b"], ["a::{b, b::c}"]);
         test_merge!(["a::b", "a::b"], ["a::b"]);
-        test_merge!(["a", "a::b", "a::b::c"], ["a::{self, b::{self, c}}"]);
+        test_merge!(["a", "a::b", "a::b::c"], ["a", "a::b", "a::b::c"]);
         test_merge!(
             ["a::{b::{self, c}, d::e}", "a::d::f"],
             ["a::{b::{self, c}, d::{e, f}}"]

--- a/tests/source/merge_imports.rs
+++ b/tests/source/merge_imports.rs
@@ -22,3 +22,6 @@ use a::{b::{c::*}};
 use a::{b::{c::{}}};
 use a::{b::{c::d}};
 use a::{b::{c::{xxx, yyy, zzz}}};
+
+use a::b;
+use a::b::c;

--- a/tests/target/merge_imports.rs
+++ b/tests/target/merge_imports.rs
@@ -14,3 +14,6 @@ use foo::{a, b, c};
 pub use foo::{bar, foobar};
 
 use a::b::c::{d, xxx, yyy, zzz, *};
+
+use a::b;
+use a::b::c;


### PR DESCRIPTION
Currently, `rustfmt` formats this:
```rust
use a::b;
use a::b::c;
```
into this:
```rust
use a::b::{self, c};
```

This changes the semantics of the imports since `use a::b;` could also be pulling in a function or macro named `b`, while `use a::b::{self, c};` only imports the module named `b`.

Just have a failing test case for now, but I should have a fix before too long.