### PR TITLE
Use correct span for match arms with the leading pipe and attributes

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -45,6 +45,7 @@ impl<'a> ArmWrapper<'a> {
 impl<'a> Spanned for ArmWrapper<'a> {
     fn span(&self) -> Span {
         if let Some(lo) = self.beginning_vert {
+            let lo = std::cmp::min(lo, self.arm.span().lo());
             mk_sp(lo, self.arm.span().hi())
         } else {
             self.arm.span()

--- a/tests/target/issue-3974.rs
+++ b/tests/target/issue-3974.rs
@@ -1,0 +1,10 @@
+fn emulate_foreign_item() {
+    match link_name {
+        // A comment here will duplicate the attribute
+        #[rustfmt::skip]
+        | "pthread_mutexattr_init"
+        | "pthread_mutexattr_settype"
+        | "pthread_mutex_init"
+        => {}
+    }
+}


### PR DESCRIPTION
Close #3974.