### PR TITLE
Add config option to control leading match arm pipes

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1508,6 +1508,88 @@ fn main() {
 
 See also: [`match_block_trailing_comma`](#match_block_trailing_comma).
 
+## `match_arm_leading_pipes`
+
+Controls whether to include a leading pipe on match arms
+
+- **Default value**: `Never`
+- **Possible values**: `Always`, `Never`, `KeepExisting`
+- **Stable**: Yes
+
+#### `Never` (default):
+```rust
+// Leading pipes are from this:
+// fn foo() {
+//     match foo {
+//         | "foo" | "bar" => {}
+//         | "baz"
+//         | "something relatively long"
+//         | "something really really really realllllllllllllly long" => println!("x"),
+//         | "qux" => println!("y"),
+//         _ => {}
+//     }
+// }
+
+// Are removed:
+fn foo() {
+    match foo {
+        "foo" | "bar" => {}
+        "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        "qux" => println!("y"),
+        _ => {}
+    }
+}
+```
+
+#### `Always`:
+```rust
+// Leading pipes are emitted on all arms of this:
+// fn foo() {
+//     match foo {
+//         "foo" | "bar" => {}
+//         "baz"
+//         | "something relatively long"
+//         | "something really really really realllllllllllllly long" => println!("x"),
+//         "qux" => println!("y"),
+//         _ => {}
+//     }
+// }
+
+// Becomes:
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        | _ => {}
+    }
+}
+```
+
+#### `KeepExisting`:
+```rust
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        _ => {}
+    }
+
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}
+```
+
 ## `match_block_trailing_comma`
 
 Put a trailing comma after a block based match arm (non-block arms are not affected)

--- a/rustfmt-core/rustfmt-lib/src/config.rs
+++ b/rustfmt-core/rustfmt-lib/src/config.rs
@@ -105,6 +105,8 @@ create_config! {
         "Align enum variants discrims, if their diffs fit within threshold";
     match_arm_blocks: bool, true, false, "Wrap the body of arms in blocks when it does not fit on \
         the same line with the pattern of arms";
+    match_arm_leading_pipes: MatchArmLeadingPipe, MatchArmLeadingPipe::Never, true,
+        "Determines whether leading pipes are emitted on match arms";
     force_multiline_blocks: bool, false, false,
         "Force multiline closure bodies and match arms to be wrapped in a block";
     fn_args_layout: Density, Density::Tall, true,
@@ -551,6 +553,7 @@ overflow_delimited_expr = false
 struct_field_align_threshold = 0
 enum_discrim_align_threshold = 0
 match_arm_blocks = true
+match_arm_leading_pipes = "Never"
 force_multiline_blocks = false
 fn_args_layout = "Tall"
 brace_style = "SameLineWhere"

--- a/rustfmt-core/rustfmt-lib/src/config/options.rs
+++ b/rustfmt-core/rustfmt-lib/src/config/options.rs
@@ -376,3 +376,14 @@ impl From<Edition> for rustc_span::edition::Edition {
         }
     }
 }
+
+/// Controls how rustfmt should handle leading pipes on match arms.
+#[config_type]
+pub enum MatchArmLeadingPipe {
+    /// Place leading pipes on all match arms
+    Always,
+    /// Never emit leading pipes on match arms
+    Never,
+    /// Maintain any existing leading pipes
+    KeepExisting,
+}

--- a/rustfmt-core/rustfmt-lib/src/matches.rs
+++ b/rustfmt-core/rustfmt-lib/src/matches.rs
@@ -7,7 +7,7 @@ use rustc_span::{BytePos, Span};
 
 use crate::comment::{combine_strs_with_missing_comments, rewrite_comment};
 use crate::config::lists::*;
-use crate::config::{Config, ControlBraceStyle, IndentStyle};
+use crate::config::{Config, ControlBraceStyle, IndentStyle, MatchArmLeadingPipe};
 use crate::expr::{
     format_expr, is_empty_block, is_simple_block, is_unsafe_block, prefer_next_line, rewrite_cond,
     ExprType, RhsTactics,
@@ -55,7 +55,13 @@ impl<'a> Spanned for ArmWrapper<'a> {
 
 impl<'a> Rewrite for ArmWrapper<'a> {
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
-        rewrite_match_arm(context, self.arm, shape, self.is_last)
+        rewrite_match_arm(
+            context,
+            self.arm,
+            shape,
+            self.is_last,
+            self.beginning_vert.is_some(),
+        )
     }
 }
 
@@ -215,6 +221,7 @@ fn rewrite_match_arm(
     arm: &ast::Arm,
     shape: Shape,
     is_last: bool,
+    has_leading_pipe: bool,
 ) -> Option<String> {
     let (missing_span, attrs_str) = if !arm.attrs.is_empty() {
         if contains_skip(&arm.attrs) {
@@ -232,9 +239,18 @@ fn rewrite_match_arm(
         (mk_sp(arm.span().lo(), arm.span().lo()), String::new())
     };
 
+    // Leading pipe offset
+    // 2 = `| `
+    let (pipe_offset, pipe_str) = match context.config.match_arm_leading_pipes() {
+        MatchArmLeadingPipe::Never => (0, ""),
+        MatchArmLeadingPipe::KeepExisting if !has_leading_pipe => (0, ""),
+        MatchArmLeadingPipe::KeepExisting | MatchArmLeadingPipe::Always => (2, "| "),
+    };
+
     // Patterns
     // 5 = ` => {`
-    let pat_shape = shape.sub_width(5)?;
+    let pat_shape = shape.sub_width(5)?.offset_left(pipe_offset)?;
+
     let pats_str = arm.pat.rewrite(context, pat_shape)?;
 
     // Guard
@@ -251,7 +267,7 @@ fn rewrite_match_arm(
     let lhs_str = combine_strs_with_missing_comments(
         context,
         &attrs_str,
-        &format!("{}{}", pats_str, guard_str),
+        &format!("{}{}{}", pipe_str, pats_str, guard_str),
         missing_span,
         shape,
         false,

--- a/rustfmt-core/rustfmt-lib/tests/source/configs/match_arm_leading_pipes/always.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/configs/match_arm_leading_pipes/always.rs
@@ -1,0 +1,27 @@
+// rustfmt-match_arm_leading_pipes: Always
+
+fn foo() {
+    match foo {
+        "foo"  |    "bar" => {}
+        "baz"
+        |  "something relatively long"
+        |     "something really really really realllllllllllllly long" => println!("x"),
+        "qux" => println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}

--- a/rustfmt-core/rustfmt-lib/tests/source/configs/match_arm_leading_pipes/keep_existing.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/configs/match_arm_leading_pipes/keep_existing.rs
@@ -1,0 +1,28 @@
+// rustfmt-match_arm_leading_pipes: KeepExisting
+
+fn foo() {
+    match foo {
+        | "foo"      | "bar" => {}
+        | "baz"
+        |                   "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" =>           println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        | "foo"
+        | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux"     => {    }
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}

--- a/rustfmt-core/rustfmt-lib/tests/source/configs/match_arm_leading_pipes/never.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/configs/match_arm_leading_pipes/never.rs
@@ -1,0 +1,28 @@
+// rustfmt-match_arm_leading_pipes: Never
+
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        | "foo"
+        | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/configs/match_arm_leading_pipes/always.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/configs/match_arm_leading_pipes/always.rs
@@ -1,0 +1,27 @@
+// rustfmt-match_arm_leading_pipes: Always
+
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        | _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        | "foo" | "bar" => {}
+        | _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        | "qux" => {}
+        | "foo" | "bar" => {}
+        | _ => {}
+    }
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/configs/match_arm_leading_pipes/keep_existing.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/configs/match_arm_leading_pipes/keep_existing.rs
@@ -1,0 +1,27 @@
+// rustfmt-match_arm_leading_pipes: KeepExisting
+
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        | "foo" | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/configs/match_arm_leading_pipes/never.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/configs/match_arm_leading_pipes/never.rs
@@ -1,0 +1,27 @@
+// rustfmt-match_arm_leading_pipes: Never
+
+fn foo() {
+    match foo {
+        "foo" | "bar" => {}
+        "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        "qux" => println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
Resolves #3973 (at least the leading pipe, not the `=>` on its own line)