### PR TITLE
restore some config tests

### DIFF
--- a/rustfmt-core/rustfmt-config/src/lib.rs
+++ b/rustfmt-core/rustfmt-config/src/lib.rs
@@ -556,36 +556,96 @@ ignore = []
         assert_eq!(&toml, &default_config);
     }
 
-    // FIXME(#2183): these tests cannot be run in parallel because they use env vars.
-    // #[test]
-    // fn test_as_not_nightly_channel() {
-    //     let mut config = Config::default();
-    //     assert_eq!(config.was_set().unstable_features(), false);
-    //     config.set().unstable_features(true);
-    //     assert_eq!(config.was_set().unstable_features(), false);
-    // }
+    mod unstable_features {
+        use super::super::*;
 
-    // #[test]
-    // fn test_as_nightly_channel() {
-    //     let v = ::std::env::var("CFG_RELEASE_CHANNEL").unwrap_or(String::from(""));
-    //     ::std::env::set_var("CFG_RELEASE_CHANNEL", "nightly");
-    //     let mut config = Config::default();
-    //     config.set().unstable_features(true);
-    //     assert_eq!(config.was_set().unstable_features(), false);
-    //     config.set().unstable_features(true);
-    //     assert_eq!(config.unstable_features(), true);
-    //     ::std::env::set_var("CFG_RELEASE_CHANNEL", v);
-    // }
+        #[test]
+        fn test_default_not_nightly_channel() {
+            if is_nightly_channel!() {
+                // This test requires non-nightly
+                return;
+            }
+            let config = Config::default();
+            assert_eq!(config.unstable_features(), false);
+            assert_eq!(config.was_set().unstable_features(), false);
+        }
 
-    // #[test]
-    // fn test_unstable_from_toml() {
-    //     let mut config = Config::from_toml("unstable_features = true").unwrap();
-    //     assert_eq!(config.was_set().unstable_features(), false);
-    //     let v = ::std::env::var("CFG_RELEASE_CHANNEL").unwrap_or(String::from(""));
-    //     ::std::env::set_var("CFG_RELEASE_CHANNEL", "nightly");
-    //     config = Config::from_toml("unstable_features = true").unwrap();
-    //     assert_eq!(config.was_set().unstable_features(), true);
-    //     assert_eq!(config.unstable_features(), true);
-    //     ::std::env::set_var("CFG_RELEASE_CHANNEL", v);
-    // }
+        #[test]
+        fn test_default_nightly_channel() {
+            if !is_nightly_channel!() {
+                // This test requires nightly
+                return;
+            }
+            let config = Config::default();
+            assert_eq!(config.unstable_features(), false);
+        }
+
+        #[test]
+        fn test_from_toml_not_nightly() {
+            if is_nightly_channel!() {
+                // This test requires non-nightly
+                return;
+            }
+            let config = Config::from_toml("unstable_features = true", Path::new("")).unwrap();
+            assert_eq!(config.was_set().unstable_features(), false);
+        }
+
+        #[test]
+        fn test_from_toml_nightly() {
+            if !is_nightly_channel!() {
+                // This test requires non-nightly
+                return;
+            }
+            let config = Config::from_toml("unstable_features = true", Path::new("")).unwrap();
+            assert_eq!(config.was_set().unstable_features(), true);
+        }
+
+        #[test]
+        fn test_set_not_nightly_channel() {
+            if is_nightly_channel!() {
+                // This test requires non-nightly
+                return;
+            }
+            let mut config = Config::default();
+            assert_eq!(config.unstable_features(), false);
+            config.set().unstable_features(true);
+            assert_eq!(config.unstable_features(), true);
+        }
+
+        #[test]
+        fn test_set_nightly_channel() {
+            if !is_nightly_channel!() {
+                // This test requires nightly
+                return;
+            }
+            let mut config = Config::default();
+            assert_eq!(config.unstable_features(), false);
+            config.set().unstable_features(true);
+            assert_eq!(config.unstable_features(), true);
+        }
+
+        #[test]
+        fn test_override_not_nightly_channel() {
+            if is_nightly_channel!() {
+                // This test requires non-nightly
+                return;
+            }
+            let mut config = Config::default();
+            assert_eq!(config.unstable_features(), false);
+            config.override_value("unstable_features", "true");
+            assert_eq!(config.unstable_features(), true);
+        }
+
+        #[test]
+        fn test_override_nightly_channel() {
+            if !is_nightly_channel!() {
+                // This test requires nightly
+                return;
+            }
+            let mut config = Config::default();
+            assert_eq!(config.unstable_features(), false);
+            config.override_value("unstable_features", "true");
+            assert_eq!(config.unstable_features(), true);
+        }
+    }
 }


### PR DESCRIPTION
Resolves #2183. I saw these again the other day when I was in the config module and decided to take a closer look at them.

`CFG_RELEASE_CHANNEL` is now checked at compile time, so the original issue with sequencing of tests that were mutating the shared env vars during test exection is no longer relevant. 

https://github.com/rust-lang/rustfmt/blob/9124dd88d6ef14d0ae77dc52ff5e9598f24a75a0/rustfmt-core/rustfmt-config/src/config_type.rs#L338-L342

Instead, I split out the tests for nightly vs. non-nightly with their respective assertions accordingly, and the latter set of tests will run as part of one of the CI jobs (ex: https://travis-ci.com/rust-lang/rustfmt/jobs/291200498). 

All that being said.. 😄 

@topecongiro in https://github.com/rust-lang/rustfmt/issues/3387#issuecomment-574150626 you mentioned removing `unstable_features` altogether as part of 2.0, so would you rather I go ahead and just remove the `unstable_features` config option (and related content like the original commented out tests) altogether?

Happy to do so if that's the plan, though based on the thread in #3387 it seems like users would be interested in having the ability to opt-in to being able to use non-stablized rustfmt config options even on stable (not available today). FWIW I can understand that request, and I believe `libtest` supports
something similar today:

This will fail (`json` format is unstable)
```bash
$ cargo +stable test -- --format json
    Finished test [unoptimized + debuginfo] target(s) in 0.31s
     Running target/debug/deps/rusty_hook-18bae14627c600cc
error: The "json" format is only accepted on the nightly compiler
error: test failed, to rerun pass '--lib'
```

but this works
```bash
$ cargo +stable test -- -Z unstable-options --format json
    Finished test [unoptimized + debuginfo] target(s) in 0.28s
     Running target/debug/deps/rusty_hook-af9ceb85a6bdee3c
{ "type": "suite", "event": "started", "test_count": 52 }
....
....
```

