### PR TITLE
Issue 4079

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/comment.rs
+++ b/rustfmt-core/rustfmt-lib/src/comment.rs
@@ -528,7 +528,6 @@ impl<'a> CommentRewrite<'a> {
             .checked_sub(closer.len() + opener.len())
             .unwrap_or(1);
         let indent_str = shape.indent.to_string_with_newline(config).to_string();
-        let fmt_indent = shape.indent + (opener.len() - line_start.len());
 
         let mut cr = CommentRewrite {
             result: String::with_capacity(orig.len() * 2),
@@ -539,14 +538,14 @@ impl<'a> CommentRewrite<'a> {
             comment_line_separator: format!("{}{}", indent_str, line_start),
             max_width,
             indent_str,
-            fmt_indent,
+            fmt_indent: shape.indent,
 
             fmt: StringFormat {
                 opener: "",
                 closer: "",
                 line_start,
                 line_end: "",
-                shape: Shape::legacy(max_width, fmt_indent),
+                shape: Shape::legacy(max_width, shape.indent),
                 trim_end: true,
                 config,
             },

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-4079.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-4079.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: true
+
+/*!
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia
+ * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem volutpat
+ */
+
+/*! Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem volutpat */

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4079.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4079.rs
@@ -1,0 +1,11 @@
+// rustfmt-wrap_comments: true
+
+/*!
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia
+ * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem
+ * volutpat
+ */
+
+/*! Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia
+ * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem
+ * volutpat */


### PR DESCRIPTION
fixes #4079 

Without this fix:
```
Mismatch at tests/source/issue-4079.rs:3:
 /*!
  * Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia
  * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem
- * volutpat
+  * volutpat
  */
 
 /*! Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia

Mismatch at tests/source/issue-4079.rs:10:
- * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem
- * volutpat */
+  * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem
+  * volutpat */
```