### PR TITLE
fix formatting mods inside cfg_if macro

### DIFF
--- a/src/modules.rs
+++ b/src/modules.rs
@@ -105,7 +105,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         visitor.visit_item(&item);
         for module_item in visitor.mods() {
             if let ast::ItemKind::Mod(ref sub_mod) = module_item.item.node {
-                self.visit_sub_mod(&item, Cow::Owned(sub_mod.clone()))?;
+                self.visit_sub_mod(&module_item.item, Cow::Owned(sub_mod.clone()))?;
             }
         }
         Ok(())
@@ -477,7 +477,14 @@ fn parse_mod_items<'a>(parser: &mut parser::Parser<'a>, inner_lo: Span) -> PResu
 
 fn is_cfg_if(item: &ast::Item) -> bool {
     match item.node {
-        ast::ItemKind::Mac(..) if item.ident.name == Symbol::intern("cfg_if") => true,
+        ast::ItemKind::Mac(ref mac) => {
+            if let Some(first_segment) = mac.node.path.segments.first() {
+                if first_segment.ident.name == Symbol::intern("cfg_if") {
+                    return true;
+                }
+            }
+            false
+        }
         _ => false,
     }
 }

--- a/src/modules/visitor.rs
+++ b/src/modules/visitor.rs
@@ -43,8 +43,21 @@ impl<'a, 'ast: 'a> Visitor<'ast> for CfgIfVisitor<'a> {
 
 impl<'a, 'ast: 'a> CfgIfVisitor<'a> {
     fn visit_mac_inner(&mut self, mac: &'ast ast::Mac) -> Result<(), &'static str> {
-        if mac.node.path != Symbol::intern("cfg_if") {
-            return Err("Expected cfg_if");
+        // Support both:
+        // ```
+        // extern crate cfg_if;
+        // cfg_if::cfg_if! {..}
+        // ```
+        // And:
+        // ```
+        // #[macro_use]
+        // extern crate cfg_if;
+        // cfg_if! {..}
+        // ```
+        if let Some(first_segment) = mac.node.path.segments.first() {
+            if first_segment.ident.name != Symbol::intern("cfg_if") {
+                return Err("Expected cfg_if");
+            }
         }
 
         let mut parser = stream_to_parser_with_base_dir(

--- a/src/modules/visitor.rs
+++ b/src/modules/visitor.rs
@@ -54,11 +54,16 @@ impl<'a, 'ast: 'a> CfgIfVisitor<'a> {
         // extern crate cfg_if;
         // cfg_if! {..}
         // ```
-        if let Some(first_segment) = mac.node.path.segments.first() {
-            if first_segment.ident.name != Symbol::intern("cfg_if") {
+        match mac.node.path.segments.first() {
+            Some(first_segment) => {
+                if first_segment.ident.name != Symbol::intern("cfg_if") {
+                    return Err("Expected cfg_if");
+                }
+            }
+            None => {
                 return Err("Expected cfg_if");
             }
-        }
+        };
 
         let mut parser = stream_to_parser_with_base_dir(
             self.parse_sess,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -30,6 +30,9 @@ const SKIP_FILE_WHITE_LIST: &[&str] = &[
     // These files and directory are a part of modules defined inside `cfg_if!`.
     "cfg_if/mod.rs",
     "cfg_if/detect",
+    "issue-3253/foo.rs",
+    "issue-3253/bar.rs",
+    "issue-3253/paths",
     // These files and directory are a part of modules defined inside `cfg_attr(..)`.
     "cfg_mod/dir",
     "cfg_mod/bar.rs",

--- a/tests/source/issue-3253/bar.rs
+++ b/tests/source/issue-3253/bar.rs
@@ -1,0 +1,4 @@
+// Empty
+   fn empty()     {
+
+}

--- a/tests/source/issue-3253/foo.rs
+++ b/tests/source/issue-3253/foo.rs
@@ -1,0 +1,6 @@
+pub    fn hello(  )
+    {
+println!("Hello World!");
+
+            }
+

--- a/tests/source/issue-3253/lib.rs
+++ b/tests/source/issue-3253/lib.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate cfg_if;
+
+cfg_if! {
+    if #[cfg(target_family = "unix")] {
+        mod foo;
+        #[path = "paths/bar_foo.rs"]
+        mod bar_foo;
+    } else {
+        mod bar;
+        #[path = "paths/foo_bar.rs"]
+        mod foo_bar;
+    }
+}

--- a/tests/source/issue-3253/paths/bar_foo.rs
+++ b/tests/source/issue-3253/paths/bar_foo.rs
@@ -1,0 +1,3 @@
+fn    foo_decl_item(x: &mut i32) {
+    x = 3;
+}

--- a/tests/source/issue-3253/paths/excluded.rs
+++ b/tests/source/issue-3253/paths/excluded.rs
@@ -1,0 +1,6 @@
+// This module is not imported in the cfg_if macro in lib.rs so it is ignored
+// while the foo and bar mods are formatted.
+// Check the corresponding file in tests/target/issue-3253/paths/excluded.rs
+trait CoolerTypes { fn dummy(&self) {
+}
+}

--- a/tests/source/issue-3253/paths/foo_bar.rs
+++ b/tests/source/issue-3253/paths/foo_bar.rs
@@ -1,0 +1,4 @@
+
+
+fn Foo<T>() where T: Bar {
+}

--- a/tests/target/issue-3253/bar.rs
+++ b/tests/target/issue-3253/bar.rs
@@ -1,0 +1,2 @@
+// Empty
+fn empty() {}

--- a/tests/target/issue-3253/foo.rs
+++ b/tests/target/issue-3253/foo.rs
@@ -1,0 +1,3 @@
+pub fn hello() {
+    println!("Hello World!");
+}

--- a/tests/target/issue-3253/lib.rs
+++ b/tests/target/issue-3253/lib.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate cfg_if;
+
+cfg_if! {
+    if #[cfg(target_family = "unix")] {
+        mod foo;
+        #[path = "paths/bar_foo.rs"]
+        mod bar_foo;
+    } else {
+        mod bar;
+        #[path = "paths/foo_bar.rs"]
+        mod foo_bar;
+    }
+}

--- a/tests/target/issue-3253/paths/bar_foo.rs
+++ b/tests/target/issue-3253/paths/bar_foo.rs
@@ -1,0 +1,3 @@
+fn foo_decl_item(x: &mut i32) {
+    x = 3;
+}

--- a/tests/target/issue-3253/paths/excluded.rs
+++ b/tests/target/issue-3253/paths/excluded.rs
@@ -1,0 +1,17 @@
+// This module is not imported in the cfg_if macro in lib.rs so it is ignored
+// while the foo and bar mods are formatted.
+// Check the corresponding file in tests/source/issue-3253/paths/excluded.rs
+
+
+
+
+    fn Foo<T>() where T: Bar {
+}
+
+
+
+trait CoolerTypes { fn dummy(&self) {
+}
+}
+
+

--- a/tests/target/issue-3253/paths/foo_bar.rs
+++ b/tests/target/issue-3253/paths/foo_bar.rs
@@ -1,0 +1,5 @@
+fn Foo<T>()
+where
+    T: Bar,
+{
+}


### PR DESCRIPTION
Refs #3253 

As this fix will allow mods defined within `cfg_if` macro to be formatted, I suspect that #3253 could probably be closed, unless the ask in that issue is to cover _any_ macro.