### PR TITLE
implement Display for enums with attribute config_type

### DIFF
--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -249,11 +249,15 @@ macro_rules! create_config {
                             }
                             name_out.push_str(name_raw);
                             name_out.push(' ');
+                            let mut default_str = format!("{}", $def);
+                            if default_str.is_empty() {
+                                default_str = String::from("\"\"");
+                            }
                             writeln!(out,
-                                    "{}{} Default: {:?}{}",
+                                    "{}{} Default: {}{}",
                                     name_out,
                                     <$ty>::doc_hint(),
-                                    $def,
+                                    default_str,
                                     if !$stb { " (unstable)" } else { "" }).unwrap();
                             $(
                                 writeln!(out, "{}{}", space_str, $dstring).unwrap();

--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -1,5 +1,6 @@
 //! This module contains types and functions to support formatting specific line ranges.
 
+use itertools::Itertools;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -92,6 +93,12 @@ impl<'a> From<&'a LineRange> for Range {
     }
 }
 
+impl fmt::Display for Range {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}..{}", self.lo, self.hi)
+    }
+}
+
 impl Range {
     pub fn new(lo: usize, hi: usize) -> Range {
         Range { lo, hi }
@@ -148,6 +155,21 @@ impl Range {
 /// lines in all files.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct FileLines(Option<HashMap<FileName, Vec<Range>>>);
+
+impl fmt::Display for FileLines {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            None => write!(f, "None")?,
+            Some(map) => {
+                for (file_name, ranges) in map.iter() {
+                    write!(f, "{}: ", file_name)?;
+                    write!(f, "{}\n", ranges.iter().format(", "))?;
+                }
+            }
+        };
+        Ok(())
+    }
+}
 
 /// Normalizes the ranges so that the invariants for `FileLines` hold: ranges are non-overlapping,
 /// and ordered by their start point.

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use atty;
+use itertools::Itertools;
 use rustfmt_config_proc_macro::config_type;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;
@@ -193,6 +194,12 @@ pub struct WidthHeuristics {
     pub single_line_if_else_max_width: usize,
 }
 
+impl fmt::Display for WidthHeuristics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 impl WidthHeuristics {
     // Using this WidthHeuristics means we ignore heuristics.
     pub fn null() -> WidthHeuristics {
@@ -262,6 +269,21 @@ pub struct IgnoreList {
     path_set: HashSet<PathBuf>,
     /// A path to rustfmt.toml.
     rustfmt_toml_path: PathBuf,
+}
+
+impl fmt::Display for IgnoreList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}]",
+            self.path_set
+                .iter()
+                .format_with(", ", |path, f| f(&format_args!(
+                    "{}",
+                    path.to_string_lossy()
+                )))
+        )
+    }
 }
 
 impl Serialize for IgnoreList {


### PR DESCRIPTION
Implementing `Display` was motivated by the default value of `edition` being `Edition2015` although it should have been `2015`. Also, it provides a `to_string` method which could be used in #3620.

Below are the differences this PR makes on the output of `--help=config --unstable-features`:

```diff
137c137
<                      edition [2015|2018] Default: Edition2015
---
>                      edition [2015|2018] Default: 2015
164c164
<             required_version <string> Default: "1.3.0" (unstable)
---
>             required_version <string> Default: 1.3.0 (unstable)
191c191
<                       ignore [<string>,..] Default: IgnoreList { path_set: {}, rustfmt_toml_path: "" } (unstable)
---
>                       ignore [<string>,..] Default: [] (unstable)
```