### PR TITLE
fix TrailingWhitespace when using line breaks in macros arguments

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -188,7 +188,7 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
         format_lines(
             &mut visitor.buffer,
             &path,
-            &visitor.skipped_range,
+            &visitor.skipped_range.borrow(),
             &self.config,
             &self.report,
         );
@@ -203,7 +203,7 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
             self.report.add_macro_format_failure();
         }
         self.report
-            .add_non_formatted_ranges(visitor.skipped_range.clone());
+            .add_non_formatted_ranges(visitor.skipped_range.borrow().clone());
 
         self.handler.handle_formatted_file(
             self.parse_session.source_map(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,7 +16,7 @@ use syntax::parse::new_parser_from_tts;
 use syntax::parse::parser::Parser;
 use syntax::parse::token::{BinOpToken, DelimToken, Token, TokenKind};
 use syntax::print::pprust;
-use syntax::source_map::{BytePos, Span};
+use syntax::source_map::{BytePos, Pos, Span};
 use syntax::symbol::kw;
 use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
 use syntax::ThinVec;
@@ -180,6 +180,11 @@ fn return_macro_parse_failure_fallback(
     if is_like_block_indent_style {
         return trim_left_preserve_layout(context.snippet(span), indent, &context.config);
     }
+
+    context
+        .skipped_range
+        .borrow_mut()
+        .push((span.lo().to_usize(), span.hi().to_usize()));
 
     // Return the snippet unmodified if the macro is not block-like
     Some(context.snippet(span).to_owned())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,7 +16,7 @@ use syntax::parse::new_parser_from_tts;
 use syntax::parse::parser::Parser;
 use syntax::parse::token::{BinOpToken, DelimToken, Token, TokenKind};
 use syntax::print::pprust;
-use syntax::source_map::{BytePos, Pos, Span};
+use syntax::source_map::{BytePos, Span};
 use syntax::symbol::kw;
 use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
 use syntax::ThinVec;
@@ -181,10 +181,10 @@ fn return_macro_parse_failure_fallback(
         return trim_left_preserve_layout(context.snippet(span), indent, &context.config);
     }
 
-    context
-        .skipped_range
-        .borrow_mut()
-        .push((span.lo().to_usize(), span.hi().to_usize()));
+    context.skipped_range.borrow_mut().push((
+        context.source_map.lookup_line(span.lo()).unwrap().line,
+        context.source_map.lookup_line(span.hi()).unwrap().line,
+    ));
 
     // Return the snippet unmodified if the macro is not block-like
     Some(context.snippet(span).to_owned())

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,6 +1,7 @@
 // A generic trait to abstract the rewriting of an element (of the AST).
 
 use std::cell::RefCell;
+use std::rc::Rc;
 
 use syntax::parse::ParseSess;
 use syntax::ptr;
@@ -41,6 +42,7 @@ pub(crate) struct RewriteContext<'a> {
     pub(crate) macro_rewrite_failure: RefCell<bool>,
     pub(crate) report: FormatReport,
     pub(crate) skip_context: SkipContext,
+    pub(crate) skipped_range: Rc<RefCell<Vec<(usize, usize)>>>,
 }
 
 impl<'a> RewriteContext<'a> {

--- a/tests/target/issue-2916.rs
+++ b/tests/target/issue-2916.rs
@@ -1,0 +1,2 @@
+a_macro!(name<Param1, Param2>, 
+);


### PR DESCRIPTION
fix #2916