### PR TITLE
do not indent impl generics

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -802,11 +802,15 @@ fn format_impl_ref_and_type(
         result.push_str(format_defaultness(defaultness));
         result.push_str(format_unsafety(unsafety));
 
-        let shape = generics_shape_from_config(
-            context.config,
-            Shape::indented(offset + last_line_width(&result), context.config),
-            0,
-        )?;
+        let shape = if context.config.version() == Version::Two {
+            Shape::indented(offset + last_line_width(&result), context.config)
+        } else {
+            generics_shape_from_config(
+                context.config,
+                Shape::indented(offset + last_line_width(&result), context.config),
+                0,
+            )?
+        };
         let generics_str = rewrite_generics(context, "impl", generics, shape)?;
         result.push_str(&generics_str);
 
@@ -2609,11 +2613,7 @@ fn rewrite_generics(
     overflow::rewrite_with_angle_brackets(context, ident, params, shape, generics.span)
 }
 
-pub(crate) fn generics_shape_from_config(
-    config: &Config,
-    shape: Shape,
-    offset: usize,
-) -> Option<Shape> {
+fn generics_shape_from_config(config: &Config, shape: Shape, offset: usize) -> Option<Shape> {
     match config.indent_style() {
         IndentStyle::Visual => shape.visual_indent(1 + offset).sub_width(offset + 2),
         IndentStyle::Block => {

--- a/tests/source/issue-3840/version-one_hard-tabs.rs
+++ b/tests/source/issue-3840/version-one_hard-tabs.rs
@@ -1,0 +1,15 @@
+// rustfmt-hard_tabs: true
+
+impl<Target: FromEvent<A> + FromEvent<B>, A: Widget2<Ctx = C>, B: Widget2<Ctx = C>, C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+{
+    type Ctx = C;
+    type Event = Vec<Target>;
+}
+
+mod foo {
+    impl<Target: FromEvent<A> + FromEvent<B>, A: Widget2<Ctx = C>, B: Widget2<Ctx = C>, C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+    {
+        type Ctx = C;
+        type Event = Vec<Target>;
+    }
+}

--- a/tests/source/issue-3840/version-one_soft-tabs.rs
+++ b/tests/source/issue-3840/version-one_soft-tabs.rs
@@ -1,0 +1,13 @@
+impl<Target: FromEvent<A> + FromEvent<B>, A: Widget2<Ctx = C>, B: Widget2<Ctx = C>, C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+{
+    type Ctx = C;
+    type Event = Vec<Target>;
+}
+
+mod foo {
+    impl<Target: FromEvent<A> + FromEvent<B>, A: Widget2<Ctx = C>, B: Widget2<Ctx = C>, C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+    {
+        type Ctx = C;
+        type Event = Vec<Target>;
+    }
+}

--- a/tests/source/issue-3840/version-two_hard-tabs.rs
+++ b/tests/source/issue-3840/version-two_hard-tabs.rs
@@ -1,0 +1,16 @@
+// rustfmt-hard_tabs: true
+// rustfmt-version: Two
+
+impl<Target: FromEvent<A> + FromEvent<B>, A: Widget2<Ctx = C>, B: Widget2<Ctx = C>, C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+{
+    type Ctx = C;
+    type Event = Vec<Target>;
+}
+
+mod foo {
+    impl<Target: FromEvent<A> + FromEvent<B>, A: Widget2<Ctx = C>, B: Widget2<Ctx = C>, C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+    {
+        type Ctx = C;
+        type Event = Vec<Target>;
+    }
+}

--- a/tests/source/issue-3840/version-two_soft-tabs.rs
+++ b/tests/source/issue-3840/version-two_soft-tabs.rs
@@ -1,0 +1,15 @@
+// rustfmt-version: Two
+
+impl<Target: FromEvent<A> + FromEvent<B>, A: Widget2<Ctx = C>, B: Widget2<Ctx = C>, C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+{
+    type Ctx = C;
+    type Event = Vec<Target>;
+}
+
+mod foo {
+    impl<Target: FromEvent<A> + FromEvent<B>, A: Widget2<Ctx = C>, B: Widget2<Ctx = C>, C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+    {
+        type Ctx = C;
+        type Event = Vec<Target>;
+    }
+}

--- a/tests/target/issue-3840/version-one_hard-tabs.rs
+++ b/tests/target/issue-3840/version-one_hard-tabs.rs
@@ -1,0 +1,25 @@
+// rustfmt-hard_tabs: true
+
+impl<
+		Target: FromEvent<A> + FromEvent<B>,
+		A: Widget2<Ctx = C>,
+		B: Widget2<Ctx = C>,
+		C: for<'a> CtxFamily<'a>,
+	> Widget2 for WidgetEventLifter<Target, A, B>
+{
+	type Ctx = C;
+	type Event = Vec<Target>;
+}
+
+mod foo {
+	impl<
+			Target: FromEvent<A> + FromEvent<B>,
+			A: Widget2<Ctx = C>,
+			B: Widget2<Ctx = C>,
+			C: for<'a> CtxFamily<'a>,
+		> Widget2 for WidgetEventLifter<Target, A, B>
+	{
+		type Ctx = C;
+		type Event = Vec<Target>;
+	}
+}

--- a/tests/target/issue-3840/version-one_soft-tabs.rs
+++ b/tests/target/issue-3840/version-one_soft-tabs.rs
@@ -1,0 +1,23 @@
+impl<
+        Target: FromEvent<A> + FromEvent<B>,
+        A: Widget2<Ctx = C>,
+        B: Widget2<Ctx = C>,
+        C: for<'a> CtxFamily<'a>,
+    > Widget2 for WidgetEventLifter<Target, A, B>
+{
+    type Ctx = C;
+    type Event = Vec<Target>;
+}
+
+mod foo {
+    impl<
+            Target: FromEvent<A> + FromEvent<B>,
+            A: Widget2<Ctx = C>,
+            B: Widget2<Ctx = C>,
+            C: for<'a> CtxFamily<'a>,
+        > Widget2 for WidgetEventLifter<Target, A, B>
+    {
+        type Ctx = C;
+        type Event = Vec<Target>;
+    }
+}

--- a/tests/target/issue-3840/version-two_hard-tabs.rs
+++ b/tests/target/issue-3840/version-two_hard-tabs.rs
@@ -1,0 +1,26 @@
+// rustfmt-hard_tabs: true
+// rustfmt-version: Two
+
+impl<
+	Target: FromEvent<A> + FromEvent<B>,
+	A: Widget2<Ctx = C>,
+	B: Widget2<Ctx = C>,
+	C: for<'a> CtxFamily<'a>,
+> Widget2 for WidgetEventLifter<Target, A, B>
+{
+	type Ctx = C;
+	type Event = Vec<Target>;
+}
+
+mod foo {
+	impl<
+		Target: FromEvent<A> + FromEvent<B>,
+		A: Widget2<Ctx = C>,
+		B: Widget2<Ctx = C>,
+		C: for<'a> CtxFamily<'a>,
+	> Widget2 for WidgetEventLifter<Target, A, B>
+	{
+		type Ctx = C;
+		type Event = Vec<Target>;
+	}
+}

--- a/tests/target/issue-3840/version-two_soft-tabs.rs
+++ b/tests/target/issue-3840/version-two_soft-tabs.rs
@@ -1,0 +1,25 @@
+// rustfmt-version: Two
+
+impl<
+    Target: FromEvent<A> + FromEvent<B>,
+    A: Widget2<Ctx = C>,
+    B: Widget2<Ctx = C>,
+    C: for<'a> CtxFamily<'a>,
+> Widget2 for WidgetEventLifter<Target, A, B>
+{
+    type Ctx = C;
+    type Event = Vec<Target>;
+}
+
+mod foo {
+    impl<
+        Target: FromEvent<A> + FromEvent<B>,
+        A: Widget2<Ctx = C>,
+        B: Widget2<Ctx = C>,
+        C: for<'a> CtxFamily<'a>,
+    > Widget2 for WidgetEventLifter<Target, A, B>
+    {
+        type Ctx = C;
+        type Event = Vec<Target>;
+    }
+}


### PR DESCRIPTION
The fix consists in removing the call to `generics_shape_from_config` which was indenting generics unnecessarily regardless of the `hard_tabs` option. The `Visual` indent style was also adding [2 leading whitespaces](https://github.com/rust-lang/rustfmt/pull/3856/files#diff-5db152a52bdaeae9dacd35f43a4a78ddR2618) which seemed odd; below is a diff of the two formatting versions.

```diff
 impl<Target: FromEvent<A> + FromEvent<B>,
-      A: Widget2<Ctx = C>,
-      B: Widget2<Ctx = C>,
-      C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
+     A: Widget2<Ctx = C>,
+     B: Widget2<Ctx = C>,
+     C: for<'a> CtxFamily<'a>> Widget2 for WidgetEventLifter<Target, A, B>
 {
     type Ctx = C;
     type Event = Vec<Target>;
 }
```

Are the 2 leading whitespaces added on purpose ? Is it OK to remove them ?

Close #3840