### PR TITLE
fix test for issue-3933

### DIFF
--- a/tests/config/issue-3933.toml
+++ b/tests/config/issue-3933.toml
@@ -1,0 +1,6 @@
+ignore = [
+  "tests/**/issue-3933/imp-a.rs",
+  "tests/**/issue-3933/imp-b.rs",
+  "tests/**/issue-3933/utils.rs"
+]
+recursive = true

--- a/tests/source/issue-3933/imp-a.rs
+++ b/tests/source/issue-3933/imp-a.rs
@@ -1,3 +1,4 @@
+// rustfmt-config: issue-3933.toml
   mod utils;
 pub 
   struct A;

--- a/tests/source/issue-3933/imp-b.rs
+++ b/tests/source/issue-3933/imp-b.rs
@@ -1,1 +1,2 @@
+// rustfmt-config: issue-3933.toml
 pub struct B;

--- a/tests/source/issue-3933/lib.rs
+++ b/tests/source/issue-3933/lib.rs
@@ -1,3 +1,4 @@
+// rustfmt-config: issue-3933.toml
 #[cfg_attr(windows, path = "imp-a.rs" )]
   #[cfg_attr(not(windows), path = "imp-b.rs")]
 mod   imp;

--- a/tests/source/issue-3933/utils.rs
+++ b/tests/source/issue-3933/utils.rs
@@ -1,3 +1,4 @@
+// rustfmt-config: issue-3933.toml
   pub fn fuga() {
 
 

--- a/tests/target/issue-3933/imp-a.rs
+++ b/tests/target/issue-3933/imp-a.rs
@@ -1,2 +1,3 @@
+// rustfmt-config: issue-3933.toml
 mod utils;
 pub struct A;

--- a/tests/target/issue-3933/imp-b.rs
+++ b/tests/target/issue-3933/imp-b.rs
@@ -1,1 +1,2 @@
+// rustfmt-config: issue-3933.toml
 pub struct B;

--- a/tests/target/issue-3933/lib.rs
+++ b/tests/target/issue-3933/lib.rs
@@ -1,3 +1,4 @@
+// rustfmt-config: issue-3933.toml
 #[cfg_attr(windows, path = "imp-a.rs")]
 #[cfg_attr(not(windows), path = "imp-b.rs")]
 mod imp;

--- a/tests/target/issue-3933/utils.rs
+++ b/tests/target/issue-3933/utils.rs
@@ -1,1 +1,2 @@
+// rustfmt-config: issue-3933.toml
 pub fn fuga() {}


### PR DESCRIPTION
related: https://github.com/rust-lang/rustfmt/pull/3938

It needs to add a config file for the test. The default behavior is not to recursive now. And should ignore files except for lib.rs.