### PR TITLE
Forbid adding or removing a block from match arms inside macro calls

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -395,25 +395,26 @@ fn rewrite_match_body(
         }
 
         let indent_str = shape.indent.to_string_with_newline(context.config);
-        let (body_prefix, body_suffix) = if context.config.match_arm_blocks() && !context.inside_macro() {
-            let comma = if context.config.match_block_trailing_comma() {
-                ","
-            } else {
-                ""
-            };
-            let semicolon = if context.config.version() == Version::One {
-                ""
-            } else {
-                if semicolon_for_expr(context, body) {
-                    ";"
+        let (body_prefix, body_suffix) =
+            if context.config.match_arm_blocks() && !context.inside_macro() {
+                let comma = if context.config.match_block_trailing_comma() {
+                    ","
                 } else {
                     ""
-                }
+                };
+                let semicolon = if context.config.version() == Version::One {
+                    ""
+                } else {
+                    if semicolon_for_expr(context, body) {
+                        ";"
+                    } else {
+                        ""
+                    }
+                };
+                ("{", format!("{}{}}}{}", semicolon, indent_str, comma))
+            } else {
+                ("", String::from(","))
             };
-            ("{", format!("{}{}}}{}", semicolon, indent_str, comma))
-        } else {
-            ("", String::from(","))
-        };
 
         let block_sep = match context.config.control_brace_style() {
             ControlBraceStyle::AlwaysNextLine => format!("{}{}", alt_block_sep, body_prefix),
@@ -469,7 +470,9 @@ fn rewrite_match_body(
         next_line_body_shape.width,
     );
     match (orig_body, next_line_body) {
-        (Some(ref orig_str), Some(ref next_line_str)) if orig_str == next_line_str || context.inside_macro() => {
+        (Some(ref orig_str), Some(ref next_line_str))
+            if orig_str == next_line_str || context.inside_macro() =>
+        {
             combine_orig_body(orig_str)
         }
         (Some(ref orig_str), Some(ref next_line_str))

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -278,6 +278,7 @@ fn block_can_be_flattened<'a>(
     match expr.node {
         ast::ExprKind::Block(ref block, _)
             if !is_unsafe_block(block)
+                && !context.inside_macro()
                 && is_simple_block(block, Some(&expr.attrs), context.source_map) =>
         {
             Some(&*block)
@@ -394,7 +395,7 @@ fn rewrite_match_body(
         }
 
         let indent_str = shape.indent.to_string_with_newline(context.config);
-        let (body_prefix, body_suffix) = if context.config.match_arm_blocks() {
+        let (body_prefix, body_suffix) = if context.config.match_arm_blocks() && !context.inside_macro() {
             let comma = if context.config.match_block_trailing_comma() {
                 ","
             } else {

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -469,7 +469,7 @@ fn rewrite_match_body(
         next_line_body_shape.width,
     );
     match (orig_body, next_line_body) {
-        (Some(ref orig_str), Some(ref next_line_str)) if orig_str == next_line_str => {
+        (Some(ref orig_str), Some(ref next_line_str)) if orig_str == next_line_str || context.inside_macro() => {
             combine_orig_body(orig_str)
         }
         (Some(ref orig_str), Some(ref next_line_str))

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -473,5 +473,14 @@ pub fn fold_abi<V: Fold + ?Sized>(_visitor: &mut V, _i: Abi) -> Abi {
 // #3463
 x ! {()}
 
+// #3746
+f!(match a {
+    4 =>
+        &[
+            (3, false), // Missing
+            (4, true)   // I-frame
+        ]  [..],
+});
+
 // #3583
 foo!(|x = y|);

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -1050,5 +1050,13 @@ pub fn fold_abi<V: Fold + ?Sized>(_visitor: &mut V, _i: Abi) -> Abi {
 // #3463
 x! {()}
 
+// #3746
+f!(match a {
+    4 => &[
+        (3, false), // Missing
+        (4, true)   // I-frame
+    ][..],
+});
+
 // #3583
 foo!(|x = y|);


### PR DESCRIPTION
Closes #3746.