### PR TITLE
fix a few tests

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -917,10 +917,11 @@ mod cargo_fmt_tests {
             let exp_other = PathBuf::from(
                 "tests/nested-test-files/root-and-nested-tests/tests/nested/other.rs",
             );
-            assert_eq!(
-                Some(vec![exp_baz, exp_foo_bar, exp_other]),
-                get_nested_integration_test_files(&target_dir, &target_dir),
-            )
+            let files = get_nested_integration_test_files(&target_dir, &target_dir).unwrap();
+            assert_eq!(3, files.len());
+            assert!(files.contains(&exp_baz));
+            assert!(files.contains(&exp_foo_bar));
+            assert!(files.contains(&exp_other));
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -476,6 +476,9 @@ mod test {
 
     #[test]
     fn test_valid_license_template_path() {
+        if !crate::is_nightly_channel!() {
+            return;
+        }
         let toml = r#"license_template_path = "tests/license-template/lt.txt""#;
         let config = Config::from_toml(toml, Path::new("")).unwrap();
         assert!(config.license_template.is_some());

--- a/tests/config/issue-3779.toml
+++ b/tests/config/issue-3779.toml
@@ -1,4 +1,3 @@
-unstable_features = true
 ignore = [
   "tests/**/issue-3779/ice.rs"
 ]

--- a/tests/source/issue-3779/lib.rs
+++ b/tests/source/issue-3779/lib.rs
@@ -1,3 +1,4 @@
+// rustfmt-unstable: true
 // rustfmt-config: issue-3779.toml
 
 #[path = "ice.rs"]

--- a/tests/target/issue-3779/lib.rs
+++ b/tests/target/issue-3779/lib.rs
@@ -1,3 +1,4 @@
+// rustfmt-unstable: true
 // rustfmt-config: issue-3779.toml
 
 #[path = "ice.rs"]


### PR DESCRIPTION
This PR fixes a few tests added by me in some recent PRs that were missing some things 😞 

Two tests (`config::test::test_valid_license_template_path` and a system tests for handling ignored files that contain parser errors) were missing the unstable/nightly check, so they were failing on the Travis job that runs on beta: https://travis-ci.com/rust-lang/rustfmt/jobs/250084463

The other test fixed here is one of the tests I added in https://github.com/rust-lang/rustfmt/pull/3777 that was a little flaky as originally written. This updates the asserts in the test to eliminate that flakiness.

Below job links show the original version failing due to the ordering of the discovered files in the vec
https://travis-ci.com/rust-lang/rustfmt/jobs/250683618
and https://travis-ci.com/rust-lang/rustfmt/jobs/250390989