### PR TITLE
upgrade rustc-ap-* version to v642

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,6 @@ dependencies = [
  "log",
  "regex",
  "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_error_codes",
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_parse",
  "rustc-ap-rustc_span",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0143016b63fd6c6e1c7df7d000f24d6cc890043d2436cec88931b29c1249c29"
+checksum = "ea82fa3d9a8add7422228ca1a2cbba0784fa8861f56148ff64da08b3c7921b03"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.1.0",
@@ -709,15 +709,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac2b3c88fdbd35b13a1fc79bfec487cabb81a24d755abeca28e20ef68b501fa"
+checksum = "638d0b2b3bcf99824e0cb5a25dbc547b61dc20942e11daf6a97e981918aa18e5"
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49803907e7937e1a833a791f63f476ced01a6ccb4c0307a05a82d74acc4ac66a"
+checksum = "d38bab04dd676dee6d2f9670506a18c31bfce38bf7f8420aa83eb1140ecde049"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e2b903ef5477eebf9da26dad4b3c6b720a5cf8d0b1bc4a9b63043c60c6d36b"
+checksum = "10b843ba8b1ed43739133047673b9f6a54d3b3b4d328d69c6ea89ff971395f35"
 dependencies = [
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_data_structures",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083abd952ad3e2976ad61e6a726e1c0a511830fce84204ddae16e56eb83e0563"
+checksum = "dc3d1c6d0a80ab0c1df76405377cec0f3d5423fb5b0953a8eac70a2ad6c44df2"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5bed73e69e342affb42b61e93af99bc722de532caf2ce44519eba01d68f2f6f"
+checksum = "4909a1eca29331332257230f29120a8ff68c9e37d868c564fcd599e430cf8914"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857757415069aa724c9a3197497aae5e2b2b7de620246fd5026a0e4f425949a0"
+checksum = "63ab887a181d795cf5fd3edadf367760deafb90aefb844f168ab5255266e3478"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -801,15 +801,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1e47b7cdb1d7e81c51f7c3cb2c8685dca5776bfdb37af37ed489ebe00e968e"
+checksum = "70814116df3c5fbec8f06f6a1d013ca481f620fd22a9475754e9bf3ee9ba70d8"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ec9fa11dfafc5bac8976c4f53f798da647a94378e7ad1356787a042a10f9e0"
+checksum = "ac1bf1d3cf3d119d41353d6fd229ef7272d5097bc0924de021c0294bf86d48bf"
 dependencies = [
  "rustc-ap-serialize",
  "smallvec 1.1.0",
@@ -817,18 +817,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df53bbac07f84a7365b0437f5a4146177c212f6d0c9806f6243046febe4423f9"
+checksum = "4cda21a32cebdc11ec4f5393aa2fcde5ed1b2f673a8571e5a4dcdf07e4ae9cac"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a8c38925dfb07740755fbcc276be359a8960bedf7475d00e38ddd2c1d633a9"
+checksum = "75c47b48ea51910ecfd853c9248a9bf4c767bc823449ab6a1d864dff65fbae16"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d2393c92bfaf04fa27495e6bd1459abdadf48d877c317d23233418eb26d9f9"
+checksum = "abd88e89cd5b5d28dcd3a347a3d534c08627d9455570dc1a2d402cb8437b9d30"
 dependencies = [
  "bitflags",
  "log",
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1751a3002e26f2326de5a023ff08e9b83672179fe5c9afaa3b8290e3dc9b95c7"
+checksum = "5b8487b4575fbb2d1fc6f1cd61225efd108a4d36817e6fb9b643d57fcae9cb12"
 dependencies = [
  "log",
  "num_cpus",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac990c0b42f5b95ac2e164a3bf3e237a49ab9d587945e438f1cf1914358f5674"
+checksum = "f69746c0d4c21bf20a5bb2bd247261a1aa8631f04202d7303352942dde70d987"
 dependencies = [
  "cfg-if",
  "log",
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9626ceaf0a278415b2aa9a0cedb7f8010c06ee6bc82dc512f957a5c712437b4"
+checksum = "8bbc6ae09b5d42ec66edd520e8412e0615c53a7c93607fe33dc4abab60ba7c8b"
 dependencies = [
  "bitflags",
  "log",
@@ -911,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb369b4ef73dcde6b60be9940b3d8c9a425fd049f4c10e90a2f642748820788"
+checksum = "e13a1ead0252fc3d96da4c336a95950be6795f2b00c84a67ccadf26142f8cb41"
 dependencies = [
  "indexmap",
  "smallvec 1.1.0",
@@ -921,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "641.0.0"
+version = "642.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077f3589b84e857a21aa734356f123f49910bc1c6e6b7e1fdacb42fbfa769ae4"
+checksum = "e1f59f48ca3a2ec16a7e82e718ed5aadf9c9e08cf63015d28b4e774767524a6a"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,10 +491,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
+name = "measureme"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef709d3257013bba7cff14fc504e07e80631d3fe0f6d38ce63b8f6510ccb932"
+dependencies = [
+ "byteorder",
+ "memmap",
+ "parking_lot",
+ "rustc-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "memoffset"
@@ -546,7 +568,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "rustc_version",
- "smallvec",
+ "smallvec 0.6.13",
  "winapi 0.3.8",
 ]
 
@@ -687,26 +709,27 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "610.0.0"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7475f4c707269b56eb7144c53591e3cd6369a5aa1d66434829ea11df96d5e7e3"
+checksum = "0b3c80eb0d9627b3f732b25fe760bf68b2a77a069982501e831d9e0fafc14c46"
 dependencies = [
  "rustc-ap-rustc_data_structures",
- "smallvec",
+ "smallvec 1.1.0",
 ]
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "610.0.0"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e59a55520f140a70a3e0fad80a36e807caa85e9d7016167b91a5b521ea929be"
+checksum = "6c943b04f7eb5e9d1ed32899091b718b2497633162bc3efe3afc797c60d08105"
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "610.0.0"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6420857d5a088f680ec1ba736ffba4ee9c1964b0d397e6318f38d461f4f7d5cb"
+checksum = "3bd42989f1f32bc90798cc743a9a897463b02b0d4d5ddc2cc4168bb530257b27"
 dependencies = [
+ "bitflags",
  "cfg-if",
  "crossbeam-utils 0.6.6",
  "ena",
@@ -714,6 +737,7 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "log",
+ "measureme",
  "parking_lot",
  "rustc-ap-graphviz",
  "rustc-ap-rustc_index",
@@ -721,51 +745,74 @@ dependencies = [
  "rustc-hash",
  "rustc-rayon",
  "rustc-rayon-core",
- "smallvec",
+ "smallvec 1.1.0",
  "stable_deref_trait",
 ]
 
 [[package]]
-name = "rustc-ap-rustc_errors"
-version = "610.0.0"
+name = "rustc-ap-rustc_error_codes"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abfca0960131262254a91d02ff4903526a261ede730d7a2c75b4234c867cdc0"
+checksum = "1836d7319437e62ea7577ac9cc1bf9bdc47a885618100a782efd350ec1c2adb1"
+
+[[package]]
+name = "rustc-ap-rustc_errors"
+version = "638.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bb52770f773c9184398a92309a200e871df6890bd812c8f0b4a7e37e905520"
 dependencies = [
  "annotate-snippets",
  "atty",
  "log",
  "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_span",
  "rustc-ap-serialize",
- "rustc-ap-syntax_pos",
  "term_size",
  "termcolor",
  "unicode-width",
 ]
 
 [[package]]
-name = "rustc-ap-rustc_index"
-version = "610.0.0"
+name = "rustc-ap-rustc_feature"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a395509dcb90a92c1479c085639594624e06b4ab3fc7c1b795b46a61f2d4f65"
+checksum = "89d7ca66d4a0a865ea01c5921b79fc600fb2b589eb36bc075812057fd7dbc079"
+dependencies = [
+ "lazy_static",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_span",
+]
+
+[[package]]
+name = "rustc-ap-rustc_fs_util"
+version = "638.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b7a65a0dd16b2770b61fa28e31cc07dd95d114925d51a9901041e7cb85b2f9"
+
+[[package]]
+name = "rustc-ap-rustc_index"
+version = "638.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c55945f7660a12bf372fd2563b64adde31f980adf980d383e63f185a5e6bcc"
 dependencies = [
  "rustc-ap-serialize",
- "smallvec",
+ "smallvec 1.1.0",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "610.0.0"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64eac8a0e6efb8f55292aa24be0208c7c0538236c613e79952fd1fa3d54bcf8e"
+checksum = "01996458f46b2b79865753a7a46fb83135635d1aa63a871eedf3d036c9aa6918"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "610.0.0"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99795e8be4877e9e05d59f201e1740c1cf673364655def5848606d9e25b75af"
+checksum = "a1345285d67bf1a2c6772003231ce9f07d197b9cc02a418c6b08dbf96bb40b97"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -775,56 +822,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-ap-rustc_target"
-version = "610.0.0"
+name = "rustc-ap-rustc_parse"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22e21fdd8e1c0030f507158fa79b9f1e080e6241aba994d0f97c14a0a07a826"
+checksum = "a3ea2f3446018c57308f372b45047e220fd65375e5ef4eed2b412fb71b63101b"
 dependencies = [
  "bitflags",
  "log",
  "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_index",
- "rustc-ap-serialize",
- "rustc-ap-syntax_pos",
-]
-
-[[package]]
-name = "rustc-ap-serialize"
-version = "610.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1cd6ef5135408d62559866e79986ca261f4c1333253d500e5e66fe66d1432e"
-dependencies = [
- "indexmap",
- "smallvec",
-]
-
-[[package]]
-name = "rustc-ap-syntax"
-version = "610.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fc1c901d2cbd24cae95d7bc5a58aa7661ec3dc5320c78c32830a52a685c33c"
-dependencies = [
- "bitflags",
- "lazy_static",
- "log",
- "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_error_codes",
  "rustc-ap-rustc_errors",
- "rustc-ap-rustc_index",
+ "rustc-ap-rustc_feature",
  "rustc-ap-rustc_lexer",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
+ "rustc-ap-syntax",
+ "smallvec 1.1.0",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "rustc-ap-rustc_session"
+version = "638.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6634d3f172841af010afbc539bed33b23a6bbdf96307c3bcf22be63b87c48c"
+dependencies = [
+ "log",
+ "num_cpus",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_error_codes",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_feature",
+ "rustc-ap-rustc_fs_util",
+ "rustc-ap-rustc_index",
+ "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
  "rustc-ap-serialize",
- "rustc-ap-syntax_pos",
- "scoped-tls",
- "smallvec",
 ]
 
 [[package]]
-name = "rustc-ap-syntax_pos"
-version = "610.0.0"
+name = "rustc-ap-rustc_span"
+version = "638.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230534f638255853bb9f13987537e00a818435a0cc54b68d97221b6822c8f1bc"
+checksum = "9c3a35517bcc912a112d193781edad537356c176860cfb36731a378d88a426ad"
 dependencies = [
  "cfg-if",
+ "log",
  "rustc-ap-arena",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_index",
@@ -832,6 +875,52 @@ dependencies = [
  "rustc-ap-serialize",
  "scoped-tls",
  "unicode-width",
+]
+
+[[package]]
+name = "rustc-ap-rustc_target"
+version = "638.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb050cc4749f7f9d42da57a24f957c5d1e235abaf63b0ad4e2a827d6ee46e7b"
+dependencies = [
+ "bitflags",
+ "log",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_index",
+ "rustc-ap-rustc_macros",
+ "rustc-ap-rustc_span",
+ "rustc-ap-serialize",
+]
+
+[[package]]
+name = "rustc-ap-serialize"
+version = "638.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b12ba383a02cafc0918e13d8a132f9f1c6dfc941df496eaf3435f29d4c81ea"
+dependencies = [
+ "indexmap",
+ "smallvec 1.1.0",
+]
+
+[[package]]
+name = "rustc-ap-syntax"
+version = "638.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d169af9fb7886fe4a2990905cdc7e13ed05f00b3ae9a019f699016c0d2c889"
+dependencies = [
+ "log",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_error_codes",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_feature",
+ "rustc-ap-rustc_index",
+ "rustc-ap-rustc_lexer",
+ "rustc-ap-rustc_macros",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
+ "rustc-ap-serialize",
+ "scoped-tls",
+ "smallvec 1.1.0",
 ]
 
 [[package]]
@@ -923,7 +1012,7 @@ dependencies = [
  "dirs",
  "itertools",
  "regex",
- "rustc-ap-syntax_pos",
+ "rustc-ap-rustc_span",
  "rustfmt-config_proc_macro",
  "serde",
  "serde_json",
@@ -955,9 +1044,12 @@ dependencies = [
  "log",
  "regex",
  "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_error_codes",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_parse",
+ "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
  "rustc-ap-syntax",
- "rustc-ap-syntax_pos",
  "rustfmt_configuration",
  "rustfmt_emitter",
  "term",
@@ -1060,6 +1152,12 @@ checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 dependencies = [
  "maybe-uninit",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1214,6 +1312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
+dependencies = [
+ "smallvec 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_users",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -445,16 +445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,7 +505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -569,7 +559,7 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -648,7 +638,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -709,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3c80eb0d9627b3f732b25fe760bf68b2a77a069982501e831d9e0fafc14c46"
+checksum = "e0143016b63fd6c6e1c7df7d000f24d6cc890043d2436cec88931b29c1249c29"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.1.0",
@@ -719,15 +709,45 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c943b04f7eb5e9d1ed32899091b718b2497633162bc3efe3afc797c60d08105"
+checksum = "6ac2b3c88fdbd35b13a1fc79bfec487cabb81a24d755abeca28e20ef68b501fa"
+
+[[package]]
+name = "rustc-ap-rustc_ast_pretty"
+version = "641.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49803907e7937e1a833a791f63f476ced01a6ccb4c0307a05a82d74acc4ac66a"
+dependencies = [
+ "log",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_span",
+ "rustc-ap-syntax",
+]
+
+[[package]]
+name = "rustc-ap-rustc_attr"
+version = "641.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e2b903ef5477eebf9da26dad4b3c6b720a5cf8d0b1bc4a9b63043c60c6d36b"
+dependencies = [
+ "rustc-ap-rustc_ast_pretty",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_feature",
+ "rustc-ap-rustc_macros",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
+ "rustc-ap-serialize",
+ "rustc-ap-syntax",
+ "smallvec 1.1.0",
+]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd42989f1f32bc90798cc743a9a897463b02b0d4d5ddc2cc4168bb530257b27"
+checksum = "083abd952ad3e2976ad61e6a726e1c0a511830fce84204ddae16e56eb83e0563"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -747,19 +767,14 @@ dependencies = [
  "rustc-rayon-core",
  "smallvec 1.1.0",
  "stable_deref_trait",
+ "winapi",
 ]
 
 [[package]]
-name = "rustc-ap-rustc_error_codes"
-version = "638.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1836d7319437e62ea7577ac9cc1bf9bdc47a885618100a782efd350ec1c2adb1"
-
-[[package]]
 name = "rustc-ap-rustc_errors"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bb52770f773c9184398a92309a200e871df6890bd812c8f0b4a7e37e905520"
+checksum = "a5bed73e69e342affb42b61e93af99bc722de532caf2ce44519eba01d68f2f6f"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -767,16 +782,17 @@ dependencies = [
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_span",
  "rustc-ap-serialize",
- "term_size",
  "termcolor",
+ "termize",
  "unicode-width",
+ "winapi",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d7ca66d4a0a865ea01c5921b79fc600fb2b589eb36bc075812057fd7dbc079"
+checksum = "857757415069aa724c9a3197497aae5e2b2b7de620246fd5026a0e4f425949a0"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -785,15 +801,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b7a65a0dd16b2770b61fa28e31cc07dd95d114925d51a9901041e7cb85b2f9"
+checksum = "7a1e47b7cdb1d7e81c51f7c3cb2c8685dca5776bfdb37af37ed489ebe00e968e"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c55945f7660a12bf372fd2563b64adde31f980adf980d383e63f185a5e6bcc"
+checksum = "75ec9fa11dfafc5bac8976c4f53f798da647a94378e7ad1356787a042a10f9e0"
 dependencies = [
  "rustc-ap-serialize",
  "smallvec 1.1.0",
@@ -801,18 +817,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01996458f46b2b79865753a7a46fb83135635d1aa63a871eedf3d036c9aa6918"
+checksum = "df53bbac07f84a7365b0437f5a4146177c212f6d0c9806f6243046febe4423f9"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1345285d67bf1a2c6772003231ce9f07d197b9cc02a418c6b08dbf96bb40b97"
+checksum = "85a8c38925dfb07740755fbcc276be359a8960bedf7475d00e38ddd2c1d633a9"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -823,14 +839,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ea2f3446018c57308f372b45047e220fd65375e5ef4eed2b412fb71b63101b"
+checksum = "39d2393c92bfaf04fa27495e6bd1459abdadf48d877c317d23233418eb26d9f9"
 dependencies = [
  "bitflags",
  "log",
+ "rustc-ap-rustc_ast_pretty",
+ "rustc-ap-rustc_attr",
  "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_error_codes",
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_feature",
  "rustc-ap-rustc_lexer",
@@ -843,14 +860,13 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6634d3f172841af010afbc539bed33b23a6bbdf96307c3bcf22be63b87c48c"
+checksum = "1751a3002e26f2326de5a023ff08e9b83672179fe5c9afaa3b8290e3dc9b95c7"
 dependencies = [
  "log",
  "num_cpus",
  "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_error_codes",
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_feature",
  "rustc-ap-rustc_fs_util",
@@ -858,13 +874,14 @@ dependencies = [
  "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
  "rustc-ap-serialize",
+ "rustc-ap-syntax",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3a35517bcc912a112d193781edad537356c176860cfb36731a378d88a426ad"
+checksum = "ac990c0b42f5b95ac2e164a3bf3e237a49ab9d587945e438f1cf1914358f5674"
 dependencies = [
  "cfg-if",
  "log",
@@ -879,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb050cc4749f7f9d42da57a24f957c5d1e235abaf63b0ad4e2a827d6ee46e7b"
+checksum = "c9626ceaf0a278415b2aa9a0cedb7f8010c06ee6bc82dc512f957a5c712437b4"
 dependencies = [
  "bitflags",
  "log",
@@ -894,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b12ba383a02cafc0918e13d8a132f9f1c6dfc941df496eaf3435f29d4c81ea"
+checksum = "0eb369b4ef73dcde6b60be9940b3d8c9a425fd049f4c10e90a2f642748820788"
 dependencies = [
  "indexmap",
  "smallvec 1.1.0",
@@ -904,19 +921,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "638.0.0"
+version = "641.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d169af9fb7886fe4a2990905cdc7e13ed05f00b3ae9a019f699016c0d2c889"
+checksum = "077f3589b84e857a21aa734356f123f49910bc1c6e6b7e1fdacb42fbfa769ae4"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_error_codes",
- "rustc-ap-rustc_errors",
- "rustc-ap-rustc_feature",
  "rustc-ap-rustc_index",
  "rustc-ap-rustc_lexer",
  "rustc-ap-rustc_macros",
- "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
  "rustc-ap-serialize",
  "scoped-tls",
@@ -1043,9 +1056,11 @@ dependencies = [
  "lazy_static",
  "log",
  "regex",
+ "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_parse",
+ "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
  "rustc-ap-syntax",
@@ -1234,18 +1249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
  "dirs",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "term_size"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
-dependencies = [
- "kernel32-sys",
- "libc",
- "winapi 0.2.8",
+ "winapi",
 ]
 
 [[package]]
@@ -1255,6 +1259,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 dependencies = [
  "wincolor",
+]
+
+[[package]]
+name = "termize"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1359,7 +1373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 dependencies = [
  "same-file",
- "winapi 0.3.8",
+ "winapi",
  "winapi-util",
 ]
 
@@ -1371,12 +1385,6 @@ checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
@@ -1384,12 +1392,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1403,7 +1405,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -1418,6 +1420,6 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi",
  "winapi-util",
 ]

--- a/rustfmt-core/rustfmt-config/Cargo.toml
+++ b/rustfmt-core/rustfmt-config/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 toml = "0.5"
 
-[dependencies.syntax_pos]
-package = "rustc-ap-syntax_pos"
-version = "610.0.0"
+[dependencies.rustc_span]
+package = "rustc-ap-rustc_span"
+version = "638.0.0"
 

--- a/rustfmt-core/rustfmt-config/Cargo.toml
+++ b/rustfmt-core/rustfmt-config/Cargo.toml
@@ -19,5 +19,5 @@ toml = "0.5"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "641.0.0"
+version = "642.0.0"
 

--- a/rustfmt-core/rustfmt-config/Cargo.toml
+++ b/rustfmt-core/rustfmt-config/Cargo.toml
@@ -19,5 +19,5 @@ toml = "0.5"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "638.0.0"
+version = "641.0.0"
 

--- a/rustfmt-core/rustfmt-config/src/file_lines.rs
+++ b/rustfmt-core/rustfmt-config/src/file_lines.rs
@@ -10,7 +10,7 @@ use serde::{ser, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json as json;
 use thiserror::Error;
 
-use syntax_pos::{self, SourceFile};
+use rustc_span::{self, SourceFile};
 
 /// A range of lines in a file, inclusive of both ends.
 pub struct LineRange {
@@ -26,21 +26,21 @@ pub enum FileName {
     Stdin,
 }
 
-impl From<syntax_pos::FileName> for FileName {
-    fn from(name: syntax_pos::FileName) -> FileName {
+impl From<rustc_span::FileName> for FileName {
+    fn from(name: rustc_span::FileName) -> FileName {
         match name {
-            syntax_pos::FileName::Real(p) => FileName::Real(p),
-            syntax_pos::FileName::Custom(ref f) if f == "stdin" => FileName::Stdin,
+            rustc_span::FileName::Real(p) => FileName::Real(p),
+            rustc_span::FileName::Custom(ref f) if f == "stdin" => FileName::Stdin,
             _ => unreachable!(),
         }
     }
 }
 
-impl From<&FileName> for syntax_pos::FileName {
-    fn from(filename: &FileName) -> syntax_pos::FileName {
+impl From<&FileName> for rustc_span::FileName {
+    fn from(filename: &FileName) -> rustc_span::FileName {
         match filename {
-            FileName::Real(path) => syntax_pos::FileName::Real(path.to_owned()),
-            FileName::Stdin => syntax_pos::FileName::Custom("stdin".to_owned()),
+            FileName::Real(path) => rustc_span::FileName::Real(path.to_owned()),
+            FileName::Stdin => rustc_span::FileName::Custom("stdin".to_owned()),
         }
     }
 }

--- a/rustfmt-core/rustfmt-config/src/options.rs
+++ b/rustfmt-core/rustfmt-config/src/options.rs
@@ -374,7 +374,7 @@ impl Default for Edition {
     }
 }
 
-impl From<Edition> for syntax_pos::edition::Edition {
+impl From<Edition> for rustc_span::edition::Edition {
     fn from(edition: Edition) -> Self {
         match edition {
             Edition::Edition2015 => Self::Edition2015,

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -38,10 +38,6 @@ version = "638.0.0"
 package = "rustc-ap-rustc_errors"
 version = "638.0.0"
 
-[dependencies.rustc_error_codes]
-package = "rustc-ap-rustc_error_codes"
-version = "638.0.0"
-
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
 version = "638.0.0"

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -30,27 +30,35 @@ unicode-width = "0.1.5"
 [dev-dependencies]
 env_logger = "0.7"
 
+[dependencies.rustc_ast_pretty]
+package = "rustc-ap-rustc_ast_pretty"
+version = "641.0.0"
+
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "638.0.0"
+version = "641.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "638.0.0"
+version = "641.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "638.0.0"
+version = "641.0.0"
+
+[dependencies.rustc_session]
+package = "rustc-ap-rustc_session"
+version = "641.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "638.0.0"
+version = "641.0.0"
 
 [dependencies.rustc_target]
 package = "rustc-ap-rustc_target"
-version = "638.0.0"
+version = "641.0.0"
 
 [dependencies.syntax]
 package = "rustc-ap-syntax"
-version = "638.0.0"
+version = "641.0.0"
 

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -32,33 +32,33 @@ env_logger = "0.7"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "641.0.0"
+version = "642.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "641.0.0"
+version = "642.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "641.0.0"
+version = "642.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "641.0.0"
+version = "642.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "641.0.0"
+version = "642.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "641.0.0"
+version = "642.0.0"
 
 [dependencies.rustc_target]
 package = "rustc-ap-rustc_target"
-version = "641.0.0"
+version = "642.0.0"
 
 [dependencies.syntax]
 package = "rustc-ap-syntax"
-version = "641.0.0"
+version = "642.0.0"
 

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -30,19 +30,31 @@ unicode-width = "0.1.5"
 [dev-dependencies]
 env_logger = "0.7"
 
+[dependencies.rustc_data_structures]
+package = "rustc-ap-rustc_data_structures"
+version = "638.0.0"
+
+[dependencies.rustc_errors]
+package = "rustc-ap-rustc_errors"
+version = "638.0.0"
+
+[dependencies.rustc_error_codes]
+package = "rustc-ap-rustc_error_codes"
+version = "638.0.0"
+
+[dependencies.rustc_parse]
+package = "rustc-ap-rustc_parse"
+version = "638.0.0"
+
+[dependencies.rustc_span]
+package = "rustc-ap-rustc_span"
+version = "638.0.0"
+
 [dependencies.rustc_target]
 package = "rustc-ap-rustc_target"
-version = "610.0.0"
+version = "638.0.0"
 
 [dependencies.syntax]
 package = "rustc-ap-syntax"
-version = "610.0.0"
-
-[dependencies.syntax_pos]
-package = "rustc-ap-syntax_pos"
-version = "610.0.0"
-
-[dependencies.rustc_data_structures]
-package = "rustc-ap-rustc_data_structures"
-version = "610.0.0"
+version = "638.0.0"
 

--- a/rustfmt-core/rustfmt-lib/src/attr.rs
+++ b/rustfmt-core/rustfmt-lib/src/attr.rs
@@ -1,8 +1,7 @@
 //! Format attributes and meta items.
 
+use rustc_span::{BytePos, DUMMY_SP, Span, symbol::sym};
 use syntax::ast;
-use syntax::source_map::{BytePos, Span, DUMMY_SP};
-use syntax::symbol::sym;
 
 use self::doc_comment::DocCommentFormatter;
 use crate::comment::{contains_comment, rewrite_doc_comment, CommentStyle};

--- a/rustfmt-core/rustfmt-lib/src/attr.rs
+++ b/rustfmt-core/rustfmt-lib/src/attr.rs
@@ -167,7 +167,7 @@ fn rewrite_initial_doc_comments(
         return Some((0, None));
     }
     // Rewrite doc comments
-    let sugared_docs = take_while_with_pred(context, attrs, |a| a.is_sugared_doc);
+    let sugared_docs = take_while_with_pred(context, attrs, |a| a.is_doc_comment());
     if !sugared_docs.is_empty() {
         let snippet = sugared_docs
             .iter()
@@ -315,7 +315,7 @@ where
 impl Rewrite for ast::Attribute {
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
         let snippet = context.snippet(self.span);
-        if self.is_sugared_doc {
+        if self.is_doc_comment() {
             rewrite_doc_comment(snippet, shape.comment(context.config), context.config)
         } else {
             let should_skip = self
@@ -437,7 +437,7 @@ impl<'a> Rewrite for [ast::Attribute] {
                     )?;
                     result.push_str(&comment);
                     if let Some(next) = attrs.get(derives.len()) {
-                        if next.is_sugared_doc {
+                        if next.is_doc_comment() {
                             let snippet = context.snippet(missing_span);
                             let (_, mlb) = has_newlines_before_after_comment(snippet);
                             result.push_str(&mlb);
@@ -470,7 +470,7 @@ impl<'a> Rewrite for [ast::Attribute] {
                 )?;
                 result.push_str(&comment);
                 if let Some(next) = attrs.get(1) {
-                    if next.is_sugared_doc {
+                    if next.is_doc_comment() {
                         let snippet = context.snippet(missing_span);
                         let (_, mlb) = has_newlines_before_after_comment(snippet);
                         result.push_str(&mlb);

--- a/rustfmt-core/rustfmt-lib/src/attr.rs
+++ b/rustfmt-core/rustfmt-lib/src/attr.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
         ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => expr.span,
         ast::StmtKind::Mac(ref mac) => {
             let (ref mac, _, _) = **mac;
-            mac.span
+            mac.span()
         }
     }
 }

--- a/rustfmt-core/rustfmt-lib/src/chains.rs
+++ b/rustfmt-core/rustfmt-lib/src/chains.rs
@@ -58,7 +58,7 @@
 use std::borrow::Cow;
 use std::cmp::min;
 
-use syntax::source_map::{BytePos, Span};
+use rustc_span::{BytePos, Span};
 use syntax::{ast, ptr};
 
 use crate::comment::{rewrite_comment, CharClasses, FullCodeCharKind, RichChar};

--- a/rustfmt-core/rustfmt-lib/src/closures.rs
+++ b/rustfmt-core/rustfmt-lib/src/closures.rs
@@ -1,4 +1,4 @@
-use syntax::source_map::Span;
+use rustc_span::Span;
 use syntax::{ast, ptr};
 
 use crate::attr::get_attrs_from_stmt;

--- a/rustfmt-core/rustfmt-lib/src/closures.rs
+++ b/rustfmt-core/rustfmt-lib/src/closures.rs
@@ -184,7 +184,7 @@ fn rewrite_closure_expr(
             | ast::ExprKind::Loop(..)
             | ast::ExprKind::Struct(..) => true,
 
-            ast::ExprKind::AddrOf(_, ref expr)
+            ast::ExprKind::AddrOf(_, _, ref expr)
             | ast::ExprKind::Box(ref expr)
             | ast::ExprKind::Try(ref expr)
             | ast::ExprKind::Unary(_, ref expr)
@@ -431,7 +431,7 @@ fn is_block_closure_forced_inner(expr: &ast::Expr) -> bool {
         | ast::ExprKind::While(..)
         | ast::ExprKind::ForLoop(..)
         | ast::ExprKind::Loop(..) => true,
-        ast::ExprKind::AddrOf(_, ref expr)
+        ast::ExprKind::AddrOf(_, _, ref expr)
         | ast::ExprKind::Box(ref expr)
         | ast::ExprKind::Try(ref expr)
         | ast::ExprKind::Unary(_, ref expr)

--- a/rustfmt-core/rustfmt-lib/src/comment.rs
+++ b/rustfmt-core/rustfmt-lib/src/comment.rs
@@ -3,7 +3,7 @@
 use std::{self, borrow::Cow, iter};
 
 use itertools::{multipeek, MultiPeek};
-use syntax::source_map::Span;
+use rustc_span::Span;
 
 use crate::config::Config;
 use crate::rewrite::RewriteContext;

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -252,8 +252,7 @@ pub(crate) fn format_expr(
             fn needs_space_before_range(context: &RewriteContext<'_>, lhs: &ast::Expr) -> bool {
                 match lhs.kind {
                     ast::ExprKind::Lit(ref lit) => match lit.kind {
-                        ast::LitKind::Float(_, ref float_type) if ast::LitFloatType::Unsuffixed == *float_type =>
-                        {
+                        ast::LitKind::Float(_, ast::LitFloatType::Unsuffixed) => {
                             context.snippet(lit.span).ends_with('.')
                         }
                         _ => false,
@@ -1336,8 +1335,12 @@ pub(crate) fn can_be_overflowed_expr(
                 || (context.use_block_indent() && args_len == 1)
         }
         ast::ExprKind::Mac(ref mac) => {
-            match (syntax::ast::MacDelimiter::from_token(mac.args.delim()), context.config.overflow_delimited_expr()) {
-                (Some(ast::MacDelimiter::Bracket), true) | (Some(ast::MacDelimiter::Brace), true) => true,
+            match (
+                syntax::ast::MacDelimiter::from_token(mac.args.delim()),
+                context.config.overflow_delimited_expr(),
+            ) {
+                (Some(ast::MacDelimiter::Bracket), true)
+                | (Some(ast::MacDelimiter::Brace), true) => true,
                 _ => context.use_block_indent() && args_len == 1,
             }
         }

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -2040,8 +2040,8 @@ fn rewrite_expr_addrof(
     shape: Shape,
 ) -> Option<String> {
     let operator_str = match mutability {
-        ast::Mutability::Immutable => "&",
-        ast::Mutability::Mutable => "&mut ",
+        ast::Mutability::Not => "&",
+        ast::Mutability::Mut => "&mut ",
     };
     rewrite_unary_prefix(context, operator_str, expr, shape)
 }

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::cmp::min;
 
 use itertools::Itertools;
+use rustc_span::{BytePos, Span};
 use syntax::parse::token::{DelimToken, LitKind};
-use syntax::source_map::{BytePos, Span};
 use syntax::{ast, ptr};
 
 use crate::chains::rewrite_chain;

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -159,7 +159,7 @@ pub(crate) fn format_expr(
         ast::ExprKind::Path(ref qself, ref path) => {
             rewrite_path(context, PathContext::Expr, qself.as_ref(), path, shape)
         }
-        ast::ExprKind::Assign(ref lhs, ref rhs) => {
+        ast::ExprKind::Assign(ref lhs, ref rhs, _) => {
             rewrite_assignment(context, lhs, rhs, None, shape)
         }
         ast::ExprKind::AssignOp(ref op, ref lhs, ref rhs) => {
@@ -213,8 +213,8 @@ pub(crate) fn format_expr(
             rewrite_unary_prefix(context, "return ", &**expr, shape)
         }
         ast::ExprKind::Box(ref expr) => rewrite_unary_prefix(context, "box ", &**expr, shape),
-        ast::ExprKind::AddrOf(mutability, ref expr) => {
-            rewrite_expr_addrof(context, mutability, expr, shape)
+        ast::ExprKind::AddrOf(borrow_kind, mutability, ref expr) => {
+            rewrite_expr_addrof(context, borrow_kind, mutability, expr, shape)
         }
         ast::ExprKind::Cast(ref expr, ref ty) => rewrite_pair(
             &**expr,
@@ -1289,7 +1289,7 @@ pub(crate) fn is_simple_expr(expr: &ast::Expr) -> bool {
     match expr.kind {
         ast::ExprKind::Lit(..) => true,
         ast::ExprKind::Path(ref qself, ref path) => qself.is_none() && path.segments.len() <= 1,
-        ast::ExprKind::AddrOf(_, ref expr)
+        ast::ExprKind::AddrOf(_, _, ref expr)
         | ast::ExprKind::Box(ref expr)
         | ast::ExprKind::Cast(ref expr, _)
         | ast::ExprKind::Field(ref expr, _)
@@ -1347,7 +1347,7 @@ pub(crate) fn can_be_overflowed_expr(
         }
 
         // Handle unary-like expressions
-        ast::ExprKind::AddrOf(_, ref expr)
+        ast::ExprKind::AddrOf(_, _, ref expr)
         | ast::ExprKind::Box(ref expr)
         | ast::ExprKind::Try(ref expr)
         | ast::ExprKind::Unary(_, ref expr)
@@ -1359,7 +1359,7 @@ pub(crate) fn can_be_overflowed_expr(
 pub(crate) fn is_nested_call(expr: &ast::Expr) -> bool {
     match expr.kind {
         ast::ExprKind::Call(..) | ast::ExprKind::Mac(..) => true,
-        ast::ExprKind::AddrOf(_, ref expr)
+        ast::ExprKind::AddrOf(_, _, ref expr)
         | ast::ExprKind::Box(ref expr)
         | ast::ExprKind::Try(ref expr)
         | ast::ExprKind::Unary(_, ref expr)
@@ -2035,6 +2035,7 @@ pub(crate) fn prefer_next_line(
 
 fn rewrite_expr_addrof(
     context: &RewriteContext<'_>,
+    _borrow_kind: ast::BorrowKind,
     mutability: ast::Mutability,
     expr: &ast::Expr,
     shape: Shape,
@@ -2049,7 +2050,7 @@ fn rewrite_expr_addrof(
 pub(crate) fn is_method_call(expr: &ast::Expr) -> bool {
     match expr.kind {
         ast::ExprKind::MethodCall(..) => true,
-        ast::ExprKind::AddrOf(_, ref expr)
+        ast::ExprKind::AddrOf(_, _, ref expr)
         | ast::ExprKind::Box(ref expr)
         | ast::ExprKind::Cast(ref expr, _)
         | ast::ExprKind::Try(ref expr)

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -252,7 +252,8 @@ pub(crate) fn format_expr(
             fn needs_space_before_range(context: &RewriteContext<'_>, lhs: &ast::Expr) -> bool {
                 match lhs.kind {
                     ast::ExprKind::Lit(ref lit) => match lit.kind {
-                        ast::LitKind::FloatUnsuffixed(..) => {
+                        ast::LitKind::Float(_, ref float_type) if ast::LitFloatType::Unsuffixed == *float_type =>
+                        {
                             context.snippet(lit.span).ends_with('.')
                         }
                         _ => false,

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -3,7 +3,7 @@ use std::cmp::min;
 
 use itertools::Itertools;
 use rustc_span::{BytePos, Span};
-use syntax::parse::token::{DelimToken, LitKind};
+use syntax::token::{DelimToken, LitKind};
 use syntax::{ast, ptr};
 
 use crate::chains::rewrite_chain;

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -1336,8 +1336,8 @@ pub(crate) fn can_be_overflowed_expr(
                 || (context.use_block_indent() && args_len == 1)
         }
         ast::ExprKind::Mac(ref mac) => {
-            match (mac.delim, context.config.overflow_delimited_expr()) {
-                (ast::MacDelimiter::Bracket, true) | (ast::MacDelimiter::Brace, true) => true,
+            match (syntax::ast::MacDelimiter::from_token(mac.args.delim()), context.config.overflow_delimited_expr()) {
+                (Some(ast::MacDelimiter::Bracket), true) | (Some(ast::MacDelimiter::Brace), true) => true,
                 _ => context.use_block_indent() && args_len == 1,
             }
         }

--- a/rustfmt-core/rustfmt-lib/src/formatting.rs
+++ b/rustfmt-core/rustfmt-lib/src/formatting.rs
@@ -93,7 +93,7 @@ fn format_project<T: FormatHandler>(
     let mut context = FormatContext::new(&krate, report, parse_session, config, handler);
     let files = modules::ModResolver::new(
         &context.parse_session,
-        directory_ownership.unwrap_or(DirectoryOwnership::UnownedViaMod(true)),
+        directory_ownership.unwrap_or(DirectoryOwnership::UnownedViaMod),
         !input_is_stdin && config.recursive(),
     )
     .visit_crate(&krate)

--- a/rustfmt-core/rustfmt-lib/src/formatting.rs
+++ b/rustfmt-core/rustfmt-lib/src/formatting.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 use std::time::{Duration, Instant};
 
+use rustc_span::Span;
 use syntax::ast;
-use syntax::source_map::Span;
 
 use self::newline_style::apply_newline_style;
 use crate::comment::{CharClasses, FullCodeCharKind};

--- a/rustfmt-core/rustfmt-lib/src/imports.rs
+++ b/rustfmt-core/rustfmt-lib/src/imports.rs
@@ -2,9 +2,8 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt;
 
+use rustc_span::{BytePos, DUMMY_SP, source_map, Span, symbol::sym};
 use syntax::ast::{self, UseTreeKind};
-use syntax::source_map::{self, BytePos, Span, DUMMY_SP};
-use syntax::symbol::sym;
 
 use crate::comment::combine_strs_with_missing_comments;
 use crate::config::lists::*;
@@ -854,7 +853,7 @@ impl Rewrite for UseTree {
 #[cfg(test)]
 mod test {
     use super::*;
-    use syntax::source_map::DUMMY_SP;
+    use rustc_span::DUMMY_SP;
 
     // Parse the path part of an import. This parser is not robust and is only
     // suitable for use in a test harness.

--- a/rustfmt-core/rustfmt-lib/src/imports.rs
+++ b/rustfmt-core/rustfmt-lib/src/imports.rs
@@ -248,7 +248,7 @@ impl UseTree {
 
                 let allow_extend = if attrs.len() == 1 {
                     let line_len = attr_str.len() + 1 + use_str.len();
-                    !attrs.first().unwrap().is_sugared_doc
+                    !attrs.first().unwrap().is_doc_comment()
                         && context.config.inline_attribute_width() >= line_len
                 } else {
                     false

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -634,7 +634,7 @@ impl<'a> FmtVisitor<'a> {
         combine_strs_with_missing_comments(&context, &attrs_str, &variant_body, span, shape, false)
     }
 
-    fn visit_impl_items(&mut self, items: &[ast::AssocItem]) {
+    fn visit_impl_items(&mut self, items: &[ptr::P<ast::AssocItem>]) {
         if self.get_context().config.reorder_impl_items() {
             // Create visitor for each items, then reorder them.
             let mut buffer = vec![];
@@ -742,7 +742,7 @@ pub(crate) fn format_impl(
     item: &ast::Item,
     offset: Indent,
 ) -> Option<String> {
-    if let ast::ItemKind::Impl(_, _, _, ref generics, _, ref self_ty, ref items) = item.kind {
+    if let ast::ItemKind::Impl { ref generics, ref self_ty, ref items, ..} = item.kind {
         let mut result = String::with_capacity(128);
         let ref_and_type = format_impl_ref_and_type(context, item, offset)?;
         let sep = offset.to_string_with_newline(context.config);
@@ -799,7 +799,7 @@ pub(crate) fn format_impl(
             }
         }
 
-        if is_impl_single_line(context, items, &result, &where_clause_str, item)? {
+        if is_impl_single_line(context, items.as_slice(), &result, &where_clause_str, item)? {
             result.push_str(&where_clause_str);
             if where_clause_str.contains('\n') || last_line_contains_single_line_comment(&result) {
                 // if the where_clause contains extra comments AND
@@ -868,7 +868,7 @@ pub(crate) fn format_impl(
 
 fn is_impl_single_line(
     context: &RewriteContext<'_>,
-    items: &[ast::AssocItem],
+    items: &[ptr::P<ast::AssocItem>],
     result: &str,
     where_clause_str: &str,
     item: &ast::Item,
@@ -890,15 +890,15 @@ fn format_impl_ref_and_type(
     item: &ast::Item,
     offset: Indent,
 ) -> Option<String> {
-    if let ast::ItemKind::Impl(
+    if let ast::ItemKind::Impl {
         unsafety,
         polarity,
         defaultness,
         ref generics,
-        ref trait_ref,
+        of_trait: ref trait_ref,
         ref self_ty,
-        _,
-    ) = item.kind
+        ..
+    } = item.kind
     {
         let mut result = String::with_capacity(128);
 

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -281,9 +281,7 @@ impl<'a> FnSig<'a> {
             visit::FnKind::Method(_, method_sig, vis, _) => {
                 let mut fn_sig = FnSig::from_method_sig(method_sig, generics);
                 fn_sig.defaultness = defaultness;
-                if let Some(vis) = vis {
-                    fn_sig.visibility = vis.clone();
-                }
+                fn_sig.visibility = vis.clone();
                 fn_sig
             }
             _ => unreachable!(),
@@ -1753,7 +1751,7 @@ impl<'a> StaticParts<'a> {
             ident: ii.ident,
             ty,
             mutability: ast::Mutability::Not,
-            expr_opt: Some(expr),
+            expr_opt: expr.as_ref(),
             defaultness: Some(ii.defaultness),
             span: ii.span,
         }

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -3139,7 +3139,7 @@ fn rewrite_attrs(
 
     let allow_extend = if attrs.len() == 1 {
         let line_len = attrs_str.len() + 1 + item_str.len();
-        !attrs.first().unwrap().is_sugared_doc
+        !attrs.first().unwrap().is_doc_comment()
             && context.config.inline_attribute_width() >= line_len
     } else {
         false

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -1709,7 +1709,7 @@ impl<'a> StaticParts<'a> {
         let (prefix, ty, mutability, expr) = match item.kind {
             ast::ItemKind::Static(ref ty, mutability, ref expr) => ("static", ty, mutability, expr),
             ast::ItemKind::Const(ref ty, ref expr) => {
-                ("const", ty, ast::Mutability::Immutable, expr)
+                ("const", ty, ast::Mutability::Not, expr)
             }
             _ => unreachable!(),
         };
@@ -1735,7 +1735,7 @@ impl<'a> StaticParts<'a> {
             vis: &DEFAULT_VISIBILITY,
             ident: ti.ident,
             ty,
-            mutability: ast::Mutability::Immutable,
+            mutability: ast::Mutability::Not,
             expr_opt: expr_opt.as_ref(),
             defaultness: None,
             span: ti.span,
@@ -1752,7 +1752,7 @@ impl<'a> StaticParts<'a> {
             vis: &ii.vis,
             ident: ii.ident,
             ty,
-            mutability: ast::Mutability::Immutable,
+            mutability: ast::Mutability::Not,
             expr_opt: Some(expr),
             defaultness: Some(ii.defaultness),
             span: ii.span,

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -4,10 +4,10 @@ use std::borrow::Cow;
 use std::cmp::{max, min, Ordering};
 
 use regex::Regex;
+use rustc_span::{BytePos, DUMMY_SP, source_map, Span, symbol};
 use rustc_target::spec::abi;
-use syntax::source_map::{self, BytePos, Span};
 use syntax::visit;
-use syntax::{ast, ptr, symbol};
+use syntax::{ast, ptr};
 
 use crate::attr::filter_inline_attrs;
 use crate::comment::{
@@ -35,7 +35,7 @@ use crate::visitor::FmtVisitor;
 
 const DEFAULT_VISIBILITY: ast::Visibility = source_map::Spanned {
     node: ast::VisibilityKind::Inherited,
-    span: source_map::DUMMY_SP,
+    span: DUMMY_SP,
 };
 
 fn type_annotation_separator(config: &Config) -> &str {

--- a/rustfmt-core/rustfmt-lib/src/lists.rs
+++ b/rustfmt-core/rustfmt-lib/src/lists.rs
@@ -3,7 +3,7 @@
 use std::cmp;
 use std::iter::Peekable;
 
-use syntax::source_map::BytePos;
+use rustc_span::BytePos;
 
 use crate::comment::{find_comment_end, rewrite_comment, FindUncommented};
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -1476,7 +1476,7 @@ fn format_lazy_static(
 
     while parser.token.kind != TokenKind::Eof {
         // Parse a `lazy_static!` item.
-        let vis = crate::utils::format_visibility(context, &parse_or!(parse_visibility, false));
+        let vis = crate::utils::format_visibility(context, &parse_or!(parse_visibility, rustc_parse::parser::FollowedByType::No));
         parser.eat_keyword(kw::Static);
         parser.eat_keyword(kw::Ref);
         let id = parse_or!(parse_ident);

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -143,7 +143,7 @@ fn rewrite_macro_name(
         // Avoid using pretty-printer in the common case.
         format!("{}!", rewrite_ident(context, path.segments[0].ident))
     } else {
-        format!("{}!", path)
+        format!("{}!", pprust::path_to_string(path))
     };
     match extra_ident {
         Some(ident) if ident.name != kw::Invalid => format!("{} {}", name, ident),
@@ -1190,7 +1190,8 @@ pub(crate) fn convert_try_mac(mac: &ast::Mac, context: &RewriteContext<'_>) -> O
     // `r#try!` must be used in the 2018 Edition.
     // https://doc.rust-lang.org/std/macro.try.html
     // https://github.com/rust-lang/rust/pull/62672
-    if &mac.path.to_string() == "try" || &mac.path.to_string() == "r#try" {
+    let path = &pprust::path_to_string(&mac.path);
+    if path == "try" || path == "r#try" {
         let ts: TokenStream = mac.tts.clone();
         let mut parser = new_parser_from_tts(context.parse_sess.inner(), ts.trees().collect());
 

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -17,7 +17,6 @@ use rustc_span::{BytePos, DUMMY_SP, Span, Symbol, symbol::kw};
 use syntax::print::pprust;
 use syntax::token::{BinOpToken, DelimToken, Token, TokenKind};
 use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
-use syntax::ThinVec;
 use syntax::{ast, ptr};
 
 use crate::comment::{
@@ -1203,7 +1202,7 @@ pub(crate) fn convert_try_mac(mac: &ast::Mac, context: &RewriteContext<'_>) -> O
             id: ast::NodeId::root(), // dummy value
             kind: ast::ExprKind::Try(kind),
             span: mac.span, // incorrect span, but shouldn't matter too much
-            attrs: ThinVec::new(),
+            attrs: ast::AttrVec::new(),
         })
     } else {
         None

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -14,8 +14,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use rustc_parse::{new_parser_from_tts, parser::Parser};
 use rustc_span::{BytePos, DUMMY_SP, Span, Symbol, symbol::kw};
-use syntax::parse::token::{BinOpToken, DelimToken, Token, TokenKind};
 use syntax::print::pprust;
+use syntax::token::{BinOpToken, DelimToken, Token, TokenKind};
 use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
 use syntax::ThinVec;
 use syntax::{ast, ptr};

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -12,16 +12,14 @@
 use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
+use rustc_span::{BytePos, DUMMY_SP, Span, Symbol, symbol::kw};
 use syntax::parse::new_parser_from_tts;
 use syntax::parse::parser::Parser;
 use syntax::parse::token::{BinOpToken, DelimToken, Token, TokenKind};
 use syntax::print::pprust;
-use syntax::source_map::{BytePos, Span};
-use syntax::symbol::kw;
 use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
 use syntax::ThinVec;
 use syntax::{ast, parse, ptr};
-use syntax_pos::{Symbol, DUMMY_SP};
 
 use crate::comment::{
     contains_comment, CharClasses, FindUncommented, FullCodeCharKind, LineClasses,

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -12,9 +12,9 @@
 use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
+use rustc_ast_pretty::pprust;
 use rustc_parse::{new_parser_from_tts, parser::Parser};
 use rustc_span::{BytePos, DUMMY_SP, Span, Symbol, symbol::kw};
-use syntax::print::pprust;
 use syntax::token::{BinOpToken, DelimToken, Token, TokenKind};
 use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
 use syntax::{ast, ptr};

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -12,14 +12,13 @@
 use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
+use rustc_parse::{new_parser_from_tts, parser::Parser};
 use rustc_span::{BytePos, DUMMY_SP, Span, Symbol, symbol::kw};
-use syntax::parse::new_parser_from_tts;
-use syntax::parse::parser::Parser;
 use syntax::parse::token::{BinOpToken, DelimToken, Token, TokenKind};
 use syntax::print::pprust;
 use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
 use syntax::ThinVec;
-use syntax::{ast, parse, ptr};
+use syntax::{ast, ptr};
 
 use crate::comment::{
     contains_comment, CharClasses, FindUncommented, FullCodeCharKind, LineClasses,
@@ -112,23 +111,23 @@ fn parse_macro_arg<'a, 'b: 'a>(parser: &'a mut Parser<'b>) -> Option<MacroArg> {
 
     parse_macro_arg!(
         Expr,
-        |parser: &mut parse::parser::Parser<'b>| parser.parse_expr(),
+        |parser: &mut rustc_parse::parser::Parser<'b>| parser.parse_expr(),
         |x: ptr::P<ast::Expr>| Some(x)
     );
     parse_macro_arg!(
         Ty,
-        |parser: &mut parse::parser::Parser<'b>| parser.parse_ty(),
+        |parser: &mut rustc_parse::parser::Parser<'b>| parser.parse_ty(),
         |x: ptr::P<ast::Ty>| Some(x)
     );
     parse_macro_arg!(
         Pat,
-        |parser: &mut parse::parser::Parser<'b>| parser.parse_pat(None),
+        |parser: &mut rustc_parse::parser::Parser<'b>| parser.parse_pat(None),
         |x: ptr::P<ast::Pat>| Some(x)
     );
     // `parse_item` returns `Option<ptr::P<ast::Item>>`.
     parse_macro_arg!(
         Item,
-        |parser: &mut parse::parser::Parser<'b>| parser.parse_item(),
+        |parser: &mut rustc_parse::parser::Parser<'b>| parser.parse_item(),
         |x: Option<ptr::P<ast::Item>>| x
     );
 

--- a/rustfmt-core/rustfmt-lib/src/matches.rs
+++ b/rustfmt-core/rustfmt-lib/src/matches.rs
@@ -2,7 +2,7 @@
 
 use std::iter::repeat;
 
-use syntax::source_map::{BytePos, Span};
+use rustc_span::{BytePos, Span};
 use syntax::{ast, ptr};
 
 use crate::comment::{combine_strs_with_missing_comments, rewrite_comment};

--- a/rustfmt-core/rustfmt-lib/src/matches.rs
+++ b/rustfmt-core/rustfmt-lib/src/matches.rs
@@ -575,7 +575,7 @@ fn can_flatten_block_around_this(body: &ast::Expr) -> bool {
         | ast::ExprKind::Mac(..)
         | ast::ExprKind::Struct(..)
         | ast::ExprKind::Tup(..) => true,
-        ast::ExprKind::AddrOf(_, ref expr)
+        ast::ExprKind::AddrOf(_, _, ref expr)
         | ast::ExprKind::Box(ref expr)
         | ast::ExprKind::Try(ref expr)
         | ast::ExprKind::Unary(_, ref expr)

--- a/rustfmt-core/rustfmt-lib/src/missed_spans.rs
+++ b/rustfmt-core/rustfmt-lib/src/missed_spans.rs
@@ -1,4 +1,4 @@
-use syntax::source_map::{BytePos, Pos, Span};
+use rustc_span::{BytePos, Pos, Span};
 
 use crate::comment::{is_last_comment_block, rewrite_comment, CodeCharKind, CommentCodeSlices};
 use crate::config::file_lines::FileLines;

--- a/rustfmt-core/rustfmt-lib/src/modules.rs
+++ b/rustfmt-core/rustfmt-lib/src/modules.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use rustc_span::symbol::{sym, Symbol};
 use syntax::ast;
-use syntax::symbol::sym;
 use syntax::visit::Visitor;
-use syntax_pos::symbol::Symbol;
 
 use crate::attr::MetaVisitor;
 use crate::config::FileName;

--- a/rustfmt-core/rustfmt-lib/src/modules.rs
+++ b/rustfmt-core/rustfmt-lib/src/modules.rs
@@ -154,7 +154,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         } else {
             // An internal module (`mod foo { /* ... */ }`);
             if let Some(path) = find_path_value(&item.attrs) {
-                let path = Path::new(&path.as_str()).to_path_buf();
+                let path = Path::new(&*path.as_str()).to_path_buf();
                 Ok(Some(SubModKind::InternalWithPath(path)))
             } else {
                 Ok(Some(SubModKind::Internal(item)))
@@ -288,7 +288,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
 
     fn push_inline_mod_directory(&mut self, id: ast::Ident, attrs: &[ast::Attribute]) {
         if let Some(path) = find_path_value(attrs) {
-            self.directory.path.push(&path.as_str());
+            self.directory.path.push(&*path.as_str());
             self.directory.ownership = DirectoryOwnership::Owned { relative: None };
         } else {
             // We have to push on the current module name in the case of relative
@@ -300,10 +300,10 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
             if let DirectoryOwnership::Owned { relative } = &mut self.directory.ownership {
                 if let Some(ident) = relative.take() {
                     // remove the relative offset
-                    self.directory.path.push(ident.as_str());
+                    self.directory.path.push(&*ident.as_str());
                 }
             }
-            self.directory.path.push(&id.as_str());
+            self.directory.path.push(&*id.as_str());
         }
     }
 

--- a/rustfmt-core/rustfmt-lib/src/modules.rs
+++ b/rustfmt-core/rustfmt-lib/src/modules.rs
@@ -252,7 +252,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
 
         let relative = match self.directory.ownership {
             DirectoryOwnership::Owned { relative } => relative,
-            DirectoryOwnership::UnownedViaBlock | DirectoryOwnership::UnownedViaMod(_) => None,
+            DirectoryOwnership::UnownedViaBlock | DirectoryOwnership::UnownedViaMod => None,
         };
         match self
             .parse_sess

--- a/rustfmt-core/rustfmt-lib/src/modules/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/modules/visitor.rs
@@ -1,6 +1,6 @@
+use rustc_span::Symbol;
 use syntax::ast;
 use syntax::visit::Visitor;
-use syntax_pos::Symbol;
 
 use crate::attr::MetaVisitor;
 use crate::syntux::parser::{Directory, Parser};

--- a/rustfmt-core/rustfmt-lib/src/overflow.rs
+++ b/rustfmt-core/rustfmt-lib/src/overflow.rs
@@ -4,7 +4,7 @@ use std::cmp::min;
 
 use itertools::Itertools;
 use rustc_span::Span;
-use syntax::parse::token::DelimToken;
+use syntax::token::DelimToken;
 use syntax::{ast, ptr};
 
 use crate::closures;

--- a/rustfmt-core/rustfmt-lib/src/overflow.rs
+++ b/rustfmt-core/rustfmt-lib/src/overflow.rs
@@ -3,8 +3,8 @@
 use std::cmp::min;
 
 use itertools::Itertools;
+use rustc_span::Span;
 use syntax::parse::token::DelimToken;
-use syntax::source_map::Span;
 use syntax::{ast, ptr};
 
 use crate::closures;

--- a/rustfmt-core/rustfmt-lib/src/patterns.rs
+++ b/rustfmt-core/rustfmt-lib/src/patterns.rs
@@ -1,6 +1,6 @@
+use rustc_span::{BytePos, Span};
 use syntax::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax};
 use syntax::ptr;
-use syntax::source_map::{BytePos, Span};
 
 use crate::comment::{combine_strs_with_missing_comments, FindUncommented};
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/patterns.rs
+++ b/rustfmt-core/rustfmt-lib/src/patterns.rs
@@ -191,8 +191,8 @@ impl Rewrite for Pat {
                     infix.to_owned()
                 };
                 rewrite_pair(
-                    &**lhs,
-                    &**rhs,
+                    &lhs.unwrap(),
+                    &rhs.unwrap(),
                     PairParts::infix(&infix),
                     context,
                     shape,

--- a/rustfmt-core/rustfmt-lib/src/patterns.rs
+++ b/rustfmt-core/rustfmt-lib/src/patterns.rs
@@ -179,25 +179,28 @@ impl Rewrite for Pat {
                     None
                 }
             }
-            PatKind::Range(ref lhs, ref rhs, ref end_kind) => {
-                let infix = match end_kind.node {
-                    RangeEnd::Included(RangeSyntax::DotDotDot) => "...",
-                    RangeEnd::Included(RangeSyntax::DotDotEq) => "..=",
-                    RangeEnd::Excluded => "..",
-                };
-                let infix = if context.config.spaces_around_ranges() {
-                    format!(" {} ", infix)
-                } else {
-                    infix.to_owned()
-                };
-                rewrite_pair(
-                    &lhs.unwrap(),
-                    &rhs.unwrap(),
-                    PairParts::infix(&infix),
-                    context,
-                    shape,
-                    SeparatorPlace::Front,
-                )
+            PatKind::Range(ref lhs, ref rhs, ref end_kind) => match (lhs, rhs) {
+                (Some(lhs), Some(rhs)) => {
+                    let infix = match end_kind.node {
+                        RangeEnd::Included(RangeSyntax::DotDotDot) => "...",
+                        RangeEnd::Included(RangeSyntax::DotDotEq) => "..=",
+                        RangeEnd::Excluded => "..",
+                    };
+                    let infix = if context.config.spaces_around_ranges() {
+                        format!(" {} ", infix)
+                    } else {
+                        infix.to_owned()
+                    };
+                    rewrite_pair(
+                        &**lhs,
+                        &**rhs,
+                        PairParts::infix(&infix),
+                        context,
+                        shape,
+                        SeparatorPlace::Front,
+                    )
+                },
+                (_, _) => unimplemented!(),
             }
             PatKind::Ref(ref pat, mutability) => {
                 let prefix = format!("&{}", format_mutability(mutability));

--- a/rustfmt-core/rustfmt-lib/src/reorder.rs
+++ b/rustfmt-core/rustfmt-lib/src/reorder.rs
@@ -8,7 +8,8 @@
 
 use std::cmp::{Ord, Ordering};
 
-use syntax::{ast, attr, source_map::Span, symbol::sym};
+use rustc_span::{Span, symbol::sym};
+use syntax::{ast, attr};
 
 use crate::config::Config;
 use crate::imports::{merge_use_trees, UseTree};
@@ -31,9 +32,9 @@ fn compare_items(a: &ast::Item, b: &ast::Item) -> Ordering {
             // `extern crate foo as bar;`
             //               ^^^ Comparing this.
             let a_orig_name =
-                a_name.map_or_else(|| a.ident.as_str(), syntax_pos::symbol::Symbol::as_str);
+                a_name.map_or_else(|| a.ident.as_str(), rustc_span::Symbol::as_str);
             let b_orig_name =
-                b_name.map_or_else(|| b.ident.as_str(), syntax_pos::symbol::Symbol::as_str);
+                b_name.map_or_else(|| b.ident.as_str(), rustc_span::Symbol::as_str);
             let result = a_orig_name.cmp(&b_orig_name);
             if result != Ordering::Equal {
                 return result;

--- a/rustfmt-core/rustfmt-lib/src/rewrite.rs
+++ b/rustfmt-core/rustfmt-lib/src/rewrite.rs
@@ -3,8 +3,8 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
+use rustc_span::Span;
 use syntax::ptr;
-use syntax::source_map::Span;
 
 use crate::config::{Config, IndentStyle};
 use crate::shape::Shape;

--- a/rustfmt-core/rustfmt-lib/src/skip.rs
+++ b/rustfmt-core/rustfmt-lib/src/skip.rs
@@ -29,10 +29,15 @@ impl SkipContext {
             }
         }
         for attr in attrs {
-            if is_skip_attr_with(&attr.get_normal_item().path.segments, |s| s == sym!(macros)) {
-                get_skip_names(&mut self.macros, attr)
-            } else if is_skip_attr_with(&attr.get_normal_item().path.segments, |s| s == sym::attributes) {
-                get_skip_names(&mut self.attributes, attr)
+            match &attr.kind {
+                syntax::ast::AttrKind::Normal(ref attr_item) => {
+                    if is_skip_attr_with(&attr_item.path.segments, |s| s == sym!(macros)) {
+                        get_skip_names(&mut self.macros, attr)
+                    } else if is_skip_attr_with(&attr_item.path.segments, |s| s == sym::attributes) {
+                        get_skip_names(&mut self.attributes, attr)
+                    }
+                }
+                _ => (),
             }
         }
     }

--- a/rustfmt-core/rustfmt-lib/src/skip.rs
+++ b/rustfmt-core/rustfmt-lib/src/skip.rs
@@ -1,7 +1,7 @@
 //! Module that contains skip related stuffs.
 
+use rustc_span::symbol::{sym, Symbol};
 use syntax::ast::{Attribute, PathSegment};
-use syntax::symbol::{sym, Symbol};
 
 macro_rules! sym {
     ($tt:tt) => {

--- a/rustfmt-core/rustfmt-lib/src/skip.rs
+++ b/rustfmt-core/rustfmt-lib/src/skip.rs
@@ -29,9 +29,9 @@ impl SkipContext {
             }
         }
         for attr in attrs {
-            if is_skip_attr_with(&attr.item.path.segments, |s| s == sym!(macros)) {
+            if is_skip_attr_with(&attr.get_normal_item().path.segments, |s| s == sym!(macros)) {
                 get_skip_names(&mut self.macros, attr)
-            } else if is_skip_attr_with(&attr.item.path.segments, |s| s == sym::attributes) {
+            } else if is_skip_attr_with(&attr.get_normal_item().path.segments, |s| s == sym::attributes) {
                 get_skip_names(&mut self.attributes, attr)
             }
         }

--- a/rustfmt-core/rustfmt-lib/src/source_map.rs
+++ b/rustfmt-core/rustfmt-lib/src/source_map.rs
@@ -1,7 +1,7 @@
 //! This module contains utilities that work with the `SourceMap` from `libsyntax`/`syntex_syntax`.
 //! This includes extension traits and methods for looking up spans and line ranges for AST nodes.
 
-use syntax::source_map::{BytePos, Span};
+use rustc_span::{BytePos, Span};
 
 use crate::comment::FindUncommented;
 use crate::config::file_lines::LineRange;

--- a/rustfmt-core/rustfmt-lib/src/spanned.rs
+++ b/rustfmt-core/rustfmt-lib/src/spanned.rs
@@ -1,9 +1,7 @@
 use std::cmp::max;
 
-use syntax::{
-    ast, ptr,
-    source_map::{self, Span},
-};
+use rustc_span::{source_map, Span};
+use syntax::{ast, ptr};
 
 use crate::macros::MacroArg;
 use crate::utils::{mk_sp, outer_attributes};

--- a/rustfmt-core/rustfmt-lib/src/spanned.rs
+++ b/rustfmt-core/rustfmt-lib/src/spanned.rs
@@ -56,13 +56,12 @@ macro_rules! implement_spanned {
 }
 
 // Implement `Spanned` for structs with `attrs` field.
+implement_spanned!(ast::AssocItem);
 implement_spanned!(ast::Expr);
 implement_spanned!(ast::Field);
 implement_spanned!(ast::ForeignItem);
 implement_spanned!(ast::Item);
 implement_spanned!(ast::Local);
-implement_spanned!(ast::TraitItem);
-implement_spanned!(ast::ImplItem);
 
 impl Spanned for ast::Stmt {
     fn span(&self) -> Span {

--- a/rustfmt-core/rustfmt-lib/src/spanned.rs
+++ b/rustfmt-core/rustfmt-lib/src/spanned.rs
@@ -29,12 +29,7 @@ macro_rules! span_with_attrs_lo_hi {
         if attrs.is_empty() {
             mk_sp($lo, $hi)
         } else {
-            // this path is already gone at latest rust-ap-* 627.0.0
-            if attrs[0].item.path.to_string() == "warn_directory_ownership" {
-                mk_sp($lo, $hi)
-            } else {
-                mk_sp(attrs[0].span.lo(), $hi)
-            }
+            mk_sp(attrs[0].span.lo(), $hi)
         }
     }};
 }

--- a/rustfmt-core/rustfmt-lib/src/stmt.rs
+++ b/rustfmt-core/rustfmt-lib/src/stmt.rs
@@ -1,5 +1,5 @@
+use rustc_span::Span;
 use syntax::ast;
-use syntax_pos::Span;
 
 use crate::comment::recover_comment_removed;
 use crate::expr::{format_expr, ExprType};

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -6,7 +6,7 @@ use rustc_parse::{new_sub_parser_from_file, parser::Parser as RawParser};
 use rustc_span::{DUMMY_SP, Span, symbol::kw};
 use syntax::ast;
 use syntax::errors::Diagnostic;
-use syntax::parse::token::{DelimToken, TokenKind};
+use syntax::token::{DelimToken, TokenKind};
 use syntax::parse::PResult;
 
 use crate::syntux::session::ParseSess;

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -2,12 +2,11 @@ use std::borrow::Cow;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
+use rustc_errors::{Diagnostic, PResult};
 use rustc_parse::{new_sub_parser_from_file, parser::Parser as RawParser};
 use rustc_span::{DUMMY_SP, Span, symbol::kw};
 use syntax::ast;
-use syntax::errors::Diagnostic;
 use syntax::token::{DelimToken, TokenKind};
-use syntax::parse::PResult;
 
 use crate::syntux::session::ParseSess;
 use crate::{Config, Input};

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -283,11 +283,7 @@ impl<'a> Parser<'a> {
         mac: &'a ast::Mac,
         base_dir: &Directory,
     ) -> Result<Vec<ast::Item>, &'static str> {
-        let token_stream: syntax::tokenstream::TokenStream = match *mac.args {
-            ast::MacArgs::Empty => syntax::tokenstream::TokenStream::default(),
-            ast::MacArgs::Delimited(_, _, token_stream) => token_stream,
-            ast::MacArgs::Eq(_, token_stream) => token_stream,
-        };
+        let token_stream = mac.args.inner_tokens();
         let mut parser = rustc_parse::stream_to_parser_with_base_dir(
             sess.inner(),
             token_stream.clone(),

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -88,7 +88,7 @@ impl<'a> ParserBuilder<'a> {
     }
 
     fn parser(
-        sess: &'a syntax::sess::ParseSess,
+        sess: &'a rustc_session::parse::ParseSess,
         input: Input,
         directory_ownership: Option<DirectoryOwnership>,
     ) -> Result<rustc_parse::parser::Parser<'a>, Vec<Diagnostic>> {

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -283,9 +283,14 @@ impl<'a> Parser<'a> {
         mac: &'a ast::Mac,
         base_dir: &Directory,
     ) -> Result<Vec<ast::Item>, &'static str> {
+        let token_stream: syntax::tokenstream::TokenStream = match *mac.args {
+            ast::MacArgs::Empty => syntax::tokenstream::TokenStream::default(),
+            ast::MacArgs::Delimited(_, _, token_stream) => token_stream,
+            ast::MacArgs::Eq(_, token_stream) => token_stream,
+        };
         let mut parser = rustc_parse::stream_to_parser_with_base_dir(
             sess.inner(),
-            mac.tts.clone(),
+            token_stream.clone(),
             base_dir.to_syntax_directory(),
         );
 

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -2,13 +2,12 @@ use std::borrow::Cow;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
+use rustc_span::{DUMMY_SP, Span, symbol::kw};
 use syntax::ast;
 use syntax::errors::Diagnostic;
 use syntax::parse::parser::Parser as RawParser;
 use syntax::parse::token::{DelimToken, TokenKind};
 use syntax::parse::{new_sub_parser_from_file, PResult};
-use syntax::source_map::{Span, DUMMY_SP};
-use syntax::symbol::kw;
 
 use crate::syntux::session::ParseSess;
 use crate::{Config, Input};
@@ -108,7 +107,7 @@ impl<'a> ParserBuilder<'a> {
             }),
             Input::Text(text) => syntax::parse::maybe_new_parser_from_source_str(
                 sess,
-                syntax::source_map::FileName::Custom("stdin".to_owned()),
+                rustc_span::FileName::Custom("stdin".to_owned()),
                 text,
             )
             .map(|mut parser| {

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -151,7 +151,11 @@ impl<'a> Parser<'a> {
                 }
                 TokenKind::DocComment(s) => {
                     // we need to get the position of this token before we bump.
-                    let attr = syntax::attr::mk_sugared_doc_attr(s, parser.token.span);
+                    let attr = syntax::attr::mk_doc_comment(
+                        syntax::util::comments::doc_comment_style(&s.as_str()),
+                        s,
+                        parser.token.span,
+                    );
                     if attr.style == ast::AttrStyle::Inner {
                         attrs.push(attr);
                         parser.bump();

--- a/rustfmt-core/rustfmt-lib/src/syntux/session.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/session.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
 
-use rustc_data_structures::sync::Send;
+use rustc_data_structures::sync::{Lrc, Send};
 use rustc_errors::emitter::{Emitter, EmitterWriter};
 use rustc_errors::{ColorConfig, Diagnostic, Handler, Level as DiagnosticLevel};
 use rustc_span::{BytePos, source_map::{FilePathMapping, SourceMap}, Span};
@@ -27,6 +27,7 @@ pub(crate) struct ParseSess {
 struct SilentEmitter;
 
 impl Emitter for SilentEmitter {
+    fn source_map(&self) -> Option<&Lrc<SourceMap>> { None }
     fn emit_diagnostic(&mut self, _db: &Diagnostic) {}
 }
 
@@ -52,6 +53,7 @@ impl SilentOnIgnoredFilesEmitter {
 }
 
 impl Emitter for SilentOnIgnoredFilesEmitter {
+    fn source_map(&self) -> Option<&Lrc<SourceMap>> { None }
     fn emit_diagnostic(&mut self, db: &Diagnostic) {
         if db.level == DiagnosticLevel::Fatal {
             return self.handle_non_ignoreable_error(db);

--- a/rustfmt-core/rustfmt-lib/src/syntux/session.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/session.rs
@@ -3,12 +3,11 @@ use std::path::Path;
 use std::rc::Rc;
 
 use rustc_data_structures::sync::Send;
+use rustc_span::{BytePos, source_map::{FilePathMapping, SourceMap}, Span};
 use syntax::ast;
 use syntax::errors::emitter::{ColorConfig, Emitter, EmitterWriter};
 use syntax::errors::{Diagnostic, Handler, Level as DiagnosticLevel};
 use syntax::parse::ParseSess as RawParseSess;
-use syntax::source_map::{FilePathMapping, SourceMap};
-use syntax_pos::{BytePos, Span};
 
 use crate::config::file_lines::LineRange;
 use crate::ignore_path::IgnorePathSet;
@@ -59,7 +58,7 @@ impl Emitter for SilentOnIgnoredFilesEmitter {
         }
         if let Some(primary_span) = &db.span.primary_span() {
             let file_name = self.source_map.span_to_filename(*primary_span);
-            if let syntax_pos::FileName::Real(ref path) = file_name {
+            if let rustc_span::FileName::Real(ref path) = file_name {
                 if self
                     .ignore_path_set
                     .is_match(&FileName::Real(path.to_path_buf()))
@@ -154,7 +153,7 @@ impl ParseSess {
     pub(crate) fn is_file_parsed(&self, path: &Path) -> bool {
         self.parse_sess
             .source_map()
-            .get_source_file(&syntax_pos::FileName::Real(path.to_path_buf()))
+            .get_source_file(&rustc_span::FileName::Real(path.to_path_buf()))
             .is_some()
     }
 
@@ -270,8 +269,7 @@ mod tests {
         use crate::is_nightly_channel;
         use crate::utils::mk_sp;
         use std::path::PathBuf;
-        use syntax::source_map::FileName as SourceMapFileName;
-        use syntax_pos::MultiSpan;
+        use rustc_span::{MultiSpan, FileName as SourceMapFileName};
 
         struct TestEmitter {
             num_emitted_errors: Rc<RefCell<u32>>,

--- a/rustfmt-core/rustfmt-lib/src/syntux/session.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/session.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 use std::rc::Rc;
 
 use rustc_data_structures::sync::Send;
+use rustc_errors::emitter::{Emitter, EmitterWriter};
+use rustc_errors::{ColorConfig, Diagnostic, Handler, Level as DiagnosticLevel};
 use rustc_span::{BytePos, source_map::{FilePathMapping, SourceMap}, Span};
 use syntax::ast;
-use syntax::errors::emitter::{ColorConfig, Emitter, EmitterWriter};
-use syntax::errors::{Diagnostic, Handler, Level as DiagnosticLevel};
 use syntax::sess::ParseSess as RawParseSess;
 
 use crate::config::file_lines::LineRange;

--- a/rustfmt-core/rustfmt-lib/src/syntux/session.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/session.rs
@@ -27,7 +27,9 @@ pub(crate) struct ParseSess {
 struct SilentEmitter;
 
 impl Emitter for SilentEmitter {
-    fn source_map(&self) -> Option<&Lrc<SourceMap>> { None }
+    fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+        None
+    }
     fn emit_diagnostic(&mut self, _db: &Diagnostic) {}
 }
 
@@ -53,7 +55,9 @@ impl SilentOnIgnoredFilesEmitter {
 }
 
 impl Emitter for SilentOnIgnoredFilesEmitter {
-    fn source_map(&self) -> Option<&Lrc<SourceMap>> { None }
+    fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+        None
+    }
     fn emit_diagnostic(&mut self, db: &Diagnostic) {
         if db.level == DiagnosticLevel::Fatal {
             return self.handle_non_ignoreable_error(db);
@@ -271,13 +275,16 @@ mod tests {
         use crate::is_nightly_channel;
         use crate::utils::mk_sp;
         use std::path::PathBuf;
-        use rustc_span::{MultiSpan, FileName as SourceMapFileName};
+        use rustc_span::{DUMMY_SP, MultiSpan, FileName as SourceMapFileName};
 
         struct TestEmitter {
             num_emitted_errors: Rc<RefCell<u32>>,
         }
 
         impl Emitter for TestEmitter {
+            fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+                None
+            }
             fn emit_diagnostic(&mut self, _db: &Diagnostic) {
                 *self.num_emitted_errors.borrow_mut() += 1;
             }
@@ -291,6 +298,7 @@ mod tests {
                 children: vec![],
                 suggestions: vec![],
                 span: span.unwrap_or_else(MultiSpan::new),
+                sort_span: DUMMY_SP,
             }
         }
 

--- a/rustfmt-core/rustfmt-lib/src/syntux/session.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/session.rs
@@ -5,9 +5,9 @@ use std::rc::Rc;
 use rustc_data_structures::sync::{Lrc, Send};
 use rustc_errors::emitter::{Emitter, EmitterWriter};
 use rustc_errors::{ColorConfig, Diagnostic, Handler, Level as DiagnosticLevel};
+use rustc_session::parse::ParseSess as RawParseSess;
 use rustc_span::{BytePos, source_map::{FilePathMapping, SourceMap}, Span};
 use syntax::ast;
-use syntax::sess::ParseSess as RawParseSess;
 
 use crate::config::file_lines::LineRange;
 use crate::ignore_path::IgnorePathSet;

--- a/rustfmt-core/rustfmt-lib/src/syntux/session.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/session.rs
@@ -7,7 +7,7 @@ use rustc_span::{BytePos, source_map::{FilePathMapping, SourceMap}, Span};
 use syntax::ast;
 use syntax::errors::emitter::{ColorConfig, Emitter, EmitterWriter};
 use syntax::errors::{Diagnostic, Handler, Level as DiagnosticLevel};
-use syntax::parse::ParseSess as RawParseSess;
+use syntax::sess::ParseSess as RawParseSess;
 
 use crate::config::file_lines::LineRange;
 use crate::ignore_path::IgnorePathSet;
@@ -141,8 +141,8 @@ impl ParseSess {
         id: ast::Ident,
         relative: Option<ast::Ident>,
         dir_path: &Path,
-    ) -> syntax::parse::parser::ModulePath {
-        syntax::parse::parser::Parser::default_submod_path(
+    ) -> rustc_parse::parser::ModulePath {
+        rustc_parse::parser::Parser::default_submod_path(
             id,
             relative,
             dir_path,

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -1,9 +1,8 @@
 use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
+use rustc_span::{BytePos, DUMMY_SP, Span, symbol::kw};
 use syntax::ast::{self, FunctionRetTy, Mutability};
-use syntax::source_map::{BytePos, Span, DUMMY_SP};
-use syntax::symbol::kw;
 
 use crate::config::lists::*;
 use crate::config::{IndentStyle, TypeDensity};

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -1,7 +1,7 @@
 use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
-use rustc_span::{BytePos, DUMMY_SP, Span, symbol::kw};
+use rustc_span::{BytePos, Span, symbol::kw};
 use syntax::ast::{self, FunctionRetTy, Mutability};
 
 use crate::config::lists::*;
@@ -274,13 +274,9 @@ fn rewrite_segment(
                 result.push_str(&generics_str)
             }
             ast::GenericArgs::Parenthesized(ref data) => {
-                let output = match data.output {
-                    Some(ref ty) => FunctionRetTy::Ty(ty.clone()),
-                    None => FunctionRetTy::Default(DUMMY_SP),
-                };
                 result.push_str(&format_function_type(
                     data.inputs.iter().map(|x| &**x),
-                    &output,
+                    &data.output,
                     false,
                     data.span,
                     context,

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -18,7 +18,7 @@ use crate::shape::Shape;
 use crate::source_map::SpanUtils;
 use crate::spanned::Spanned;
 use crate::utils::{
-    colon_spaces, extra_offset, first_line_width, format_abi, format_mutability,
+    colon_spaces, extra_offset, first_line_width, format_extern, format_mutability,
     last_line_extendable, last_line_width, mk_sp, rewrite_ident,
 };
 
@@ -772,8 +772,8 @@ fn rewrite_bare_fn(
 
     result.push_str(crate::utils::format_unsafety(bare_fn.unsafety));
 
-    result.push_str(&format_abi(
-        bare_fn.abi,
+    result.push_str(&format_extern(
+        bare_fn.ext,
         context.config.force_explicit_abi(),
         false,
     ));

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -523,6 +523,7 @@ impl Rewrite for ast::GenericBound {
                     ast::TraitBoundModifier::Maybe => poly_trait_ref
                         .rewrite(context, shape.offset_left(1)?)
                         .map(|s| format!("?{}", s)),
+                    _ => unimplemented!(),
                 };
                 rewrite.map(|s| if has_paren { format!("({})", s) } else { s })
             }

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -633,8 +633,8 @@ impl Rewrite for ast::Ty {
             }
             ast::TyKind::Ptr(ref mt) => {
                 let prefix = match mt.mutbl {
-                    Mutability::Mutable => "*mut ",
-                    Mutability::Immutable => "*const ",
+                    Mutability::Mut => "*mut ",
+                    Mutability::Not => "*const ",
                 };
 
                 rewrite_unary_prefix(context, prefix, &*mt.ty, shape)

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -133,6 +133,16 @@ pub(crate) fn format_mutability(mutability: ast::Mutability) -> &'static str {
 }
 
 #[inline]
+pub(crate) fn format_extern(ext: ast::Extern, explicit_abi: bool, is_mod: bool) -> Cow<'static, str> {
+    match (ext, explicit_abi, is_mod) {
+        (ast::Extern::None, _, false) => Cow::from(""),
+        (ast::Extern::Implicit, false, _) => Cow::from("extern "),
+        (ast::Extern::Explicit(abi), _, _) => Cow::from(format!("extern {} ", abi.symbol_unescaped.as_str())),
+        (_, _, _) => unreachable!(),
+    }
+}
+
+#[inline]
 pub(crate) fn format_abi(abi: abi::Abi, explicit_abi: bool, is_mod: bool) -> Cow<'static, str> {
     if abi == abi::Abi::Rust && !is_mod {
         Cow::from("")

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -127,8 +127,8 @@ pub(crate) fn format_auto(is_auto: ast::IsAuto) -> &'static str {
 #[inline]
 pub(crate) fn format_mutability(mutability: ast::Mutability) -> &'static str {
     match mutability {
-        ast::Mutability::Mutable => "mut ",
-        ast::Mutability::Immutable => "",
+        ast::Mutability::Mut => "mut ",
+        ast::Mutability::Not => "",
     }
 }
 

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -418,7 +418,7 @@ pub(crate) fn left_most_sub_expr(e: &ast::Expr) -> &ast::Expr {
         | ast::ExprKind::Binary(_, ref e, _)
         | ast::ExprKind::Cast(ref e, _)
         | ast::ExprKind::Type(ref e, _)
-        | ast::ExprKind::Assign(ref e, _)
+        | ast::ExprKind::Assign(ref e,_,  _)
         | ast::ExprKind::AssignOp(_, ref e, _)
         | ast::ExprKind::Field(ref e, _)
         | ast::ExprKind::Index(ref e, _)

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -242,7 +242,7 @@ fn is_skip(meta_item: &MetaItem) -> bool {
     match meta_item.kind {
         MetaItemKind::Word => {
             let path_str = pprust::path_to_string(&meta_item.path);
-            path_str == skip_annotation().as_str() || path_str == depr_skip_annotation().as_str()
+            path_str == &*skip_annotation().as_str() || path_str == &*depr_skip_annotation().as_str()
         }
         MetaItemKind::List(ref l) => {
             meta_item.check_name(sym::cfg_attr) && l.len() == 2 && is_skip_nested(&l[1])

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -1,12 +1,13 @@
 use std::borrow::Cow;
 
+use rustc_ast_pretty::pprust;
 use rustc_span::{BytePos, ExpnId, Span, sym, Symbol, SyntaxContext};
 use rustc_target::spec::abi;
 use syntax::ast::{
     self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem, NodeId, Path, Visibility,
     VisibilityKind,
 };
-use syntax::{ptr, print::pprust};
+use syntax::ptr;
 use unicode_width::UnicodeWidthStr;
 
 use crate::comment::{filter_normal_code, CharClasses, FullCodeCharKind, LineClasses};

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -1,14 +1,12 @@
 use std::borrow::Cow;
 
+use rustc_span::{BytePos, ExpnId, Span, sym, Symbol, SyntaxContext};
 use rustc_target::spec::abi;
 use syntax::ast::{
     self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem, NodeId, Path, Visibility,
     VisibilityKind,
 };
 use syntax::ptr;
-use syntax::source_map::{BytePos, Span, SyntaxContext};
-use syntax::symbol::{sym, Symbol};
-use syntax_pos::ExpnId;
 use unicode_width::UnicodeWidthStr;
 
 use crate::comment::{filter_normal_code, CharClasses, FullCodeCharKind, LineClasses};

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -6,7 +6,7 @@ use syntax::ast::{
     self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem, NodeId, Path, Visibility,
     VisibilityKind,
 };
-use syntax::ptr;
+use syntax::{ptr, print::pprust};
 use unicode_width::UnicodeWidthStr;
 
 use crate::comment::{filter_normal_code, CharClasses, FullCodeCharKind, LineClasses};
@@ -42,7 +42,7 @@ pub(crate) fn is_same_visibility(a: &Visibility, b: &Visibility) -> bool {
         (
             VisibilityKind::Restricted { path: p, .. },
             VisibilityKind::Restricted { path: q, .. },
-        ) => p.to_string() == q.to_string(),
+        ) => pprust::path_to_string(p) == pprust::path_to_string(q),
         (VisibilityKind::Public, VisibilityKind::Public)
         | (VisibilityKind::Inherited, VisibilityKind::Inherited)
         | (
@@ -241,7 +241,7 @@ pub(crate) fn last_line_extendable(s: &str) -> bool {
 fn is_skip(meta_item: &MetaItem) -> bool {
     match meta_item.kind {
         MetaItemKind::Word => {
-            let path_str = meta_item.path.to_string();
+            let path_str = pprust::path_to_string(&meta_item.path);
             path_str == skip_annotation().as_str() || path_str == depr_skip_annotation().as_str()
         }
         MetaItemKind::List(ref l) => {

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -133,17 +133,19 @@ pub(crate) fn format_mutability(mutability: ast::Mutability) -> &'static str {
 }
 
 #[inline]
-pub(crate) fn format_extern(ext: ast::Extern, explicit_abi: bool, is_mod: bool) -> Cow<'static, str> {
-    match (ext, explicit_abi, is_mod) {
-        (ast::Extern::None, _, false) => Cow::from(""),
-        (ast::Extern::Implicit, false, _) => Cow::from("extern "),
-        (ast::Extern::Explicit(abi), _, _) => Cow::from(format!("extern {} ", abi.symbol_unescaped.as_str())),
-        (_, _, _) => unreachable!(),
-    }
-}
+pub(crate) fn format_extern(
+    ext: ast::Extern,
+    explicit_abi: bool,
+    is_mod: bool,
+) -> Cow<'static, str> {
+    let abi = match ext {
+        ast::Extern::None => abi::Abi::Rust,
+        ast::Extern::Implicit => abi::Abi::C,
+        ast::Extern::Explicit(abi) => {
+            abi::lookup(&abi.symbol_unescaped.as_str()).unwrap_or(abi::Abi::Rust)
+        }
+    };
 
-#[inline]
-pub(crate) fn format_abi(abi: abi::Abi, explicit_abi: bool, is_mod: bool) -> Cow<'static, str> {
     if abi == abi::Abi::Rust && !is_mod {
         Cow::from("")
     } else if abi == abi::Abi::C && !explicit_abi {
@@ -428,7 +430,7 @@ pub(crate) fn left_most_sub_expr(e: &ast::Expr) -> &ast::Expr {
         | ast::ExprKind::Binary(_, ref e, _)
         | ast::ExprKind::Cast(ref e, _)
         | ast::ExprKind::Type(ref e, _)
-        | ast::ExprKind::Assign(ref e,_,  _)
+        | ast::ExprKind::Assign(ref e, _, _)
         | ast::ExprKind::AssignOp(_, ref e, _)
         | ast::ExprKind::Field(ref e, _)
         | ast::ExprKind::Index(ref e, _)

--- a/rustfmt-core/rustfmt-lib/src/vertical.rs
+++ b/rustfmt-core/rustfmt-lib/src/vertical.rs
@@ -3,8 +3,8 @@
 use std::cmp;
 
 use itertools::Itertools;
+use rustc_span::{BytePos, Span};
 use syntax::ast;
-use syntax::source_map::{BytePos, Span};
 
 use crate::comment::combine_strs_with_missing_comments;
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -781,7 +781,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         ErrorKind::DeprecatedAttr,
                     )],
                 );
-            } else if self.is_unknown_rustfmt_attr(&attr.path.segments) {
+            } else if self.is_unknown_rustfmt_attr(&attr.get_normal_item().path.segments) {
                 let file_name = self.parse_sess.span_to_filename(attr.span);
                 self.report.append(
                     file_name,

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use syntax::source_map::{BytePos, Pos, Span};
+use rustc_span::{BytePos, Pos, Span};
 use syntax::{ast, visit};
 
 use crate::attr::*;

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -524,16 +524,29 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     );
                     self.push_rewrite(item.span, rewrite);
                 }
-                ast::ItemKind::OpaqueTy(ref generic_bounds, ref generics) => {
-                    let rewrite = rewrite_opaque_type(
-                        &self.get_context(),
-                        self.block_indent,
-                        item.ident,
-                        generic_bounds,
-                        generics,
-                        &item.vis,
-                    );
-                    self.push_rewrite(item.span, rewrite);
+                ast::ItemKind::TyAlias(ref ty, ref generics) => match ty.kind.opaque_top_hack() {
+                    None => {
+                        let rewrite = rewrite_type_alias(
+                            &self.get_context(),
+                            self.block_indent,
+                            item.ident,
+                            ty,
+                            generics,
+                            &item.vis,
+                        );
+                        self.push_rewrite(item.span, rewrite);
+                    },
+                    Some(generic_bounds) => {
+                        let rewrite = rewrite_opaque_type(
+                            &self.get_context(),
+                            self.block_indent,
+                            item.ident,
+                            generic_bounds,
+                            generics,
+                            &item.vis,
+                        );
+                        self.push_rewrite(item.span, rewrite);
+                    }
                 }
                 ast::ItemKind::GlobalAsm(..) => {
                     let snippet = Some(self.snippet(item.span).to_owned());

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -656,12 +656,12 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     }
 
     fn visit_mac(&mut self, mac: &ast::Mac, ident: Option<ast::Ident>, pos: MacroPosition) {
-        skip_out_of_file_lines_range_visitor!(self, mac.span);
+        skip_out_of_file_lines_range_visitor!(self, mac.span());
 
         // 1 = ;
         let shape = self.shape().saturating_sub_width(1);
         let rewrite = self.with_context(|ctx| rewrite_macro(mac, ident, ctx, shape, pos));
-        self.push_rewrite(mac.span, rewrite);
+        self.push_rewrite(mac.span(), rewrite);
     }
 
     pub(crate) fn push_str(&mut self, s: &str) {

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -502,12 +502,12 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 ast::ItemKind::Static(..) | ast::ItemKind::Const(..) => {
                     self.visit_static(&StaticParts::from_item(item));
                 }
-                ast::ItemKind::Fn(ref decl, ref fn_header, ref generics, ref body) => {
+                ast::ItemKind::Fn(ref fn_signature, ref generics, ref body) => {
                     let inner_attrs = inner_attributes(&item.attrs);
                     self.visit_fn(
-                        visit::FnKind::ItemFn(item.ident, fn_header, &item.vis, body),
+                        visit::FnKind::ItemFn(item.ident, &fn_signature.header, &item.vis, body),
                         generics,
-                        decl,
+                        &fn_signature.decl,
                         item.span,
                         ast::Defaultness::Final,
                         Some(&inner_attrs),
@@ -587,8 +587,9 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             }
             ast::AssocItemKind::Fn(ref sig, Some(ref body)) => {
                 let inner_attrs = inner_attributes(&ti.attrs);
+                let vis = rustc_span::source_map::dummy_spanned(ast::VisibilityKind::Inherited);
                 self.visit_fn(
-                    visit::FnKind::Method(ti.ident, sig, None, body),
+                    visit::FnKind::Method(ti.ident, sig, &vis, body),
                     &ti.generics,
                     &sig.decl,
                     ti.span,
@@ -625,7 +626,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             ast::AssocItemKind::Fn(ref sig, Some(ref body)) => {
                 let inner_attrs = inner_attributes(&ii.attrs);
                 self.visit_fn(
-                    visit::FnKind::Fn(ii.ident, sig, Some(&ii.vis), body),
+                    visit::FnKind::Method(ii.ident, sig, &ii.vis, body),
                     &ii.generics,
                     &sig.decl,
                     ii.span,

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -448,7 +448,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         if should_visit_node_again {
             match item.kind {
                 ast::ItemKind::Use(ref tree) => self.format_import(item, tree),
-                ast::ItemKind::Impl(..) => {
+                ast::ItemKind::Impl {..} => {
                     let block_indent = self.block_indent;
                     let rw = self.with_context(|ctx| format_impl(&ctx, item, block_indent));
                     self.push_rewrite(item.span, rw);

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-2916.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-2916.rs
@@ -1,0 +1,2 @@
+a_macro!(name<Param1, Param2>, 
+)    ;

--- a/rustfmt-core/rustfmt-lib/tests/source/macros.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/macros.rs
@@ -199,7 +199,7 @@ fn issue_3174() {
 gfx_pipeline!(pipe {
     vbuf: gfx::VertexBuffer<Vertex> = (),
     out: gfx::RenderTarget<ColorFormat> = "Target0",
-});
+})     ;
 
 // #1919
 #[test]

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-2916.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-2916.rs
@@ -1,2 +1,2 @@
-a_macro!(name<Param1, Param2>, 
+a_macro!(name<Param1, Param2>,
 );


### PR DESCRIPTION
I structured the changes into several smaller commits that were focused on a specific change/related set of changes in the upstream rustc crates, and included details about the upstream change in the commit messages (hope this makes it somewhat easier to review!). 

I decided to focus on getting rustfmt to just "work" with the latest rustc crate versions, and defer making certain other changes (like refactoring, supporting the new half open range syntax - #4009, etc.) to future PRs.  My thinking is defering those other changes will hopefully make this easier to merge since there's already a decent sized diff just from upgrading the rustc-ap versions, and I suspect this PR has a higher potential than normal for merge conflicts