### PR TITLE
Add #[ignore] to test that runs external process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - |
     if [ -z ${INTEGRATION} ]; then
       cargo build
-      cargo test
+      cargo test --features "test-binary"
     else
       ./ci/integration.sh
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - |
     if [ -z ${INTEGRATION} ]; then
       cargo build
-      cargo test --features "test-binary"
+      cargo test -- --ignored
     else
       ./ci/integration.sh
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ script:
   - |
     if [ -z ${INTEGRATION} ]; then
       cargo build
+      cargo test
       cargo test -- --ignored
     else
       ./ci/integration.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default = ["cargo-fmt", "rustfmt-format-diff"]
 cargo-fmt = []
 rustfmt-format-diff = []
 generic-simd = ["bytecount/generic-simd"]
+test-binary = []
 
 [dependencies]
 atty = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ default = ["cargo-fmt", "rustfmt-format-diff"]
 cargo-fmt = []
 rustfmt-format-diff = []
 generic-simd = ["bytecount/generic-simd"]
-test-binary = []
 
 [dependencies]
 atty = "0.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,4 +49,5 @@ build: false
 
 test_script:
   - cargo build --verbose
+  - cargo test
   - cargo test -- --ignored

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,4 +49,4 @@ build: false
 
 test_script:
   - cargo build --verbose
-  - cargo test
+  - cargo test --features "test-binary"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,4 +49,4 @@ build: false
 
 test_script:
   - cargo build --verbose
-  - cargo test --features "test-binary"
+  - cargo test -- --ignored

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -16,7 +16,7 @@
 //! following values of `chain_indent`:
 //! Block:
 //!
-//! ```ignore
+//! ```text
 //! let foo = {
 //!     aaaa;
 //!     bbb;
@@ -27,7 +27,7 @@
 //!
 //! Visual:
 //!
-//! ```ignore
+//! ```text
 //! let foo = {
 //!               aaaa;
 //!               bbb;
@@ -41,7 +41,7 @@
 //! the braces.
 //! Block:
 //!
-//! ```ignore
+//! ```text
 //! let a = foo.bar
 //!     .baz()
 //!     .qux
@@ -49,7 +49,7 @@
 //!
 //! Visual:
 //!
-//! ```ignore
+//! ```text
 //! let a = foo.bar
 //!            .baz()
 //!            .qux
@@ -454,7 +454,7 @@ trait ChainFormatter {
     // Parent is the first item in the chain, e.g., `foo` in `foo.bar.baz()`.
     // Root is the parent plus any other chain items placed on the first line to
     // avoid an orphan. E.g.,
-    // ```ignore
+    // ```text
     // foo.bar
     //     .baz()
     // ```
@@ -516,7 +516,7 @@ impl<'a> ChainFormatterShared<'a> {
     // know whether 'overflowing' the last child make a better formatting:
     //
     // A chain with overflowing the last child:
-    // ```ignore
+    // ```text
     // parent.child1.child2.last_child(
     //     a,
     //     b,
@@ -525,7 +525,7 @@ impl<'a> ChainFormatterShared<'a> {
     // ```
     //
     // A chain without overflowing the last child (in vertical layout):
-    // ```ignore
+    // ```text
     // parent
     //     .child1
     //     .child2
@@ -534,7 +534,7 @@ impl<'a> ChainFormatterShared<'a> {
     //
     // In particular, overflowing is effective when the last child is a method with a multi-lined
     // block-like argument (e.g., closure):
-    // ```ignore
+    // ```text
     // parent.child1.child2.last_child(|a, b, c| {
     //     let x = foo(a, b, c);
     //     let y = bar(a, b, c);

--- a/src/config/license.rs
+++ b/src/config/license.rs
@@ -82,7 +82,7 @@ impl TemplateParser {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```text
     /// assert_eq!(
     ///     TemplateParser::parse(
     ///         r"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1417,7 +1417,7 @@ impl MacroBranch {
 ///
 /// # Expected syntax
 ///
-/// ```ignore
+/// ```text
 /// lazy_static! {
 ///     [pub] static ref NAME_1: TYPE_1 = EXPR_1;
 ///     [pub] static ref NAME_2: TYPE_2 = EXPR_2;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -507,7 +507,7 @@ pub(crate) fn remove_trailing_white_spaces(text: &str) -> String {
 /// Indent each line according to the specified `indent`.
 /// e.g.
 ///
-/// ```rust,ignore
+/// ```rust,compile_fail
 /// foo!{
 /// x,
 /// y,
@@ -521,7 +521,7 @@ pub(crate) fn remove_trailing_white_spaces(text: &str) -> String {
 ///
 /// will become
 ///
-/// ```rust,ignore
+/// ```rust,compile_fail
 /// foo!{
 ///     x,
 ///     y,

--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -1,5 +1,7 @@
 // Integration tests for cargo-fmt.
 
+#![cfg(feature = "test-binary")]
+
 use std::env;
 use std::process::Command;
 

--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -1,7 +1,5 @@
 // Integration tests for cargo-fmt.
 
-#![cfg(feature = "test-binary")]
-
 use std::env;
 use std::process::Command;
 
@@ -48,6 +46,7 @@ macro_rules! assert_that {
     };
 }
 
+#[ignore]
 #[test]
 fn version() {
     assert_that!(&["--version"], starts_with("rustfmt "));
@@ -56,6 +55,7 @@ fn version() {
     assert_that!(&["--", "--version"], starts_with("rustfmt "));
 }
 
+#[ignore]
 #[test]
 fn print_config() {
     assert_that!(
@@ -64,6 +64,7 @@ fn print_config() {
     );
 }
 
+#[ignore]
 #[test]
 fn rustfmt_help() {
     assert_that!(&["--", "--help"], contains("Format Rust code"));

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -1,7 +1,5 @@
 //! Integration tests for rustfmt.
 
-#![cfg(feature = "test-binary")]
-
 use std::env;
 use std::fs::remove_file;
 use std::path::Path;
@@ -50,6 +48,7 @@ macro_rules! assert_that {
     };
 }
 
+#[ignore]
 #[test]
 fn print_config() {
     assert_that!(

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -1,5 +1,7 @@
 //! Integration tests for rustfmt.
 
+#![cfg(feature = "test-binary")]
+
 use std::env;
 use std::fs::remove_file;
 use std::path::Path;

--- a/tests/source/issue-3055/original.rs
+++ b/tests/source/issue-3055/original.rs
@@ -17,7 +17,7 @@
 /// ```
 ///
 /// Should not format with ignore attribute
-/// ```ignore
+/// ```text
 ///           .--------------.
 ///           |              v
 /// Park <- Idle -> Poll -> Probe -> Download -> Install -> Reboot

--- a/tests/target/issue-3055/original.rs
+++ b/tests/target/issue-3055/original.rs
@@ -18,7 +18,7 @@
 /// ```
 ///
 /// Should not format with ignore attribute
-/// ```ignore
+/// ```text
 ///           .--------------.
 ///           |              v
 /// Park <- Idle -> Poll -> Probe -> Download -> Install -> Reboot


### PR DESCRIPTION
~This PR adds `test-binary` feature to work around test failures which appears in the rustc repo [1].~

This PR adds `#[ignore]` to test that runs an external process to work around test failures that appears in the rustc repo [1].

[1] https://github.com/rust-lang/rust/pull/62688#issuecomment-511589355