### PR TITLE
Insert an empty line when normalizing `#[doc = ""]`

### DIFF
--- a/src/attr/doc_comment.rs
+++ b/src/attr/doc_comment.rs
@@ -12,6 +12,12 @@ impl Display for DocCommentFormatter<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let opener = self.style.opener().trim_end();
         let mut lines = self.literal.lines().peekable();
+
+        // Handle `#[doc = ""]`.
+        if lines.peek().is_none() {
+            return write!(formatter, "{}", opener);
+        }
+
         while let Some(line) = lines.next() {
             let is_last_line = lines.peek().is_none();
             if is_last_line {

--- a/tests/source/normalize_multiline_doc_attribute.rs
+++ b/tests/source/normalize_multiline_doc_attribute.rs
@@ -5,3 +5,8 @@
 is split
 on multiple lines"]
 fn foo() {}
+
+#[doc = " B1"]
+#[doc = ""]
+#[doc = " A1"]
+fn bar() {}

--- a/tests/target/normalize_multiline_doc_attribute.rs
+++ b/tests/target/normalize_multiline_doc_attribute.rs
@@ -5,3 +5,8 @@
 ///is split
 ///on multiple lines
 fn foo() {}
+
+/// B1
+///
+/// A1
+fn bar() {}


### PR DESCRIPTION
Closes #3575.