### PR TITLE
wrap_long_multiline_chains

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -996,7 +996,7 @@ fn lorem() -> usize {
 
 ```rust
 fn lorem() -> usize {
-    42 // tabs before 42
+	42 // tabs before 42
 }
 ```
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -996,7 +996,7 @@ fn lorem() -> usize {
 
 ```rust
 fn lorem() -> usize {
-	42 // tabs before 42
+    42 // tabs before 42
 }
 ```
 
@@ -2426,6 +2426,68 @@ Break comments to fit on the line
 // magna aliqua. Ut enim ad minim veniam, quis nostrud
 // exercitation ullamco laboris nisi ut aliquip ex ea
 // commodo consequat.
+```
+
+## `wrap_long_multiline_chains`
+
+Wrap the right hand side of a let binding when it is a long multiline chain.
+Leave other right hand expressions alone.
+
+- **Default value**: false
+- **Possible values**: true, false
+- **Stable**: Yes
+
+### Example
+
+#### `false` (default):
+```rust
+fn main() {
+    let chain = my_struct
+        .map(|e| e + 1)
+        .and_then(|e| e + 1)
+        .and_then(|e| e + 1)
+        .and_then(|e| e + 1)
+        .and_then(|e| e + 1)
+        .collect();
+
+    let struct_let = Struct {
+        item_one,
+        item_two,
+        item_three,
+        item_four,
+        item_five,
+        item_six,
+        item_seven,
+        item_eight,
+    };
+}
+```
+
+#### `true`:
+```rust
+fn main() {
+    let chain =
+        my_struct
+        .map(|e| e + 1)
+        .and_then(|e| e + 1)
+        .and_then(|e| e + 1)
+        .and_then(|e| e + 1)
+        .and_then(|e| e + 1)
+        .collect();
+
+    let short_chain = my_struct.map(|e| e + 1);
+
+    let struct_let = Struct {
+        item_one,
+        item_two,
+        item_three,
+        item_four,
+        item_five,
+        item_six,
+        item_seven,
+        item_eight,
+    };
+}
 ```
 
 # Internal Options

--- a/rustfmt-core/rustfmt-config/src/lib.rs
+++ b/rustfmt-core/rustfmt-config/src/lib.rs
@@ -78,6 +78,8 @@ create_config! {
         "Where to put a binary operator when a binary expression goes multiline";
 
     // Misc.
+    wrap_long_multiline_chains: bool, false, true,
+        "Wrap the right hand side of a let binding When it is a multiline chain";
     remove_nested_parens: bool, true, true, "Remove nested parens";
     combine_control_expr: bool, true, false, "Combine control expressions with function calls";
     overflow_delimited_expr: bool, false, false,
@@ -516,6 +518,7 @@ space_before_colon = false
 space_after_colon = true
 spaces_around_ranges = false
 binop_separator = "Front"
+wrap_long_multiline_chains = false
 remove_nested_parens = true
 combine_control_expr = true
 overflow_delimited_expr = false

--- a/rustfmt-core/rustfmt-config/src/lib.rs
+++ b/rustfmt-core/rustfmt-config/src/lib.rs
@@ -79,7 +79,7 @@ create_config! {
 
     // Misc.
     wrap_long_multiline_chains: bool, false, true,
-        "Wrap the right hand side of a let binding When it is a multiline chain";
+        "Wrap the right hand side of a let binding when it is a multiline chain";
     remove_nested_parens: bool, true, true, "Remove nested parens";
     combine_control_expr: bool, true, false, "Combine control expressions with function calls";
     overflow_delimited_expr: bool, false, false,

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -1990,6 +1990,18 @@ fn choose_rhs<R: Rewrite>(
             let before_space_str = if has_rhs_comment { "" } else { " " };
 
             match (orig_rhs, new_rhs) {
+                (Some(ref orig_rhs), Some(_))
+                    if context.config.wrap_long_multiline_chains()
+                        && orig_rhs.matches('.').collect::<Vec<_>>().len() > 1 =>
+                {
+                    let new_shape = shape_from_rhs_tactic(
+                        context,
+                        shape,
+                        RhsTactics::ForceNextLineWithoutIndent,
+                    )?;
+                    let new_rhs = expr.rewrite(context, new_shape)?;
+                    Some(format!("{}{}", new_indent_str, new_rhs))
+                }
                 (Some(ref orig_rhs), Some(ref new_rhs))
                     if wrap_str(new_rhs.clone(), context.config.max_width(), new_shape)
                         .is_none() =>


### PR DESCRIPTION
This allows configuring the way chains are wrapped in a let binding in order to write: 
```rust
let chain = 
    my_builder
    .call()
    .call()
    .call();
```