### PR TITLE
switch to non-recursive mode by default

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1720,6 +1720,14 @@ fn example() {
 }
 ```
 
+## `recursive` 
+
+Format all encountered modules recursively, including those defined in external files.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: Yes
+
 ## `remove_nested_parens`
 
 Remove nested parens.

--- a/Configurations.md
+++ b/Configurations.md
@@ -1720,14 +1720,6 @@ fn example() {
 }
 ```
 
-## `recursive` 
-
-Format all encountered modules recursively regardless of whether the modules are defined inline or in another file
-
-- **Default value**: `false`
-- **Possible values**: `true`, `false`
-- **Stable**: Yes
-
 ## `remove_nested_parens`
 
 Remove nested parens.
@@ -2453,3 +2445,6 @@ Internal option
 ## `print_misformatted_file_names`
 
 Internal option, use `-l` or `--files-with-diff`
+
+## `recursive`
+Internal option, use `-r` or `--recursive`

--- a/Configurations.md
+++ b/Configurations.md
@@ -1722,7 +1722,7 @@ fn example() {
 
 ## `recursive` 
 
-Format all encountered modules recursively, including those defined in external files.
+Format all encountered modules recursively regardless of whether the modules are defined inline or in another file
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -574,14 +574,11 @@ impl GetOptsOptions {
         }
 
         if matches.opt_present("recursive") {
-            if let Some(skip) = options.skip_children {
-                if skip {
-                    return Err(format_err!(
-                        "Conflicting config options `skip_children` and `recursive` are \
-                        both enabled. `skip_children` has been deprecated and should be \
-                        removed from your config.",
-                    ));
-                }
+            if let Some(true) = options.skip_children {
+                return Err(format_err!(
+                    "Conflicting options `skip_children` and `recursive` were specified. \
+                    `skip_children` has been deprecated and should no longer be used. ",
+                ));
             }
             options.recursive = Some(true);
         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -173,7 +173,8 @@ fn make_opts() -> Options {
     opts.optflag(
         "r",
         "recursive",
-        "Format all encountered modules recursively, including those defined in external files.",
+        "Format all encountered modules recursively regardless of whether the modules\
+         are defined inline or in another file",
     );
     opts.optflag("v", "verbose", "Print verbose output");
     opts.optflag("q", "quiet", "Print less output");

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -248,8 +248,8 @@ macro_rules! create_config {
 
             #[allow(unreachable_pub)]
             pub fn is_hidden_option(name: &str) -> bool {
-                const HIDE_OPTIONS: [&str; 4] =
-                    ["verbose", "verbose_diff", "file_lines", "width_heuristics"];
+                const HIDE_OPTIONS: [&str; 6] =
+                    ["verbose", "verbose_diff", "file_lines", "width_heuristics", "recursive", "print_misformatted_file_names"];
                 HIDE_OPTIONS.contains(&name)
             }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -130,8 +130,6 @@ create_config! {
             "Enables unstable features. Only available on nightly channel";
     disable_all_formatting: bool, false, false, "Don't reformat anything";
     skip_children: bool, false, false, "Don't reformat out of line modules";
-    recursive: bool, false, true,
-        "Format all encountered modules recursively, including those defined in external files.";
     hide_parse_errors: bool, false, false, "Hide errors from the parser";
     error_on_line_overflow: bool, false, false, "Error if unable to get all lines within max_width";
     error_on_unformatted: bool, false, false,
@@ -156,6 +154,8 @@ create_config! {
     print_misformatted_file_names: bool, false, true,
         "Prints the names of mismatched files that were formatted. Prints the names of \
          files that would be formated when used with `--check` mode. ";
+    recursive: bool, false, true,
+        "Format all encountered modules recursively, including those defined in external files.";
 }
 
 impl PartialConfig {
@@ -166,6 +166,7 @@ impl PartialConfig {
         cloned.verbose = None;
         cloned.width_heuristics = None;
         cloned.print_misformatted_file_names = None;
+        cloned.recursive = None;
 
         ::toml::to_string(&cloned).map_err(|e| format!("Could not output config: {}", e))
     }
@@ -573,7 +574,6 @@ required_version = "{}"
 unstable_features = false
 disable_all_formatting = false
 skip_children = false
-recursive = false
 hide_parse_errors = false
 error_on_line_overflow = false
 error_on_unformatted = false

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -84,10 +84,8 @@ impl<'a> ParserBuilder<'a> {
         };
 
         parser.cfg_mods = false;
+        parser.recurse_into_file_modules = config.recursive();
 
-        if config.skip_children() {
-            parser.recurse_into_file_modules = false;
-        }
 
         Ok(Parser { parser, sess })
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -40,6 +40,10 @@ const SKIP_FILE_WHITE_LIST: &[&str] = &[
     "cfg_mod/bar.rs",
     "cfg_mod/foo.rs",
     "cfg_mod/wasm32.rs",
+    // We want to ensure `recursive` is working correctly, so do not test
+    // these files directly
+    "configs/recursive/disabled/foo.rs",
+    "configs/recursive/enabled/foo.rs",
 ];
 
 fn init_log() {

--- a/tests/source/configs/recursive/disabled/foo.rs
+++ b/tests/source/configs/recursive/disabled/foo.rs
@@ -1,0 +1,6 @@
+pub fn foo(  ) {
+
+println!(
+    "bar"
+        );
+}

--- a/tests/source/configs/recursive/disabled/lib.rs
+++ b/tests/source/configs/recursive/disabled/lib.rs
@@ -1,0 +1,10 @@
+// rustfmt-recursive: false
+
+mod foo;
+
+fn bar(
+
+){
+println!(
+        "baz")
+;}

--- a/tests/source/configs/recursive/enabled/foo.rs
+++ b/tests/source/configs/recursive/enabled/foo.rs
@@ -1,0 +1,6 @@
+pub fn foo(  ) {
+
+println!(
+    "bar"
+        );
+}

--- a/tests/source/configs/recursive/enabled/lib.rs
+++ b/tests/source/configs/recursive/enabled/lib.rs
@@ -1,0 +1,10 @@
+// rustfmt-recursive: true
+
+mod foo;
+
+fn bar(
+
+){
+println!(
+        "baz")
+;}

--- a/tests/target/configs/recursive/disabled/foo.rs
+++ b/tests/target/configs/recursive/disabled/foo.rs
@@ -1,0 +1,6 @@
+pub fn foo(  ) {
+
+println!(
+    "bar"
+        );
+}

--- a/tests/target/configs/recursive/disabled/lib.rs
+++ b/tests/target/configs/recursive/disabled/lib.rs
@@ -1,0 +1,7 @@
+// rustfmt-recursive: false
+
+mod foo;
+
+fn bar() {
+    println!("baz");
+}

--- a/tests/target/configs/recursive/enabled/foo.rs
+++ b/tests/target/configs/recursive/enabled/foo.rs
@@ -1,0 +1,3 @@
+pub fn foo() {
+    println!("bar");
+}

--- a/tests/target/configs/recursive/enabled/lib.rs
+++ b/tests/target/configs/recursive/enabled/lib.rs
@@ -1,0 +1,7 @@
+// rustfmt-recursive: true
+
+mod foo;
+
+fn bar() {
+    println!("baz");
+}


### PR DESCRIPTION
Resolves #3587 and refs #3887 

This PR updates the default mode of `rustfmt` to not format submods in external files, with an accompanying new CLI arg (`--recursive`)/config option to enable recursive submod formatting mode (which was the default behavior of rustfmt 1.x).

`cargo fmt` behavior remains unchanged, as `cargo fmt` will automatically pass the `--recursive` flag to `rustfmt`.

I went ahead and marked the new `recursive` config option as stable because it is relatively simple. Also because it would be pretty weird IMO if both `recursive` and `skip_children` were only available on nightly, especially with `skip_children` now deprecated (that would make it impossible to format sub mods on stable).

Lastly, I did a bit of refactoring in cargo fmt to consolidate/simplify the adding of args to `rustfmt` (for example the transformation of `--message-format` to `--emit ..` for rustfmt, `--check`, etc.) which had been discussed on some earlier threads.