### PR TITLE
add new flag to list names of misformatted files

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2445,3 +2445,7 @@ Internal option
 ## `make_backup`
 
 Internal option, use `--backup`
+
+## `print_misformatted_file_names`
+
+Internal option, use `-l` or `--files-with-matches`

--- a/Configurations.md
+++ b/Configurations.md
@@ -2448,4 +2448,4 @@ Internal option, use `--backup`
 
 ## `print_misformatted_file_names`
 
-Internal option, use `-l` or `--files-with-matches`
+Internal option, use `-l` or `--files-with-diff`

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -126,6 +126,12 @@ fn make_opts() -> Options {
          `current` writes to stdout current config as if formatting the file at PATH.",
         "[default|minimal|current] PATH",
     );
+    opts.optflag(
+        "l",
+        "files-with-diff",
+        "Prints the names of mismatched files that were formatted. Prints the names of \
+         files that would be formated when used with `--check` mode. ",
+    );
 
     if is_nightly {
         opts.optflag(
@@ -480,6 +486,7 @@ struct GetOptsOptions {
     file_lines: FileLines, // Default is all lines in all files.
     unstable_features: bool,
     error_on_unformatted: Option<bool>,
+    print_misformatted_file_names: bool,
 }
 
 impl GetOptsOptions {
@@ -547,6 +554,10 @@ impl GetOptsOptions {
             options.backup = true;
         }
 
+        if matches.opt_present("files-with-diff") {
+            options.print_misformatted_file_names = true;
+        }
+
         if !rust_nightly {
             if !STABLE_EMIT_MODES.contains(&options.emit_mode) {
                 return Err(format_err!(
@@ -609,6 +620,9 @@ impl CliOptions for GetOptsOptions {
         }
         if let Some(color) = self.color {
             config.set().color(color);
+        }
+        if self.print_misformatted_file_names {
+            config.set().print_misformatted_file_names(true);
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -152,6 +152,9 @@ create_config! {
     emit_mode: EmitMode, EmitMode::Files, false,
         "What emit Mode to use when none is supplied";
     make_backup: bool, false, false, "Backup changed files";
+    print_misformatted_file_names: bool, false, true,
+        "Prints the names of misformatted files that were formatted. Prints the names of \
+         files that would be formated when used with `--check` mode. ";
 }
 
 impl PartialConfig {
@@ -161,6 +164,7 @@ impl PartialConfig {
         cloned.file_lines = None;
         cloned.verbose = None;
         cloned.width_heuristics = None;
+        cloned.print_misformatted_file_names = None;
 
         ::toml::to_string(&cloned).map_err(|e| format!("Could not output config: {}", e))
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -153,7 +153,7 @@ create_config! {
         "What emit Mode to use when none is supplied";
     make_backup: bool, false, false, "Backup changed files";
     print_misformatted_file_names: bool, false, true,
-        "Prints the names of misformatted files that were formatted. Prints the names of \
+        "Prints the names of mismatched files that were formatted. Prints the names of \
          files that would be formated when used with `--check` mode. ";
 }
 

--- a/src/emitter/files.rs
+++ b/src/emitter/files.rs
@@ -2,12 +2,22 @@ use super::*;
 use std::fs;
 
 #[derive(Debug, Default)]
-pub(crate) struct FilesEmitter;
+pub(crate) struct FilesEmitter {
+    print_misformatted_file_names: bool,
+}
+
+impl FilesEmitter {
+    pub(crate) fn new(print_misformatted_file_names: bool) -> Self {
+        Self {
+            print_misformatted_file_names,
+        }
+    }
+}
 
 impl Emitter for FilesEmitter {
     fn emit_formatted_file(
         &mut self,
-        _output: &mut dyn Write,
+        output: &mut dyn Write,
         FormattedFile {
             filename,
             original_text,
@@ -18,6 +28,9 @@ impl Emitter for FilesEmitter {
         let filename = ensure_real_path(filename);
         if original_text != formatted_text {
             fs::write(filename, formatted_text)?;
+            if self.print_misformatted_file_names {
+                writeln!(output, "{}", filename.display())?;
+            }
         }
         Ok(EmitterResult::default())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,9 @@ pub(crate) fn create_emitter<'a>(config: &Config) -> Box<dyn Emitter + 'a> {
         EmitMode::Files if config.make_backup() => {
             Box::new(emitter::FilesWithBackupEmitter::default())
         }
-        EmitMode::Files => Box::new(emitter::FilesEmitter::default()),
+        EmitMode::Files => Box::new(emitter::FilesEmitter::new(
+            config.print_misformatted_file_names(),
+        )),
         EmitMode::Stdout | EmitMode::Coverage => {
             Box::new(emitter::StdoutEmitter::new(config.verbose()))
         }


### PR DESCRIPTION
Closes #3738 

Adds new command line flag (`-l,--files-with-diff` as suggested in https://github.com/rust-lang/rustfmt/issues/3738#issuecomment-520640244) to list the names of misformatted files

- [X] On `cargo fmt -- --check -l`, displays the names of files that would be reformatted
- [x] On `cargo fmt -- -l`, displays the names of files that were reformatted