### PR TITLE
fix handling of newline_style conflicts

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -243,8 +243,14 @@ impl<'b, T: Write + 'b> FormatHandler for Session<'b, T> {
         report: &mut FormatReport,
     ) -> Result<(), ErrorKind> {
         if let Some(ref mut out) = self.out {
-            match source_file::write_file(Some(source_map), &path, &result, out, &mut *self.emitter)
-            {
+            match source_file::write_file(
+                Some(source_map),
+                &path,
+                &result,
+                out,
+                &mut *self.emitter,
+                self.config.newline_style(),
+            ) {
                 Ok(ref result) if result.has_diff => report.add_diff(),
                 Err(e) => {
                     // Create a new error with path_str to help users see which files failed


### PR DESCRIPTION
Fixes #3849 

There were two underyling issues with the way we were handling newline style differences that only surfaced when the source files have Windows style line feeds and/or when the `newline_style` config was set to `Windows`. 

Details inline below