### PR TITLE
fix handling of nested comments in patterns and ControlFlows

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -112,7 +112,7 @@ impl<'a> CommentStyle<'a> {
     }
 }
 
-fn comment_style(orig: &str, normalize_comments: bool) -> CommentStyle<'_> {
+pub(crate) fn comment_style(orig: &str, normalize_comments: bool) -> CommentStyle<'_> {
     if !normalize_comments {
         if orig.starts_with("/**") && !orig.starts_with("/**/") {
             CommentStyle::DoubleBullet

--- a/tests/source/issue_3853.rs
+++ b/tests/source/issue_3853.rs
@@ -33,3 +33,20 @@ fn issue_3853() {
 if let Some(ref /*mut*/ state) = foo {
 					}
 }
+
+fn double_slash_comment_between_lhs_and_rhs() {
+    if let Some(e) =
+				 // self.foo.bar(e, tx)
+				 packet.transaction.state.committed
+                {
+            // body
+                            println!(
+                                "a2304712836123");
+                                }
+}
+
+fn block_comment_between_lhs_and_rhs() {
+if let Some(ref     /*def*/  mut     /*abc*/       state)=          /*abc*/foo{
+				println!(
+        "asdfasdfasdf");	}
+}

--- a/tests/source/issue_3853.rs
+++ b/tests/source/issue_3853.rs
@@ -1,0 +1,35 @@
+fn by_ref_with_block_before_ident() {
+if let Some(ref     /*def*/      state)=        foo{
+				println!(
+        "asdfasdfasdf");	}
+}
+
+fn mut_block_before_ident() {
+if   let Some(mut     /*def*/    state  ) =foo{
+				println!(
+        "123"   );	}
+}
+
+fn ref_and_mut_blocks_before_ident() {
+if   let Some(ref  /*abc*/
+    mut     /*def*/    state  )    =       foo {
+				println!(
+ "deefefefefefwea"   );	}
+}
+
+fn sub_pattern() {
+    let foo @             /*foo*/
+bar(f) = 42;
+}
+
+fn no_prefix_block_before_ident() {
+if   let Some(
+    /*def*/    state  )    =       foo {
+				println!(
+ "129387123123"   );	}
+}
+
+fn issue_3853() {
+if let Some(ref /*mut*/ state) = foo {
+					}
+}

--- a/tests/target/issue_3853.rs
+++ b/tests/target/issue_3853.rs
@@ -29,3 +29,19 @@ fn no_prefix_block_before_ident() {
 fn issue_3853() {
     if let Some(ref /*mut*/ state) = foo {}
 }
+
+fn double_slash_comment_between_lhs_and_rhs() {
+    if let Some(e) =
+        // self.foo.bar(e, tx)
+        packet.transaction.state.committed
+    {
+        // body
+        println!("a2304712836123");
+    }
+}
+
+fn block_comment_between_lhs_and_rhs() {
+    if let Some(ref /*def*/ mut /*abc*/ state) = /*abc*/ foo {
+        println!("asdfasdfasdf");
+    }
+}

--- a/tests/target/issue_3853.rs
+++ b/tests/target/issue_3853.rs
@@ -1,0 +1,31 @@
+fn by_ref_with_block_before_ident() {
+    if let Some(ref /*def*/ state) = foo {
+        println!("asdfasdfasdf");
+    }
+}
+
+fn mut_block_before_ident() {
+    if let Some(mut /*def*/ state) = foo {
+        println!("123");
+    }
+}
+
+fn ref_and_mut_blocks_before_ident() {
+    if let Some(ref /*abc*/ mut /*def*/ state) = foo {
+        println!("deefefefefefwea");
+    }
+}
+
+fn sub_pattern() {
+    let foo @ /*foo*/ bar(f) = 42;
+}
+
+fn no_prefix_block_before_ident() {
+    if let Some(/*def*/ state) = foo {
+        println!("129387123123");
+    }
+}
+
+fn issue_3853() {
+    if let Some(ref /*mut*/ state) = foo {}
+}


### PR DESCRIPTION
Fixes #3853 

The previous behavior was dropping all these nested comments which had the cascading effect of the expression blocks being left unformatted as well. This updates the relevant logic to combine strings with `combine_strs_with_missing_comments` instead of `format!`