### PR TITLE
Use versionsort for everything that's auto-reordered by name

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/imports.rs
+++ b/rustfmt-core/rustfmt-lib/src/imports.rs
@@ -726,7 +726,8 @@ impl Ord for UseTree {
             }
         }
 
-        self.path.len().cmp(&other.path.len())
+        Ord::cmp(&self.path.len(), &other.path.len())
+            .then(Ord::cmp(&self.path.last(), &other.path.last()))
     }
 }
 

--- a/rustfmt-core/rustfmt-lib/src/imports.rs
+++ b/rustfmt-core/rustfmt-lib/src/imports.rs
@@ -707,12 +707,11 @@ impl Ord for UseSegment {
 impl Ord for UseTree {
     fn cmp(&self, other: &UseTree) -> Ordering {
         for (a, b) in self.path.iter().zip(other.path.iter()) {
-            let ord = a.cmp(b);
             // The comparison without aliases is a hack to avoid situations like
             // comparing `a::b` to `a as c` - where the latter should be ordered
             // first since it is shorter.
-            if ord != Ordering::Equal && a.remove_alias().cmp(&b.remove_alias()) != Ordering::Equal
-            {
+            let ord = a.remove_alias().cmp(&b.remove_alias());
+            if ord != Ordering::Equal {
                 return ord;
             }
         }

--- a/rustfmt-core/rustfmt-lib/src/imports.rs
+++ b/rustfmt-core/rustfmt-lib/src/imports.rs
@@ -11,6 +11,7 @@ use crate::config::{Edition, IndentStyle};
 use crate::lists::{
     definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator,
 };
+use crate::reorder::{compare_as_versions, compare_opt_ident_as_versions};
 use crate::rewrite::{Rewrite, RewriteContext};
 use crate::shape::Shape;
 use crate::source_map::SpanUtils;
@@ -677,18 +678,8 @@ impl Ord for UseSegment {
                 if !is_upper_snake_case(ia) && is_upper_snake_case(ib) {
                     return Ordering::Less;
                 }
-                let ident_ord = ia.cmp(ib);
-                if ident_ord != Ordering::Equal {
-                    return ident_ord;
-                }
-                match (aa, ab) {
-                    (None, Some(_)) => Ordering::Less,
-                    (Some(_), None) => Ordering::Greater,
-                    (Some(aas), Some(abs)) => aas
-                        .trim_start_matches("r#")
-                        .cmp(abs.trim_start_matches("r#")),
-                    (None, None) => Ordering::Equal,
-                }
+
+                compare_as_versions(&ia, &ib).then_with(|| compare_opt_ident_as_versions(&aa, &ab))
             }
             (&List(ref a), &List(ref b)) => {
                 for (a, b) in a.iter().zip(b.iter()) {

--- a/rustfmt-core/rustfmt-lib/src/imports.rs
+++ b/rustfmt-core/rustfmt-lib/src/imports.rs
@@ -655,12 +655,7 @@ impl Ord for UseSegment {
         match (self, other) {
             (&Slf(ref a), &Slf(ref b))
             | (&Super(ref a), &Super(ref b))
-            | (&Crate(ref a), &Crate(ref b)) => match (a, b) {
-                (Some(sa), Some(sb)) => {
-                    sa.trim_start_matches("r#").cmp(sb.trim_start_matches("r#"))
-                }
-                (_, _) => a.cmp(b),
-            },
+            | (&Crate(ref a), &Crate(ref b)) => compare_opt_ident_as_versions(&a, &b),
             (&Glob, &Glob) => Ordering::Equal,
             (&Ident(ref pia, ref aa), &Ident(ref pib, ref ab)) => {
                 let ia = pia.trim_start_matches("r#");

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -23,6 +23,7 @@ use crate::expr::{
 use crate::lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
 use crate::macros::{rewrite_macro, MacroPosition};
 use crate::overflow;
+use crate::reorder::compare_as_versions;
 use crate::rewrite::{Rewrite, RewriteContext};
 use crate::shape::{Indent, Shape};
 use crate::source_map::{LineRangeUtils, SpanUtils};
@@ -701,10 +702,10 @@ impl<'a> FmtVisitor<'a> {
                 (TyAlias(_, _, _, ref lty), TyAlias(_, _, _, ref rty))
                     if both_type(lty, rty) || both_opaque(lty, rty) =>
                 {
-                    a.ident.as_str().cmp(&b.ident.as_str())
+                    compare_as_versions(&a.ident.as_str(), &b.ident.as_str())
                 }
                 (Const(..), Const(..)) | (MacCall(..), MacCall(..)) => {
-                    a.ident.as_str().cmp(&b.ident.as_str())
+                    compare_as_versions(&a.ident.as_str(), &b.ident.as_str())
                 }
                 (Fn(..), Fn(..)) => a.span.lo().cmp(&b.span.lo()),
                 (TyAlias(_, _, _, ref ty), _) if is_type(ty) => Ordering::Less,

--- a/rustfmt-core/rustfmt-lib/src/reorder.rs
+++ b/rustfmt-core/rustfmt-lib/src/reorder.rs
@@ -403,4 +403,13 @@ mod tests {
             strings = tail;
         }
     }
+    #[test]
+    fn test_compare_opt_ident_as_versions() {
+        use super::compare_opt_ident_as_versions;
+        use std::cmp::Ordering;
+        let items: &[Option<&'static str>] = &[None, Some("a"), Some("r#a"), Some("a")];
+        for (p, n) in items[..items.len() - 1].iter().zip(items[1..].iter()) {
+            assert!(compare_opt_ident_as_versions(p, n) != Ordering::Greater);
+        }
+    }
 }

--- a/rustfmt-core/rustfmt-lib/src/reorder.rs
+++ b/rustfmt-core/rustfmt-lib/src/reorder.rs
@@ -117,6 +117,26 @@ pub(crate) fn compare_as_versions(left: &str, right: &str) -> Ordering {
     }
 }
 
+/// Compare identifiers, trimming `r#` if present, according to version sort
+pub(crate) fn compare_ident_as_versions(left: &str, right: &str) -> Ordering {
+    compare_as_versions(
+        left.trim_start_matches("r#"),
+        right.trim_start_matches("r#"),
+    )
+}
+
+pub(crate) fn compare_opt_ident_as_versions<S>(left: &Option<S>, right: &Option<S>) -> Ordering
+where
+    S: AsRef<str>,
+{
+    match (left, right) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(left), Some(right)) => compare_ident_as_versions(left.as_ref(), right.as_ref()),
+    }
+}
+
 /// Choose the ordering between the given two items.
 fn compare_items(a: &ast::Item, b: &ast::Item) -> Ordering {
     match (&a.kind, &b.kind) {

--- a/rustfmt-core/rustfmt-lib/src/reorder.rs
+++ b/rustfmt-core/rustfmt-lib/src/reorder.rs
@@ -141,14 +141,14 @@ where
 fn compare_items(a: &ast::Item, b: &ast::Item) -> Ordering {
     match (&a.kind, &b.kind) {
         (&ast::ItemKind::Mod(..), &ast::ItemKind::Mod(..)) => {
-            a.ident.as_str().cmp(&b.ident.as_str())
+            compare_as_versions(&a.ident.as_str(), &b.ident.as_str())
         }
         (&ast::ItemKind::ExternCrate(ref a_name), &ast::ItemKind::ExternCrate(ref b_name)) => {
             // `extern crate foo as bar;`
             //               ^^^ Comparing this.
             let a_orig_name = a_name.map_or_else(|| a.ident.as_str(), rustc_span::Symbol::as_str);
             let b_orig_name = b_name.map_or_else(|| b.ident.as_str(), rustc_span::Symbol::as_str);
-            let result = a_orig_name.cmp(&b_orig_name);
+            let result = compare_as_versions(&a_orig_name, &b_orig_name);
             if result != Ordering::Equal {
                 return result;
             }
@@ -159,7 +159,7 @@ fn compare_items(a: &ast::Item, b: &ast::Item) -> Ordering {
                 (Some(..), None) => Ordering::Greater,
                 (None, Some(..)) => Ordering::Less,
                 (None, None) => Ordering::Equal,
-                (Some(..), Some(..)) => a.ident.as_str().cmp(&b.ident.as_str()),
+                (Some(..), Some(..)) => compare_as_versions(&a.ident.as_str(), &b.ident.as_str()),
             }
         }
         _ => unreachable!(),

--- a/rustfmt-core/rustfmt-lib/tests/source/imports-reorder-lines.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/imports-reorder-lines.rs
@@ -30,3 +30,14 @@ mod test {}
 
 use test::{a as aa, c};
 use test::{self as bb, b};
+
+#[path = "empty_file.rs"]
+mod v10;
+#[path = "empty_file.rs"]
+mod v2;
+
+extern crate crate10;
+extern crate crate2;
+
+extern crate my as c10;
+extern crate my as c2;

--- a/rustfmt-core/rustfmt-lib/tests/source/imports-reorder.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/imports-reorder.rs
@@ -7,3 +7,5 @@ use {ab, ac, aa, Z, b};
 // The sort order shall follow versionsort
 use {u8, u128, u64, u16, u32};
 use {v1, v0200, v0030, v0002, v02000, v02001};
+// Order by alias should use versionsort too
+use {crate as crate10, crate as crate2, crate as crate1};

--- a/rustfmt-core/rustfmt-lib/tests/source/imports-reorder.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/imports-reorder.rs
@@ -3,3 +3,7 @@
 use path::{C,/*A*/ A, B /* B */, self /* self */};
 
 use {ab, ac, aa, Z, b};
+
+// The sort order shall follow versionsort
+use {u8, u128, u64, u16, u32};
+use {v1, v0200, v0030, v0002, v02000, v02001};

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-2863.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-2863.rs
@@ -22,4 +22,6 @@ impl<T> IntoIterator for SafeVec<T> {
     type E = impl Trait;
     const AnotherConst: i32 = 100;
     fn foo8() {println!("hello, world");}
+    const AnyConst10: i32 = 100;
+    const AnyConst2: i32 = 100;
 }

--- a/rustfmt-core/rustfmt-lib/tests/target/imports-reorder-lines.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/imports-reorder-lines.rs
@@ -29,3 +29,14 @@ mod test {}
 
 use test::{self as bb, b};
 use test::{a as aa, c};
+
+#[path = "empty_file.rs"]
+mod v2;
+#[path = "empty_file.rs"]
+mod v10;
+
+extern crate crate2;
+extern crate crate10;
+
+extern crate my as c2;
+extern crate my as c10;

--- a/rustfmt-core/rustfmt-lib/tests/target/imports-reorder-lines.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/imports-reorder-lines.rs
@@ -15,14 +15,14 @@ use aaa::*;
 mod test {}
 // If item names are equal, order by rename
 
-use test::{a as bb, b};
 use test::{a as aa, c};
+use test::{a as bb, b};
 
 mod test {}
 // If item names are equal, order by rename - no rename comes before a rename
 
-use test::{a as bb, b};
 use test::{a, c};
+use test::{a as bb, b};
 
 mod test {}
 // `self` always comes first

--- a/rustfmt-core/rustfmt-lib/tests/target/imports-reorder.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/imports-reorder.rs
@@ -3,3 +3,7 @@
 use path::{self /* self */, /* A */ A, B /* B */, C};
 
 use {aa, ab, ac, b, Z};
+
+// The sort order shall follow versionsort
+use {u8, u16, u32, u64, u128};
+use {v0002, v0030, v0200, v02000, v02001, v1};

--- a/rustfmt-core/rustfmt-lib/tests/target/imports-reorder.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/imports-reorder.rs
@@ -7,3 +7,5 @@ use {aa, ab, ac, b, Z};
 // The sort order shall follow versionsort
 use {u8, u16, u32, u64, u128};
 use {v0002, v0030, v0200, v02000, v02001, v1};
+// Order by alias should use versionsort too
+use {crate as crate1, crate as crate2, crate as crate10};

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-2863.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-2863.rs
@@ -13,6 +13,8 @@ impl<T> IntoIterator for SafeVec<T> {
     type F = impl Trait;
 
     const AnotherConst: i32 = 100;
+    const AnyConst2: i32 = 100;
+    const AnyConst10: i32 = 100;
     const SomeConst: i32 = 100;
 
     // comment on foo()


### PR DESCRIPTION
This change has been initially discussed in rust-dev-tools/fmt-rfcs#143 and is motivated by the following example from using `nom`:

```rust
// Formatting before this PR
use nom::number::complete::{le_u128, le_u16, le_u32, le_u64, le_u8};
// Formatting after this PR
use nom::number::complete::{le_u8, le_u16, le_u32, le_u64, le_u128};
```

I've covered imports with `use` (including renames), `mod` and `extern crate` statements (including renames), and item names. Is there anything else I've missed?

Technically this is a **breaking change**; however, in most cases it results in more readable code, so I'd consider it a bugfix. The only case I know that this change makes worse is names including fixed-width hex value which are ordered fine today but may become misordered
```rust
use some_crate::{CONST_10C0, CONST_1040, CONST_1080};
```
because the comparison runs between numerical segments of different length. I've thought about making this change configurable or version-gating it, but could not find out whether the config is available in some TLS, while some changed code is called via `Ord` impls and passing down the config explicitly is going to be a bigger refactoring.

The second commit reverts a change introduced in fa75ef466396a48d5aac03a83ac2c92f89f3bf2e (#2535) that was likely unintentional as the comments in the tests still documented the old behavior.