### PR TITLE
Use the correct shape when formatting comment in empty struct

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -1441,7 +1441,9 @@ fn format_empty_struct_or_tuple(
         result.push_str(&offset.to_string_with_newline(context.config))
     }
     result.push_str(opener);
-    match rewrite_missing_comment(span, Shape::indented(offset, context.config), context) {
+    let comment_shape =
+        Shape::indented(offset, context.config).block_indent(context.config.tab_spaces());
+    match rewrite_missing_comment(span, comment_shape, context) {
         Some(ref s) if s.is_empty() => (),
         Some(ref s) => {
             if !is_single_line(s) || first_line_contains_single_line_comment(s) {

--- a/rustfmt-core/rustfmt-lib/tests/source/structs.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/structs.rs
@@ -285,3 +285,9 @@ struct Test {
 // #2818
 struct Paren((i32)) where i32: Trait;
 struct Parens((i32, i32)) where i32: Trait;
+
+// #4014
+struct X {
+// foo
+// bar
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/structs.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/structs.rs
@@ -342,3 +342,9 @@ where
 struct Parens((i32, i32))
 where
     i32: Trait;
+
+// #4014
+struct X {
+    // foo
+    // bar
+}


### PR DESCRIPTION
Close #4014.