### PR TITLE
Add newline after help text

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -96,7 +96,8 @@ fn execute() -> i32 {
 fn print_usage_to_stderr(reason: &str) {
     eprintln!("{}", reason);
     let app = Opts::clap();
-    app.write_help(&mut io::stderr())
+    app.after_help("")
+        .write_help(&mut io::stderr())
         .expect("failed to write to stderr");
 }
 


### PR DESCRIPTION
Add a newline after help text is shown for a smoother experience.

Solves #3644 