### PR TITLE
Add syntux module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ ignore = "0.4.6"
 annotate-snippets = { version = "0.6", features = ["ansi_term"] }
 structopt = "0.3"
 rustfmt-config_proc_macro = { version = "0.2", path = "config_proc_macro" }
+lazy_static = "1.0.0"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
@@ -74,5 +75,3 @@ version = "610.0.0"
 package = "rustc-ap-syntax_pos"
 version = "610.0.0"
 
-[dev-dependencies]
-lazy_static = "1.0.0"

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -43,7 +43,7 @@ pub(crate) fn rewrite_closure(
 
     if let ast::ExprKind::Block(ref block, _) = body.kind {
         // The body of the closure is an empty block.
-        if block.stmts.is_empty() && !block_contains_comment(block, context.source_map) {
+        if block.stmts.is_empty() && !block_contains_comment(context, block) {
             return body
                 .rewrite(context, shape)
                 .map(|s| format!("{} {}", prefix, s));
@@ -112,7 +112,7 @@ fn needs_block(block: &ast::Block, prefix: &str, context: &RewriteContext<'_>) -
     is_unsafe_block(block)
         || block.stmts.len() > 1
         || has_attributes
-        || block_contains_comment(block, context.source_map)
+        || block_contains_comment(context, block)
         || prefix.contains('\n')
 }
 
@@ -304,7 +304,7 @@ pub(crate) fn rewrite_last_closure(
             ast::ExprKind::Block(ref block, _)
                 if !is_unsafe_block(block)
                     && !context.inside_macro()
-                    && is_simple_block(block, Some(&body.attrs), context.source_map) =>
+                    && is_simple_block(context, block, Some(&body.attrs)) =>
             {
                 stmt_expr(&block.stmts[0]).unwrap_or(body)
             }

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1556,10 +1556,10 @@ pub(crate) fn recover_comment_removed(
         // We missed some comments. Warn and keep the original text.
         if context.config.error_on_unformatted() {
             context.report.append(
-                context.source_map.span_to_filename(span).into(),
+                context.parse_sess.span_to_filename(span),
                 vec![FormattingError::from_span(
                     span,
-                    &context.source_map,
+                    &context.parse_sess,
                     ErrorKind::LostComment,
                 )],
             );

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3,7 +3,7 @@ use std::cmp::min;
 
 use itertools::Itertools;
 use syntax::parse::token::{DelimToken, LitKind};
-use syntax::source_map::{BytePos, SourceMap, Span};
+use syntax::source_map::{BytePos, Span};
 use syntax::{ast, ptr};
 
 use crate::chains::rewrite_chain;
@@ -430,7 +430,7 @@ fn rewrite_empty_block(
         return None;
     }
 
-    if !block_contains_comment(block, context.source_map) && shape.width >= 2 {
+    if !block_contains_comment(context, block) && shape.width >= 2 {
         return Some(format!("{}{}{{}}", prefix, label_str));
     }
 
@@ -487,7 +487,7 @@ fn rewrite_single_line_block(
     label: Option<ast::Label>,
     shape: Shape,
 ) -> Option<String> {
-    if is_simple_block(block, attrs, context.source_map) {
+    if is_simple_block(context, block, attrs) {
         let expr_shape = shape.offset_left(last_line_width(prefix))?;
         let expr_str = block.stmts[0].rewrite(context, expr_shape)?;
         let label_str = rewrite_label(label);
@@ -750,8 +750,8 @@ impl<'a> ControlFlow<'a> {
         let fixed_cost = self.keyword.len() + "  {  } else {  }".len();
 
         if let ast::ExprKind::Block(ref else_node, _) = else_block.kind {
-            if !is_simple_block(self.block, None, context.source_map)
-                || !is_simple_block(else_node, None, context.source_map)
+            if !is_simple_block(context, self.block, None)
+                || !is_simple_block(context, else_node, None)
                 || pat_expr_str.contains('\n')
             {
                 return None;
@@ -1105,9 +1105,8 @@ fn extract_comment(span: Span, context: &RewriteContext<'_>, shape: Shape) -> Op
     }
 }
 
-pub(crate) fn block_contains_comment(block: &ast::Block, source_map: &SourceMap) -> bool {
-    let snippet = source_map.span_to_snippet(block.span).unwrap();
-    contains_comment(&snippet)
+pub(crate) fn block_contains_comment(context: &RewriteContext<'_>, block: &ast::Block) -> bool {
+    contains_comment(context.snippet(block.span))
 }
 
 // Checks that a block contains no statements, an expression and no comments or
@@ -1115,37 +1114,37 @@ pub(crate) fn block_contains_comment(block: &ast::Block, source_map: &SourceMap)
 // FIXME: incorrectly returns false when comment is contained completely within
 // the expression.
 pub(crate) fn is_simple_block(
+    context: &RewriteContext<'_>,
     block: &ast::Block,
     attrs: Option<&[ast::Attribute]>,
-    source_map: &SourceMap,
 ) -> bool {
     (block.stmts.len() == 1
         && stmt_is_expr(&block.stmts[0])
-        && !block_contains_comment(block, source_map)
+        && !block_contains_comment(context, block)
         && attrs.map_or(true, |a| a.is_empty()))
 }
 
 /// Checks whether a block contains at most one statement or expression, and no
 /// comments or attributes.
 pub(crate) fn is_simple_block_stmt(
+    context: &RewriteContext<'_>,
     block: &ast::Block,
     attrs: Option<&[ast::Attribute]>,
-    source_map: &SourceMap,
 ) -> bool {
     block.stmts.len() <= 1
-        && !block_contains_comment(block, source_map)
+        && !block_contains_comment(context, block)
         && attrs.map_or(true, |a| a.is_empty())
 }
 
 /// Checks whether a block contains no statements, expressions, comments, or
 /// inner attributes.
 pub(crate) fn is_empty_block(
+    context: &RewriteContext<'_>,
     block: &ast::Block,
     attrs: Option<&[ast::Attribute]>,
-    source_map: &SourceMap,
 ) -> bool {
     block.stmts.is_empty()
-        && !block_contains_comment(block, source_map)
+        && !block_contains_comment(context, block)
         && attrs.map_or(true, |a| inner_attributes(a).is_empty())
 }
 

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -68,14 +68,13 @@ fn format_project<T: FormatHandler>(
     }
 
     // Parse the crate.
-    let is_stdin = !input.is_text();
     let mut report = FormatReport::new();
     let directory_ownership = input.to_directory_ownership();
 
     let krate = match Parser::parse_crate(config, input, directory_ownership, &parse_session) {
         Ok(krate) => krate,
         Err(e) => {
-            let forbid_verbose = is_stdin || e != ParserError::ParsePanicError;
+            let forbid_verbose = input_is_stdin || e != ParserError::ParsePanicError;
             should_emit_verbose(forbid_verbose, config, || {
                 eprintln!("The Rust parser panicked");
             });

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -142,7 +142,7 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
         is_root: bool,
     ) -> Result<(), ErrorKind> {
         let snippet_provider = self.parse_session.snippet_provider(module.inner);
-        let mut visitor = FmtVisitor::from_source_map(
+        let mut visitor = FmtVisitor::from_parse_sess(
             &self.parse_session,
             &self.config,
             &snippet_provider,

--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -2,6 +2,8 @@ use ignore::{self, gitignore};
 
 use crate::config::{FileName, IgnoreList};
 
+unsafe impl Send for IgnorePathSet {}
+
 pub(crate) struct IgnorePathSet {
     ignore_set: gitignore::Gitignore,
 }

--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -2,8 +2,6 @@ use ignore::{self, gitignore};
 
 use crate::config::{FileName, IgnoreList};
 
-unsafe impl Send for IgnorePathSet {}
-
 pub(crate) struct IgnorePathSet {
     ignore_set: gitignore::Gitignore,
 }

--- a/src/items.rs
+++ b/src/items.rs
@@ -360,17 +360,17 @@ impl<'a> FmtVisitor<'a> {
             return None;
         }
 
-        let source_map = self.get_context().source_map;
+        let context = self.get_context();
 
         if self.config.empty_item_single_line()
-            && is_empty_block(block, None, source_map)
+            && is_empty_block(&context, block, None)
             && self.block_indent.width() + fn_str.len() + 3 <= self.config.max_width()
             && !last_line_contains_single_line_comment(fn_str)
         {
             return Some(format!("{} {{}}", fn_str));
         }
 
-        if !self.config.fn_single_line() || !is_simple_block_stmt(block, None, source_map) {
+        if !self.config.fn_single_line() || !is_simple_block_stmt(&context, block, None) {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,14 @@ use std::rc::Rc;
 
 use failure::Fail;
 use ignore;
-use syntax::{ast, parse::DirectoryOwnership};
+use syntax::ast;
 
 use crate::comment::LineClasses;
 use crate::emitter::Emitter;
 use crate::formatting::{FormatErrorMap, FormattingError, ReportedErrors, SourceFile};
 use crate::issues::Issue;
 use crate::shape::Indent;
+use crate::syntux::parser::DirectoryOwnership;
 use crate::utils::indent_next_line;
 
 pub use crate::config::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,13 +509,6 @@ pub enum Input {
 }
 
 impl Input {
-    fn is_text(&self) -> bool {
-        match *self {
-            Input::File(_) => false,
-            Input::Text(_) => true,
-        }
-    }
-
     fn file_name(&self) -> FileName {
         match *self {
             Input::File(ref file) => FileName::Real(file.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub(crate) mod source_map;
 mod spanned;
 mod stmt;
 mod string;
+mod syntux;
 #[cfg(test)]
 mod test;
 mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 #[macro_use]
 extern crate derive_new;
-#[cfg(test)]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -560,7 +560,7 @@ pub(crate) struct ListItems<'a, I, F1, F2, F3>
 where
     I: Iterator,
 {
-    snippet_provider: &'a SnippetProvider<'a>,
+    snippet_provider: &'a SnippetProvider,
     inner: Peekable<I>,
     get_lo: F1,
     get_hi: F2,
@@ -777,7 +777,7 @@ where
 #[allow(clippy::too_many_arguments)]
 // Creates an iterator over a list's items with associated comments.
 pub(crate) fn itemize_list<'a, T, I, F1, F2, F3>(
-    snippet_provider: &'a SnippetProvider<'_>,
+    snippet_provider: &'a SnippetProvider,
     inner: I,
     terminator: &'a str,
     separator: &'a str,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -182,8 +182,8 @@ fn return_macro_parse_failure_fallback(
     }
 
     context.skipped_range.borrow_mut().push((
-        context.source_map.lookup_line(span.lo()).unwrap().line,
-        context.source_map.lookup_line(span.hi()).unwrap().line,
+        context.parse_sess.line_of_byte_pos(span.lo()),
+        context.parse_sess.line_of_byte_pos(span.hi()),
     ));
 
     // Return the snippet unmodified if the macro is not block-like
@@ -290,7 +290,7 @@ fn rewrite_macro_inner(
         }
     }
 
-    let mut parser = new_parser_from_tts(context.parse_session.inner(), ts.trees().collect());
+    let mut parser = new_parser_from_tts(context.parse_sess.inner(), ts.trees().collect());
     let mut arg_vec = Vec::new();
     let mut vec_with_semi = false;
     let mut trailing_comma = false;
@@ -1192,7 +1192,7 @@ fn next_space(tok: &TokenKind) -> SpaceState {
 pub(crate) fn convert_try_mac(mac: &ast::Mac, context: &RewriteContext<'_>) -> Option<ast::Expr> {
     if &mac.path.to_string() == "try" {
         let ts: TokenStream = mac.tts.clone();
-        let mut parser = new_parser_from_tts(context.parse_session.inner(), ts.trees().collect());
+        let mut parser = new_parser_from_tts(context.parse_sess.inner(), ts.trees().collect());
 
         Some(ast::Expr {
             id: ast::NodeId::root(), // dummy value
@@ -1424,7 +1424,7 @@ fn format_lazy_static(
     ts: &TokenStream,
 ) -> Option<String> {
     let mut result = String::with_capacity(1024);
-    let mut parser = new_parser_from_tts(context.parse_session.inner(), ts.trees().collect());
+    let mut parser = new_parser_from_tts(context.parse_sess.inner(), ts.trees().collect());
     let nested_shape = shape
         .block_indent(context.config.tab_spaces())
         .with_max_width(context.config);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -290,7 +290,7 @@ fn rewrite_macro_inner(
         }
     }
 
-    let mut parser = new_parser_from_tts(context.parse_session, ts.trees().collect());
+    let mut parser = new_parser_from_tts(context.parse_session.inner(), ts.trees().collect());
     let mut arg_vec = Vec::new();
     let mut vec_with_semi = false;
     let mut trailing_comma = false;
@@ -1192,7 +1192,7 @@ fn next_space(tok: &TokenKind) -> SpaceState {
 pub(crate) fn convert_try_mac(mac: &ast::Mac, context: &RewriteContext<'_>) -> Option<ast::Expr> {
     if &mac.path.to_string() == "try" {
         let ts: TokenStream = mac.tts.clone();
-        let mut parser = new_parser_from_tts(context.parse_session, ts.trees().collect());
+        let mut parser = new_parser_from_tts(context.parse_session.inner(), ts.trees().collect());
 
         Some(ast::Expr {
             id: ast::NodeId::root(), // dummy value
@@ -1424,7 +1424,7 @@ fn format_lazy_static(
     ts: &TokenStream,
 ) -> Option<String> {
     let mut result = String::with_capacity(1024);
-    let mut parser = new_parser_from_tts(context.parse_session, ts.trees().collect());
+    let mut parser = new_parser_from_tts(context.parse_session.inner(), ts.trees().collect());
     let nested_shape = shape
         .block_indent(context.config.tab_spaces())
         .with_max_width(context.config);

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -276,7 +276,7 @@ fn block_can_be_flattened<'a>(
         ast::ExprKind::Block(ref block, _)
             if !is_unsafe_block(block)
                 && !context.inside_macro()
-                && is_simple_block(block, Some(&expr.attrs), context.source_map) =>
+                && is_simple_block(context, block, Some(&expr.attrs)) =>
         {
             Some(&*block)
         }
@@ -332,10 +332,7 @@ fn rewrite_match_body(
         shape.offset_left(extra_offset(pats_str, shape) + 4),
     );
     let (is_block, is_empty_block) = if let ast::ExprKind::Block(ref block, _) = body.kind {
-        (
-            true,
-            is_empty_block(block, Some(&body.attrs), context.source_map),
-        )
+        (true, is_empty_block(context, block, Some(&body.attrs)))
     } else {
         (false, false)
     };

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use syntax::ast;
-use syntax::source_map;
 use syntax::symbol::sym;
 use syntax::visit::Visitor;
 use syntax_pos::symbol::Symbol;
@@ -66,12 +65,9 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         mut self,
         krate: &'ast ast::Crate,
     ) -> Result<FileModMap<'ast>, String> {
-        let root_filename = self.parse_sess.source_map().span_to_filename(krate.span);
+        let root_filename = self.parse_sess.span_to_filename(krate.span);
         self.directory.path = match root_filename {
-            source_map::FileName::Real(ref path) => path
-                .parent()
-                .expect("Parent directory should exists")
-                .to_path_buf(),
+            FileName::Real(ref p) => p.parent().unwrap_or(Path::new("")).to_path_buf(),
             _ => PathBuf::new(),
         };
 
@@ -81,7 +77,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         }
 
         self.file_map
-            .insert(root_filename.into(), Cow::Borrowed(&krate.module));
+            .insert(root_filename, Cow::Borrowed(&krate.module));
         Ok(self.file_map)
     }
 

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -3,18 +3,16 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use syntax::ast;
-use syntax::attr;
-use syntax::parse::{
-    new_sub_parser_from_file, parser, token::TokenKind, DirectoryOwnership, PResult, ParseSess,
-};
-use syntax::source_map::{self, Span};
+use syntax::source_map;
 use syntax::symbol::sym;
 use syntax::visit::Visitor;
-use syntax_pos::{self, symbol::Symbol, DUMMY_SP};
+use syntax_pos::{self, symbol::Symbol};
 
 use crate::attr::MetaVisitor;
 use crate::config::FileName;
 use crate::items::is_mod_decl;
+use crate::syntux::parser::{Directory, DirectoryOwnership, ModulePathSuccess, Parser};
+use crate::syntux::session::ParseSess;
 use crate::utils::contains_skip;
 
 mod visitor;
@@ -27,21 +25,6 @@ pub(crate) struct ModResolver<'ast, 'sess> {
     directory: Directory,
     file_map: FileModMap<'ast>,
     recursive: bool,
-}
-
-#[derive(Clone)]
-struct Directory {
-    path: PathBuf,
-    ownership: DirectoryOwnership,
-}
-
-impl<'a> Directory {
-    fn to_syntax_directory(&'a self) -> syntax::parse::Directory<'a> {
-        syntax::parse::Directory {
-            path: Cow::Borrowed(&self.path),
-            ownership: self.ownership.clone(),
-        }
-    }
 }
 
 #[derive(Clone)]
@@ -100,8 +83,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
 
     /// Visit `cfg_if` macro and look for module declarations.
     fn visit_cfg_if(&mut self, item: Cow<'ast, ast::Item>) -> Result<(), String> {
-        let mut visitor =
-            visitor::CfgIfVisitor::new(self.parse_sess, self.directory.to_syntax_directory());
+        let mut visitor = visitor::CfgIfVisitor::new(self.parse_sess, &self.directory);
         visitor.visit_item(&item);
         for module_item in visitor.mods() {
             if let ast::ItemKind::Mod(ref sub_mod) = module_item.item.kind {
@@ -259,7 +241,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         attrs: &[ast::Attribute],
         sub_mod: &Cow<'ast, ast::Mod>,
     ) -> Result<SubModKind<'c, 'ast>, String> {
-        if let Some(path) = parser::Parser::submod_path_from_attr(attrs, &self.directory.path) {
+        if let Some(path) = Parser::submod_path_from_attr(attrs, &self.directory.path) {
             return Ok(SubModKind::External(
                 path,
                 DirectoryOwnership::Owned { relative: None },
@@ -267,23 +249,18 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         }
 
         // Look for nested path, like `#[cfg_attr(feature = "foo", path = "bar.rs")]`.
-        let mut mods_outside_ast = self
-            .find_mods_ouside_of_ast(attrs, sub_mod)
-            .unwrap_or(vec![]);
+        let mut mods_outside_ast = self.find_mods_outside_of_ast(attrs, sub_mod);
 
         let relative = match self.directory.ownership {
             DirectoryOwnership::Owned { relative } => relative,
             DirectoryOwnership::UnownedViaBlock | DirectoryOwnership::UnownedViaMod(_) => None,
         };
-        match parser::Parser::default_submod_path(
-            mod_name,
-            relative,
-            &self.directory.path,
-            self.parse_sess.source_map(),
-        )
-        .result
+        match self
+            .parse_sess
+            .default_submod_path(mod_name, relative, &self.directory.path)
+            .result
         {
-            Ok(parser::ModulePathSuccess {
+            Ok(ModulePathSuccess {
                 path,
                 directory_ownership,
                 ..
@@ -324,21 +301,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         }
     }
 
-    fn find_mods_ouside_of_ast(
-        &self,
-        attrs: &[ast::Attribute],
-        sub_mod: &Cow<'ast, ast::Mod>,
-    ) -> Option<Vec<(PathBuf, DirectoryOwnership, Cow<'ast, ast::Mod>)>> {
-        use std::panic::{catch_unwind, AssertUnwindSafe};
-        Some(
-            catch_unwind(AssertUnwindSafe(|| {
-                self.find_mods_ouside_of_ast_inner(attrs, sub_mod)
-            }))
-            .ok()?,
-        )
-    }
-
-    fn find_mods_ouside_of_ast_inner(
+    fn find_mods_outside_of_ast(
         &self,
         attrs: &[ast::Attribute],
         sub_mod: &Cow<'ast, ast::Mod>,
@@ -350,6 +313,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                 path_visitor.visit_meta_item(&meta)
             }
         }
+
         let mut result = vec![];
         for path in path_visitor.paths() {
             let mut actual_path = self.directory.path.clone();
@@ -357,14 +321,9 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
             if !actual_path.exists() {
                 continue;
             }
-            let file_name = syntax_pos::FileName::Real(actual_path.clone());
-            if self
-                .parse_sess
-                .source_map()
-                .get_source_file(&file_name)
-                .is_some()
-            {
-                // If the specfied file is already parsed, then we just use that.
+
+            if self.parse_sess.is_file_parsed(&actual_path) {
+                // If the specified file is already parsed, then we just use that.
                 result.push((
                     actual_path,
                     DirectoryOwnership::Owned { relative: None },
@@ -372,32 +331,16 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                 ));
                 continue;
             }
-            let mut parser = new_sub_parser_from_file(
+
+            let m = match Parser::parse_file_as_module(
+                self.directory.ownership,
                 self.parse_sess,
                 &actual_path,
-                self.directory.ownership,
-                None,
-                DUMMY_SP,
-            );
-            parser.cfg_mods = false;
-            let lo = parser.token.span;
-            // FIXME(topecongiro) Format inner attributes (#3606).
-            let _mod_attrs = match parse_inner_attributes(&mut parser) {
-                Ok(attrs) => attrs,
-                Err(mut e) => {
-                    e.cancel();
-                    parser.sess.span_diagnostic.reset_err_count();
-                    continue;
-                }
+            ) {
+                Some(m) => m,
+                None => continue,
             };
-            let m = match parse_mod_items(&mut parser, lo) {
-                Ok(m) => m,
-                Err(mut e) => {
-                    e.cancel();
-                    parser.sess.span_diagnostic.reset_err_count();
-                    continue;
-                }
-            };
+
             result.push((
                 actual_path,
                 DirectoryOwnership::Owned { relative: None },
@@ -421,58 +364,6 @@ fn path_value(attr: &ast::Attribute) -> Option<Symbol> {
 // as unused attributes.
 fn find_path_value(attrs: &[ast::Attribute]) -> Option<Symbol> {
     attrs.iter().flat_map(path_value).next()
-}
-
-// FIXME(topecongiro) Use the method from libsyntax[1] once it become public.
-//
-// [1] https://github.com/rust-lang/rust/blob/master/src/libsyntax/parse/attr.rs
-fn parse_inner_attributes<'a>(parser: &mut parser::Parser<'a>) -> PResult<'a, Vec<ast::Attribute>> {
-    let mut attrs: Vec<ast::Attribute> = vec![];
-    loop {
-        match parser.token.kind {
-            TokenKind::Pound => {
-                // Don't even try to parse if it's not an inner attribute.
-                if !parser.look_ahead(1, |t| t == &TokenKind::Not) {
-                    break;
-                }
-
-                let attr = parser.parse_attribute(true)?;
-                assert_eq!(attr.style, ast::AttrStyle::Inner);
-                attrs.push(attr);
-            }
-            TokenKind::DocComment(s) => {
-                // we need to get the position of this token before we bump.
-                let attr = attr::mk_sugared_doc_attr(s, parser.token.span);
-                if attr.style == ast::AttrStyle::Inner {
-                    attrs.push(attr);
-                    parser.bump();
-                } else {
-                    break;
-                }
-            }
-            _ => break,
-        }
-    }
-    Ok(attrs)
-}
-
-fn parse_mod_items<'a>(parser: &mut parser::Parser<'a>, inner_lo: Span) -> PResult<'a, ast::Mod> {
-    let mut items = vec![];
-    while let Some(item) = parser.parse_item()? {
-        items.push(item);
-    }
-
-    let hi = if parser.token.span.is_dummy() {
-        inner_lo
-    } else {
-        parser.prev_span
-    };
-
-    Ok(ast::Mod {
-        inner: inner_lo.to(hi),
-        items,
-        inline: false,
-    })
 }
 
 fn is_cfg_if(item: &ast::Item) -> bool {

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -6,7 +6,7 @@ use syntax::ast;
 use syntax::source_map;
 use syntax::symbol::sym;
 use syntax::visit::Visitor;
-use syntax_pos::{self, symbol::Symbol};
+use syntax_pos::symbol::Symbol;
 
 use crate::attr::MetaVisitor;
 use crate::config::FileName;
@@ -18,6 +18,10 @@ use crate::utils::contains_skip;
 mod visitor;
 
 type FileModMap<'ast> = BTreeMap<FileName, Cow<'ast, ast::Mod>>;
+
+lazy_static! {
+    static ref CFG_IF: Symbol = Symbol::intern("cfg_if");
+}
 
 /// Maps each module to the corresponding file.
 pub(crate) struct ModResolver<'ast, 'sess> {
@@ -370,7 +374,7 @@ fn is_cfg_if(item: &ast::Item) -> bool {
     match item.kind {
         ast::ItemKind::Mac(ref mac) => {
             if let Some(first_segment) = mac.path.segments.first() {
-                if first_segment.ident.name == Symbol::intern("cfg_if") {
+                if first_segment.ident.name == *CFG_IF {
                     return true;
                 }
             }

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -208,13 +208,13 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         item_kind: ReorderableItemKind,
         in_group: bool,
     ) -> usize {
-        let mut last = self.source_map.lookup_line_range(items[0].span());
+        let mut last = self.parse_sess.lookup_line_range(items[0].span());
         let item_length = items
             .iter()
             .take_while(|ppi| {
                 item_kind.is_same_item_kind(&***ppi)
                     && (!in_group || {
-                        let current = self.source_map.lookup_line_range(ppi.span());
+                        let current = self.parse_sess.lookup_line_range(ppi.span());
                         let in_same_group = current.lo < last.hi + 2;
                         last = current;
                         in_same_group

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -3,13 +3,13 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use syntax::parse::ParseSess;
 use syntax::ptr;
 use syntax::source_map::{SourceMap, Span};
 
 use crate::config::{Config, IndentStyle};
 use crate::shape::Shape;
 use crate::skip::SkipContext;
+use crate::syntux::session::ParseSess;
 use crate::visitor::SnippetProvider;
 use crate::FormatReport;
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -4,7 +4,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use syntax::ptr;
-use syntax::source_map::{SourceMap, Span};
+use syntax::source_map::Span;
 
 use crate::config::{Config, IndentStyle};
 use crate::shape::Shape;
@@ -26,8 +26,7 @@ impl<T: Rewrite> Rewrite for ptr::P<T> {
 
 #[derive(Clone)]
 pub(crate) struct RewriteContext<'a> {
-    pub(crate) parse_session: &'a ParseSess,
-    pub(crate) source_map: &'a SourceMap,
+    pub(crate) parse_sess: &'a ParseSess,
     pub(crate) config: &'a Config,
     pub(crate) inside_macro: Rc<Cell<bool>>,
     // Force block indent style even if we are using visual indent style.
@@ -37,7 +36,7 @@ pub(crate) struct RewriteContext<'a> {
     pub(crate) is_if_else_block: Cell<bool>,
     // When rewriting chain, veto going multi line except the last element
     pub(crate) force_one_line_chain: Cell<bool>,
-    pub(crate) snippet_provider: &'a SnippetProvider<'a>,
+    pub(crate) snippet_provider: &'a SnippetProvider,
     // Used for `format_snippet`
     pub(crate) macro_rewrite_failure: Cell<bool>,
     pub(crate) report: FormatReport,

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -2,10 +2,9 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
 
-use syntax::source_map::SourceMap;
-
 use crate::config::FileName;
 use crate::emitter::{self, Emitter};
+use crate::syntux::session::ParseSess;
 use crate::NewlineStyle;
 
 #[cfg(test)]
@@ -14,6 +13,7 @@ use crate::config::Config;
 use crate::create_emitter;
 #[cfg(test)]
 use crate::formatting::FileRecord;
+use std::rc::Rc;
 
 // Append a newline to the end of each file.
 pub(crate) fn append_newline(s: &mut String) {
@@ -48,7 +48,7 @@ where
 }
 
 pub(crate) fn write_file<T>(
-    source_map: Option<&SourceMap>,
+    parse_sess: Option<&ParseSess>,
     filename: &FileName,
     formatted_text: &str,
     out: &mut T,
@@ -84,20 +84,17 @@ where
     // source map instead of hitting the file system. This also supports getting
     // original text for `FileName::Stdin`.
     let original_text = if newline_style != NewlineStyle::Auto && *filename != FileName::Stdin {
-        fs::read_to_string(ensure_real_path(filename))?
+        Rc::new(fs::read_to_string(ensure_real_path(filename))?)
     } else {
-        match source_map
-            .and_then(|x| x.get_source_file(&filename.into()))
-            .and_then(|x| x.src.as_ref().map(ToString::to_string))
-        {
+        match parse_sess.and_then(|sess| sess.get_original_snippet(filename)) {
             Some(ori) => ori,
-            None => fs::read_to_string(ensure_real_path(filename))?,
+            None => Rc::new(fs::read_to_string(ensure_real_path(filename))?),
         }
     };
 
     let formatted_file = emitter::FormattedFile {
         filename,
-        original_text: &original_text,
+        original_text: original_text.as_str(),
         formatted_text,
     };
 

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -1,11 +1,10 @@
 //! This module contains utilities that work with the `SourceMap` from `libsyntax`/`syntex_syntax`.
 //! This includes extension traits and methods for looking up spans and line ranges for AST nodes.
 
-use syntax::source_map::{BytePos, SourceMap, Span};
+use syntax::source_map::{BytePos, Span};
 
 use crate::comment::FindUncommented;
 use crate::config::file_lines::LineRange;
-use crate::utils::starts_with_newline;
 use crate::visitor::SnippetProvider;
 
 pub(crate) trait SpanUtils {
@@ -26,7 +25,7 @@ pub(crate) trait LineRangeUtils {
     fn lookup_line_range(&self, span: Span) -> LineRange;
 }
 
-impl<'a> SpanUtils for SnippetProvider<'a> {
+impl SpanUtils for SnippetProvider {
     fn span_after(&self, original: Span, needle: &str) -> BytePos {
         self.opt_span_after(original, needle).unwrap_or_else(|| {
             panic!(
@@ -79,29 +78,5 @@ impl<'a> SpanUtils for SnippetProvider<'a> {
         let offset = snippet.find_uncommented(needle)?;
 
         Some(original.lo() + BytePos(offset as u32))
-    }
-}
-
-impl LineRangeUtils for SourceMap {
-    fn lookup_line_range(&self, span: Span) -> LineRange {
-        let snippet = self.span_to_snippet(span).unwrap_or_default();
-        let lo = self.lookup_line(span.lo()).unwrap();
-        let hi = self.lookup_line(span.hi()).unwrap();
-
-        debug_assert_eq!(
-            lo.sf.name, hi.sf.name,
-            "span crossed file boundary: lo: {:?}, hi: {:?}",
-            lo, hi
-        );
-
-        // in case the span starts with a newline, the line range is off by 1 without the
-        // adjustment below
-        let offset = 1 + if starts_with_newline(&snippet) { 1 } else { 0 };
-        // Line numbers start at 1
-        LineRange {
-            file: lo.sf.clone(),
-            lo: lo.line + offset,
-            hi: hi.line + offset,
-        }
     }
 }

--- a/src/syntux.rs
+++ b/src/syntux.rs
@@ -1,0 +1,3 @@
+//! This module defines a thin abstract layer on top of the rustc's parser and syntax libraries.
+
+pub(crate) mod session;

--- a/src/syntux.rs
+++ b/src/syntux.rs
@@ -1,3 +1,4 @@
 //! This module defines a thin abstract layer on top of the rustc's parser and syntax libraries.
 
+pub(crate) mod parser;
 pub(crate) mod session;

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -79,7 +79,6 @@ impl<'a> ParserBuilder<'a> {
             Ok(p) => p,
             Err(db) => {
                 sess.emit_diagnostics(db);
-                // report.add_parsing_error();
                 return Err(ParserError::ParserCreationError);
             }
         };

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -1,13 +1,35 @@
+use std::borrow::Cow;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
 
 use syntax::ast;
 use syntax::errors::Diagnostic;
 use syntax::parse::parser::Parser as RawParser;
-use syntax::parse::DirectoryOwnership;
-use syntax::source_map::DUMMY_SP;
+use syntax::parse::token::{DelimToken, TokenKind};
+use syntax::parse::{new_sub_parser_from_file, PResult};
+use syntax::source_map::{Span, DUMMY_SP};
+use syntax::symbol::kw;
 
 use crate::syntux::session::ParseSess;
 use crate::{Config, Input};
+
+pub(crate) type DirectoryOwnership = syntax::parse::DirectoryOwnership;
+pub(crate) type ModulePathSuccess = syntax::parse::parser::ModulePathSuccess;
+
+#[derive(Clone)]
+pub(crate) struct Directory {
+    pub(crate) path: PathBuf,
+    pub(crate) ownership: DirectoryOwnership,
+}
+
+impl<'a> Directory {
+    pub(crate) fn to_syntax_directory(&'a self) -> syntax::parse::Directory<'a> {
+        syntax::parse::Directory {
+            path: Cow::Borrowed(&self.path),
+            ownership: self.ownership.clone(),
+        }
+    }
+}
 
 /// A parser for Rust source code.
 pub(crate) struct Parser<'a> {
@@ -112,6 +134,98 @@ pub(crate) enum ParserError {
 }
 
 impl<'a> Parser<'a> {
+    pub(crate) fn submod_path_from_attr(attrs: &[ast::Attribute], path: &Path) -> Option<PathBuf> {
+        syntax::parse::parser::Parser::submod_path_from_attr(attrs, path)
+    }
+
+    // FIXME(topecongiro) Use the method from libsyntax[1] once it become public.
+    //
+    // [1] https://github.com/rust-lang/rust/blob/master/src/libsyntax/parse/attr.rs
+    fn parse_inner_attrs(parser: &mut RawParser<'a>) -> PResult<'a, Vec<ast::Attribute>> {
+        let mut attrs: Vec<ast::Attribute> = vec![];
+        loop {
+            match parser.token.kind {
+                TokenKind::Pound => {
+                    // Don't even try to parse if it's not an inner attribute.
+                    if !parser.look_ahead(1, |t| t == &TokenKind::Not) {
+                        break;
+                    }
+
+                    let attr = parser.parse_attribute(true)?;
+                    assert_eq!(attr.style, ast::AttrStyle::Inner);
+                    attrs.push(attr);
+                }
+                TokenKind::DocComment(s) => {
+                    // we need to get the position of this token before we bump.
+                    let attr = syntax::attr::mk_sugared_doc_attr(s, parser.token.span);
+                    if attr.style == ast::AttrStyle::Inner {
+                        attrs.push(attr);
+                        parser.bump();
+                    } else {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+        Ok(attrs)
+    }
+
+    fn parse_mod_items(parser: &mut RawParser<'a>, span: Span) -> PResult<'a, ast::Mod> {
+        let mut items = vec![];
+        while let Some(item) = parser.parse_item()? {
+            items.push(item);
+        }
+
+        let hi = if parser.token.span.is_dummy() {
+            span
+        } else {
+            parser.prev_span
+        };
+
+        Ok(ast::Mod {
+            inner: span.to(hi),
+            items,
+            inline: false,
+        })
+    }
+
+    pub(crate) fn parse_file_as_module(
+        directory_ownership: DirectoryOwnership,
+        sess: &'a ParseSess,
+        path: &Path,
+    ) -> Option<ast::Mod> {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut parser =
+                new_sub_parser_from_file(sess.inner(), &path, directory_ownership, None, DUMMY_SP);
+
+            parser.cfg_mods = false;
+            let lo = parser.token.span;
+            // FIXME(topecongiro) Format inner attributes (#3606).
+            match Parser::parse_inner_attrs(&mut parser) {
+                Ok(_attrs) => (),
+                Err(mut e) => {
+                    e.cancel();
+                    sess.reset_errors();
+                    return None;
+                }
+            }
+
+            match Parser::parse_mod_items(&mut parser, lo) {
+                Ok(m) => Some(m.clone()),
+                Err(mut db) => {
+                    db.cancel();
+                    sess.reset_errors();
+                    None
+                }
+            }
+        }));
+        match result {
+            Ok(Some(m)) => Some(m),
+            _ => None,
+        }
+    }
+
     pub(crate) fn parse_crate(
         config: &'a Config,
         input: Input,
@@ -150,5 +264,85 @@ impl<'a> Parser<'a> {
             }
             Err(_) => Err(ParserError::ParsePanicError),
         }
+    }
+
+    pub(crate) fn parse_cfg_if(
+        sess: &'a ParseSess,
+        mac: &'a ast::Mac,
+        base_dir: &Directory,
+    ) -> Result<Vec<ast::Item>, &'static str> {
+        match catch_unwind(AssertUnwindSafe(|| {
+            Parser::parse_cfg_if_inner(sess, mac, base_dir)
+        })) {
+            Ok(Ok(items)) => Ok(items),
+            Ok(err @ Err(_)) => err,
+            Err(..) => Err("failed to parse cfg_if!"),
+        }
+    }
+
+    fn parse_cfg_if_inner(
+        sess: &'a ParseSess,
+        mac: &'a ast::Mac,
+        base_dir: &Directory,
+    ) -> Result<Vec<ast::Item>, &'static str> {
+        let mut parser = syntax::parse::stream_to_parser_with_base_dir(
+            sess.inner(),
+            mac.tts.clone(),
+            base_dir.to_syntax_directory(),
+        );
+
+        parser.cfg_mods = false;
+        let mut items = vec![];
+        let mut process_if_cfg = true;
+
+        while parser.token.kind != TokenKind::Eof {
+            if process_if_cfg {
+                if !parser.eat_keyword(kw::If) {
+                    return Err("Expected `if`");
+                }
+                parser
+                    .parse_attribute(false)
+                    .map_err(|_| "Failed to parse attributes")?;
+            }
+
+            if !parser.eat(&TokenKind::OpenDelim(DelimToken::Brace)) {
+                return Err("Expected an opening brace");
+            }
+
+            while parser.token != TokenKind::CloseDelim(DelimToken::Brace)
+                && parser.token.kind != TokenKind::Eof
+            {
+                let item = match parser.parse_item() {
+                    Ok(Some(item_ptr)) => item_ptr.into_inner(),
+                    Ok(None) => continue,
+                    Err(mut err) => {
+                        err.cancel();
+                        parser.sess.span_diagnostic.reset_err_count();
+                        return Err(
+                            "Expected item inside cfg_if block, but failed to parse it as an item",
+                        );
+                    }
+                };
+                if let ast::ItemKind::Mod(..) = item.kind {
+                    items.push(item);
+                }
+            }
+
+            if !parser.eat(&TokenKind::CloseDelim(DelimToken::Brace)) {
+                return Err("Expected a closing brace");
+            }
+
+            if parser.eat(&TokenKind::Eof) {
+                break;
+            }
+
+            if !parser.eat_keyword(kw::Else) {
+                return Err("Expected `else`");
+            }
+
+            process_if_cfg = parser.token.is_keyword(kw::If);
+        }
+
+        Ok(items)
     }
 }

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -23,7 +23,7 @@ pub(crate) struct Directory {
 }
 
 impl<'a> Directory {
-    pub(crate) fn to_syntax_directory(&'a self) -> syntax::parse::Directory<'a> {
+    fn to_syntax_directory(&'a self) -> syntax::parse::Directory<'a> {
         syntax::parse::Directory {
             path: Cow::Borrowed(&self.path),
             ownership: self.ownership.clone(),

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -1,0 +1,39 @@
+use syntax::parse::parser::Parser as RawParser;
+
+use crate::Input;
+
+/// A parser for Rust source code.
+pub struct Parser<'a> {
+    parser: RawParser<'a>,
+}
+
+/// A builder for the `Parser`.
+pub struct ParserBuilder {
+    silent: bool,
+    input: Input,
+}
+
+impl ParserBuilder {
+    pub fn input(&mut self, input: Input) -> &mut ParserBuilder {
+        self.input = input;
+        self
+    }
+
+    pub fn build(self) -> Result<Parser, ParserError> {
+        match self.input {
+            Input::File(ref file) => {
+                parse::new_parser_from_file(par)
+            }
+        }
+        Ok(Parser)
+    }
+}
+
+enum ParserError {
+    ParserCreationError,
+}
+
+impl<'a> Parser<'a> {
+    pub fn from_string(text: String) -> Result<Parser<'a>, ParserError> {
+    }
+}

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -1,39 +1,154 @@
-use syntax::parse::parser::Parser as RawParser;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use crate::Input;
+use syntax::ast;
+use syntax::errors::Diagnostic;
+use syntax::parse::parser::Parser as RawParser;
+use syntax::parse::DirectoryOwnership;
+use syntax::source_map::DUMMY_SP;
+
+use crate::syntux::session::ParseSess;
+use crate::{Config, Input};
 
 /// A parser for Rust source code.
-pub struct Parser<'a> {
+pub(crate) struct Parser<'a> {
     parser: RawParser<'a>,
+    sess: &'a ParseSess,
 }
 
 /// A builder for the `Parser`.
-pub struct ParserBuilder {
-    silent: bool,
-    input: Input,
+#[derive(Default)]
+pub(crate) struct ParserBuilder<'a> {
+    config: Option<&'a Config>,
+    sess: Option<&'a ParseSess>,
+    input: Option<Input>,
+    directory_ownership: Option<DirectoryOwnership>,
 }
 
-impl ParserBuilder {
-    pub fn input(&mut self, input: Input) -> &mut ParserBuilder {
-        self.input = input;
+impl<'a> ParserBuilder<'a> {
+    pub(crate) fn input(mut self, input: Input) -> ParserBuilder<'a> {
+        self.input = Some(input);
         self
     }
 
-    pub fn build(self) -> Result<Parser, ParserError> {
-        match self.input {
-            Input::File(ref file) => {
-                parse::new_parser_from_file(par)
+    pub(crate) fn sess(mut self, sess: &'a ParseSess) -> ParserBuilder<'a> {
+        self.sess = Some(sess);
+        self
+    }
+
+    pub(crate) fn config(mut self, config: &'a Config) -> ParserBuilder<'a> {
+        self.config = Some(config);
+        self
+    }
+
+    pub(crate) fn directory_ownership(
+        mut self,
+        directory_ownership: Option<DirectoryOwnership>,
+    ) -> ParserBuilder<'a> {
+        self.directory_ownership = directory_ownership;
+        self
+    }
+
+    pub(crate) fn build(self) -> Result<Parser<'a>, ParserError> {
+        let config = self.config.ok_or(ParserError::NoConfig)?;
+        let sess = self.sess.ok_or(ParserError::NoParseSess)?;
+        let input = self.input.ok_or(ParserError::NoInput)?;
+
+        let mut parser = match Self::parser(sess.inner(), input, self.directory_ownership) {
+            Ok(p) => p,
+            Err(db) => {
+                sess.emit_diagnostics(db);
+                // report.add_parsing_error();
+                return Err(ParserError::ParserCreationError);
             }
+        };
+
+        parser.cfg_mods = false;
+
+        if config.skip_children() {
+            parser.recurse_into_file_modules = false;
         }
-        Ok(Parser)
+
+        Ok(Parser { parser, sess })
+    }
+
+    fn parser(
+        sess: &'a syntax::parse::ParseSess,
+        input: Input,
+        directory_ownership: Option<DirectoryOwnership>,
+    ) -> Result<syntax::parse::parser::Parser<'a>, Vec<Diagnostic>> {
+        match input {
+            Input::File(ref file) => Ok(if let Some(directory_ownership) = directory_ownership {
+                syntax::parse::new_sub_parser_from_file(
+                    sess,
+                    file,
+                    directory_ownership,
+                    None,
+                    DUMMY_SP,
+                )
+            } else {
+                syntax::parse::new_parser_from_file(sess, file)
+            }),
+            Input::Text(text) => syntax::parse::maybe_new_parser_from_source_str(
+                sess,
+                syntax::source_map::FileName::Custom("stdin".to_owned()),
+                text,
+            )
+            .map(|mut parser| {
+                parser.recurse_into_file_modules = false;
+                parser
+            }),
+        }
     }
 }
 
-enum ParserError {
+#[derive(Debug, PartialEq)]
+pub(crate) enum ParserError {
+    NoConfig,
+    NoParseSess,
+    NoInput,
     ParserCreationError,
+    ParseError,
+    ParsePanicError,
 }
 
 impl<'a> Parser<'a> {
-    pub fn from_string(text: String) -> Result<Parser<'a>, ParserError> {
+    pub(crate) fn parse_crate(
+        config: &'a Config,
+        input: Input,
+        directory_ownership: Option<DirectoryOwnership>,
+        sess: &'a ParseSess,
+    ) -> Result<ast::Crate, ParserError> {
+        let mut parser = ParserBuilder::default()
+            .config(config)
+            .input(input)
+            .directory_ownership(directory_ownership)
+            .sess(sess)
+            .build()?;
+
+        parser.parse_crate_inner()
+    }
+
+    fn parse_crate_inner(&mut self) -> Result<ast::Crate, ParserError> {
+        let mut parser = AssertUnwindSafe(&mut self.parser);
+
+        match catch_unwind(move || parser.parse_crate_mod()) {
+            Ok(Ok(krate)) => {
+                if !self.sess.has_errors() {
+                    return Ok(krate);
+                }
+
+                if self.sess.can_reset_errors() {
+                    self.sess.reset_errors();
+                    return Ok(krate);
+                }
+
+                Err(ParserError::ParseError)
+            }
+            Ok(Err(mut db)) => {
+                db.emit();
+                Err(ParserError::ParseError)
+            }
+            Err(_) => Err(ParserError::ParsePanicError),
+        }
     }
 }

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -172,7 +172,7 @@ impl ParseSess {
         self.parse_sess.span_diagnostic.reset_err_count();
     }
 
-    pub(crate) fn source_map(&self) -> &SourceMap {
+    fn source_map(&self) -> &SourceMap {
         &self.parse_sess.source_map()
     }
 

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -154,10 +154,6 @@ impl ParseSess {
             .is_some()
     }
 
-    pub(super) fn can_reset_errors(&self) -> bool {
-        *self.can_reset_errors.borrow()
-    }
-
     pub(crate) fn ignore_file(&self, path: &FileName) -> bool {
         self.ignore_path_set.as_ref().is_match(&path)
     }
@@ -196,14 +192,6 @@ impl ParseSess {
         &self.parse_sess
     }
 
-    pub(crate) fn has_errors(&self) -> bool {
-        self.parse_sess.span_diagnostic.has_errors()
-    }
-
-    pub(crate) fn reset_errors(&self) {
-        self.parse_sess.span_diagnostic.reset_err_count();
-    }
-
     pub(crate) fn snippet_provider(&self, span: Span) -> SnippetProvider {
         let source_file = self.parse_sess.source_map().lookup_char_pos(span.lo()).file;
         SnippetProvider::new(
@@ -219,11 +207,26 @@ impl ParseSess {
             .get_source_file(&file_name.into())
             .and_then(|source_file| source_file.src.clone())
     }
+}
 
-    pub(crate) fn emit_diagnostics(&self, diagnostics: Vec<Diagnostic>) {
+// Methods that should be restricted within the syntux module.
+impl ParseSess {
+    pub(super) fn emit_diagnostics(&self, diagnostics: Vec<Diagnostic>) {
         for diagnostic in diagnostics {
             self.parse_sess.span_diagnostic.emit_diagnostic(&diagnostic);
         }
+    }
+
+    pub(super) fn can_reset_errors(&self) -> bool {
+        *self.can_reset_errors.borrow()
+    }
+
+    pub(super) fn has_errors(&self) -> bool {
+        self.parse_sess.span_diagnostic.has_errors()
+    }
+
+    pub(super) fn reset_errors(&self) {
+        self.parse_sess.span_diagnostic.reset_err_count();
     }
 }
 

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
+use std::path::Path;
 use std::rc::Rc;
 
+use syntax::ast;
 use syntax::errors::emitter::{ColorConfig, Emitter, EmitterWriter};
 use syntax::errors::{Diagnostic, Handler};
 use syntax::parse::ParseSess as RawParseSess;
@@ -126,7 +128,27 @@ impl ParseSess {
         })
     }
 
-    pub(crate) fn can_reset_errors(&self) -> bool {
+    pub(crate) fn default_submod_path(
+        &self,
+        id: ast::Ident,
+        relative: Option<ast::Ident>,
+        dir_path: &Path,
+    ) -> syntax::parse::parser::ModulePath {
+        syntax::parse::parser::Parser::default_submod_path(
+            id,
+            relative,
+            dir_path,
+            self.source_map(),
+        )
+    }
+
+    pub(crate) fn is_file_parsed(&self, path: &Path) -> bool {
+        self.source_map()
+            .get_source_file(&syntax_pos::FileName::Real(path.to_path_buf()))
+            .is_some()
+    }
+
+    pub(super) fn can_reset_errors(&self) -> bool {
         *self.can_reset_errors.borrow()
     }
 

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -1,0 +1,165 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use syntax::errors::emitter::{ColorConfig, Emitter, EmitterWriter};
+use syntax::errors::{Diagnostic, Handler};
+use syntax::parse::ParseSess as RawParseSess;
+use syntax::source_map::{FilePathMapping, SourceMap};
+
+use crate::ignore_path::IgnorePathSet;
+use crate::FileName;
+
+/// ParseSess holds structs necessary for constructing a parser.
+pub(crate) struct ParseSess {
+    parse_sess: RawParseSess,
+    ignore_path_set: Rc<IgnorePathSet>,
+    can_reset_errors: Rc<RefCell<bool>>,
+}
+
+/// Emitter which discards every error.
+struct SilentEmitter;
+
+impl Emitter for SilentEmitter {
+    fn emit_diagnostic(&mut self, _db: &Diagnostic) {}
+}
+
+fn silent_emitter() -> Box<SilentEmitter> {
+    Box::new(SilentEmitter {})
+}
+
+/// Emit errors against every files expect ones specified in the `ignore_path_set`.
+struct SilentOnIgnoredFilesEmitter {
+    ignore_path_set: Rc<IgnorePathSet>,
+    source_map: Rc<SourceMap>,
+    emitter: EmitterWriter,
+    has_non_ignorable_parser_errors: bool,
+    can_reset: Rc<RefCell<bool>>,
+}
+
+impl Emitter for SilentOnIgnoredFilesEmitter {
+    fn emit_diagnostic(&mut self, db: &Diagnostic) {
+        if let Some(primary_span) = &db.span.primary_span() {
+            let file_name = self.source_map.span_to_filename(*primary_span);
+            match file_name {
+                syntax_pos::FileName::Real(ref path) => {
+                    if self
+                        .ignore_path_set
+                        .is_match(&FileName::Real(path.to_path_buf()))
+                    {
+                        if !self.has_non_ignorable_parser_errors {
+                            *self.can_reset.borrow_mut() = true;
+                        }
+                        return;
+                    }
+                }
+                _ => (),
+            };
+        }
+
+        self.has_non_ignorable_parser_errors = true;
+        *self.can_reset.borrow_mut() = false;
+        self.emitter.emit_diagnostic(db);
+    }
+}
+
+pub(crate) enum ErrorEmission {
+    /// Do not emit errors from the underlying parser.
+    Silence,
+    /// Emit every parser error except ones from files specified in the `ignore` config option.
+    Default,
+}
+
+fn silent_handler() -> Handler {
+    Handler::with_emitter(true, None, silent_emitter())
+}
+
+fn default_handler(
+    source_map: Rc<SourceMap>,
+    ignore_path_set: Rc<IgnorePathSet>,
+    can_reset: Rc<RefCell<bool>>,
+) -> Handler {
+    let supports_color = term::stderr().map_or(false, |term| term.supports_color());
+    let color_cfg = if supports_color {
+        ColorConfig::Auto
+    } else {
+        ColorConfig::Never
+    };
+
+    let emitter = EmitterWriter::stderr(
+        color_cfg,
+        Some(source_map.clone()),
+        false,
+        false,
+        None,
+        false,
+    );
+    Handler::with_emitter(
+        true,
+        None,
+        Box::new(SilentOnIgnoredFilesEmitter {
+            has_non_ignorable_parser_errors: false,
+            source_map,
+            emitter,
+            ignore_path_set,
+            can_reset,
+        }),
+    )
+}
+
+impl ParseSess {
+    pub(crate) fn new(error_emission: ErrorEmission, ignore_path_set: IgnorePathSet) -> ParseSess {
+        let ignore_path_set = Rc::new(ignore_path_set);
+        let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
+        let can_reset_errors = Rc::new(RefCell::new(false));
+
+        let handler = match error_emission {
+            ErrorEmission::Silence => silent_handler(),
+            ErrorEmission::Default => default_handler(
+                Rc::clone(&source_map),
+                Rc::clone(&ignore_path_set),
+                Rc::clone(&can_reset_errors),
+            ),
+        };
+        let parse_sess = RawParseSess::with_span_handler(handler, Rc::clone(&source_map));
+
+        ParseSess {
+            parse_sess,
+            ignore_path_set,
+            can_reset_errors,
+        }
+    }
+
+    pub(crate) fn can_reset_errors(&self) -> bool {
+        *self.can_reset_errors.borrow()
+    }
+
+    pub(crate) fn ignore_file(&self, path: &FileName) -> bool {
+        self.ignore_path_set.as_ref().is_match(&path)
+    }
+
+    pub(crate) fn set_silent_emitter(&mut self) {
+        self.parse_sess.span_diagnostic = Handler::with_emitter(true, None, silent_emitter());
+    }
+
+    pub(crate) fn inner(&self) -> &RawParseSess {
+        &self.parse_sess
+    }
+
+    pub(crate) fn has_errors(&self) -> bool {
+        self.parse_sess.span_diagnostic.has_errors()
+    }
+
+    pub(crate) fn reset_errors(&self) {
+        self.parse_sess.span_diagnostic.reset_err_count();
+    }
+
+    pub(crate) fn source_map(&self) -> &SourceMap {
+        &self.parse_sess.source_map()
+    }
+
+    pub(crate) fn emit_diagnostics(&self, diagnostics: Vec<Diagnostic>) {
+        for diagnostic in diagnostics {
+            self.parse_sess.span_diagnostic.emit_diagnostic(&diagnostic);
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
 use syntax::ast::{self, FunctionRetTy, Mutability};
-use syntax::source_map::{self, BytePos, Span};
+use syntax::source_map::{BytePos, Span, DUMMY_SP};
 use syntax::symbol::kw;
 
 use crate::config::lists::*;
@@ -277,7 +277,7 @@ fn rewrite_segment(
             ast::GenericArgs::Parenthesized(ref data) => {
                 let output = match data.output {
                     Some(ref ty) => FunctionRetTy::Ty(ty.clone()),
-                    None => FunctionRetTy::Default(source_map::DUMMY_SP),
+                    None => FunctionRetTy::Default(DUMMY_SP),
                 };
                 result.push_str(&format_function_type(
                     data.inputs.iter().map(|x| &**x),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -343,7 +343,7 @@ macro_rules! out_of_file_lines_range {
             && !$self
                 .config
                 .file_lines()
-                .intersects(&$self.source_map.lookup_line_range($span))
+                .intersects(&$self.parse_sess.lookup_line_range($span))
     };
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1,7 +1,6 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use syntax::parse::ParseSess;
 use syntax::source_map::{self, BytePos, Pos, SourceMap, Span};
 use syntax::{ast, visit};
 
@@ -23,6 +22,7 @@ use crate::skip::{is_skip_attr, SkipContext};
 use crate::source_map::{LineRangeUtils, SpanUtils};
 use crate::spanned::Spanned;
 use crate::stmt::Stmt;
+use crate::syntux::session::ParseSess;
 use crate::utils::{
     self, contains_skip, count_newlines, depr_skip_annotation, inner_attributes, last_line_width,
     mk_sp, ptr_vec_to_ref_vec, rewrite_ident, stmt_expr,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use syntax::source_map::{self, BytePos, Pos, SourceMap, Span};
+use syntax::source_map::{BytePos, Pos, Span};
 use syntax::{ast, visit};
 
 use crate::attr::*;
@@ -30,40 +30,53 @@ use crate::utils::{
 use crate::{ErrorKind, FormatReport, FormattingError};
 
 /// Creates a string slice corresponding to the specified span.
-pub(crate) struct SnippetProvider<'a> {
+pub(crate) struct SnippetProvider {
     /// A pointer to the content of the file we are formatting.
-    big_snippet: &'a str,
+    big_snippet: Rc<String>,
     /// A position of the start of `big_snippet`, used as an offset.
     start_pos: usize,
+    /// A end position of the file that this snippet lives.
+    end_pos: usize,
 }
 
-impl<'a> SnippetProvider<'a> {
+impl SnippetProvider {
     pub(crate) fn span_to_snippet(&self, span: Span) -> Option<&str> {
         let start_index = span.lo().to_usize().checked_sub(self.start_pos)?;
         let end_index = span.hi().to_usize().checked_sub(self.start_pos)?;
         Some(&self.big_snippet[start_index..end_index])
     }
 
-    pub(crate) fn new(start_pos: BytePos, big_snippet: &'a str) -> Self {
+    pub(crate) fn new(start_pos: BytePos, end_pos: BytePos, big_snippet: Rc<String>) -> Self {
         let start_pos = start_pos.to_usize();
+        let end_pos = end_pos.to_usize();
         SnippetProvider {
             big_snippet,
             start_pos,
+            end_pos,
         }
+    }
+
+    pub(crate) fn entire_snippet(&self) -> &str {
+        self.big_snippet.as_str()
+    }
+    pub(crate) fn start_pos(&self) -> BytePos {
+        BytePos::from_usize(self.start_pos)
+    }
+    pub(crate) fn end_pos(&self) -> BytePos {
+        BytePos::from_usize(self.end_pos)
     }
 }
 
 pub(crate) struct FmtVisitor<'a> {
     parent_context: Option<&'a RewriteContext<'a>>,
-    pub(crate) parse_session: &'a ParseSess,
-    pub(crate) source_map: &'a SourceMap,
+    pub(crate) parse_sess: &'a ParseSess,
     pub(crate) buffer: String,
     pub(crate) last_pos: BytePos,
     // FIXME: use an RAII util or closure for indenting
     pub(crate) block_indent: Indent,
     pub(crate) config: &'a Config,
     pub(crate) is_if_else_block: bool,
-    pub(crate) snippet_provider: &'a SnippetProvider<'a>,
+    pub(crate) snippet_provider: &'a SnippetProvider,
     pub(crate) line_number: usize,
     /// List of 1-based line ranges which were annotated with skip
     /// Both bounds are inclusifs.
@@ -98,10 +111,8 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
 
     fn visit_stmt(&mut self, stmt: &Stmt<'_>) {
         debug!(
-            "visit_stmt: {:?} {:?} `{}`",
-            self.source_map.lookup_char_pos(stmt.span().lo()),
-            self.source_map.lookup_char_pos(stmt.span().hi()),
-            self.snippet(stmt.span()),
+            "visit_stmt: {}",
+            self.parse_sess.span_to_debug_info(stmt.span())
         );
 
         // https://github.com/rust-lang/rust/issues/63679.
@@ -183,9 +194,8 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         has_braces: bool,
     ) {
         debug!(
-            "visit_block: {:?} {:?}",
-            self.source_map.lookup_char_pos(b.span.lo()),
-            self.source_map.lookup_char_pos(b.span.hi())
+            "visit_block: {}",
+            self.parse_sess.span_to_debug_info(b.span),
         );
 
         // Check if this block has braces.
@@ -681,10 +691,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         // do not take into account the lines with attributes as part of the skipped range
         let attrs_end = attrs
             .iter()
-            .map(|attr| self.source_map.lookup_char_pos(attr.span.hi()).line)
+            .map(|attr| self.parse_sess.line_of_byte_pos(attr.span.hi()))
             .max()
             .unwrap_or(1);
-        let first_line = self.source_map.lookup_char_pos(main_span.lo()).line;
+        let first_line = self.parse_sess.line_of_byte_pos(main_span.lo());
         // Statement can start after some newlines and/or spaces
         // or it can be on the same line as the last attribute.
         // So here we need to take a minimum between the two.
@@ -696,7 +706,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
 
     pub(crate) fn from_context(ctx: &'a RewriteContext<'_>) -> FmtVisitor<'a> {
         let mut visitor = FmtVisitor::from_source_map(
-            ctx.parse_session,
+            ctx.parse_sess,
             ctx.config,
             ctx.snippet_provider,
             ctx.report.clone(),
@@ -709,13 +719,12 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     pub(crate) fn from_source_map(
         parse_session: &'a ParseSess,
         config: &'a Config,
-        snippet_provider: &'a SnippetProvider<'_>,
+        snippet_provider: &'a SnippetProvider,
         report: FormatReport,
     ) -> FmtVisitor<'a> {
         FmtVisitor {
             parent_context: None,
-            parse_session,
-            source_map: parse_session.source_map(),
+            parse_sess: parse_session,
             buffer: String::with_capacity(snippet_provider.big_snippet.len() * 2),
             last_pos: BytePos(0),
             block_indent: Indent::empty(),
@@ -742,22 +751,22 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     pub(crate) fn visit_attrs(&mut self, attrs: &[ast::Attribute], style: ast::AttrStyle) -> bool {
         for attr in attrs {
             if attr.check_name(depr_skip_annotation()) {
-                let file_name = self.source_map.span_to_filename(attr.span).into();
+                let file_name = self.parse_sess.span_to_filename(attr.span);
                 self.report.append(
                     file_name,
                     vec![FormattingError::from_span(
                         attr.span,
-                        &self.source_map,
+                        self.parse_sess,
                         ErrorKind::DeprecatedAttr,
                     )],
                 );
             } else if self.is_unknown_rustfmt_attr(&attr.path.segments) {
-                let file_name = self.source_map.span_to_filename(attr.span).into();
+                let file_name = self.parse_sess.span_to_filename(attr.span);
                 self.report.append(
                     file_name,
                     vec![FormattingError::from_span(
                         attr.span,
-                        &self.source_map,
+                        self.parse_sess,
                         ErrorKind::BadAttr,
                     )],
                 );
@@ -862,14 +871,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         }
     }
 
-    pub(crate) fn format_separate_mod(
-        &mut self,
-        m: &ast::Mod,
-        source_file: &source_map::SourceFile,
-    ) {
+    pub(crate) fn format_separate_mod(&mut self, m: &ast::Mod, end_pos: BytePos) {
         self.block_indent = Indent::empty();
         self.walk_mod_items(m);
-        self.format_missing_with_indent(source_file.end_pos);
+        self.format_missing_with_indent(end_pos);
     }
 
     pub(crate) fn skip_empty_lines(&mut self, end_pos: BytePos) {
@@ -900,8 +905,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
 
     pub(crate) fn get_context(&self) -> RewriteContext<'_> {
         RewriteContext {
-            parse_session: self.parse_session,
-            source_map: self.source_map,
+            parse_sess: self.parse_sess,
             config: self.config,
             inside_macro: Rc::new(Cell::new(false)),
             use_block: Cell::new(false),

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -705,7 +705,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     }
 
     pub(crate) fn from_context(ctx: &'a RewriteContext<'_>) -> FmtVisitor<'a> {
-        let mut visitor = FmtVisitor::from_source_map(
+        let mut visitor = FmtVisitor::from_parse_sess(
             ctx.parse_sess,
             ctx.config,
             ctx.snippet_provider,
@@ -716,7 +716,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         visitor
     }
 
-    pub(crate) fn from_source_map(
+    pub(crate) fn from_parse_sess(
         parse_session: &'a ParseSess,
         config: &'a Config,
         snippet_provider: &'a SnippetProvider,


### PR DESCRIPTION
This PR adds a `syntux` module which aims to provide a thin and safe abstraction layer on top of `libsyntax`. The idea is to make rustfmt resistant to breaking changes in the rustc codebase. The ultimate goal is to factor out the `syntux` module into a separate crate and avoid using `rustc-ap-*` crates directly from rustfmt codebase.