### PR TITLE
RUSTFMT_BOOTSTRAP=1 allows the compiler's stage0 toolchain to be used upstream

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -16,8 +16,8 @@ use ansi_term::Colour::Red;
 use getopts::{Matches, Options};
 
 use crate::rustfmt::{
-    load_config, CliOptions, Color, Config, Edition, EmitMode, FileLines, FileName,
-    FormatReportFormatterBuilder, Input, Session, Verbosity,
+    load_config, release_channel::is_nightly, CliOptions, Color, Config, Edition, EmitMode,
+    FileLines, FileName, FormatReportFormatterBuilder, Input, Session, Verbosity,
 };
 
 fn main() {
@@ -187,10 +187,6 @@ fn make_opts() -> Options {
     );
 
     opts
-}
-
-fn is_nightly() -> bool {
-    option_env!("CFG_RELEASE_CHANNEL").map_or(true, |c| c == "nightly" || c == "dev")
 }
 
 // Returned i32 is an exit code

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -155,7 +155,7 @@ macro_rules! create_config {
                         self.$i.1 = true;
                         self.$i.2 = val;
                     } else {
-                        if crate::is_nightly_channel!() {
+                        if crate::release_channel::is_nightly() {
                             self.$i.1 = true;
                             self.$i.2 = val;
                         } else {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -476,7 +476,7 @@ mod test {
 
     #[test]
     fn test_valid_license_template_path() {
-        if !crate::is_nightly_channel!() {
+        if !crate::release_channel::is_nightly() {
             return;
         }
         let toml = r#"license_template_path = "tests/license-template/lt.txt""#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod modules;
 mod overflow;
 mod pairs;
 mod patterns;
-mod release_channel;
+pub mod release_channel;
 mod reorder;
 mod rewrite;
 pub(crate) mod rustfmt_diff;

--- a/src/release_channel.rs
+++ b/src/release_channel.rs
@@ -8,6 +8,10 @@
 /// If we're being built by cargo (e.g., `cargo +nightly install rustfmt-nightly`),
 /// `CFG_RELEASE_CHANNEL` is not set. As we only support being built against the
 /// nightly compiler when installed from crates.io, default to nightly mode.
+///
+/// Additionally, the RUSTFMT_BOOTSTRAP environment variable can be set to `1` to
+/// allow for use of unstable features when used within the compiler's stage0.
 pub fn is_nightly() -> bool {
     option_env!("CFG_RELEASE_CHANNEL").map_or(true, |c| c == "nightly" || c == "dev")
+        || std::env::var("RUSTFMT_BOOTSTRAP") == Ok("1".to_string())
 }

--- a/src/release_channel.rs
+++ b/src/release_channel.rs
@@ -8,9 +8,6 @@
 /// If we're being built by cargo (e.g., `cargo +nightly install rustfmt-nightly`),
 /// `CFG_RELEASE_CHANNEL` is not set. As we only support being built against the
 /// nightly compiler when installed from crates.io, default to nightly mode.
-#[macro_export]
-macro_rules! is_nightly_channel {
-    () => {
-        option_env!("CFG_RELEASE_CHANNEL").map_or(true, |c| c == "nightly" || c == "dev")
-    };
+pub fn is_nightly() -> bool {
+    option_env!("CFG_RELEASE_CHANNEL").map_or(true, |c| c == "nightly" || c == "dev")
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -11,7 +11,7 @@ use std::thread;
 
 use crate::config::{Color, Config, EmitMode, FileName, NewlineStyle, ReportTactic};
 use crate::formatting::{ReportedErrors, SourceFile};
-use crate::is_nightly_channel;
+use crate::release_channel::is_nightly;
 use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, ModifiedChunk, OutputWriter};
 use crate::source_file;
 use crate::{FormatReport, FormatReportFormatterBuilder, Input, Session};
@@ -312,7 +312,7 @@ fn idempotence_tests() {
     init_log();
     run_test_with(&TestSetting::default(), || {
         // these tests require nightly
-        if !is_nightly_channel!() {
+        if !is_nightly() {
             return;
         }
         // Get all files in the tests/target directory.
@@ -336,7 +336,7 @@ fn idempotence_tests() {
 fn self_tests() {
     init_log();
     // Issue-3443: these tests require nightly
-    if !is_nightly_channel!() {
+    if !is_nightly() {
         return;
     }
     let mut files = get_test_files(Path::new("tests"), false);
@@ -491,7 +491,7 @@ fn check_files(files: Vec<PathBuf>, opt_config: &Option<PathBuf>) -> (Vec<Format
 
     for file_name in files {
         let sig_comments = read_significant_comments(&file_name);
-        if sig_comments.contains_key("unstable") && !is_nightly_channel!() {
+        if sig_comments.contains_key("unstable") && !is_nightly() {
             debug!(
                 "Skipping '{}' because it requires unstable \
                  features which are only available on nightly...",


### PR DESCRIPTION
I'm working on [tooling to automate enforcement of rustfmt usage upstream](https://github.com/rust-lang/rust/pull/65939). My current approach requires downloading a nightly rustfmt, while the compiler prefers to use beta toolchain releases for stage0. In [a review comment](https://github.com/rust-lang/rust/pull/65939#discussion_r341424553) @Mark-Simulacrum recommended adding this environment variable similar to the one used by rustc for bootstrapping.

Is this the right approach? Are there other places this should be propagated?