### PR TITLE
more GitHub Actions enablement

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,18 @@
+[alias]
+t = "test-all"
+ta = "test-all"
+test-all = "test --manifest-path rustfmt-core/Cargo.toml"
+
+test-bin = "test --manifest-path rustfmt-core/rustfmt-bin/Cargo.toml"
+tb = "test-bin"
+
+test-config = "test --manifest-path rustfmt-core/rustfmt-config/Cargo.toml"
+tc = "test-config"
+
+test-emitter = "test --manifest-path rustfmt-core/rustfmt-emitter/Cargo.toml"
+te = "test-emitter"
+
+test-lib = "test --manifest-path rustfmt-core/rustfmt-lib/Cargo.toml"
+tl = "test-lib"
+
+i = "install --path . --force --locked"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
+    name: ${{ matrix.integration }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,70 @@
+name: integration
+on: [push, pull_request]
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        integration: [
+          bitflags,
+          chalk,
+          crater,
+          error-chain,
+          glob,
+          log,
+          mdbook,
+          packed_simd,
+          rust-semverver,
+          stdsimd,
+          tempdir,
+          futures-rs,
+          rust-clippy,
+          failure,
+        ]
+        include:
+          # Allowed Failures
+          # Actions doesn't yet support explicitly marking matrix legs as allowed failures
+          # https://github.community/t5/GitHub-Actions/continue-on-error-allow-failure-UI-indication/td-p/37033
+          # https://github.community/t5/GitHub-Actions/Why-a-matrix-step-will-be-canceled-if-another-one-failed/td-p/30920
+          # Instead, leverage `continue-on-error`
+          # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error
+          #
+          # Using old rustfmt configuration option
+          - integration: rand
+            allow-failure: true
+          # Keep this as an allowed failure as it's fragile to breaking changes of rustc.
+          - integration: rust-clippy
+            allow-failure: true
+          # Using old rustfmt configuration option
+          - integration: packed_simd
+            allow-failure: true
+          # calebcartwright (2019-12-24)
+          # Keeping this as an allowed failure since it was flagged as such in the TravisCI config, even though
+          # it appears to have been passing for quite some time.
+          # Original comment was: temporal build failure due to breaking changes in the nightly compiler
+          - integration: rust-semverver
+            allow-failure: true
+          # Can be moved back to include section after https://github.com/rust-lang-nursery/failure/pull/298 is merged
+          - integration: failure
+            allow-failure: true
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+      # Run build
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly-x86_64-unknown-linux-gnu
+        target: x86_64-unknown-linux-gnu
+        override: true
+        profile: minimal
+        default: true
+    - name: run integration tests
+      env:
+        INTEGRATION: ${{ matrix.integration }}
+      run: ./ci/integration.sh
+      continue-on-error: ${{ matrix.allow-failure == true }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,8 +37,9 @@ jobs:
       run: |
         rustc -Vv
         cargo -V
-        cargo build
+        cargo build --manifest-path rustfmt-core/Cargo.toml --workspace
+
     - name: test
-      run: cargo test
-    - name: 'test ignored'
-      run: cargo test -- --ignored
+      run: cargo test-all
+    - name: test ignored
+      run: cargo test-all -- --ignored

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,43 @@
+name: linux
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          x86_64-unknown-linux-gnu,
+        ]
+        channel: [ nightly ]
+        cfg-release-channel: [
+          beta,
+          nightly,
+        ]
+
+    env:
+      CFG_RELEASE_CHANNEL: ${{ matrix.cfg-release-channel }}
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+      # Run build
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.channel }}-${{ matrix.target }}
+        target: ${{ matrix.target }}
+        override: true
+        profile: minimal
+        default: true
+    - name: build
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build
+    - name: test
+      run: cargo test
+    - name: 'test ignored'
+      run: cargo test -- --ignored

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    name: (${{ matrix.target }}, ${{ matrix.channel }}, ${{ matrix.cfg-release-channel }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -32,8 +32,9 @@ jobs:
       run: |
         rustc -Vv
         cargo -V
-        cargo build
+        cargo build --manifest-path rustfmt-core/Cargo.toml --workspace
+
     - name: test
-      run: cargo test
-    - name: 'test ignored'
-      run: cargo test -- --ignored
+      run: cargo test-all
+    - name: test ignored
+      run: cargo test-all -- --ignored

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,38 @@
+name: mac
+on: [push, pull_request]
+
+jobs:
+  test:
+    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
+    # macOS Catalina 10.15
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          x86_64-apple-darwin,
+        ]
+        channel: [ nightly ]
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+      # Run build
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.channel }}-${{ matrix.target }}
+        target: ${{ matrix.target }}
+        override: true
+        profile: minimal
+        default: true
+    - name: build
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build
+    - name: test
+      run: cargo test
+    - name: 'test ignored'
+      run: cargo test -- --ignored

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -6,6 +6,7 @@ jobs:
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
     # macOS Catalina 10.15
     runs-on: macos-latest
+    name: (${{ matrix.target }}, ${{ matrix.channel }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: windows-latest
+    name: (${{ matrix.target }}, ${{ matrix.channel }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,17 +77,12 @@ jobs:
       run: |
         rustc -Vv
         cargo -V
-        cargo build
+        cargo build --manifest-path rustfmt-core/Cargo.toml --workspace
       shell: cmd
+
     - name: test
-      run: cargo test
+      run: cargo test-all
       shell: cmd
-    - name: 'test ignored'
-      run: cargo test -- --ignored
-      shell: cmd
-    - name: 'test rustfmt-core'
-      run: cargo test --manifest-path rustfmt-core/Cargo.toml
-      shell: cmd
-    - name: 'test rustfmt-core ignored'
-      run: cargo test --manifest-path rustfmt-core/Cargo.toml -- --ignored
+    - name: test ignored
+      run: cargo test-all -- --ignored
       shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,10 @@ jobs:
           x86_64-pc-windows-msvc,
         ]
         channel: [ nightly ]
+        include:
+          - channel: nightly
+            target: i686-pc-windows-gnu
+            mingw-7z-path: mingw
 
     steps:
     # The Windows runners have autocrlf enabled by default
@@ -22,6 +26,7 @@ jobs:
       run: git config --global core.autocrlf false
     - name: checkout
       uses: actions/checkout@v2
+
     # The Windows runners do not (yet) have a proper msys/mingw environment
     # pre-configured like AppVeyor does, though they will likely be added in the future.
     # https://github.com/actions/virtual-environments/issues/30
@@ -32,16 +37,33 @@ jobs:
     # package and numworks/setup-msys2 action.
     # https://github.com/rust-lang/rust/blob/master/src/ci/scripts/install-mingw.sh#L59
     # https://github.com/rust-lang/rustup/blob/master/appveyor.yml
-    - name: install mingw32
+    #
+    # Use GitHub Actions cache support to avoid downloading the .7z file every time
+    # to be cognizant of the AWS egress cost impacts
+    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+    - name: cache mingw.7z
+      id: cache-mingw
+      with:
+        path: ${{ matrix.mingw-7z-path }}
+        key: ${{ matrix.channel }}-${{ matrix.target }}-mingw
+      uses: actions/cache@v1
+      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly'
+    - name: download mingw.7z
       run: |
         # Disable the download progress bar which can cause perf issues
         $ProgressPreference = "SilentlyContinue"
-        Invoke-WebRequest https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z -OutFile mingw.7z
-        7z x -y mingw.7z -oC:\msys64 | Out-Null
-        del mingw.7z
-        echo ::add-path::C:\msys64\mingw32\bin
-      if: matrix.target == 'i686-pc-windows-gnu'
+        md -Force ${{ matrix.mingw-7z-path }}
+        Invoke-WebRequest https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z -OutFile ${{ matrix.mingw-7z-path }}/mingw.7z
+      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly' && steps.cache-mingw.outputs.cache-hit != 'true'
       shell: powershell
+    - name: install mingw32
+      run: |
+        7z x -y ${{ matrix.mingw-7z-path }}/mingw.7z -oC:\msys64 | Out-Null
+        echo ::add-path::C:\msys64\mingw32\bin
+      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly'
+      shell: powershell
+
+      # Run build
     - name: setup
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
Follow up to #3969 that enables GHA for Linux, Mac, and the Integration test jobs that are currently executed on Travis. I decided to go ahead and work on this since some of the other issues I was eyeing are blocked 😄 

Similar to my experience enabling GHA for Windows in #3969, I found a few things took a little longer to set up due to the immaturity of the platform/features that haven't yet been released. However, overall it still seems really promising with several opportunities for continued improvement. 