### PR TITLE
setup windows builds on GitHub Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,64 @@
+name: windows
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          i686-pc-windows-gnu,
+          i686-pc-windows-msvc,
+          x86_64-pc-windows-gnu,
+          x86_64-pc-windows-msvc,
+        ]
+        channel: [ nightly ]
+
+    steps:
+    # The Windows runners have autocrlf enabled by default
+    # which causes failures for some of rustfmt's line-ending sensitive tests
+    - name: disable git eol translation
+      run: git config --global core.autocrlf false
+    - name: checkout
+      uses: actions/checkout@v2
+    # The Windows runners do not (yet) have a proper msys/mingw environment
+    # pre-configured like AppVeyor does, though they will likely be added in the future.
+    # https://github.com/actions/virtual-environments/issues/30
+    #
+    # In the interim, this ensures mingw32 is installed and available on the PATH
+    # for the i686-pc-windows-gnu target. This approach is used because it's common in
+    # other rust projects and there are issues/limitations with the msys2 chocolatey nuget
+    # package and numworks/setup-msys2 action.
+    # https://github.com/rust-lang/rust/blob/master/src/ci/scripts/install-mingw.sh#L59
+    # https://github.com/rust-lang/rustup/blob/master/appveyor.yml
+    - name: install mingw32
+      run: |
+        # Disable the download progress bar which can cause perf issues
+        $ProgressPreference = "SilentlyContinue"
+        Invoke-WebRequest https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z -OutFile mingw.7z
+        7z x -y mingw.7z -oC:\msys64 | Out-Null
+        del mingw.7z
+        echo ::add-path::C:\msys64\mingw32\bin
+      if: matrix.target == 'i686-pc-windows-gnu'
+      shell: powershell
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.channel }}-${{ matrix.target }}
+        target: ${{ matrix.target }}
+        override: true
+        profile: minimal
+        default: true
+    - name: build
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build
+      shell: cmd
+    - name: test
+      run: cargo test
+      shell: cmd
+    - name: 'test ignored'
+      run: cargo test -- --ignored
+      shell: cmd


### PR DESCRIPTION
I've been meaning to try out GitHub Actions (GHA) for a while, and I also feel like the AppVeyor jobs for rustfmt can take a while, get backed up in a queue, etc. so figured I'd try setting up windows jobs for rustfmt on GHA. 

If folks are interested in giving GHA a try, my suggestion would be that we enable GHA alongside the current AppVeyor jobs for a trial period, and if it works well then we can disable the AppVeyor jobs later on. 

The main benefits I see for using GHA:
* **faster builds/parallelization** - AppVeyor only supports running 1 job at a time, resulting in a sequential execution of the channel/target combinations whereas GHA allows for running jobs in parallel. The result is that for rustfmt, AppVeyor takes 20+ minutes to complete whereas GHA will only take ~6-7 minutes (which will likely get faster in the future, details below)
* **inline within GitHub** - just a bit easier/less context switching to have the CI right inline

One challenge I encountered while working on this was for the `nightly-i686-pc-windows-gnu` triple. However, after a chat in Discord earlier with @Kinnison (thanks!) I realized that GHA does not (yet) have all the same pre-installed software that AppVeyor does: notably GHA is missing msys/mingw32. 

GHA is likely to add msys2 to the pre-installed software set on the Windows runners, but in the interim, I added an extra step to work around that for the `i686-pc-windows-gnu` target which adds a 1 minute or so to the total build time (so the builds will presumably be a bit faster once msys2 is pre-isntalled)
