### PR TITLE
Avoid poor-formatting of the rhs of lazy_static macro

### DIFF
--- a/rustfmt-core/rustfmt-config/src/lib.rs
+++ b/rustfmt-core/rustfmt-config/src/lib.rs
@@ -428,10 +428,7 @@ mod test {
 
         let used_options = config.used_options();
         let toml = used_options.to_toml().unwrap();
-        assert_eq!(
-            toml,
-            "merge_derives = false\n"
-        );
+        assert_eq!(toml, "merge_derives = false\n");
     }
 
     #[test]

--- a/rustfmt-core/rustfmt-emitter/src/diff.rs
+++ b/rustfmt-core/rustfmt-emitter/src/diff.rs
@@ -1,7 +1,7 @@
 use rustfmt_configuration::Config;
 
-use crate::rustfmt_diff::{make_diff, print_diff};
 use super::*;
+use crate::rustfmt_diff::{make_diff, print_diff};
 
 pub struct DiffEmitter {
     config: Config,

--- a/rustfmt-core/rustfmt-emitter/src/rustfmt_diff.rs
+++ b/rustfmt-core/rustfmt-emitter/src/rustfmt_diff.rs
@@ -424,5 +424,4 @@ mod test {
         let diff = make_diff("a\nb\nc\nd", "a\nb\nc\nd", 3);
         assert_eq!(diff, vec![]);
     }
-
 }

--- a/rustfmt-core/rustfmt-lib/src/closures.rs
+++ b/rustfmt-core/rustfmt-lib/src/closures.rs
@@ -415,8 +415,8 @@ fn is_block_closure_forced(
         false
     } else {
         if let ast::ExprKind::Match(..) = expr.kind {
-          let is_move_closure_without_brace =
-              capture == ast::CaptureBy::Value && !context.snippet(expr.span).trim().starts_with("{");
+            let is_move_closure_without_brace = capture == ast::CaptureBy::Value
+                && !context.snippet(expr.span).trim().starts_with("{");
 
             is_block_closure_forced_inner(expr) || is_move_closure_without_brace
         } else {

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -127,9 +127,7 @@ pub(crate) fn format_expr(
         ast::ExprKind::Block(ref block, opt_label) => {
             match expr_type {
                 ExprType::Statement => {
-                    if is_unsafe_block(block) {
-                        rewrite_block(block, Some(&expr.attrs), opt_label, context, shape)
-                    } else if let rw @ Some(_) =
+                    if let rw @ Some(_) =
                         rewrite_empty_block(context, block, Some(&expr.attrs), opt_label, "", shape)
                     {
                         // Rewrite block without trying to put it in a single line.

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -34,7 +34,10 @@ use crate::rewrite::{Rewrite, RewriteContext};
 use crate::shape::{Indent, Shape};
 use crate::source_map::SpanUtils;
 use crate::spanned::Spanned;
-use crate::utils::{format_visibility, indent_next_line, is_empty_line, mk_sp, remove_trailing_white_spaces, rewrite_ident, trim_left_preserve_layout, wrap_str, NodeIdExt, count_newlines};
+use crate::utils::{
+    count_newlines, format_visibility, indent_next_line, is_empty_line, mk_sp,
+    remove_trailing_white_spaces, rewrite_ident, trim_left_preserve_layout, wrap_str, NodeIdExt,
+};
 use crate::visitor::FmtVisitor;
 
 const FORCED_BRACKET_MACROS: &[&str] = &["vec!"];

--- a/rustfmt-core/rustfmt-lib/src/stmt.rs
+++ b/rustfmt-core/rustfmt-lib/src/stmt.rs
@@ -107,7 +107,5 @@ fn format_stmt(
         }
         ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) => None,
     };
-    result.and_then(|res| {
-        recover_comment_removed(res, stmt.span(), context)
-    })
+    result.and_then(|res| recover_comment_removed(res, stmt.span(), context))
 }

--- a/rustfmt-core/rustfmt-lib/src/test/configuration_snippet.rs
+++ b/rustfmt-core/rustfmt-lib/src/test/configuration_snippet.rs
@@ -6,9 +6,9 @@ use std::path::{Path, PathBuf};
 
 use rustfmt_emitter::rustfmt_diff::{make_diff, Mismatch};
 
+use super::{print_mismatches, write_message, DIFF_CONTEXT_SIZE};
 use crate::config::{Config, EmitMode, Verbosity};
 use crate::{Input, Session};
-use super::{print_mismatches, write_message, DIFF_CONTEXT_SIZE};
 
 const CONFIGURATIONS_FILE_NAME: &str = "../../Configurations.md";
 

--- a/rustfmt-core/rustfmt-lib/src/test/mod.rs
+++ b/rustfmt-core/rustfmt-lib/src/test/mod.rs
@@ -7,9 +7,7 @@ use std::path::{Path, PathBuf};
 use std::str::Chars;
 use std::thread;
 
-use rustfmt_emitter::rustfmt_diff::{
-    make_diff, print_diff, Mismatch, ModifiedChunk, OutputWriter,
-};
+use rustfmt_emitter::rustfmt_diff::{make_diff, print_diff, Mismatch, ModifiedChunk, OutputWriter};
 
 use crate::config::{Color, Config, EmitMode, FileName, NewlineStyle, ReportTactic};
 use crate::formatting::{ReportedErrors, SourceFile};
@@ -809,4 +807,3 @@ fn string_eq_ignore_newline_repr_test() {
     assert!(string_eq_ignore_newline_repr("a\r\n\r\n\r\nb", "a\n\n\nb"));
     assert!(!string_eq_ignore_newline_repr("a\r\nbcd", "a\nbcdefghijk"));
 }
-

--- a/rustfmt-core/rustfmt-lib/tests/source/lazy_static.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/lazy_static.rs
@@ -43,3 +43,13 @@ static ref FOO: HashMap<String,
 fn(Foo) -> Result<Box<Bar>, Either<FooError, BarError>>
 ),> = HashMap::new();
 }
+
+lazy_static! {
+    pub static ref BLOCKING_POOL: tokio_threadpool::ThreadPool = {
+        tokio_threadpool::Builder::new().pool_size(1).build()
+    };
+
+    static ref FOO: Foo = unsafe {
+        very_long_function_name().another_function_with_really_long_name()
+    };
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/catch.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/catch.rs
@@ -6,7 +6,9 @@ fn main() {
 
     let x = try /* Invisible comment */ { foo()? };
 
-    let x = try { unsafe { foo()? } };
+    let x = try {
+        unsafe { foo()? }
+    };
 
     let y = match (try { foo()? }) {
         _ => (),

--- a/rustfmt-core/rustfmt-lib/tests/target/expr.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/expr.rs
@@ -152,7 +152,9 @@ fn baz() {
         // Regular unsafe block
     }
 
-    unsafe { foo() }
+    unsafe {
+        foo()
+    }
 
     unsafe {
         foo();

--- a/rustfmt-core/rustfmt-lib/tests/target/lazy_static.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/lazy_static.rs
@@ -47,3 +47,13 @@ lazy_static! {
         ),
     > = HashMap::new();
 }
+
+lazy_static! {
+    pub static ref BLOCKING_POOL: tokio_threadpool::ThreadPool = {
+        tokio_threadpool::Builder::new().pool_size(1).build()
+    };
+
+    static ref FOO: Foo = unsafe {
+        very_long_function_name().another_function_with_really_long_name()
+    };
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/match.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/match.rs
@@ -243,7 +243,9 @@ fn issue383() {
 
 fn issue507() {
     match 1 {
-        1 => unsafe { std::intrinsics::abort() },
+        1 => unsafe {
+            std::intrinsics::abort()
+        },
         _ => (),
     }
 }


### PR DESCRIPTION
- Parse the rhs as statement
- Do not format unsafe block on the statement position in a single line

Close #3419.