### PR TITLE
Add --config command line option

### DIFF
--- a/config_proc_macro/src/item_enum.rs
+++ b/config_proc_macro/src/item_enum.rs
@@ -105,13 +105,18 @@ fn impl_from_str(ident: &syn::Ident, variants: &Variants) -> TokenStream {
             }
         }
     });
+    let mut err_msg = String::from("Bad variant, expected one of:");
+    for v in variants.iter().filter(|v| is_unit(v)) {
+        err_msg.push_str(&format!(" `{}`", v.ident));
+    }
+
     quote! {
         impl ::std::str::FromStr for #ident {
             type Err = &'static str;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 #if_patterns
-                return Err("Bad variant");
+                return Err(#err_msg);
             }
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -137,7 +137,7 @@ fn make_opts() -> Options {
         "",
         "config",
         "Set options from command line. These settings take priority over .rustfmt.toml",
-        "[--config 'key1=val1,key2=val2...']",
+        "[key1=val1,key2=val2...]",
     );
 
     if is_nightly {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,6 +4,7 @@ use io::Error as IoError;
 
 use rustfmt_nightly as rustfmt;
 
+use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::{self, stdout, Read, Write};
@@ -131,6 +132,12 @@ fn make_opts() -> Options {
         "files-with-diff",
         "Prints the names of mismatched files that were formatted. Prints the names of \
          files that would be formated when used with `--check` mode. ",
+    );
+    opts.optmulti(
+        "",
+        "config",
+        "Set options from command line. These settings take priority over .rustfmt.toml",
+        "[--config 'key1=val1,key2=val2...']",
     );
 
     if is_nightly {
@@ -478,6 +485,7 @@ struct GetOptsOptions {
     quiet: bool,
     verbose: bool,
     config_path: Option<PathBuf>,
+    inline_config: HashMap<String, String>,
     emit_mode: EmitMode,
     backup: bool,
     check: bool,
@@ -536,6 +544,29 @@ impl GetOptsOptions {
         }
 
         options.config_path = matches.opt_str("config-path").map(PathBuf::from);
+
+        options.inline_config = matches
+            .opt_strs("config")
+            .iter()
+            .flat_map(|config| config.split(","))
+            .map(
+                |key_val| match key_val.char_indices().find(|(_, ch)| *ch == '=') {
+                    Some((middle, _)) => {
+                        let (key, val) = (&key_val[..middle], &key_val[middle + 1..]);
+                        if !Config::is_valid_key_val(key, val) {
+                            Err(format_err!("invalid key=val pair: `{}`", key_val))
+                        } else {
+                            Ok((key.to_string(), val.to_string()))
+                        }
+                    }
+
+                    None => Err(format_err!(
+                        "--config expects comma-separated list of key=val pairs, found `{}`",
+                        key_val
+                    )),
+                },
+            )
+            .collect::<Result<HashMap<_, _>, _>>()?;
 
         options.check = matches.opt_present("check");
         if let Some(ref emit_str) = matches.opt_str("emit") {
@@ -623,6 +654,10 @@ impl CliOptions for GetOptsOptions {
         }
         if self.print_misformatted_file_names {
             config.set().print_misformatted_file_names(true);
+        }
+
+        for (key, val) in self.inline_config {
+            config.override_value(&key, &val);
         }
     }
 

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -179,6 +179,16 @@ macro_rules! create_config {
             }
 
             #[allow(unreachable_pub)]
+            pub fn is_valid_key_val(key: &str, val: &str) -> bool {
+                match key {
+                    $(
+                        stringify!($i) => val.parse::<$ty>().is_ok(),
+                    )+
+                        _ => false,
+                }
+            }
+
+            #[allow(unreachable_pub)]
             pub fn used_options(&self) -> PartialConfig {
                 PartialConfig {
                     $(

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -30,17 +30,16 @@ fn rustfmt(args: &[&str]) -> (String, String) {
 }
 
 macro_rules! assert_that {
-    ($args:expr, $check:ident $check_args:tt) => {
+    ($args:expr, $($check:ident $check_args:tt)&&+) => {
         let (stdout, stderr) = rustfmt($args);
-        if !stdout.$check$check_args && !stderr.$check$check_args {
+        if $(!stdout.$check$check_args && !stderr.$check$check_args)||* {
             panic!(
                 "Output not expected for rustfmt {:?}\n\
-                 expected: {}{}\n\
+                 expected: {}\n\
                  actual stdout:\n{}\n\
                  actual stderr:\n{}",
                 $args,
-                stringify!($check),
-                stringify!($check_args),
+                stringify!($( $check$check_args )&&*),
                 stdout,
                 stderr
             );
@@ -75,4 +74,21 @@ fn print_config() {
         stderr
     );
     remove_file("minimal-config").unwrap();
+}
+
+#[ignore]
+#[test]
+fn inline_config() {
+    // single invocation
+    assert_that!(
+        &[
+            "--print-config",
+            "current",
+            ".",
+            "--config=color=Never,edition=2015"
+        ],
+        contains("color = \"Never\"") && contains("edition = \"2015\"")
+    );
+
+    // multiple invocations
 }

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -85,10 +85,18 @@ fn inline_config() {
             "--print-config",
             "current",
             ".",
-            "--config=color=Never,edition=2015"
+            "--config=color=Never,edition=2018"
         ],
-        contains("color = \"Never\"") && contains("edition = \"2015\"")
+        contains("color = \"Never\"") && contains("edition = \"2018\"")
     );
 
-    // multiple invocations
+    // multiple overriding invocations
+    assert_that!(
+        &["--print-config", "current", ".",
+        "--config", "color=never,edition=2018",
+        "--config", "color=always,format_strings=true"],
+        contains("color = \"Always\"") &&
+        contains("edition = \"2018\"") &&
+        contains("format_strings = true")
+    );
 }


### PR DESCRIPTION
Closes #3549 

Adds `--config` command line option that takes comma-separated list of `key=value` pairs. This option can be passed multiple times, keys that are encountered latter override former ones. 

I also tweaked error message in `config_proc_macro` - this helped me very much when I was trying to figure out why my code wasn't working. If you think it's not welcome - I can roll it back.

Also I wrote a simple test, I'll add more this evening (~5 hours from now)