### PR TITLE
handle unicode chars in closures

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2028,6 +2028,15 @@ fn shape_from_rhs_tactic(
     }
 }
 
+/// Returns true if formatting next_line_rhs is better on a new line when compared to the
+/// original's line formatting.
+///
+/// It is considered better if:
+/// 1. the tactic is ForceNextLineWithoutIndent
+/// 2. next_line_rhs doesn't have newlines
+/// 3. the original line has more newlines than next_line_rhs
+/// 4. the original formatting of the first line ends with `(`, `{`, or `[` and next_line_rhs
+///    doesn't
 pub(crate) fn prefer_next_line(
     orig_rhs: &str,
     next_line_rhs: &str,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -10,7 +10,10 @@ use crate::config::lists::*;
 use crate::config::{Config, IndentStyle};
 use crate::rewrite::RewriteContext;
 use crate::shape::{Indent, Shape};
-use crate::utils::{count_newlines, first_line_width, last_line_width, mk_sp, starts_with_newline};
+use crate::utils::{
+    count_newlines, first_line_width, last_line_width, mk_sp, starts_with_newline,
+    unicode_str_width,
+};
 use crate::visitor::SnippetProvider;
 
 pub(crate) struct ListFormatting<'a> {
@@ -386,7 +389,7 @@ where
                         result.push('\n');
                         result.push_str(indent_str);
                         // This is the width of the item (without comments).
-                        line_len = item.item.as_ref().map_or(0, String::len);
+                        line_len = item.item.as_ref().map_or(0, |s| unicode_str_width(&s));
                     }
                 } else {
                     result.push(' ');
@@ -808,7 +811,7 @@ where
 pub(crate) fn total_item_width(item: &ListItem) -> usize {
     comment_len(item.pre_comment.as_ref().map(|x| &(*x)[..]))
         + comment_len(item.post_comment.as_ref().map(|x| &(*x)[..]))
-        + item.item.as_ref().map_or(0, String::len)
+        + &item.item.as_ref().map_or(0, |s| unicode_str_width(&s))
 }
 
 fn comment_len(comment: Option<&str>) -> usize {

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -468,6 +468,9 @@ fn rewrite_match_body(
         next_line_body_shape.width,
     );
     match (orig_body, next_line_body) {
+        (Some(ref orig_str), Some(ref next_line_str)) if orig_str == next_line_str => {
+            combine_orig_body(orig_str)
+        }
         (Some(ref orig_str), Some(ref next_line_str))
             if prefer_next_line(orig_str, next_line_str, RhsTactics::Default) =>
         {

--- a/tests/source/unicode.rs
+++ b/tests/source/unicode.rs
@@ -23,3 +23,11 @@ pub fn bar(config: &Config) {
         csv.write_record(None::<&[u8]>).unwrap();
     }
 }
+
+// The NotUnicode line is below 100 wrt chars but over it wrt String::len
+fn baz() {
+    let our_error_b = result_b_from_func.or_else(|e| match e {
+        NotPresent => Err(e).chain_err(|| "env var wasn't provided"),
+        NotUnicode(_) => Err(e).chain_err(|| "env var was very very very borkæ–‡å­—åŒ–ã"),
+    });
+}

--- a/tests/target/unicode.rs
+++ b/tests/target/unicode.rs
@@ -20,3 +20,11 @@ pub fn bar(config: &Config) {
         csv.write_record(None::<&[u8]>).unwrap();
     }
 }
+
+// The NotUnicode line is below 100 wrt chars but over it wrt String::len
+fn baz() {
+    let our_error_b = result_b_from_func.or_else(|e| match e {
+        NotPresent => Err(e).chain_err(|| "env var wasn't provided"),
+        NotUnicode(_) => Err(e).chain_err(|| "env var was very very very borkæ–‡å­—åŒ–ã"),
+    });
+}


### PR DESCRIPTION
The `NotUnicode` branch was unnecessarily put on a new line, although it
was within max width:

```diff
 fn baz() {
     let our_error_b = result_b_from_func.or_else(|e| match e {
         NotPresent => Err(e).chain_err(|| "env var wasn't provided"),
-        NotUnicode(_) => Err(e).chain_err(|| "env var was very very very borkæ–‡å­—åŒ–ã"),
+        NotUnicode(_) => {
+            Err(e).chain_err(|| "env var was very very very borkæ–‡å­—åŒ–ã")
+        }
     });
 }
```

Related to #6