### PR TITLE
Fix --check -l with stdin.

### DIFF
--- a/src/emitter/diff.rs
+++ b/src/emitter/diff.rs
@@ -28,7 +28,7 @@ impl Emitter for DiffEmitter {
 
         if has_diff {
             if self.config.print_misformatted_file_names() {
-                writeln!(output, "{}", ensure_real_path(filename).display())?;
+                writeln!(output, "{}", filename)?;
             } else {
                 print_diff(
                     mismatch,
@@ -40,8 +40,7 @@ impl Emitter for DiffEmitter {
             // This occurs when the only difference between the original and formatted values
             // is the newline style. This happens because The make_diff function compares the
             // original and formatted values line by line, independent of line endings.
-            let file_path = ensure_real_path(filename);
-            writeln!(output, "Incorrect newline style in {}", file_path.display())?;
+            writeln!(output, "Incorrect newline style in {}", filename)?;
             return Ok(EmitterResult { has_diff: true });
         }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -958,3 +958,29 @@ fn verify_check_works_with_stdin() {
         .expect("Failed to wait on rustfmt child");
     assert!(output.status.success());
 }
+
+#[test]
+fn verify_check_l_works_with_stdin() {
+    init_log();
+
+    let mut child = Command::new(rustfmt().to_str().unwrap())
+        .arg("--check")
+        .arg("-l")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run with check option failed");
+
+    {
+        let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+        stdin
+            .write_all("fn main()\n{}\n".as_bytes())
+            .expect("Failed to write to rustfmt --check");
+    }
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait on rustfmt child");
+    assert!(output.status.success());
+    assert_eq!(std::str::from_utf8(&output.stdout).unwrap(), "stdin\n");
+}


### PR DESCRIPTION
This would also fix a panic with stdin on line ending differences, but these aren't detected as the saved source is kept with unix line endings so compares equal to the output.