### PR TITLE
Print entire comment line for report_todo/report_fixme

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -491,6 +491,9 @@ impl<'a> FormatLines<'a> {
 
     // Iterate over the chars in the file map.
     fn iterate(&mut self, text: &mut String) {
+        // List of TODO or FIXME issues on the current line
+        let mut issues_on_line = Vec::new();
+
         for (kind, c) in CharClasses::new(text.chars()) {
             if c == '\r' {
                 continue;
@@ -499,11 +502,17 @@ impl<'a> FormatLines<'a> {
             if self.allow_issue_seek && self.format_line {
                 // Add warnings for bad todos/ fixmes
                 if let Some(issue) = self.issue_seeker.inspect(c) {
-                    self.push_err(ErrorKind::BadIssue(issue), false, false);
+                    issues_on_line.push(issue);
                 }
             }
 
             if c == '\n' {
+                // Accumulate TODO or FIXME issues for the rest of the line so the resulting error
+                // messages contain the entire comment line
+                for issue in issues_on_line.drain(..) {
+                    self.push_err(ErrorKind::BadIssue(issue), false, false);
+                }
+
                 self.new_line(kind);
             } else {
                 self.char(c, kind);


### PR DESCRIPTION
This changeset make it so the entire comment line is printed when `report_todo` or `report_fixme` finds an issue.

It is motivated by the following example. Consider the following source:

```
// TODO implement something!
fn main() {}
```

Currently `rustfmt` will output something similar to:
```
warning: found TODO without issue number
  --> path/to/source/file.rs
   |
 1 | // TODO
   |
```

This change accumulates all the TODO and FIXME issues for each line and outputs the entire comment in the error message:
```
warning: found TODO without issue number
  --> path/to/source/file.rs
   |
 1 | // TODO implement something!
   |
```

Some concerns:
- I'm not sure if `CharClasses` or files always end in a `\n`, or if we need to handle the "todo in a comment at the end of a file with no trailing newline" edge case explicitly.
- I'm not sure how to test this effectively.

Thanks for your time!