### PR TITLE
Bump rustfmt-config_proc_macro to min v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ ignore = "0.4.6"
 annotate-snippets = { version = "0.6", features = ["ansi_term"] }
 structopt = "0.2.18"
 
-rustfmt-config_proc_macro = { version = "0.1", path = "config_proc_macro" }
+rustfmt-config_proc_macro = { version = "0.1.2", path = "config_proc_macro" }
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`


### PR DESCRIPTION
I tried to update Rustfmt 1.4.1 in the RLS and encountered the following error:
```
    Checking rustfmt-nightly v1.4.1
error[E0277]: `config::options::__define_config_type_on_enum_NewlineStyle::NewlineStyle` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:36:34
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
35  | |     tab_spaces: usize, 4, true, "Number of spaces per tab";
36  | |     newline_style: NewlineStyle, NewlineStyle::Auto, true, "Unix or Windows line endings";
    | |                                  ^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_NewlineStyle::NewlineStyle` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_NewlineStyle::NewlineStyle`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_Heuristics::Heuristics` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:37:39
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
37  | |     use_small_heuristics: Heuristics, Heuristics::Default, true, "Whether to use different \
    | |                                       ^^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_Heuristics::Heuristics` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_Heuristics::Heuristics`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_IndentStyle::IndentStyle` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:39:32
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
39  | |     indent_style: IndentStyle, IndentStyle::Block, false, "How do we indent expressions or items";
    | |                                ^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_IndentStyle::IndentStyle` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_IndentStyle::IndentStyle`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_IndentStyle::IndentStyle` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:64:34
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
64  | |     imports_indent: IndentStyle, IndentStyle::Block, false, "Indent of imports";
    | |                                  ^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_IndentStyle::IndentStyle` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_IndentStyle::IndentStyle`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::lists::__define_config_type_on_enum_ListTactic::ListTactic` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:65:33
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
65  | |     imports_layout: ListTactic, ListTactic::Mixed, false, "Item layout inside a import block";
    | |                                 ^^^^^^^^^^^^^^^^^ `config::lists::__define_config_type_on_enum_ListTactic::ListTactic` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::lists::__define_config_type_on_enum_ListTactic::ListTactic`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_TypeDensity::TypeDensity` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:74:44
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
74  | |     type_punctuation_density: TypeDensity, TypeDensity::Wide, false,
    | |                                            ^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_TypeDensity::TypeDensity` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_TypeDensity::TypeDensity`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::lists::__define_config_type_on_enum_SeparatorPlace::SeparatorPlace` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:79:38
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
79  | |     binop_separator: SeparatorPlace, SeparatorPlace::Front, false,
    | |                                      ^^^^^^^^^^^^^^^^^^^^^ `config::lists::__define_config_type_on_enum_SeparatorPlace::SeparatorPlace` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::lists::__define_config_type_on_enum_SeparatorPlace::SeparatorPlace`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_Density::Density` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:95:30
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
95  | |     fn_args_layout: Density, Density::Tall, true,
    | |                              ^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_Density::Density` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_Density::Density`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_BraceStyle::BraceStyle` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:97:30
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
97  | |     brace_style: BraceStyle, BraceStyle::SameLineWhere, false, "Brace style for items";
    | |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_BraceStyle::BraceStyle` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_BraceStyle::BraceStyle`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_ControlBraceStyle::ControlBraceStyle` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:98:45
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
98  | |     control_brace_style: ControlBraceStyle, ControlBraceStyle::AlwaysSameLine, false,
    | |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_ControlBraceStyle::ControlBraceStyle` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_ControlBraceStyle::ControlBraceStyle`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::lists::__define_config_type_on_enum_SeparatorTactic::SeparatorTactic` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:102:38
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
102 | |     trailing_comma: SeparatorTactic, SeparatorTactic::Vertical, false,
    | |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^ `config::lists::__define_config_type_on_enum_SeparatorTactic::SeparatorTactic` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::lists::__define_config_type_on_enum_SeparatorTactic::SeparatorTactic`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_Edition::Edition` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:110:23
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
110 | |     edition: Edition, Edition::Edition2015, true, "The edition of the parser (RFC 2052)";
    | |                       ^^^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_Edition::Edition` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_Edition::Edition`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_Version::Version` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:111:23
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
111 | |     version: Version, Version::One, false, "Version of formatting rules";
    | |                       ^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_Version::Version` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_Version::Version`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_Color::Color` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:125:19
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
125 | |     color: Color, Color::Auto, false,
    | |                   ^^^^^^^^^^^ `config::options::__define_config_type_on_enum_Color::Color` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_Color::Color`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_ReportTactic::ReportTactic` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:138:32
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
138 | |     report_todo: ReportTactic, ReportTactic::Never, false,
    | |                                ^^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_ReportTactic::ReportTactic` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_ReportTactic::ReportTactic`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_ReportTactic::ReportTactic` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:140:33
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
140 | |     report_fixme: ReportTactic, ReportTactic::Never, false,
    | |                                 ^^^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_ReportTactic::ReportTactic` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_ReportTactic::ReportTactic`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_Verbosity::Verbosity` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:146:25
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
146 | |     verbose: Verbosity, Verbosity::Normal, false, "How much to information to emit to the user";
    | |                         ^^^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_Verbosity::Verbosity` cannot be formatted with the default formatter
...   |
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_Verbosity::Verbosity`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error[E0277]: `config::options::__define_config_type_on_enum_EmitMode::EmitMode` doesn't implement `std::fmt::Display`
   --> /home/xanewok/.cargo/registry/src/github.com-1ecc6299db9ec823/rustfmt-nightly-1.4.1/src/config/mod.rs:152:26
    |
31  | / create_config! {
32  | |     // Fundamental stuff
33  | |     max_width: usize, 100, true, "Maximum width of each line";
34  | |     hard_tabs: bool, false, true, "Use tab characters for indentation, spaces for alignment";
...   |
152 | |     emit_mode: EmitMode, EmitMode::Files, false,
    | |                          ^^^^^^^^^^^^^^^ `config::options::__define_config_type_on_enum_EmitMode::EmitMode` cannot be formatted with the default formatter
153 | |         "What emit Mode to use when none is supplied";
154 | |     make_backup: bool, false, false, "Backup changed files";
155 | | }
    | |_- in this macro invocation
    |
    = help: the trait `std::fmt::Display` is not implemented for `config::options::__define_config_type_on_enum_EmitMode::EmitMode`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`

error: aborting due to 18 previous errors

For more information about this error, try `rustc --explain E0277`.
error: Could not compile `rustfmt-nightly`.

To learn more, run the command again with --verbose.
```

Turns out that `Display` wasn't implemented for enums and I needed to manually run `cargo update -p rustfmt-config_proc_macro` to make it compile again because it still used 0.1.0 version of the proc macro from the lockfile.

That seems like it was breaking change and the fix was somewhat hard to find so it'd be good to release a patch release with this, assuming someone else uses Rustfmt-as-a-library except RLS :stuck_out_tongue: 