### PR TITLE
Print out error message and file when detecting that rust parser panicked

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -76,7 +76,10 @@ fn format_project<T: FormatHandler>(
         Err(e) => {
             let forbid_verbose = input_is_stdin || e != ParserError::ParsePanicError;
             should_emit_verbose(forbid_verbose, config, || {
-                eprintln!("The Rust parser panicked");
+                eprintln!(
+                    "The Rust parser panicked while parsing input: {:?}: {:?}",
+                    main_file, e
+                );
             });
             report.add_parsing_error();
             return Ok(report);


### PR DESCRIPTION
We're seeing that rustfmt just fails to run with no error message whatsoever without `--verbose` in https://github.com/rust-lang/rust/pull/65939, and once that was passed managed to track it down to rustfmt printing "Rust parser panicked" (see [this log](https://dev.azure.com/rust-lang/e71b0ddf-dd27-435a-873c-e30f86eea377/_apis/build/builds/16212/logs/87) for example). This is my attempt to try and get rustfmt to print some more information in the hope that once this propagates into nightly we can run it by that PR.

If you have thoughts on how to debug the failure I'd love to hear that too!

r? @topecongiro 