### PR TITLE
Don't panic on license check errors

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -313,7 +313,8 @@ impl FormattingError {
             | ErrorKind::DeprecatedAttr
             | ErrorKind::BadIssue(_)
             | ErrorKind::BadAttr
-            | ErrorKind::LostComment => {
+            | ErrorKind::LostComment
+            | ErrorKind::LicenseCheck => {
                 let trailing_ws_start = self
                     .line_buffer
                     .rfind(|c: char| !c.is_whitespace())


### PR DESCRIPTION
Without this case, an ErrorKind::LicenseCheck results in a panic:

    thread 'main' panicked at 'internal error: entered unreachable code', src/tools/rustfmt/src/formatting.rs:320:18

N.B.: errors of this type are only raised when the configuration file
contains `license_tempate_path = "TEMPLATE_FILE"`.