### PR TITLE
suppress internal error

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -364,7 +364,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     mk_sp(s.lo(), b.span.lo()),
                 )
             }
-            _ => unreachable!(),
+            _ => return,
         };
 
         if let Some((fn_str, fn_brace_style)) = rewrite {

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -364,7 +364,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     mk_sp(s.lo(), b.span.lo()),
                 )
             }
-            _ => return,
+            _ => unreachable!(),
         };
 
         if let Some((fn_str, fn_brace_style)) = rewrite {
@@ -502,7 +502,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 ast::ItemKind::Static(..) | ast::ItemKind::Const(..) => {
                     self.visit_static(&StaticParts::from_item(item));
                 }
-                ast::ItemKind::Fn(ref fn_signature, ref generics, ref body) => {
+                ast::ItemKind::Fn(ref fn_signature, ref generics, Some(ref body)) => {
                     let inner_attrs = inner_attributes(&item.attrs);
                     let fn_ctxt = match fn_signature.header.ext {
                         ast::Extern::None => visit::FnCtxt::Free,
@@ -514,7 +514,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                             item.ident,
                             &fn_signature,
                             &item.vis,
-                            body.as_deref(),
+                            Some(body),
                         ),
                         generics,
                         &fn_signature.decl,
@@ -522,6 +522,17 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         ast::Defaultness::Final,
                         Some(&inner_attrs),
                     )
+                }
+                ast::ItemKind::Fn(ref fn_signature, ref generics, None) => {
+                    let indent = self.block_indent;
+                    let rewrite = self.rewrite_required_fn(
+                        indent,
+                        item.ident,
+                        &fn_signature,
+                        generics,
+                        item.span,
+                    );
+                    self.push_rewrite(item.span, rewrite);
                 }
                 ast::ItemKind::TyAlias(ref ty, ref generics) => match ty.kind.opaque_top_hack() {
                     None => {

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4068.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4068.rs
@@ -1,4 +1,4 @@
 // following code is invalid but should not cause an internal error
 fn main() {
-extern "C" fn packet_records_options_impl_layout_length_encoding_option_len_multiplier();
+    extern "C" fn packet_records_options_impl_layout_length_encoding_option_len_multiplier();
 }

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4068.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4068.rs
@@ -1,0 +1,4 @@
+// following code is invalid but should not cause an internal error
+fn main() {
+extern "C" fn packet_records_options_impl_layout_length_encoding_option_len_multiplier();
+}


### PR DESCRIPTION
related: #4068

I think #4068 code is invalid, but rustfmt should not cause an internal error. So I send this PR.