### PR TITLE
fix issue with --all when workspace member crate also exists in dep tree

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -340,7 +340,7 @@ fn get_targets_recursive(
             let dependency_package = metadata_with_deps
                 .packages
                 .iter()
-                .find(|p| p.name == dependency.name);
+                .find(|p| p.name == dependency.name && p.source.is_none());
             let manifest_path = if dependency_package.is_some() {
                 PathBuf::from(&dependency_package.unwrap().manifest_path)
             } else {


### PR DESCRIPTION
Fixes #3725 