### PR TITLE
fix compiler warning

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -1157,10 +1157,10 @@ pub(crate) fn is_simple_block(
     block: &ast::Block,
     attrs: Option<&[ast::Attribute]>,
 ) -> bool {
-    (block.stmts.len() == 1
+    block.stmts.len() == 1
         && stmt_is_expr(&block.stmts[0])
         && !block_contains_comment(context, block)
-        && attrs.map_or(true, |a| a.is_empty()))
+        && attrs.map_or(true, |a| a.is_empty())
 }
 
 /// Checks whether a block contains at most one statement or expression, and no


### PR DESCRIPTION
This fixes a recent compiler warning I've been seeing (may have started with the updated rustc-ap versions)

```bash
warning: unnecessary parentheses around block return value
    --> rustfmt-lib/src/expr.rs:1171:5
     |
1171 | /     (block.stmts.len() == 1
1172 | |         && stmt_is_expr(&block.stmts[0])
1173 | |         && !block_contains_comment(context, block)
1174 | |         && attrs.map_or(true, |a| a.is_empty()))
     | |________________________________________________^
     |
     = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
```