### PR TITLE
Use Cell instead of RefCell

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -647,7 +647,7 @@ impl<'a> ChainFormatterShared<'a> {
             Cow::from("")
         } else {
             // Use new lines.
-            if *context.force_one_line_chain.borrow() {
+            if context.force_one_line_chain.get() {
                 return None;
             }
             child_shape.to_string_with_newline(context.config)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -528,7 +528,7 @@ pub(crate) fn rewrite_macro_def(
             Some(v) => Some(v),
             // if the rewrite returned None because a macro could not be rewritten, then return the
             // original body
-            None if *context.macro_rewrite_failure.borrow() => {
+            None if context.macro_rewrite_failure.get() => {
                 Some(context.snippet(branch.body).trim().to_string())
             }
             None => None,

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -465,7 +465,7 @@ impl<'a> Context<'a> {
         // Replace the last item with its first line to see if it fits with
         // first arguments.
         let placeholder = if overflow_last {
-            let old_value = *self.context.force_one_line_chain.borrow();
+            let old_value = self.context.force_one_line_chain.get();
             match self.last_item() {
                 Some(OverflowableItem::Expr(expr))
                     if !combine_arg_with_callee && is_method_call(expr) =>

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,6 +1,6 @@
 // A generic trait to abstract the rewriting of an element (of the AST).
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use syntax::parse::ParseSess;
@@ -29,17 +29,17 @@ pub(crate) struct RewriteContext<'a> {
     pub(crate) parse_session: &'a ParseSess,
     pub(crate) source_map: &'a SourceMap,
     pub(crate) config: &'a Config,
-    pub(crate) inside_macro: Rc<RefCell<bool>>,
+    pub(crate) inside_macro: Rc<Cell<bool>>,
     // Force block indent style even if we are using visual indent style.
-    pub(crate) use_block: RefCell<bool>,
+    pub(crate) use_block: Cell<bool>,
     // When `is_if_else_block` is true, unindent the comment on top
     // of the `else` or `else if`.
-    pub(crate) is_if_else_block: RefCell<bool>,
+    pub(crate) is_if_else_block: Cell<bool>,
     // When rewriting chain, veto going multi line except the last element
-    pub(crate) force_one_line_chain: RefCell<bool>,
+    pub(crate) force_one_line_chain: Cell<bool>,
     pub(crate) snippet_provider: &'a SnippetProvider<'a>,
     // Used for `format_snippet`
-    pub(crate) macro_rewrite_failure: RefCell<bool>,
+    pub(crate) macro_rewrite_failure: Cell<bool>,
     pub(crate) report: FormatReport,
     pub(crate) skip_context: SkipContext,
     pub(crate) skipped_range: Rc<RefCell<Vec<(usize, usize)>>>,
@@ -47,7 +47,7 @@ pub(crate) struct RewriteContext<'a> {
 
 pub(crate) struct InsideMacroGuard {
     is_nested_macro_context: bool,
-    inside_macro_ref: Rc<RefCell<bool>>,
+    inside_macro_ref: Rc<Cell<bool>>,
 }
 
 impl InsideMacroGuard {
@@ -69,7 +69,7 @@ impl<'a> RewriteContext<'a> {
 
     /// Returns `true` if we should use block indent style for rewriting function call.
     pub(crate) fn use_block_indent(&self) -> bool {
-        self.config.indent_style() == IndentStyle::Block || *self.use_block.borrow()
+        self.config.indent_style() == IndentStyle::Block || self.use_block.get()
     }
 
     pub(crate) fn budget(&self, used_width: usize) -> usize {
@@ -77,7 +77,7 @@ impl<'a> RewriteContext<'a> {
     }
 
     pub(crate) fn inside_macro(&self) -> bool {
-        *self.inside_macro.borrow()
+        self.inside_macro.get()
     }
 
     pub(crate) fn enter_macro(&self) -> InsideMacroGuard {
@@ -93,6 +93,6 @@ impl<'a> RewriteContext<'a> {
     }
 
     pub(crate) fn is_if_else_block(&self) -> bool {
-        *self.is_if_else_block.borrow()
+        self.is_if_else_block.get()
     }
 }


### PR DESCRIPTION
Their only uses are `*foo.borrow()` and `foo.replace(..)`, which is not taking any advantage of `RefCell` over `Cell`.