### PR TITLE
do not force comments to be indented with a comment trailing a line of code

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -193,19 +193,26 @@ pub(crate) fn is_attributes_extendable(attrs_str: &str) -> bool {
     !attrs_str.contains('\n') && !last_line_contains_single_line_comment(attrs_str)
 }
 
-// The width of the first line in s.
+/// The width of the first line in s.
 #[inline]
 pub(crate) fn first_line_width(s: &str) -> usize {
     unicode_str_width(s.splitn(2, '\n').next().unwrap_or(""))
 }
 
-// The width of the last line in s.
+/// The width of the last line in s.
 #[inline]
 pub(crate) fn last_line_width(s: &str) -> usize {
     unicode_str_width(s.rsplitn(2, '\n').next().unwrap_or(""))
 }
 
-// The total used width of the last line.
+/// The indent width of the last line in s.
+#[inline]
+pub(crate) fn last_line_indent(s: &str) -> usize {
+    let last_line = s.rsplitn(2, '\n').next().unwrap_or("");
+    last_line.chars().take_while(|c| c.is_whitespace()).count()
+}
+
+/// The total used width of the last line.
 #[inline]
 pub(crate) fn last_line_used_width(s: &str, offset: usize) -> usize {
     if s.contains('\n') {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -7,6 +7,7 @@ use syntax::{ast, visit};
 
 use crate::attr::*;
 use crate::comment::{rewrite_comment, CodeCharKind, CommentCodeSlices};
+use crate::config::Version;
 use crate::config::{BraceStyle, Config};
 use crate::coverage::transform_missing_snippet;
 use crate::items::{
@@ -252,32 +253,60 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
 
                     let mut comment_shape =
                         Shape::indented(self.block_indent, config).comment(config);
-                    if comment_on_same_line {
-                        // 1 = a space before `//`
-                        let offset_len = 1 + last_line_width(&self.buffer)
-                            .saturating_sub(self.block_indent.width());
-                        match comment_shape
-                            .visual_indent(offset_len)
-                            .sub_width(offset_len)
-                        {
-                            Some(shp) => comment_shape = shp,
-                            None => comment_on_same_line = false,
-                        }
-                    };
-
-                    if comment_on_same_line {
+                    if self.config.version() == Version::Two && comment_on_same_line {
                         self.push_str(" ");
-                    } else {
-                        if count_newlines(snippet_in_between) >= 2 || extra_newline {
-                            self.push_str("\n");
-                        }
-                        self.push_str(&self.block_indent.to_string_with_newline(config));
-                    }
+                        // put the first line of the comment on the same line as the
+                        // block's last line
+                        match sub_slice.find("\n") {
+                            None => {
+                                self.push_str(&sub_slice);
+                            }
+                            Some(offset) if offset + 1 == sub_slice.len() => {
+                                self.push_str(&sub_slice[..offset]);
+                            }
+                            Some(offset) => {
+                                let first_line = &sub_slice[..offset];
+                                self.push_str(first_line);
+                                self.push_str(&self.block_indent.to_string_with_newline(config));
 
-                    let comment_str = rewrite_comment(&sub_slice, false, comment_shape, config);
-                    match comment_str {
-                        Some(ref s) => self.push_str(s),
-                        None => self.push_str(&sub_slice),
+                                // put the other lines below it, shaping it as needed
+                                let other_lines = &sub_slice[offset + 1..];
+                                let comment_str =
+                                    rewrite_comment(other_lines, false, comment_shape, config);
+                                match comment_str {
+                                    Some(ref s) => self.push_str(s),
+                                    None => self.push_str(other_lines),
+                                }
+                            }
+                        }
+                    } else {
+                        if comment_on_same_line {
+                            // 1 = a space before `//`
+                            let offset_len = 1 + last_line_width(&self.buffer)
+                                .saturating_sub(self.block_indent.width());
+                            match comment_shape
+                                .visual_indent(offset_len)
+                                .sub_width(offset_len)
+                            {
+                                Some(shp) => comment_shape = shp,
+                                None => comment_on_same_line = false,
+                            }
+                        };
+
+                        if comment_on_same_line {
+                            self.push_str(" ");
+                        } else {
+                            if count_newlines(snippet_in_between) >= 2 || extra_newline {
+                                self.push_str("\n");
+                            }
+                            self.push_str(&self.block_indent.to_string_with_newline(config));
+                        }
+
+                        let comment_str = rewrite_comment(&sub_slice, false, comment_shape, config);
+                        match comment_str {
+                            Some(ref s) => self.push_str(s),
+                            None => self.push_str(&sub_slice),
+                        }
                     }
                 }
                 CodeCharKind::Normal if skip_normal(&sub_slice) => {

--- a/tests/source/trailing_comments.rs
+++ b/tests/source/trailing_comments.rs
@@ -1,0 +1,21 @@
+// rustfmt-version: Two
+// rustfmt-wrap_comments: true
+
+pub const IFF_MULTICAST: ::c_int = 0x0000000800; // Supports multicast
+// Multicast using broadcst. add.
+
+pub const SQ_CRETAB: u16 = 0x000e; // CREATE TABLE
+pub const SQ_DRPTAB: u16 = 0x000f; // DROP TABLE
+pub const SQ_CREIDX: u16 = 0x0010; // CREATE INDEX
+//const SQ_DRPIDX: u16 = 0x0011;	// DROP INDEX
+//const SQ_GRANT: u16 = 0x0012;	// GRANT
+//const SQ_REVOKE: u16 = 0x0013;	// REVOKE
+
+fn foo() {
+    let f = bar(); // Donec consequat mi. Quisque vitae dolor. Integer lobortis. Maecenas id nulla. Lorem.
+    // Id turpis. Nam posuere lectus vitae nibh. Etiam tortor orci, sagittis malesuada, rhoncus quis, hendrerit eget, libero. Quisque commodo nulla at nunc. Mauris consequat, enim vitae venenatis sollicitudin, dolor orci bibendum enim, a sagittis nulla nunc quis elit. Phasellus augue. Nunc suscipit, magna tincidunt lacinia faucibus, lacus tellus ornare purus, a pulvinar lacus orci eget nibh.  Maecenas sed nibh non lacus tempor faucibus. In hac habitasse platea dictumst. Vivamus a orci at nulla tristique condimentum. Donec arcu quam, dictum accumsan, convallis accumsan, cursus sit amet, ipsum.  In pharetra sagittis nunc.
+    let b = baz();
+
+    let normalized = self.ctfont.all_traits().normalized_weight(); // [-1.0, 1.0]
+    // TODO(emilio): It may make sense to make this range [.01, 10.0], to align with css-fonts-4's range of [1, 1000].
+}

--- a/tests/target/trailing_comments.rs
+++ b/tests/target/trailing_comments.rs
@@ -1,0 +1,30 @@
+// rustfmt-version: Two
+// rustfmt-wrap_comments: true
+
+pub const IFF_MULTICAST: ::c_int = 0x0000000800; // Supports multicast
+// Multicast using broadcst. add.
+
+pub const SQ_CRETAB: u16 = 0x000e; // CREATE TABLE
+pub const SQ_DRPTAB: u16 = 0x000f; // DROP TABLE
+pub const SQ_CREIDX: u16 = 0x0010; // CREATE INDEX
+//const SQ_DRPIDX: u16 = 0x0011;	// DROP INDEX
+//const SQ_GRANT: u16 = 0x0012;	// GRANT
+//const SQ_REVOKE: u16 = 0x0013;	// REVOKE
+
+fn foo() {
+    let f = bar(); // Donec consequat mi. Quisque vitae dolor. Integer lobortis. Maecenas id nulla. Lorem.
+    // Id turpis. Nam posuere lectus vitae nibh. Etiam tortor orci, sagittis
+    // malesuada, rhoncus quis, hendrerit eget, libero. Quisque commodo nulla at
+    // nunc. Mauris consequat, enim vitae venenatis sollicitudin, dolor orci
+    // bibendum enim, a sagittis nulla nunc quis elit. Phasellus augue. Nunc
+    // suscipit, magna tincidunt lacinia faucibus, lacus tellus ornare purus, a
+    // pulvinar lacus orci eget nibh.  Maecenas sed nibh non lacus tempor faucibus.
+    // In hac habitasse platea dictumst. Vivamus a orci at nulla tristique
+    // condimentum. Donec arcu quam, dictum accumsan, convallis accumsan, cursus sit
+    // amet, ipsum.  In pharetra sagittis nunc.
+    let b = baz();
+
+    let normalized = self.ctfont.all_traits().normalized_weight(); // [-1.0, 1.0]
+    // TODO(emilio): It may make sense to make this range [.01, 10.0], to align
+    // with css-fonts-4's range of [1, 1000].
+}


### PR DESCRIPTION
The proposed change assumes that a trailing comment belongs to the code on the same line. To prevent it being mixed with possible comments below it, that trailing comment is not rewritten together with the rest. For the same reason, it does not attempt to wrap the trailing comment.

Close #3792
Close #3826
Close #2996
Close #3254