### PR TITLE
Return an error if `--check` or `--emit json` are used with stdin.

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -77,6 +77,10 @@ pub enum OperationError {
     /// supported.
     #[fail(display = "The `--check` option is not supported with standard input.")]
     CheckWithStdin,
+    /// Attempt to use --emit=json with stdin, which isn't currently
+    /// supported.
+    #[fail(display = "Emitting json is not supported with standard input.")]
+    EmitJsonWithStdin,
 }
 
 impl From<IoError> for OperationError {
@@ -470,6 +474,11 @@ fn determine_operation(matches: &Matches) -> Result<Operation, OperationError> {
         }
         if matches.opt_present("check") {
             return Err(OperationError::CheckWithStdin);
+        }
+        if let Some(mode) = matches.opt_str("emit") {
+            if mode == "json" {
+                return Err(OperationError::EmitJsonWithStdin);
+            }
         }
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer)?;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -73,6 +73,10 @@ pub enum OperationError {
     /// An io error during reading or writing.
     #[fail(display = "io error: {}", _0)]
     IoError(IoError),
+    /// Attempt to use --check with stdin, which isn't currently
+    /// supported.
+    #[fail(display = "The `--check` option is not supported with standard input.")]
+    CheckWithStdin,
 }
 
 impl From<IoError> for OperationError {
@@ -463,6 +467,9 @@ fn determine_operation(matches: &Matches) -> Result<Operation, OperationError> {
     if files.is_empty() {
         if minimal_config_path.is_some() {
             return Err(OperationError::MinimalPathWithStdin);
+        }
+        if matches.opt_present("check") {
+            return Err(OperationError::CheckWithStdin);
         }
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer)?;


### PR DESCRIPTION
The intention is to implement these cases, but return an error is better than silently ignoring them in the meantime.
See #3871 .