### PR TITLE
Change default value for `blank_lines_upper_bound` from 1 to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Change the default value for `blank_lines_upper_bound` from 1 to 5.
+
 ## [1.4.9] 2019-10-07
 
 ### Changed
@@ -13,7 +16,7 @@
 - Fix aligning comments of different group
 - Fix flattening imports with a single `self`.
 - Fix removing attributes on function parameters.
-- Fix removing `impl` keyword from opaque type. 
+- Fix removing `impl` keyword from opaque type.
 
 ## [1.4.8] 2019-09-08
 
@@ -45,7 +48,7 @@
 
 - Add `--message-format` command line option to `cargo-fmt`.
 - Add `-l,--files-with-diff` command line option to `rustfmt`.
-- Add `json` emit mode. 
+- Add `json` emit mode.
 
 ### Fixed
 
@@ -96,7 +99,7 @@
 
 ### Added
 
-- Add new attribute `rustfmt::skip::attributes` to prevent rustfmt 
+- Add new attribute `rustfmt::skip::attributes` to prevent rustfmt
 from formatting an attribute #3665
 
 ### Changed

--- a/Configurations.md
+++ b/Configurations.md
@@ -103,7 +103,7 @@ fn bar() {
 Maximum number of blank lines which can be put between items. If more than this number of consecutive empty
 lines are found, they are trimmed down to match this integer.
 
-- **Default value**: `1`
+- **Default value**: `5`
 - **Possible values**: any non-negative integer
 - **Stable**: No (tracking issue: #3381)
 
@@ -127,7 +127,7 @@ fn bar() {
 }
 ```
 
-#### `1` (default):
+#### `1`:
 ```rust
 fn foo() {
     println!("a");

--- a/rustfmt-core/rustfmt-config/src/lib.rs
+++ b/rustfmt-core/rustfmt-config/src/lib.rs
@@ -101,7 +101,7 @@ create_config! {
         "How to handle trailing commas for lists";
     match_block_trailing_comma: bool, false, false,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
-    blank_lines_upper_bound: usize, 1, false,
+    blank_lines_upper_bound: usize, 5, false,
         "Maximum number of blank lines which can be put between items";
     blank_lines_lower_bound: usize, 0, false,
         "Minimum number of blank lines which must be put between items";
@@ -529,7 +529,7 @@ control_brace_style = "AlwaysSameLine"
 trailing_semicolon = true
 trailing_comma = "Vertical"
 match_block_trailing_comma = false
-blank_lines_upper_bound = 1
+blank_lines_upper_bound = 5
 blank_lines_lower_bound = 0
 edition = "2018"
 version = "One"


### PR DESCRIPTION
I explained my reasoning in [this comment](https://github.com/rust-lang/rustfmt/issues/3381#issuecomment-573777732), copied here for convenience:

> May I ask why the default is 1? That's basically the only thing where I disagree with the standard style. I'd love to avoid having a `rustfmt.toml`. 
> 
> My reasoning: more space between items is a useful visual separator. Rust files tend to get fairly long and often contain many different kinds of items. Compare that to some other languages, where there is usually just one class per file, for example. So in Rust files I often have "blocks" of items that somehow belong together. Maybe it's something like:
> 
> ```rust
> struct A;
> 
> impl A {
> }
> 
> impl Display for A {
> }
> 
> 
> struct B;
> 
> impl B {
> }
> 
> impl Display for B {
> }
> ```
> 
> I think it should be pretty clear that some items belong closer together than others (specifically: all the `A` things should be somehow separated from all `B` things). And this is just a small example. Often I have multiple "layers" of items. So I naturally want to have larger separation between items of different "blocks". I usually use up to three blank lines between items. 
> 
> So I'd like to propose increasing the default value to 3 or even 5. I think rustfmt shouldn't really be getting in the way of the programmer in this case.
> 
> But maybe people have strong opinions against large separators. I tried searching for previous discussions about this, but I found nothing. So please let me know either way!

As people agreed with my comment and no one had any counter argument, I just changed it now.

I hope this is a step in stabilizing `blank_lines_upper_bound` and `blank_lines_lower_bound`.

CC @ForLoveOfCats 