### PR TITLE
use offline by default with `cargo fmt` with online fallback

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -519,11 +519,12 @@ fn get_cargo_metadata(
     if let Some(manifest_path) = manifest_path {
         cmd.manifest_path(manifest_path);
     }
+    cmd.other_options(&[String::from("--offline")]);
 
     match cmd.exec() {
         Ok(metadata) => Ok(metadata),
         Err(_) => {
-            cmd.other_options(&[String::from("--offline")]);
+            cmd.other_options(vec![]);
             match cmd.exec() {
                 Ok(metadata) => Ok(metadata),
                 Err(error) => Err(io::Error::new(io::ErrorKind::Other, error.to_string())),


### PR DESCRIPTION
Refs #3811, #3813, and #3831 

There was discussion on #3811 with concerns raised that the solution in #3813 (keep the default `online` just like current/existing behavior, with an `offline` fallback) doesn't fully solve the problem, so opening this for consideration as an alternative (a mutually exclusive alternative to #3831)