### PR TITLE
align match arms with match_arm_align_threshold

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1463,6 +1463,48 @@ fn main() {
 
 See also: [`match_block_trailing_comma`](#match_block_trailing_comma).
 
+
+## `match_arm_align_threshold`
+
+Maximum number of spaces between `match` statement patterns for its arms to be aligned with each other. Alignment is reset after arms with block bodies. The default value of `0` will never align match arms.
+
+- **Default value**: `0`
+- **Possible values**: any positive integer
+
+#### `0` (default):
+```rust
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            lorem();
+            ipsum();
+        }
+        Lorem::DolorSitAmetConsectetur => (),
+        Lorem::Adipiscing => {
+            lorem();
+            ipsum();
+        }
+    }
+}
+```
+
+#### `20`:
+```rust
+fn main() {
+    match lorem {
+        Lorem::Ipsum => {
+            lorem();
+            ipsum();
+        }
+        Lorem::DolorSitAmetConsectetur => (),
+        Lorem::Adipiscing              => {
+            lorem();
+            ipsum();
+        }
+    }
+}
+```
+
 ## `match_block_trailing_comma`
 
 Put a trailing comma after a block based match arm (non-block arms are not affected)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -91,6 +91,8 @@ create_config! {
         "Align enum variants discrims, if their diffs fit within threshold";
     match_arm_blocks: bool, true, false, "Wrap the body of arms in blocks when it does not fit on \
         the same line with the pattern of arms";
+    match_arm_align_threshold: usize, 0, false, "Maximum difference in width between match arms \
+        for them to be aligned. 0 means never align.";
     force_multiline_blocks: bool, false, false,
         "Force multiline closure bodies and match arms to be wrapped in a block";
     fn_args_layout: Density, Density::Tall, true,
@@ -559,6 +561,7 @@ overflow_delimited_expr = false
 struct_field_align_threshold = 0
 enum_discrim_align_threshold = 0
 match_arm_blocks = true
+match_arm_align_threshold = 0
 force_multiline_blocks = false
 fn_args_layout = "Tall"
 brace_style = "SameLineWhere"

--- a/tests/source/configs/match_arm_align_threshold/above.rs
+++ b/tests/source/configs/match_arm_align_threshold/above.rs
@@ -1,0 +1,19 @@
+// rustfmt-match_arm_align_threshold: 10
+// Align match arms
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum     => (),
+        Lorem::DolorSitAmetConsecteturAdipiscingElitSedDo     => (),
+        Lorem::Eiusmod     => {
+            lorem();
+            ipsum();
+        }
+        Lorem::Donec | Lorem::Hendrerit | Lorem::Tempor | Lorem::Tellus | Lorem::Proin |
+        Lorem::Quam | Lorem::Nisl    => (),
+        Lorem::Donec => (),
+        Lorem::Hendrerit |
+        Lorem::TemporTellusProinQuamNislTinciduntEtMattisEgetConvallisNecPurusCumSociis     => (),
+        Lorem::Natoque if lorem()     => (),
+    }
+}

--- a/tests/source/configs/match_arm_align_threshold/below.rs
+++ b/tests/source/configs/match_arm_align_threshold/below.rs
@@ -1,0 +1,19 @@
+// rustfmt-match_arm_align_threshold: 100
+// Align match arms
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum     => (),
+        Lorem::DolorSitAmetConsecteturAdipiscingElitSedDo     => (),
+        Lorem::Eiusmod     => {
+            lorem();
+            ipsum();
+        }
+        Lorem::Donec | Lorem::Hendrerit | Lorem::Tempor | Lorem::Tellus | Lorem::Proin |
+        Lorem::Quam | Lorem::Nisl    => (),
+        Lorem::Donec => (),
+        Lorem::Hendrerit |
+        Lorem::TemporTellusProinQuamNislTinciduntEtMattisEgetConvallisNecPurusCumSociis     => (),
+        Lorem::Natoque if lorem()     => (),
+    }
+}

--- a/tests/target/configs/match_arm_align_threshold/above.rs
+++ b/tests/target/configs/match_arm_align_threshold/above.rs
@@ -1,0 +1,24 @@
+// rustfmt-match_arm_align_threshold: 10
+// Align match arms
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum => (),
+        Lorem::DolorSitAmetConsecteturAdipiscingElitSedDo => (),
+        Lorem::Eiusmod => {
+            lorem();
+            ipsum();
+        }
+        Lorem::Donec
+        | Lorem::Hendrerit
+        | Lorem::Tempor
+        | Lorem::Tellus
+        | Lorem::Proin
+        | Lorem::Quam
+        | Lorem::Nisl => (),
+        Lorem::Donec => (),
+        Lorem::Hendrerit
+        | Lorem::TemporTellusProinQuamNislTinciduntEtMattisEgetConvallisNecPurusCumSociis => (),
+        Lorem::Natoque if lorem() => (),
+    }
+}

--- a/tests/target/configs/match_arm_align_threshold/below.rs
+++ b/tests/target/configs/match_arm_align_threshold/below.rs
@@ -1,0 +1,24 @@
+// rustfmt-match_arm_align_threshold: 100
+// Align match arms
+
+fn main() {
+    match lorem {
+        Lorem::Ipsum                                      => (),
+        Lorem::DolorSitAmetConsecteturAdipiscingElitSedDo => (),
+        Lorem::Eiusmod                                    => {
+            lorem();
+            ipsum();
+        }
+        Lorem::Donec
+        | Lorem::Hendrerit
+        | Lorem::Tempor
+        | Lorem::Tellus
+        | Lorem::Proin
+        | Lorem::Quam
+        | Lorem::Nisl                                                                     => (),
+        Lorem::Donec                                                                      => (),
+        Lorem::Hendrerit
+        | Lorem::TemporTellusProinQuamNislTinciduntEtMattisEgetConvallisNecPurusCumSociis => (),
+        Lorem::Natoque if lorem()                                                         => (),
+    }
+}


### PR DESCRIPTION
This is an implementation of match arm alignment as proposed in #894. A previous attempt #1704 stalled out over a year ago. This implementation has a few important differences:

- Alignment is reset after a match arm with a block body. Subjectively, this makes alignment look better (as shown in the added example in Configurations.md), since a block implies there's at least two lines code between the arms (as empty blocks are collapsed), and having lines interrupting match arms looks.. strange. I have since realized, however, that single-expression bodies circumvent this check, so we may need a different approach if we want this. I want to get your feedback before revisiting this, though.
- The "threshold greater than max_width forces always alignment" was dropped, as no other threshold configuration parameter has this behaviour.
- Match arms are rewritten _before_ alignment, which is the correct behaviour.
- Only the length of the last line of the match arm LHS is considered, as opposed to the max of all lines. This can be seen in the following fragment. Not sure what's the correct behaviour here, so I picked my favorite:
```rust
match foo {
    Foo   => (),
    FooBarBaz
    | Baz => (),
```

Another unanswered question:
- Alignment is currently not performed at all if any arm causes the number of inserted spaces to exceed the threshold. We could instead align the preceding arms (if they satisfy the threshold) and start a new alignment group. We could also try to find the set of arm groups which end up aligning the most arms, but the naive implementation of that, at least, would be an exponential search.

Also, since I did copy some documentation phrasing and tests from #1704, I'm not sure what attribution / licensing implications that has. I could always try to re-write those.