### PR TITLE
fix Issue 4020: problem reformatting block comments

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/comment.rs
+++ b/rustfmt-core/rustfmt-lib/src/comment.rs
@@ -92,8 +92,9 @@ impl<'a> CommentStyle<'a> {
             | CommentStyle::TripleSlash
             | CommentStyle::Custom(..)
             | CommentStyle::Doc => "",
-            CommentStyle::DoubleBullet => " **/",
-            CommentStyle::SingleBullet | CommentStyle::Exclamation => " */",
+            CommentStyle::SingleBullet | CommentStyle::DoubleBullet | CommentStyle::Exclamation => {
+                " */"
+            }
         }
     }
 
@@ -102,8 +103,9 @@ impl<'a> CommentStyle<'a> {
             CommentStyle::DoubleSlash => "// ",
             CommentStyle::TripleSlash => "/// ",
             CommentStyle::Doc => "//! ",
-            CommentStyle::SingleBullet | CommentStyle::Exclamation => " * ",
-            CommentStyle::DoubleBullet => " ** ",
+            CommentStyle::SingleBullet | CommentStyle::DoubleBullet | CommentStyle::Exclamation => {
+                " * "
+            }
             CommentStyle::Custom(opener) => opener,
         }
     }

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-4020.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-4020.rs
@@ -1,0 +1,9 @@
+// rustfmt-wrap_comments: true
+
+/** foobar */
+const foo1: u32 = 0;
+
+/**
+ * foobar
+ */
+const foo2: u32 = 0;

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-4020.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-4020.rs
@@ -1,9 +1,0 @@
-// rustfmt-wrap_comments: true
-
-/** foobar */
-const foo1: u32 = 0;
-
-/**
- * foobar
- */
-const foo2: u32 = 0;

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4020.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4020.rs
@@ -1,0 +1,9 @@
+// rustfmt-wrap_comments: true
+
+/** foobar */
+const foo1: u32 = 0;
+
+/**
+ * foobar
+ */
+const foo2: u32 = 0;


### PR DESCRIPTION
Fixes #4020 

prior to the fix, the tests fail like this:
```
Mismatch at tests/source/issue-4020.rs:1:
 // rustfmt-wrap_comments: true
 
-/** foobar */
+/** foobar **/
 const foo1: u32 = 0;
 
 /**

Mismatch at tests/source/issue-4020.rs:7:
- * foobar
- */
+ ** foobar
+ **/
 const foo2: u32 = 0;
```