### PR TITLE
bump rustfmt 1x to rustc-ap v651

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +514,19 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -617,97 +639,97 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ena 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "measureme 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-graphviz 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-graphviz 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -718,15 +740,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -735,52 +757,52 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_passes 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_passes 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -788,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -799,75 +821,74 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_fs_util 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_fs_util 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-arena 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-arena 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -949,15 +970,15 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_expand 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_expand 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-config_proc_macro 0.2.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1299,8 +1320,10 @@ dependencies = [
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum packed_simd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220"
+"checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+"checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -1314,25 +1337,25 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
-"checksum rustc-ap-arena 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7ba8774d4d5c8d42727c74836f478c51e0a16daeeee80017c133f9e1ebf4f6f"
-"checksum rustc-ap-graphviz 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "feba68cc05f42d227b258e07a84df7d690d1f20200593754a789ab39acb581e5"
-"checksum rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "989d221c292a3c777fc4921f87e4962d8d89633cf52a3a82f6f34d5b3d66efc7"
-"checksum rustc-ap-rustc_ast_passes 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "865c0bddabe735c8f8116cf14239b41d5789e5c38d1c503888779721b98bdd9e"
-"checksum rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "595c0092a2fa00dd0e572739279f771d96242f7626fc3999b4b027f08664417f"
-"checksum rustc-ap-rustc_attr 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be021d73b25feb33dc0aa91f91ff37b939a0ef54f9620684bc2846278b5e637"
-"checksum rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a41551e5393a1abb4401e82f4e4bb64e097facb7d0362a1736b117186c0966dd"
-"checksum rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8715e95fd29d92a7799f9c65cb5583485bbf902dda17900c884fbb7956d593d8"
-"checksum rustc-ap-rustc_expand 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ecc53789a88bb89caf81a6572db077b8679450b384fc03bf797d8453f86354b"
-"checksum rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf6304d5df6f803f43d15a71d1c4b4aa6b68a01fe587ad62fcdfb83049e3ec77"
-"checksum rustc-ap-rustc_fs_util 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7c05da9f8dfd5c086465ad0263749453c13739226233c0354de5fc93b20204a"
-"checksum rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c292880ff00cd1e61710396f9379b2c99a533cfb1bc9c3274d566ada2c6027"
-"checksum rustc-ap-rustc_lexer 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51e5ac7071163642ff52dda1bc41ff7464fcd832b5ea3fabf162569d26969410"
-"checksum rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e147f23b65b716b58bd8687170914d3e2d2bfd004ec3fc8d2749e9d601482c0"
-"checksum rustc-ap-rustc_parse 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c5e12622f831b7344899229f2f776ff2cdd14f7f82b257d6bbcb79c850996298"
-"checksum rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18fb72a26080a34d35c8dd7ba5ac593812c1c3f97edffe6f1bf30c1ef5c4c550"
-"checksum rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe2d8db305496f9dc5f43408044735a942eadeeb2a28d6da8dd6b23b5ef60f93"
-"checksum rustc-ap-rustc_target 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2797ddd7911ba6681f500fa0d5af651635bdc74813363a1216bafc6156cb3d2"
-"checksum rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8567212bd0f0a93bbf3675e1ae819937e4a57d48b705522462c31ff8efc0604"
+"checksum rustc-ap-arena 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "632704fb93ca8148957191e5d2d827082f93c4aa20cdd242fb46d8cca57029da"
+"checksum rustc-ap-graphviz 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bdd4689b814859c9f1b3e314ed2bde596acac428a256a16894635f600bed46b4"
+"checksum rustc-ap-rustc_ast 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "101c1517d3fd19d083aaca5b113f9965e6ae353a0bb09c49959b0f62b95b75d9"
+"checksum rustc-ap-rustc_ast_passes 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab3f5a7e939b37c99d8ca371f09b10bb5b5c85ad5d5b8d1d736ce8248c71be0"
+"checksum rustc-ap-rustc_ast_pretty 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05046d3a2b8de22b20bcda9a1c063dc5c1f2f721f042b6c2809df2d23c64a13e"
+"checksum rustc-ap-rustc_attr 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f00b7ccad6fc3628fb44950435772945a425575f9ea0b3708c536fe75623a6e8"
+"checksum rustc-ap-rustc_data_structures 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c6121ab6766644fa76b711f65d4c39f2e335488ab768324567fed0ed191166e"
+"checksum rustc-ap-rustc_errors 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "adab84c842003ad1c8435fd71b8d0cc19bf0d702a8a2147d5be06e083db2d207"
+"checksum rustc-ap-rustc_expand 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb001df541ea02b65c8e294252530010c6f90e3c6a5716e8e24e58c12dd1cd86"
+"checksum rustc-ap-rustc_feature 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "446cc60613cc3b05d0bdbcab7feb02305790b5617fa43c532d51ae3223d677a4"
+"checksum rustc-ap-rustc_fs_util 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ac99d6f67e7db3bb300895630e769ed41bd3e336c0e725870c70e676c1a5ff1"
+"checksum rustc-ap-rustc_index 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5608c1cf50d2251b7e10a138cf6dd388e97f139b21c00b06a22d06f89c6591f6"
+"checksum rustc-ap-rustc_lexer 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e9c1c6f5dc85977b3adb6fb556b2ff23354d1a12021da15eb1d36353458bde"
+"checksum rustc-ap-rustc_macros 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3226b5ec864312a5d23eb40a5d621ee06bdc0754228d20d6eb76d4ddc4f2d4a1"
+"checksum rustc-ap-rustc_parse 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba3b042344c2280b50d5df0058d11379028a8f016a407e575bb3ea8b6c798049"
+"checksum rustc-ap-rustc_session 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff35ef4b5d9fbcb2fd539c7c908eb3cdd1f68ddbccd042945ef50ae65564f941"
+"checksum rustc-ap-rustc_span 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e323b1f4a824039886eed8e33cad20ea4f492a9f9b3c9441009797c91de3e87a"
+"checksum rustc-ap-rustc_target 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e161eb7b3a5b7993c6b480135296dc61476db80041d49dd446422742426e390b"
+"checksum rustc-ap-serialize 651.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af510a659098d8c45a7303fb882fa780f4a87ec5f5d7a2053521e7d5d7f332c4"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f32767f90d938f1b7199a174ef249ae1924f6e5bbdb9d112fea141e016f25b3a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,65 +617,82 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "rustc-ap-rustc_ast_pretty"
-version = "647.0.0"
+name = "rustc-ap-rustc_ast_passes"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-ap-rustc_ast_pretty"
+version = "650.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -688,9 +705,9 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "measureme 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-graphviz 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-graphviz 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -701,15 +718,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,32 +734,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-ap-rustc_expand"
+version = "650.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_passes 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-ap-rustc_feature"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -750,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -761,75 +799,75 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_fs_util 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_fs_util 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-arena 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-arena 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -911,14 +949,15 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_expand 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-config_proc_macro 0.2.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1275,23 +1314,25 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
-"checksum rustc-ap-arena 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0c144addf28721384a516382f1f7b7c518ebb87a330623dc9e2427b4ed01512"
-"checksum rustc-ap-graphviz 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4bdd6f563273576220a075afefae7b9e20953c70e7cfe4b664ce1c240f88841"
-"checksum rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b4b7aa06b8d9d6bf02075f91cdaf027cbce34aedd6ab5a6f4759de4c05de099"
-"checksum rustc-ap-rustc_ast_pretty 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aeb9a73b0f1c632fd09dd02444efe753445de17da8ffb1df28adc5766a581ada"
-"checksum rustc-ap-rustc_attr 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a420a672006a07f51cfc603ab394a066ccaf51323862c6b6b44bb673812df32"
-"checksum rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f224fd21a3c82b84e9914b4b1de31b0099e2083345c739285130017f5b2882"
-"checksum rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "312120a27c404bae22ed957b8d4e9cca2b872998558d227130aca9f3ff4edce9"
-"checksum rustc-ap-rustc_feature 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7615aa561db78b1acacbedfa475e3ba5ed7071a33e5ede30d9660069be7b5e"
-"checksum rustc-ap-rustc_fs_util 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ad7d6ee7fe47355214989c1638d9353344dfd2ac46eda5ac971533c543468d0"
-"checksum rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a570533637a35eb7ed51de75a819a9f290fbd45b6cd4ca21e4ffe35ee2fcdf5"
-"checksum rustc-ap-rustc_lexer 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47a9df68feec956275dfd12cdeadc46fc55e48859417e4301f2b330d680de96e"
-"checksum rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "623e619c676c376f079c4504a6047f76630bb3d23d1a6c4a4beee79158082c74"
-"checksum rustc-ap-rustc_parse 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "465685a06a0a897cacd3c6bc6e0f50c79e1347cca9eb061361b5fa90ce46fb62"
-"checksum rustc-ap-rustc_session 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf21db47cebe929bcac82f66da0faa1f38ace2091d6a887acdd87dcdfb7a823d"
-"checksum rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7bb21edcd0e2603efee36ffb1bc4c08b7288478fe107159dbffed0ec8a894a1"
-"checksum rustc-ap-rustc_target 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e8cb1a2d38583099f392c6ea8d3f77b1fc8368e4edfce1978d94c249dc9a828"
-"checksum rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25317d226bf1d0243d4df231edcc9bf1c0e40c503ef0290cc7aa5658d3819915"
+"checksum rustc-ap-arena 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7ba8774d4d5c8d42727c74836f478c51e0a16daeeee80017c133f9e1ebf4f6f"
+"checksum rustc-ap-graphviz 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "feba68cc05f42d227b258e07a84df7d690d1f20200593754a789ab39acb581e5"
+"checksum rustc-ap-rustc_ast 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "989d221c292a3c777fc4921f87e4962d8d89633cf52a3a82f6f34d5b3d66efc7"
+"checksum rustc-ap-rustc_ast_passes 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "865c0bddabe735c8f8116cf14239b41d5789e5c38d1c503888779721b98bdd9e"
+"checksum rustc-ap-rustc_ast_pretty 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "595c0092a2fa00dd0e572739279f771d96242f7626fc3999b4b027f08664417f"
+"checksum rustc-ap-rustc_attr 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be021d73b25feb33dc0aa91f91ff37b939a0ef54f9620684bc2846278b5e637"
+"checksum rustc-ap-rustc_data_structures 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a41551e5393a1abb4401e82f4e4bb64e097facb7d0362a1736b117186c0966dd"
+"checksum rustc-ap-rustc_errors 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8715e95fd29d92a7799f9c65cb5583485bbf902dda17900c884fbb7956d593d8"
+"checksum rustc-ap-rustc_expand 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ecc53789a88bb89caf81a6572db077b8679450b384fc03bf797d8453f86354b"
+"checksum rustc-ap-rustc_feature 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf6304d5df6f803f43d15a71d1c4b4aa6b68a01fe587ad62fcdfb83049e3ec77"
+"checksum rustc-ap-rustc_fs_util 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7c05da9f8dfd5c086465ad0263749453c13739226233c0354de5fc93b20204a"
+"checksum rustc-ap-rustc_index 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c292880ff00cd1e61710396f9379b2c99a533cfb1bc9c3274d566ada2c6027"
+"checksum rustc-ap-rustc_lexer 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51e5ac7071163642ff52dda1bc41ff7464fcd832b5ea3fabf162569d26969410"
+"checksum rustc-ap-rustc_macros 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e147f23b65b716b58bd8687170914d3e2d2bfd004ec3fc8d2749e9d601482c0"
+"checksum rustc-ap-rustc_parse 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c5e12622f831b7344899229f2f776ff2cdd14f7f82b257d6bbcb79c850996298"
+"checksum rustc-ap-rustc_session 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18fb72a26080a34d35c8dd7ba5ac593812c1c3f97edffe6f1bf30c1ef5c4c550"
+"checksum rustc-ap-rustc_span 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe2d8db305496f9dc5f43408044735a942eadeeb2a28d6da8dd6b23b5ef60f93"
+"checksum rustc-ap-rustc_target 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2797ddd7911ba6681f500fa0d5af651635bdc74813363a1216bafc6156cb3d2"
+"checksum rustc-ap-serialize 650.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8567212bd0f0a93bbf3675e1ae819937e4a57d48b705522462c31ff8efc0604"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f32767f90d938f1b7199a174ef249ae1924f6e5bbdb9d112fea141e016f25b3a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,49 +617,65 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc-ap-rustc_ast_pretty"
-version = "644.0.0"
+name = "rustc-ap-rustc_ast"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-ap-rustc_ast_pretty"
+version = "647.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_ast_pretty 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -672,9 +688,9 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "measureme 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-graphviz 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-graphviz 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,15 +701,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -702,31 +718,31 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -734,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -745,94 +761,78 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_fs_util 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_fs_util 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-arena 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-arena 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rustc-ap-syntax"
-version = "644.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -911,14 +911,14 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-config_proc_macro 0.2.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1275,23 +1275,23 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
-"checksum rustc-ap-arena 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80a4f7385e1a0bd8869b1c49738eb6a5c552d66cbea1b880d0481048588fc565"
-"checksum rustc-ap-graphviz 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da134a8459132ec83aba664fbc791c5e409539534bcdeb9df3d29b6ca7c37a76"
-"checksum rustc-ap-rustc_ast_pretty 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41b1280428ae4a3e6b944f2045578a4737cf367db1ac1bdcf66e6e3f886ec981"
-"checksum rustc-ap-rustc_attr 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3f27b42985109679eadcf07e0b0f227b9ba3d203173766b2c1a9ee0bbda05e4"
-"checksum rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d3f4519ec1dad0b704129a4f891e7c75239850fa683765a63f163ea8ffa7b9"
-"checksum rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e870484235e89654b66b10467862f3d60a698c0d5983aa51b42563733b77f71"
-"checksum rustc-ap-rustc_feature 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03e3e31e687890adfbc606e8f41e460408bc5b7a94c785d36e7cebc4c9193d00"
-"checksum rustc-ap-rustc_fs_util 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23e0f0111c0b6ce58385784ecb4945f6b02c449591c13087dba5e82bbd900ac1"
-"checksum rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "808d42ae6e32607870710ff7ac0faa89b4ce8f8a4aa0a0d875e8ea62e4911a6c"
-"checksum rustc-ap-rustc_lexer 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1494650ca657dd164503e03ebe5a3172fdfe1750e427aa7e139fbda4460817e"
-"checksum rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df5ad90674b7aac5606fc923d1aa8b804a11a4e65bf2fe850447b28a2bd9a011"
-"checksum rustc-ap-rustc_parse 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb47830cfbb7b05eba5d5ec7c53dfb57dd76d09977e9a78eb7798a2b606bfec6"
-"checksum rustc-ap-rustc_session 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d44935089371d9e4c91eb90c9a3358b44c0b59ef1b4552f05cecb8025b1971f0"
-"checksum rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ccd71ce20995448afe2af68c32d06b01ee160d55ef9e5eebe81a7ca085324dd0"
-"checksum rustc-ap-rustc_target 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf8ba8d508f3e4e9e625566295bc1437d0327e7cd3c821e08f65e5801da6904"
-"checksum rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7b029cc11516918c37b55230edbfc693dabbe1481013cadc506bdd345e63587"
-"checksum rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "478155ef59211e934a79bd1ed4dbbbb5d1226bd8921e2aa7edb23d8f5f8d1080"
+"checksum rustc-ap-arena 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0c144addf28721384a516382f1f7b7c518ebb87a330623dc9e2427b4ed01512"
+"checksum rustc-ap-graphviz 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4bdd6f563273576220a075afefae7b9e20953c70e7cfe4b664ce1c240f88841"
+"checksum rustc-ap-rustc_ast 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b4b7aa06b8d9d6bf02075f91cdaf027cbce34aedd6ab5a6f4759de4c05de099"
+"checksum rustc-ap-rustc_ast_pretty 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aeb9a73b0f1c632fd09dd02444efe753445de17da8ffb1df28adc5766a581ada"
+"checksum rustc-ap-rustc_attr 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4a420a672006a07f51cfc603ab394a066ccaf51323862c6b6b44bb673812df32"
+"checksum rustc-ap-rustc_data_structures 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f224fd21a3c82b84e9914b4b1de31b0099e2083345c739285130017f5b2882"
+"checksum rustc-ap-rustc_errors 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "312120a27c404bae22ed957b8d4e9cca2b872998558d227130aca9f3ff4edce9"
+"checksum rustc-ap-rustc_feature 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7615aa561db78b1acacbedfa475e3ba5ed7071a33e5ede30d9660069be7b5e"
+"checksum rustc-ap-rustc_fs_util 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ad7d6ee7fe47355214989c1638d9353344dfd2ac46eda5ac971533c543468d0"
+"checksum rustc-ap-rustc_index 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a570533637a35eb7ed51de75a819a9f290fbd45b6cd4ca21e4ffe35ee2fcdf5"
+"checksum rustc-ap-rustc_lexer 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47a9df68feec956275dfd12cdeadc46fc55e48859417e4301f2b330d680de96e"
+"checksum rustc-ap-rustc_macros 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "623e619c676c376f079c4504a6047f76630bb3d23d1a6c4a4beee79158082c74"
+"checksum rustc-ap-rustc_parse 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "465685a06a0a897cacd3c6bc6e0f50c79e1347cca9eb061361b5fa90ce46fb62"
+"checksum rustc-ap-rustc_session 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf21db47cebe929bcac82f66da0faa1f38ace2091d6a887acdd87dcdfb7a823d"
+"checksum rustc-ap-rustc_span 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7bb21edcd0e2603efee36ffb1bc4c08b7288478fe107159dbffed0ec8a894a1"
+"checksum rustc-ap-rustc_target 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e8cb1a2d38583099f392c6ea8d3f77b1fc8368e4edfce1978d94c249dc9a828"
+"checksum rustc-ap-serialize 647.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25317d226bf1d0243d4df231edcc9bf1c0e40c503ef0290cc7aa5658d3819915"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f32767f90d938f1b7199a174ef249ae1924f6e5bbdb9d112fea141e016f25b3a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,49 +617,49 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_ast_pretty 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -672,9 +672,9 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "measureme 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-graphviz 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-graphviz 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,15 +685,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -702,31 +702,31 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -734,10 +734,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -746,75 +745,75 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_fs_util 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_fs_util 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-arena 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-arena 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -823,16 +822,16 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -912,14 +911,14 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-config_proc_macro 0.2.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1276,23 +1275,23 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
-"checksum rustc-ap-arena 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea82fa3d9a8add7422228ca1a2cbba0784fa8861f56148ff64da08b3c7921b03"
-"checksum rustc-ap-graphviz 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "638d0b2b3bcf99824e0cb5a25dbc547b61dc20942e11daf6a97e981918aa18e5"
-"checksum rustc-ap-rustc_ast_pretty 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d38bab04dd676dee6d2f9670506a18c31bfce38bf7f8420aa83eb1140ecde049"
-"checksum rustc-ap-rustc_attr 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "10b843ba8b1ed43739133047673b9f6a54d3b3b4d328d69c6ea89ff971395f35"
-"checksum rustc-ap-rustc_data_structures 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc3d1c6d0a80ab0c1df76405377cec0f3d5423fb5b0953a8eac70a2ad6c44df2"
-"checksum rustc-ap-rustc_errors 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4909a1eca29331332257230f29120a8ff68c9e37d868c564fcd599e430cf8914"
-"checksum rustc-ap-rustc_feature 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63ab887a181d795cf5fd3edadf367760deafb90aefb844f168ab5255266e3478"
-"checksum rustc-ap-rustc_fs_util 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70814116df3c5fbec8f06f6a1d013ca481f620fd22a9475754e9bf3ee9ba70d8"
-"checksum rustc-ap-rustc_index 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac1bf1d3cf3d119d41353d6fd229ef7272d5097bc0924de021c0294bf86d48bf"
-"checksum rustc-ap-rustc_lexer 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4cda21a32cebdc11ec4f5393aa2fcde5ed1b2f673a8571e5a4dcdf07e4ae9cac"
-"checksum rustc-ap-rustc_macros 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75c47b48ea51910ecfd853c9248a9bf4c767bc823449ab6a1d864dff65fbae16"
-"checksum rustc-ap-rustc_parse 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "abd88e89cd5b5d28dcd3a347a3d534c08627d9455570dc1a2d402cb8437b9d30"
-"checksum rustc-ap-rustc_session 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8487b4575fbb2d1fc6f1cd61225efd108a4d36817e6fb9b643d57fcae9cb12"
-"checksum rustc-ap-rustc_span 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f69746c0d4c21bf20a5bb2bd247261a1aa8631f04202d7303352942dde70d987"
-"checksum rustc-ap-rustc_target 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8bbc6ae09b5d42ec66edd520e8412e0615c53a7c93607fe33dc4abab60ba7c8b"
-"checksum rustc-ap-serialize 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e13a1ead0252fc3d96da4c336a95950be6795f2b00c84a67ccadf26142f8cb41"
-"checksum rustc-ap-syntax 642.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1f59f48ca3a2ec16a7e82e718ed5aadf9c9e08cf63015d28b4e774767524a6a"
+"checksum rustc-ap-arena 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80a4f7385e1a0bd8869b1c49738eb6a5c552d66cbea1b880d0481048588fc565"
+"checksum rustc-ap-graphviz 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da134a8459132ec83aba664fbc791c5e409539534bcdeb9df3d29b6ca7c37a76"
+"checksum rustc-ap-rustc_ast_pretty 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41b1280428ae4a3e6b944f2045578a4737cf367db1ac1bdcf66e6e3f886ec981"
+"checksum rustc-ap-rustc_attr 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3f27b42985109679eadcf07e0b0f227b9ba3d203173766b2c1a9ee0bbda05e4"
+"checksum rustc-ap-rustc_data_structures 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d3f4519ec1dad0b704129a4f891e7c75239850fa683765a63f163ea8ffa7b9"
+"checksum rustc-ap-rustc_errors 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e870484235e89654b66b10467862f3d60a698c0d5983aa51b42563733b77f71"
+"checksum rustc-ap-rustc_feature 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03e3e31e687890adfbc606e8f41e460408bc5b7a94c785d36e7cebc4c9193d00"
+"checksum rustc-ap-rustc_fs_util 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23e0f0111c0b6ce58385784ecb4945f6b02c449591c13087dba5e82bbd900ac1"
+"checksum rustc-ap-rustc_index 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "808d42ae6e32607870710ff7ac0faa89b4ce8f8a4aa0a0d875e8ea62e4911a6c"
+"checksum rustc-ap-rustc_lexer 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1494650ca657dd164503e03ebe5a3172fdfe1750e427aa7e139fbda4460817e"
+"checksum rustc-ap-rustc_macros 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df5ad90674b7aac5606fc923d1aa8b804a11a4e65bf2fe850447b28a2bd9a011"
+"checksum rustc-ap-rustc_parse 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb47830cfbb7b05eba5d5ec7c53dfb57dd76d09977e9a78eb7798a2b606bfec6"
+"checksum rustc-ap-rustc_session 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d44935089371d9e4c91eb90c9a3358b44c0b59ef1b4552f05cecb8025b1971f0"
+"checksum rustc-ap-rustc_span 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ccd71ce20995448afe2af68c32d06b01ee160d55ef9e5eebe81a7ca085324dd0"
+"checksum rustc-ap-rustc_target 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf8ba8d508f3e4e9e625566295bc1437d0327e7cd3c821e08f65e5801da6904"
+"checksum rustc-ap-serialize 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7b029cc11516918c37b55230edbfc693dabbe1481013cadc506bdd345e63587"
+"checksum rustc-ap-syntax 644.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "478155ef59211e934a79bd1ed4dbbbb5d1226bd8921e2aa7edb23d8f5f8d1080"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f32767f90d938f1b7199a174ef249ae1924f6e5bbdb9d112fea141e016f25b3a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ ignore = "0.4.11"
 annotate-snippets = { version = "0.6", features = ["ansi_term"] }
 structopt = "0.3"
 rustfmt-config_proc_macro = { version = "0.2", path = "config_proc_macro" }
+lazy_static = "1.0.0"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
@@ -93,6 +94,3 @@ version = "647.0.0"
 [dependencies.syntax]
 package = "rustc-ap-rustc_ast"
 version = "647.0.0"
-
-[dev-dependencies]
-lazy_static = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,32 +65,36 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "647.0.0"
+version = "650.0.0"
+
+[dependencies.rustc_expand]
+package = "rustc-ap-rustc_expand"
+version = "650.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_target]
 package = "rustc-ap-rustc_target"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.syntax]
 package = "rustc-ap-rustc_ast"
-version = "647.0.0"
+version = "650.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,35 +64,35 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_target]
 package = "rustc-ap-rustc_target"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.syntax]
-package = "rustc-ap-syntax"
-version = "644.0.0"
+package = "rustc-ap-rustc_ast"
+version = "647.0.0"
 
 [dev-dependencies]
 lazy_static = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,36 +65,36 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_target]
 package = "rustc-ap-rustc_target"
-version = "650.0.0"
+version = "651.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ lazy_static = "1.0.0"
 # for more information.
 rustc-workspace-hack = "1.0.0"
 
+[dependencies.rustc_ast]
+package = "rustc-ap-rustc_ast"
+version = "650.0.0"
+
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
 version = "650.0.0"
@@ -93,8 +97,4 @@ version = "650.0.0"
 
 [dependencies.rustc_target]
 package = "rustc-ap-rustc_target"
-version = "650.0.0"
-
-[dependencies.syntax]
-package = "rustc-ap-rustc_ast"
 version = "650.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,35 +64,35 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_target]
 package = "rustc-ap-rustc_target"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.syntax]
 package = "rustc-ap-syntax"
-version = "642.0.0"
+version = "644.0.0"
 
 [dev-dependencies]
 lazy_static = "1.0.0"

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -18,12 +18,13 @@ use crate::utils::{count_newlines, mk_sp};
 mod doc_comment;
 
 /// Returns attributes on the given statement.
-pub(crate) fn get_attrs_from_stmt(stmt: &ast::Stmt) -> &[ast::Attribute] {
+pub(crate) fn get_attrs_from_stmt(stmt: &ast::Stmt) -> Option<&[ast::Attribute]> {
     match stmt.kind {
-        ast::StmtKind::Local(ref local) => &local.attrs,
-        ast::StmtKind::Item(ref item) => &item.attrs,
-        ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => &expr.attrs,
-        ast::StmtKind::Mac(ref mac) => &mac.2,
+        ast::StmtKind::Local(ref local) => Some(&local.attrs),
+        ast::StmtKind::Item(ref item) => Some(&item.attrs),
+        ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => Some(&expr.attrs),
+        ast::StmtKind::Mac(ref mac) => Some(&mac.2),
+        ast::StmtKind::Empty => None,
     }
 }
 
@@ -36,6 +37,7 @@ pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
             let (ref mac, _, _) = **mac;
             mac.span()
         }
+        ast::StmtKind::Empty => stmt.span,
     }
 }
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1,7 +1,7 @@
 //! Format attributes and meta items.
 
+use rustc_ast::ast;
 use rustc_span::{symbol::sym, BytePos, Span, DUMMY_SP};
-use syntax::ast;
 
 use self::doc_comment::DocCommentFormatter;
 use crate::comment::{contains_comment, rewrite_doc_comment, CommentStyle};

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -23,7 +23,7 @@ pub(crate) fn get_attrs_from_stmt(stmt: &ast::Stmt) -> Option<&[ast::Attribute]>
         ast::StmtKind::Local(ref local) => Some(&local.attrs),
         ast::StmtKind::Item(ref item) => Some(&item.attrs),
         ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => Some(&expr.attrs),
-        ast::StmtKind::Mac(ref mac) => Some(&mac.2),
+        ast::StmtKind::MacCall(ref mac) => Some(&mac.2),
         ast::StmtKind::Empty => None,
     }
 }
@@ -33,7 +33,7 @@ pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
         ast::StmtKind::Local(ref local) => local.span,
         ast::StmtKind::Item(ref item) => item.span,
         ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => expr.span,
-        ast::StmtKind::Mac(ref mac) => {
+        ast::StmtKind::MacCall(ref mac) => {
             let (ref mac, _, _) = **mac;
             mac.span()
         }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1,6 +1,7 @@
 //! Format attributes and meta items.
 
 use rustc_ast::ast;
+use rustc_ast::attr::HasAttrs;
 use rustc_span::{symbol::sym, BytePos, Span, DUMMY_SP};
 
 use self::doc_comment::DocCommentFormatter;
@@ -18,14 +19,8 @@ use crate::utils::{count_newlines, mk_sp};
 mod doc_comment;
 
 /// Returns attributes on the given statement.
-pub(crate) fn get_attrs_from_stmt(stmt: &ast::Stmt) -> Option<&[ast::Attribute]> {
-    match stmt.kind {
-        ast::StmtKind::Local(ref local) => Some(&local.attrs),
-        ast::StmtKind::Item(ref item) => Some(&item.attrs),
-        ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => Some(&expr.attrs),
-        ast::StmtKind::MacCall(ref mac) => Some(&mac.2),
-        ast::StmtKind::Empty => None,
-    }
+pub(crate) fn get_attrs_from_stmt(stmt: &ast::Stmt) -> &[ast::Attribute] {
+    stmt.attrs()
 }
 
 pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -58,8 +58,8 @@
 use std::borrow::Cow;
 use std::cmp::min;
 
+use rustc_ast::{ast, ptr};
 use rustc_span::{BytePos, Span};
-use syntax::{ast, ptr};
 
 use crate::comment::{rewrite_comment, CharClasses, FullCodeCharKind, RichChar};
 use crate::config::IndentStyle;

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -148,7 +148,15 @@ impl ChainItemKind {
             ast::ExprKind::MethodCall(ref segment, ref expressions) => {
                 let types = if let Some(ref generic_args) = segment.args {
                     if let ast::GenericArgs::AngleBracketed(ref data) = **generic_args {
-                        data.args.clone()
+                        data.args
+                            .iter()
+                            .filter_map(|x| match x {
+                                ast::AngleBracketedArg::Arg(ref generic_arg) => {
+                                    Some(generic_arg.clone())
+                                }
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
                     } else {
                         vec![]
                     }

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -403,7 +403,7 @@ impl Chain {
 
     fn convert_try(expr: &ast::Expr, context: &RewriteContext<'_>) -> ast::Expr {
         match expr.kind {
-            ast::ExprKind::Mac(ref mac) if context.config.use_try_shorthand() => {
+            ast::ExprKind::MacCall(ref mac) if context.config.use_try_shorthand() => {
                 if let Some(subexpr) = convert_try_mac(mac, context) {
                     subexpr
                 } else {

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -1,5 +1,5 @@
+use rustc_ast::{ast, ptr};
 use rustc_span::Span;
-use syntax::{ast, ptr};
 
 use crate::attr::get_attrs_from_stmt;
 use crate::config::lists::*;

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -105,9 +105,13 @@ fn get_inner_expr<'a>(
 
 // Figure out if a block is necessary.
 fn needs_block(block: &ast::Block, prefix: &str, context: &RewriteContext<'_>) -> bool {
-    let has_attributes = block.stmts.first().map_or(false, |first_stmt| {
-        !get_attrs_from_stmt(first_stmt).is_empty()
-    });
+    let has_attributes = block
+        .stmts
+        .first()
+        .map_or(false, |first_stmt| match get_attrs_from_stmt(first_stmt) {
+            Some(attrs) => !attrs.is_empty(),
+            None => false,
+        });
 
     is_unsafe_block(block)
         || block.stmts.len() > 1

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -25,7 +25,7 @@ use crate::utils::{last_line_width, left_most_sub_expr, stmt_expr, NodeIdExt};
 
 pub(crate) fn rewrite_closure(
     capture: ast::CaptureBy,
-    is_async: &ast::IsAsync,
+    is_async: &ast::Async,
     movability: ast::Movability,
     fn_decl: &ast::FnDecl,
     body: &ast::Expr,
@@ -50,7 +50,7 @@ pub(crate) fn rewrite_closure(
         }
 
         let result = match fn_decl.output {
-            ast::FunctionRetTy::Default(_) if !context.inside_macro() => {
+            ast::FnRetTy::Default(_) if !context.inside_macro() => {
                 try_rewrite_without_block(body, &prefix, context, shape, body_shape)
             }
             _ => None,
@@ -214,7 +214,7 @@ fn rewrite_closure_block(
 // Return type is (prefix, extra_offset)
 fn rewrite_closure_fn_decl(
     capture: ast::CaptureBy,
-    asyncness: &ast::IsAsync,
+    asyncness: &ast::Async,
     movability: ast::Movability,
     fn_decl: &ast::FnDecl,
     body: &ast::Expr,

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -105,13 +105,9 @@ fn get_inner_expr<'a>(
 
 // Figure out if a block is necessary.
 fn needs_block(block: &ast::Block, prefix: &str, context: &RewriteContext<'_>) -> bool {
-    let has_attributes = block
-        .stmts
-        .first()
-        .map_or(false, |first_stmt| match get_attrs_from_stmt(first_stmt) {
-            Some(attrs) => !attrs.is_empty(),
-            None => false,
-        });
+    let has_attributes = block.stmts.first().map_or(false, |first_stmt| {
+        !get_attrs_from_stmt(first_stmt).is_empty()
+    });
 
     is_unsafe_block(block)
         || block.stmts.len() > 1

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -43,7 +43,7 @@ pub(crate) fn rewrite_closure(
 
     if let ast::ExprKind::Block(ref block, _) = body.kind {
         // The body of the closure is an empty block.
-        if block.stmts.is_empty() && !block_contains_comment(block, context.source_map) {
+        if block.stmts.is_empty() && !block_contains_comment(context, block) {
             return body
                 .rewrite(context, shape)
                 .map(|s| format!("{} {}", prefix, s));
@@ -116,7 +116,7 @@ fn needs_block(block: &ast::Block, prefix: &str, context: &RewriteContext<'_>) -
     is_unsafe_block(block)
         || block.stmts.len() > 1
         || has_attributes
-        || block_contains_comment(block, context.source_map)
+        || block_contains_comment(context, block)
         || prefix.contains('\n')
 }
 
@@ -309,7 +309,7 @@ pub(crate) fn rewrite_last_closure(
             ast::ExprKind::Block(ref block, _)
                 if !is_unsafe_block(block)
                     && !context.inside_macro()
-                    && is_simple_block(block, Some(&body.attrs), context.source_map) =>
+                    && is_simple_block(context, block, Some(&body.attrs)) =>
             {
                 stmt_expr(&block.stmts[0]).unwrap_or(body)
             }

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1556,10 +1556,10 @@ pub(crate) fn recover_comment_removed(
         // We missed some comments. Warn and keep the original text.
         if context.config.error_on_unformatted() {
             context.report.append(
-                context.source_map.span_to_filename(span).into(),
+                context.parse_sess.span_to_filename(span),
                 vec![FormattingError::from_span(
                     span,
-                    &context.source_map,
+                    &context.parse_sess,
                     ErrorKind::LostComment,
                 )],
             );

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::cmp::min;
 
 use itertools::Itertools;
+use rustc_ast::token::{DelimToken, LitKind};
+use rustc_ast::{ast, ptr};
 use rustc_span::{BytePos, Span};
-use syntax::token::{DelimToken, LitKind};
-use syntax::{ast, ptr};
 
 use crate::chains::rewrite_chain;
 use crate::closures;
@@ -1314,7 +1314,7 @@ pub(crate) fn can_be_overflowed_expr(
         }
         ast::ExprKind::MacCall(ref mac) => {
             match (
-                syntax::ast::MacDelimiter::from_token(mac.args.delim()),
+                rustc_ast::ast::MacDelimiter::from_token(mac.args.delim()),
                 context.config.overflow_delimited_expr(),
             ) {
                 (Some(ast::MacDelimiter::Bracket), true)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -199,7 +199,7 @@ pub(crate) fn format_expr(
         ast::ExprKind::Try(..) | ast::ExprKind::Field(..) | ast::ExprKind::MethodCall(..) => {
             rewrite_chain(expr, context, shape)
         }
-        ast::ExprKind::Mac(ref mac) => {
+        ast::ExprKind::MacCall(ref mac) => {
             rewrite_macro(mac, None, context, shape, MacroPosition::Expression).or_else(|| {
                 wrap_str(
                     context.snippet(expr.span).to_owned(),
@@ -1312,7 +1312,7 @@ pub(crate) fn can_be_overflowed_expr(
             context.config.overflow_delimited_expr()
                 || (context.use_block_indent() && args_len == 1)
         }
-        ast::ExprKind::Mac(ref mac) => {
+        ast::ExprKind::MacCall(ref mac) => {
             match (
                 syntax::ast::MacDelimiter::from_token(mac.args.delim()),
                 context.config.overflow_delimited_expr(),
@@ -1340,7 +1340,7 @@ pub(crate) fn can_be_overflowed_expr(
 
 pub(crate) fn is_nested_call(expr: &ast::Expr) -> bool {
     match expr.kind {
-        ast::ExprKind::Call(..) | ast::ExprKind::Mac(..) => true,
+        ast::ExprKind::Call(..) | ast::ExprKind::MacCall(..) => true,
         ast::ExprKind::AddrOf(_, _, ref expr)
         | ast::ExprKind::Box(ref expr)
         | ast::ExprKind::Try(ref expr)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -322,7 +322,7 @@ pub(crate) fn format_expr(
         }
         // We do not format these expressions yet, but they should still
         // satisfy our width restrictions.
-        ast::ExprKind::InlineAsm(..) => Some(context.snippet(expr.span).to_owned()),
+        ast::ExprKind::LlvmInlineAsm(..) => Some(context.snippet(expr.span).to_owned()),
         ast::ExprKind::TryBlock(ref block) => {
             if let rw @ Some(_) =
                 rewrite_single_line_block(context, "try ", block, Some(&expr.attrs), None, shape)

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,29 +1,20 @@
 // High level formatting functions.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::{self, Write};
-use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use rustc_data_structures::sync::{Lrc, Send};
-use rustc_errors::emitter::{Emitter, EmitterWriter};
-use rustc_errors::{ColorConfig, Diagnostic, DiagnosticBuilder, Handler, Level as DiagnosticLevel};
-use rustc_session::parse::ParseSess;
-use rustc_span::{
-    source_map::{FilePathMapping, SourceMap},
-    Span, DUMMY_SP,
-};
+use rustc_span::Span;
 use syntax::ast;
 
 use self::newline_style::apply_newline_style;
 use crate::comment::{CharClasses, FullCodeCharKind};
 use crate::config::{Config, FileName, Verbosity};
-use crate::ignore_path::IgnorePathSet;
 use crate::issues::BadIssueSeeker;
+use crate::syntux::parser::{DirectoryOwnership, Parser, ParserError};
+use crate::syntux::session::ParseSess;
 use crate::utils::count_newlines;
-use crate::visitor::{FmtVisitor, SnippetProvider};
+use crate::visitor::FmtVisitor;
 use crate::{modules, source_file, ErrorKind, FormatReport, Input, Session};
 
 mod newline_style;
@@ -71,54 +62,41 @@ fn format_project<T: FormatHandler>(
     let main_file = input.file_name();
     let input_is_stdin = main_file == FileName::Stdin;
 
-    let ignore_path_set = match IgnorePathSet::from_ignore_list(&config.ignore()) {
-        Ok(set) => Rc::new(set),
-        Err(e) => return Err(ErrorKind::InvalidGlobPattern(e)),
-    };
-    if config.skip_children() && ignore_path_set.is_match(&main_file) {
+    let mut parse_session = ParseSess::new(config)?;
+    if config.skip_children() && parse_session.ignore_file(&main_file) {
         return Ok(FormatReport::new());
     }
 
     // Parse the crate.
-    let can_reset_parser_errors = Rc::new(RefCell::new(false));
-    let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
-    let mut parse_session = make_parse_sess(
-        source_map.clone(),
-        config,
-        Rc::clone(&ignore_path_set),
-        can_reset_parser_errors.clone(),
-    );
     let mut report = FormatReport::new();
     let directory_ownership = input.to_directory_ownership();
-    let krate = match parse_crate(
-        input,
-        &parse_session,
-        config,
-        &mut report,
-        directory_ownership,
-        can_reset_parser_errors.clone(),
-    ) {
+    let krate = match Parser::parse_crate(config, input, directory_ownership, &parse_session) {
         Ok(krate) => krate,
         // Surface parse error via Session (errors are merged there from report)
-        Err(ErrorKind::ParseError) => return Ok(report),
-        Err(e) => return Err(e),
+        Err(e) => {
+            let forbid_verbose = input_is_stdin || e != ParserError::ParsePanicError;
+            should_emit_verbose(forbid_verbose, config, || {
+                eprintln!("The Rust parser panicked");
+            });
+            report.add_parsing_error();
+            return Ok(report);
+        }
     };
     timer = timer.done_parsing();
 
     // Suppress error output if we have to do any further parsing.
-    let silent_emitter = silent_emitter();
-    parse_session.span_diagnostic = Handler::with_emitter(true, None, silent_emitter);
+    parse_session.set_silent_emitter();
 
     let mut context = FormatContext::new(&krate, report, parse_session, config, handler);
     let files = modules::ModResolver::new(
         &context.parse_session,
-        directory_ownership.unwrap_or(rustc_parse::DirectoryOwnership::UnownedViaMod),
+        directory_ownership.unwrap_or(DirectoryOwnership::UnownedViaMod),
         !(input_is_stdin || config.skip_children()),
     )
     .visit_crate(&krate)
     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     for (path, module) in files {
-        let should_ignore = !input_is_stdin && ignore_path_set.is_match(&path);
+        let should_ignore = !input_is_stdin && context.ignore_file(&path);
         if (config.skip_children() && path != main_file) || should_ignore {
             continue;
         }
@@ -150,6 +128,10 @@ struct FormatContext<'a, T: FormatHandler> {
 }
 
 impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
+    fn ignore_file(&self, path: &FileName) -> bool {
+        self.parse_session.ignore_file(path)
+    }
+
     // Formats a single file/module.
     fn format_file(
         &mut self,
@@ -157,15 +139,8 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
         module: &ast::Mod,
         is_root: bool,
     ) -> Result<(), ErrorKind> {
-        let source_file = self
-            .parse_session
-            .source_map()
-            .lookup_char_pos(module.inner.lo())
-            .file;
-        let big_snippet = source_file.src.as_ref().unwrap();
-        let snippet_provider =
-            SnippetProvider::new(source_file.start_pos, source_file.end_pos, big_snippet);
-        let mut visitor = FmtVisitor::from_source_map(
+        let snippet_provider = self.parse_session.snippet_provider(module.inner);
+        let mut visitor = FmtVisitor::from_parse_sess(
             &self.parse_session,
             &self.config,
             &snippet_provider,
@@ -175,16 +150,16 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
 
         // Format inner attributes if available.
         if !self.krate.attrs.is_empty() && is_root {
-            visitor.skip_empty_lines(source_file.end_pos);
+            visitor.skip_empty_lines(snippet_provider.end_pos());
             if visitor.visit_attrs(&self.krate.attrs, ast::AttrStyle::Inner) {
                 visitor.push_rewrite(module.inner, None);
             } else {
-                visitor.format_separate_mod(module, &*source_file);
+                visitor.format_separate_mod(module, snippet_provider.end_pos());
             }
         } else {
-            visitor.last_pos = source_file.start_pos;
-            visitor.skip_empty_lines(source_file.end_pos);
-            visitor.format_separate_mod(module, &*source_file);
+            visitor.last_pos = snippet_provider.start_pos();
+            visitor.skip_empty_lines(snippet_provider.end_pos());
+            visitor.format_separate_mod(module, snippet_provider.end_pos());
         };
 
         debug_assert_eq!(
@@ -209,7 +184,7 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
         apply_newline_style(
             self.config.newline_style(),
             &mut visitor.buffer,
-            &big_snippet,
+            snippet_provider.entire_snippet(),
         );
 
         if visitor.macro_rewrite_failure {
@@ -219,7 +194,7 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
             .add_non_formatted_ranges(visitor.skipped_range.borrow().clone());
 
         self.handler.handle_formatted_file(
-            self.parse_session.source_map(),
+            &self.parse_session,
             path,
             visitor.buffer.to_owned(),
             &mut self.report,
@@ -231,7 +206,7 @@ impl<'a, T: FormatHandler + 'a> FormatContext<'a, T> {
 trait FormatHandler {
     fn handle_formatted_file(
         &mut self,
-        source_map: &SourceMap,
+        parse_session: &ParseSess,
         path: FileName,
         result: String,
         report: &mut FormatReport,
@@ -242,14 +217,14 @@ impl<'b, T: Write + 'b> FormatHandler for Session<'b, T> {
     // Called for each formatted file.
     fn handle_formatted_file(
         &mut self,
-        source_map: &SourceMap,
+        parse_session: &ParseSess,
         path: FileName,
         result: String,
         report: &mut FormatReport,
     ) -> Result<(), ErrorKind> {
         if let Some(ref mut out) = self.out {
             match source_file::write_file(
-                Some(source_map),
+                Some(parse_session),
                 &path,
                 &result,
                 out,
@@ -282,23 +257,15 @@ pub(crate) struct FormattingError {
 impl FormattingError {
     pub(crate) fn from_span(
         span: Span,
-        source_map: &SourceMap,
+        parse_sess: &ParseSess,
         kind: ErrorKind,
     ) -> FormattingError {
         FormattingError {
-            line: source_map.lookup_char_pos(span.lo()).line,
+            line: parse_sess.line_of_byte_pos(span.lo()),
             is_comment: kind.is_comment(),
             kind,
             is_string: false,
-            line_buffer: source_map
-                .span_to_lines(span)
-                .ok()
-                .and_then(|fl| {
-                    fl.file
-                        .get_line(fl.lines[0].line_index)
-                        .map(std::borrow::Cow::into_owned)
-                })
-                .unwrap_or_else(String::new),
+            line_buffer: parse_sess.span_to_first_line_string(span),
         }
     }
 
@@ -633,358 +600,11 @@ impl<'a> FormatLines<'a> {
     }
 }
 
-fn parse_crate(
-    input: Input,
-    parse_session: &ParseSess,
-    config: &Config,
-    report: &mut FormatReport,
-    directory_ownership: Option<rustc_parse::DirectoryOwnership>,
-    can_reset_parser_errors: Rc<RefCell<bool>>,
-) -> Result<ast::Crate, ErrorKind> {
-    let input_is_stdin = input.is_text();
-
-    let parser = match input {
-        Input::File(ref file) => {
-            // Use `new_sub_parser_from_file` when we the input is a submodule.
-            Ok(if let Some(dir_own) = directory_ownership {
-                rustc_parse::new_sub_parser_from_file(parse_session, file, dir_own, None, DUMMY_SP)
-            } else {
-                rustc_parse::new_parser_from_file(parse_session, file)
-            })
-        }
-        Input::Text(text) => rustc_parse::maybe_new_parser_from_source_str(
-            parse_session,
-            rustc_span::FileName::Custom("stdin".to_owned()),
-            text,
-        )
-        .map(|mut parser| {
-            parser.recurse_into_file_modules = false;
-            parser
-        }),
-    };
-
-    let result = match parser {
-        Ok(mut parser) => {
-            parser.cfg_mods = false;
-            if config.skip_children() {
-                parser.recurse_into_file_modules = false;
-            }
-
-            let mut parser = AssertUnwindSafe(parser);
-            catch_unwind(move || parser.0.parse_crate_mod().map_err(|d| vec![d]))
-        }
-        Err(diagnostics) => {
-            for diagnostic in diagnostics {
-                parse_session.span_diagnostic.emit_diagnostic(&diagnostic);
-            }
-            report.add_parsing_error();
-            return Err(ErrorKind::ParseError);
-        }
-    };
-
-    match result {
-        Ok(Ok(c)) => {
-            if !parse_session.span_diagnostic.has_errors() {
-                return Ok(c);
-            }
-            // This scenario occurs when the parser encountered errors
-            // but was still able to recover. If all of the parser errors
-            // occurred in files that are ignored, then reset
-            // the error count and continue.
-            // https://github.com/rust-lang/rustfmt/issues/3779
-            if *can_reset_parser_errors.borrow() {
-                parse_session.span_diagnostic.reset_err_count();
-                return Ok(c);
-            }
-        }
-        Ok(Err(mut diagnostics)) => diagnostics.iter_mut().for_each(DiagnosticBuilder::emit),
-        Err(_) => {
-            // Note that if you see this message and want more information,
-            // then run the `parse_crate_mod` function above without
-            // `catch_unwind` so rustfmt panics and you can get a backtrace.
-            should_emit_verbose(input_is_stdin, config, || {
-                println!("The Rust parser panicked")
-            });
-        }
-    }
-
-    report.add_parsing_error();
-    Err(ErrorKind::ParseError)
-}
-
-struct SilentOnIgnoredFilesEmitter {
-    ignore_path_set: Rc<IgnorePathSet>,
-    source_map: Rc<SourceMap>,
-    emitter: Box<dyn Emitter + Send>,
-    has_non_ignorable_parser_errors: bool,
-    can_reset: Rc<RefCell<bool>>,
-}
-
-impl SilentOnIgnoredFilesEmitter {
-    fn handle_non_ignoreable_error(&mut self, db: &Diagnostic) {
-        self.has_non_ignorable_parser_errors = true;
-        *self.can_reset.borrow_mut() = false;
-        self.emitter.emit_diagnostic(db);
-    }
-}
-
-impl Emitter for SilentOnIgnoredFilesEmitter {
-    fn source_map(&self) -> Option<&Lrc<SourceMap>> {
-        None
-    }
-
-    fn emit_diagnostic(&mut self, db: &Diagnostic) {
-        if db.level == DiagnosticLevel::Fatal {
-            return self.handle_non_ignoreable_error(db);
-        }
-        if let Some(primary_span) = &db.span.primary_span() {
-            let file_name = self.source_map.span_to_filename(*primary_span);
-            if let rustc_span::FileName::Real(ref path) = file_name {
-                if self
-                    .ignore_path_set
-                    .is_match(&FileName::Real(path.to_path_buf()))
-                {
-                    if !self.has_non_ignorable_parser_errors {
-                        *self.can_reset.borrow_mut() = true;
-                    }
-                    return;
-                }
-            };
-        }
-        self.handle_non_ignoreable_error(db);
-    }
-}
-
-/// Emitter which discards every error.
-struct SilentEmitter;
-
-impl Emitter for SilentEmitter {
-    fn source_map(&self) -> Option<&Lrc<SourceMap>> {
-        None
-    }
-    fn emit_diagnostic(&mut self, _db: &Diagnostic) {}
-}
-
-fn silent_emitter() -> Box<dyn Emitter + Send> {
-    Box::new(SilentEmitter {})
-}
-
-fn make_parse_sess(
-    source_map: Rc<SourceMap>,
-    config: &Config,
-    ignore_path_set: Rc<IgnorePathSet>,
-    can_reset: Rc<RefCell<bool>>,
-) -> ParseSess {
-    let supports_color = term::stderr().map_or(false, |term| term.supports_color());
-    let color_cfg = if supports_color {
-        ColorConfig::Auto
-    } else {
-        ColorConfig::Never
-    };
-
-    let emitter = if config.hide_parse_errors() {
-        silent_emitter()
-    } else {
-        Box::new(EmitterWriter::stderr(
-            color_cfg,
-            Some(source_map.clone()),
-            false,
-            false,
-            None,
-            false,
-        ))
-    };
-    let handler = Handler::with_emitter(
-        true,
-        None,
-        Box::new(SilentOnIgnoredFilesEmitter {
-            has_non_ignorable_parser_errors: false,
-            source_map: source_map.clone(),
-            emitter,
-            ignore_path_set,
-            can_reset,
-        }),
-    );
-
-    ParseSess::with_span_handler(handler, source_map)
-}
-
-fn should_emit_verbose<F>(is_stdin: bool, config: &Config, f: F)
+fn should_emit_verbose<F>(forbid_verbose_output: bool, config: &Config, f: F)
 where
     F: Fn(),
 {
-    if config.verbose() == Verbosity::Verbose && !is_stdin {
+    if config.verbose() == Verbosity::Verbose && !forbid_verbose_output {
         f();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    mod emitter {
-        use super::*;
-        use crate::config::IgnoreList;
-        use crate::is_nightly_channel;
-        use crate::utils::mk_sp;
-        use rustc_span::{BytePos, FileName as SourceMapFileName, MultiSpan, DUMMY_SP};
-        use std::path::{Path, PathBuf};
-
-        struct TestEmitter {
-            num_emitted_errors: Rc<RefCell<u32>>,
-        }
-
-        impl Emitter for TestEmitter {
-            fn source_map(&self) -> Option<&Lrc<SourceMap>> {
-                None
-            }
-            fn emit_diagnostic(&mut self, _db: &Diagnostic) {
-                *self.num_emitted_errors.borrow_mut() += 1;
-            }
-        }
-
-        fn build_diagnostic(level: DiagnosticLevel, span: Option<MultiSpan>) -> Diagnostic {
-            Diagnostic {
-                level,
-                code: None,
-                message: vec![],
-                children: vec![],
-                suggestions: vec![],
-                span: span.unwrap_or_else(MultiSpan::new),
-                sort_span: DUMMY_SP,
-            }
-        }
-
-        fn build_emitter(
-            num_emitted_errors: Rc<RefCell<u32>>,
-            can_reset: Rc<RefCell<bool>>,
-            source_map: Option<Rc<SourceMap>>,
-            ignore_list: Option<IgnoreList>,
-        ) -> SilentOnIgnoredFilesEmitter {
-            let emitter_writer = TestEmitter { num_emitted_errors };
-            let source_map =
-                source_map.unwrap_or_else(|| Rc::new(SourceMap::new(FilePathMapping::empty())));
-            let ignore_path_set =
-                Rc::new(IgnorePathSet::from_ignore_list(&ignore_list.unwrap_or_default()).unwrap());
-            SilentOnIgnoredFilesEmitter {
-                has_non_ignorable_parser_errors: false,
-                source_map,
-                emitter: Box::new(emitter_writer),
-                ignore_path_set,
-                can_reset,
-            }
-        }
-
-        fn get_ignore_list(config: &str) -> IgnoreList {
-            Config::from_toml(config, Path::new("")).unwrap().ignore()
-        }
-
-        #[test]
-        fn handles_fatal_parse_error_in_ignored_file() {
-            let num_emitted_errors = Rc::new(RefCell::new(0));
-            let can_reset_errors = Rc::new(RefCell::new(false));
-            let ignore_list = get_ignore_list(r#"ignore = ["foo.rs"]"#);
-            let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
-            let source =
-                String::from(r#"extern "system" fn jni_symbol!( funcName ) ( ... ) -> {} "#);
-            source_map.new_source_file(SourceMapFileName::Real(PathBuf::from("foo.rs")), source);
-            let mut emitter = build_emitter(
-                Rc::clone(&num_emitted_errors),
-                Rc::clone(&can_reset_errors),
-                Some(Rc::clone(&source_map)),
-                Some(ignore_list),
-            );
-            let span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
-            let fatal_diagnostic = build_diagnostic(DiagnosticLevel::Fatal, Some(span));
-            emitter.emit_diagnostic(&fatal_diagnostic);
-            assert_eq!(*num_emitted_errors.borrow(), 1);
-            assert_eq!(*can_reset_errors.borrow(), false);
-        }
-
-        #[test]
-        fn handles_recoverable_parse_error_in_ignored_file() {
-            if !is_nightly_channel!() {
-                return;
-            }
-            let num_emitted_errors = Rc::new(RefCell::new(0));
-            let can_reset_errors = Rc::new(RefCell::new(false));
-            let ignore_list = get_ignore_list(r#"ignore = ["foo.rs"]"#);
-            let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
-            let source = String::from(r#"pub fn bar() { 1x; }"#);
-            source_map.new_source_file(SourceMapFileName::Real(PathBuf::from("foo.rs")), source);
-            let mut emitter = build_emitter(
-                Rc::clone(&num_emitted_errors),
-                Rc::clone(&can_reset_errors),
-                Some(Rc::clone(&source_map)),
-                Some(ignore_list),
-            );
-            let span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
-            let non_fatal_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(span));
-            emitter.emit_diagnostic(&non_fatal_diagnostic);
-            assert_eq!(*num_emitted_errors.borrow(), 0);
-            assert_eq!(*can_reset_errors.borrow(), true);
-        }
-
-        #[test]
-        fn handles_recoverable_parse_error_in_non_ignored_file() {
-            if !is_nightly_channel!() {
-                return;
-            }
-            let num_emitted_errors = Rc::new(RefCell::new(0));
-            let can_reset_errors = Rc::new(RefCell::new(false));
-            let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
-            let source = String::from(r#"pub fn bar() { 1x; }"#);
-            source_map.new_source_file(SourceMapFileName::Real(PathBuf::from("foo.rs")), source);
-            let mut emitter = build_emitter(
-                Rc::clone(&num_emitted_errors),
-                Rc::clone(&can_reset_errors),
-                Some(Rc::clone(&source_map)),
-                None,
-            );
-            let span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
-            let non_fatal_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(span));
-            emitter.emit_diagnostic(&non_fatal_diagnostic);
-            assert_eq!(*num_emitted_errors.borrow(), 1);
-            assert_eq!(*can_reset_errors.borrow(), false);
-        }
-
-        #[test]
-        fn handles_mix_of_recoverable_parse_error() {
-            if !is_nightly_channel!() {
-                return;
-            }
-            let num_emitted_errors = Rc::new(RefCell::new(0));
-            let can_reset_errors = Rc::new(RefCell::new(false));
-            let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
-            let ignore_list = get_ignore_list(r#"ignore = ["foo.rs"]"#);
-            let bar_source = String::from(r#"pub fn bar() { 1x; }"#);
-            let foo_source = String::from(r#"pub fn foo() { 1x; }"#);
-            let fatal_source =
-                String::from(r#"extern "system" fn jni_symbol!( funcName ) ( ... ) -> {} "#);
-            source_map
-                .new_source_file(SourceMapFileName::Real(PathBuf::from("bar.rs")), bar_source);
-            source_map
-                .new_source_file(SourceMapFileName::Real(PathBuf::from("foo.rs")), foo_source);
-            source_map.new_source_file(
-                SourceMapFileName::Real(PathBuf::from("fatal.rs")),
-                fatal_source,
-            );
-            let mut emitter = build_emitter(
-                Rc::clone(&num_emitted_errors),
-                Rc::clone(&can_reset_errors),
-                Some(Rc::clone(&source_map)),
-                Some(ignore_list),
-            );
-            let bar_span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
-            let foo_span = MultiSpan::from_span(mk_sp(BytePos(21), BytePos(22)));
-            let bar_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(bar_span));
-            let foo_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(foo_span));
-            let fatal_diagnostic = build_diagnostic(DiagnosticLevel::Fatal, None);
-            emitter.emit_diagnostic(&bar_diagnostic);
-            emitter.emit_diagnostic(&foo_diagnostic);
-            emitter.emit_diagnostic(&fatal_diagnostic);
-            assert_eq!(*num_emitted_errors.borrow(), 2);
-            assert_eq!(*can_reset_errors.borrow(), false);
-        }
     }
 }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 use std::time::{Duration, Instant};
 
+use rustc_ast::ast;
 use rustc_span::Span;
-use syntax::ast;
 
 use self::newline_style::apply_newline_style;
 use crate::comment::{CharClasses, FullCodeCharKind};
@@ -29,7 +29,7 @@ impl<'b, T: Write + 'b> Session<'b, T> {
             return Err(ErrorKind::VersionMismatch);
         }
 
-        syntax::with_globals(self.config.edition().to_libsyntax_pos_edition(), || {
+        rustc_ast::with_globals(self.config.edition().to_libsyntax_pos_edition(), || {
             if self.config.disable_all_formatting() {
                 // When the input is from stdin, echo back the input.
                 if let Input::Text(ref buf) = input {

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -91,10 +91,11 @@ fn format_project<T: FormatHandler>(
     let files = modules::ModResolver::new(
         &context.parse_session,
         directory_ownership.unwrap_or(DirectoryOwnership::UnownedViaMod),
-        !(input_is_stdin || config.skip_children()),
+        !input_is_stdin && !config.skip_children(),
     )
     .visit_crate(&krate)
     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
     for (path, module) in files {
         let should_ignore = !input_is_stdin && context.ignore_file(&path);
         if (config.skip_children() && path != main_file) || should_ignore {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt;
 
+use rustc_ast::ast::{self, UseTreeKind};
 use rustc_span::{source_map, symbol::sym, BytePos, Span, DUMMY_SP};
-use syntax::ast::{self, UseTreeKind};
 
 use crate::comment::combine_strs_with_missing_comments;
 use crate::config::lists::*;

--- a/src/items.rs
+++ b/src/items.rs
@@ -4,9 +4,9 @@ use std::borrow::Cow;
 use std::cmp::{max, min, Ordering};
 
 use regex::Regex;
+use rustc_ast::visit;
+use rustc_ast::{ast, ptr};
 use rustc_span::{source_map, symbol, BytePos, Span, DUMMY_SP};
-use syntax::visit;
-use syntax::{ast, ptr};
 
 use crate::attr::filter_inline_attrs;
 use crate::comment::{
@@ -594,7 +594,7 @@ impl<'a> FmtVisitor<'a> {
                 self.buffer.clear();
             }
 
-            fn is_type(ty: &Option<syntax::ptr::P<ast::Ty>>) -> bool {
+            fn is_type(ty: &Option<rustc_ast::ptr::P<ast::Ty>>) -> bool {
                 match ty {
                     None => true,
                     Some(lty) => match lty.kind.opaque_top_hack() {
@@ -604,7 +604,7 @@ impl<'a> FmtVisitor<'a> {
                 }
             }
 
-            fn is_opaque(ty: &Option<syntax::ptr::P<ast::Ty>>) -> bool {
+            fn is_opaque(ty: &Option<rustc_ast::ptr::P<ast::Ty>>) -> bool {
                 match ty {
                     None => false,
                     Some(lty) => match lty.kind.opaque_top_hack() {
@@ -615,15 +615,15 @@ impl<'a> FmtVisitor<'a> {
             }
 
             fn both_type(
-                a: &Option<syntax::ptr::P<ast::Ty>>,
-                b: &Option<syntax::ptr::P<ast::Ty>>,
+                a: &Option<rustc_ast::ptr::P<ast::Ty>>,
+                b: &Option<rustc_ast::ptr::P<ast::Ty>>,
             ) -> bool {
                 is_type(a) && is_type(b)
             }
 
             fn both_opaque(
-                a: &Option<syntax::ptr::P<ast::Ty>>,
-                b: &Option<syntax::ptr::P<ast::Ty>>,
+                a: &Option<rustc_ast::ptr::P<ast::Ty>>,
+                b: &Option<rustc_ast::ptr::P<ast::Ty>>,
             ) -> bool {
                 is_opaque(a) && is_opaque(b)
             }

--- a/src/items.rs
+++ b/src/items.rs
@@ -363,17 +363,17 @@ impl<'a> FmtVisitor<'a> {
             return None;
         }
 
-        let source_map = self.get_context().source_map;
+        let context = self.get_context();
 
         if self.config.empty_item_single_line()
-            && is_empty_block(block, None, source_map)
+            && is_empty_block(&context, block, None)
             && self.block_indent.width() + fn_str.len() + 3 <= self.config.max_width()
             && !last_line_contains_single_line_comment(fn_str)
         {
             return Some(format!("{} {{}}", fn_str));
         }
 
-        if !self.config.fn_single_line() || !is_simple_block_stmt(block, None, source_map) {
+        if !self.config.fn_single_line() || !is_simple_block_stmt(&context, block, None) {
             return None;
         }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -298,8 +298,14 @@ impl<'a> FmtVisitor<'a> {
 
     fn format_foreign_item(&mut self, item: &ast::ForeignItem) {
         let rewrite = item.rewrite(&self.get_context(), self.shape());
-        self.push_rewrite(item.span, rewrite);
-        self.last_pos = item.span.hi();
+        let hi = item.span.hi();
+        let span = if item.attrs.is_empty() {
+            item.span
+        } else {
+            mk_sp(item.attrs[0].span.lo(), hi)
+        };
+        self.push_rewrite(span, rewrite);
+        self.last_pos = hi;
     }
 
     pub(crate) fn rewrite_fn_before_block(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 #[macro_use]
 extern crate derive_new;
-#[cfg(test)]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -20,7 +19,6 @@ use std::rc::Rc;
 
 use failure::Fail;
 use ignore;
-use rustc_parse::DirectoryOwnership;
 use syntax::ast;
 
 use crate::comment::LineClasses;
@@ -28,6 +26,7 @@ use crate::emitter::Emitter;
 use crate::formatting::{FormatErrorMap, FormattingError, ReportedErrors, SourceFile};
 use crate::issues::Issue;
 use crate::shape::Indent;
+use crate::syntux::parser::DirectoryOwnership;
 use crate::utils::indent_next_line;
 
 pub use crate::config::{
@@ -75,6 +74,7 @@ pub(crate) mod source_map;
 mod spanned;
 mod stmt;
 mod string;
+mod syntux;
 #[cfg(test)]
 mod test;
 mod types;
@@ -509,13 +509,6 @@ pub enum Input {
 }
 
 impl Input {
-    fn is_text(&self) -> bool {
-        match *self {
-            Input::File(_) => false,
-            Input::Text(_) => true,
-        }
-    }
-
     fn file_name(&self) -> FileName {
         match *self {
             Input::File(ref file) => FileName::Real(file.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 
 use failure::Fail;
 use ignore;
-use syntax::ast;
+use rustc_ast::ast;
 
 use crate::comment::LineClasses;
 use crate::emitter::Emitter;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -560,7 +560,7 @@ pub(crate) struct ListItems<'a, I, F1, F2, F3>
 where
     I: Iterator,
 {
-    snippet_provider: &'a SnippetProvider<'a>,
+    snippet_provider: &'a SnippetProvider,
     inner: Peekable<I>,
     get_lo: F1,
     get_hi: F2,
@@ -777,7 +777,7 @@ where
 #[allow(clippy::too_many_arguments)]
 // Creates an iterator over a list's items with associated comments.
 pub(crate) fn itemize_list<'a, T, I, F1, F2, F3>(
-    snippet_provider: &'a SnippetProvider<'_>,
+    snippet_provider: &'a SnippetProvider,
     inner: I,
     terminator: &'a str,
     separator: &'a str,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,12 +12,12 @@
 use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
+use rustc_ast::token::{BinOpToken, DelimToken, Token, TokenKind};
+use rustc_ast::tokenstream::{Cursor, TokenStream, TokenTree};
+use rustc_ast::{ast, ptr};
 use rustc_ast_pretty::pprust;
 use rustc_parse::{new_parser_from_tts, parser::Parser};
 use rustc_span::{symbol::kw, BytePos, Span, Symbol, DUMMY_SP};
-use syntax::token::{BinOpToken, DelimToken, Token, TokenKind};
-use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
-use syntax::{ast, ptr};
 
 use crate::comment::{
     contains_comment, CharClasses, FindUncommented, FullCodeCharKind, LineClasses,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -178,8 +178,8 @@ fn return_macro_parse_failure_fallback(
     }
 
     context.skipped_range.borrow_mut().push((
-        context.source_map.lookup_line(span.lo()).unwrap().line,
-        context.source_map.lookup_line(span.hi()).unwrap().line,
+        context.parse_sess.line_of_byte_pos(span.lo()),
+        context.parse_sess.line_of_byte_pos(span.hi()),
     ));
 
     // Return the snippet unmodified if the macro is not block-like
@@ -286,7 +286,7 @@ fn rewrite_macro_inner(
         }
     }
 
-    let mut parser = new_parser_from_tts(context.parse_session, ts.trees().collect());
+    let mut parser = new_parser_from_tts(context.parse_sess.inner(), ts.trees().collect());
     let mut arg_vec = Vec::new();
     let mut vec_with_semi = false;
     let mut trailing_comma = false;
@@ -1190,7 +1190,7 @@ pub(crate) fn convert_try_mac(mac: &ast::Mac, context: &RewriteContext<'_>) -> O
     let path = &pprust::path_to_string(&mac.path);
     if path == "try" || path == "r#try" {
         let ts = mac.args.inner_tokens();
-        let mut parser = new_parser_from_tts(context.parse_session, ts.trees().collect());
+        let mut parser = new_parser_from_tts(context.parse_sess.inner(), ts.trees().collect());
 
         Some(ast::Expr {
             id: ast::NodeId::root(), // dummy value
@@ -1422,7 +1422,7 @@ fn format_lazy_static(
     ts: &TokenStream,
 ) -> Option<String> {
     let mut result = String::with_capacity(1024);
-    let mut parser = new_parser_from_tts(context.parse_session, ts.trees().collect());
+    let mut parser = new_parser_from_tts(context.parse_sess.inner(), ts.trees().collect());
     let nested_shape = shape
         .block_indent(context.config.tab_spaces())
         .with_max_width(context.config);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -231,7 +231,7 @@ fn check_keyword<'a, 'b: 'a>(parser: &'a mut Parser<'b>) -> Option<MacroArg> {
         {
             parser.bump();
             let macro_arg =
-                MacroArg::Keyword(ast::Ident::with_dummy_span(keyword), parser.prev_span);
+                MacroArg::Keyword(ast::Ident::with_dummy_span(keyword), parser.prev_token.span);
             return Some(macro_arg);
         }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1186,7 +1186,10 @@ fn next_space(tok: &TokenKind) -> SpaceState {
 /// Tries to convert a macro use into a short hand try expression. Returns `None`
 /// when the macro is not an instance of `try!` (or parsing the inner expression
 /// failed).
-pub(crate) fn convert_try_mac(mac: &ast::MacCall, context: &RewriteContext<'_>) -> Option<ast::Expr> {
+pub(crate) fn convert_try_mac(
+    mac: &ast::MacCall,
+    context: &RewriteContext<'_>,
+) -> Option<ast::Expr> {
     let path = &pprust::path_to_string(&mac.path);
     if path == "try" || path == "r#try" {
         let ts = mac.args.inner_tokens();

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -2,8 +2,8 @@
 
 use std::iter::repeat;
 
+use rustc_ast::{ast, ptr};
 use rustc_span::{BytePos, Span};
-use syntax::{ast, ptr};
 
 use crate::comment::{combine_strs_with_missing_comments, rewrite_comment};
 use crate::config::lists::*;

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -276,7 +276,7 @@ fn block_can_be_flattened<'a>(
         ast::ExprKind::Block(ref block, _)
             if !is_unsafe_block(block)
                 && !context.inside_macro()
-                && is_simple_block(block, Some(&expr.attrs), context.source_map) =>
+                && is_simple_block(context, block, Some(&expr.attrs)) =>
         {
             Some(&*block)
         }
@@ -332,10 +332,7 @@ fn rewrite_match_body(
         shape.offset_left(extra_offset(pats_str, shape) + 4),
     );
     let (is_block, is_empty_block) = if let ast::ExprKind::Block(ref block, _) = body.kind {
-        (
-            true,
-            is_empty_block(block, Some(&body.attrs), context.source_map),
-        )
+        (true, is_empty_block(context, block, Some(&body.attrs)))
     } else {
         (false, false)
     };

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -559,7 +559,7 @@ fn can_flatten_block_around_this(body: &ast::Expr) -> bool {
         | ast::ExprKind::Array(..)
         | ast::ExprKind::Call(..)
         | ast::ExprKind::MethodCall(..)
-        | ast::ExprKind::Mac(..)
+        | ast::ExprKind::MacCall(..)
         | ast::ExprKind::Struct(..)
         | ast::ExprKind::Tup(..) => true,
         ast::ExprKind::AddrOf(_, _, ref expr)

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use rustc_ast::ast;
+use rustc_ast::visit::Visitor;
 use rustc_span::symbol::{sym, Symbol};
-use syntax::ast;
-use syntax::visit::Visitor;
 
 use crate::attr::MetaVisitor;
 use crate::config::FileName;

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -251,11 +251,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
             if self.parse_sess.is_file_parsed(&path) {
                 return Ok(None);
             }
-            return match Parser::parse_file_as_module(
-                self.parse_sess,
-                &path,
-                sub_mod.inner,
-            ) {
+            return match Parser::parse_file_as_module(self.parse_sess, &path, sub_mod.inner) {
                 Some(m) => Ok(Some(SubModKind::External(
                     path,
                     DirectoryOwnership::Owned { relative: None },
@@ -293,16 +289,10 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                         return Ok(Some(SubModKind::MultiExternal(mods_outside_ast)));
                     }
                 }
-                match Parser::parse_file_as_module(
-                    self.parse_sess,
-                    &path,
-                    sub_mod.inner,
-                ) {
-                    Some(m) if outside_mods_empty => Ok(Some(SubModKind::External(
-                        path,
-                        ownership,
-                        Cow::Owned(m),
-                    ))),
+                match Parser::parse_file_as_module(self.parse_sess, &path, sub_mod.inner) {
+                    Some(m) if outside_mods_empty => {
+                        Ok(Some(SubModKind::External(path, ownership, Cow::Owned(m))))
+                    }
                     Some(m) => {
                         mods_outside_ast.push((path.clone(), ownership, Cow::Owned(m)));
                         if should_insert {
@@ -319,7 +309,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                             mods_outside_ast.push((path, ownership, sub_mod.clone()));
                         }
                         Ok(Some(SubModKind::MultiExternal(mods_outside_ast)))
-                    },
+                    }
                 }
             }
             Err(mut e) if !mods_outside_ast.is_empty() => {
@@ -385,11 +375,8 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                 ));
                 continue;
             }
-            let m = match Parser::parse_file_as_module(
-                self.parse_sess,
-                &actual_path,
-                sub_mod.inner,
-            ) {
+            let m = match Parser::parse_file_as_module(self.parse_sess, &actual_path, sub_mod.inner)
+            {
                 Some(m) => m,
                 None => continue,
             };

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -468,7 +468,7 @@ fn parse_mod_items<'a>(parser: &mut parser::Parser<'a>, inner_lo: Span) -> PResu
     let hi = if parser.token.span.is_dummy() {
         inner_lo
     } else {
-        parser.prev_span
+        parser.prev_token.span
     };
 
     Ok(ast::Mod {

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -2,23 +2,24 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use rustc_errors::PResult;
-use rustc_parse::{new_sub_parser_from_file, parser, DirectoryOwnership};
-use rustc_session::parse::ParseSess;
 use rustc_span::symbol::{sym, Symbol};
-use rustc_span::{source_map, Span, DUMMY_SP};
 use syntax::ast;
-use syntax::token::TokenKind;
 use syntax::visit::Visitor;
 
 use crate::attr::MetaVisitor;
 use crate::config::FileName;
 use crate::items::is_mod_decl;
+use crate::syntux::parser::{Directory, DirectoryOwnership, ModulePathSuccess, Parser};
+use crate::syntux::session::ParseSess;
 use crate::utils::contains_skip;
 
 mod visitor;
 
 type FileModMap<'ast> = BTreeMap<FileName, Cow<'ast, ast::Mod>>;
+
+lazy_static! {
+    static ref CFG_IF: Symbol = Symbol::intern("cfg_if");
+}
 
 /// Maps each module to the corresponding file.
 pub(crate) struct ModResolver<'ast, 'sess> {
@@ -26,21 +27,6 @@ pub(crate) struct ModResolver<'ast, 'sess> {
     directory: Directory,
     file_map: FileModMap<'ast>,
     recursive: bool,
-}
-
-#[derive(Clone)]
-struct Directory {
-    path: PathBuf,
-    ownership: DirectoryOwnership,
-}
-
-impl<'a> Directory {
-    fn to_syntax_directory(&'a self) -> rustc_parse::Directory {
-        rustc_parse::Directory {
-            path: self.path.clone(),
-            ownership: self.ownership.clone(),
-        }
-    }
 }
 
 #[derive(Clone)]
@@ -78,12 +64,9 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         mut self,
         krate: &'ast ast::Crate,
     ) -> Result<FileModMap<'ast>, String> {
-        let root_filename = self.parse_sess.source_map().span_to_filename(krate.span);
+        let root_filename = self.parse_sess.span_to_filename(krate.span);
         self.directory.path = match root_filename {
-            source_map::FileName::Real(ref path) => path
-                .parent()
-                .expect("Parent directory should exists")
-                .to_path_buf(),
+            FileName::Real(ref p) => p.parent().unwrap_or(Path::new("")).to_path_buf(),
             _ => PathBuf::new(),
         };
 
@@ -93,14 +76,13 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         }
 
         self.file_map
-            .insert(root_filename.into(), Cow::Borrowed(&krate.module));
+            .insert(root_filename, Cow::Borrowed(&krate.module));
         Ok(self.file_map)
     }
 
     /// Visit `cfg_if` macro and look for module declarations.
     fn visit_cfg_if(&mut self, item: Cow<'ast, ast::Item>) -> Result<(), String> {
-        let mut visitor =
-            visitor::CfgIfVisitor::new(self.parse_sess, self.directory.to_syntax_directory());
+        let mut visitor = visitor::CfgIfVisitor::new(self.parse_sess, &self.directory);
         visitor.visit_item(&item);
         for module_item in visitor.mods() {
             if let ast::ItemKind::Mod(ref sub_mod) = module_item.item.kind {
@@ -258,7 +240,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         attrs: &[ast::Attribute],
         sub_mod: &Cow<'ast, ast::Mod>,
     ) -> Result<SubModKind<'c, 'ast>, String> {
-        if let Some(path) = parser::Parser::submod_path_from_attr(attrs, &self.directory.path) {
+        if let Some(path) = Parser::submod_path_from_attr(attrs, &self.directory.path) {
             return Ok(SubModKind::External(
                 path,
                 DirectoryOwnership::Owned { relative: None },
@@ -266,23 +248,18 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         }
 
         // Look for nested path, like `#[cfg_attr(feature = "foo", path = "bar.rs")]`.
-        let mut mods_outside_ast = self
-            .find_mods_ouside_of_ast(attrs, sub_mod)
-            .unwrap_or(vec![]);
+        let mut mods_outside_ast = self.find_mods_outside_of_ast(attrs, sub_mod);
 
         let relative = match self.directory.ownership {
             DirectoryOwnership::Owned { relative } => relative,
             DirectoryOwnership::UnownedViaBlock | DirectoryOwnership::UnownedViaMod => None,
         };
-        match parser::Parser::default_submod_path(
-            mod_name,
-            relative,
-            &self.directory.path,
-            self.parse_sess.source_map(),
-        )
-        .result
+        match self
+            .parse_sess
+            .default_submod_path(mod_name, relative, &self.directory.path)
+            .result
         {
-            Ok(parser::ModulePathSuccess {
+            Ok(ModulePathSuccess {
                 path,
                 directory_ownership,
                 ..
@@ -323,21 +300,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         }
     }
 
-    fn find_mods_ouside_of_ast(
-        &self,
-        attrs: &[ast::Attribute],
-        sub_mod: &Cow<'ast, ast::Mod>,
-    ) -> Option<Vec<(PathBuf, DirectoryOwnership, Cow<'ast, ast::Mod>)>> {
-        use std::panic::{catch_unwind, AssertUnwindSafe};
-        Some(
-            catch_unwind(AssertUnwindSafe(|| {
-                self.find_mods_ouside_of_ast_inner(attrs, sub_mod)
-            }))
-            .ok()?,
-        )
-    }
-
-    fn find_mods_ouside_of_ast_inner(
+    fn find_mods_outside_of_ast(
         &self,
         attrs: &[ast::Attribute],
         sub_mod: &Cow<'ast, ast::Mod>,
@@ -356,14 +319,8 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
             if !actual_path.exists() {
                 continue;
             }
-            let file_name = rustc_span::FileName::Real(actual_path.clone());
-            if self
-                .parse_sess
-                .source_map()
-                .get_source_file(&file_name)
-                .is_some()
-            {
-                // If the specfied file is already parsed, then we just use that.
+            if self.parse_sess.is_file_parsed(&actual_path) {
+                // If the specified file is already parsed, then we just use that.
                 result.push((
                     actual_path,
                     DirectoryOwnership::Owned { relative: None },
@@ -371,32 +328,15 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                 ));
                 continue;
             }
-            let mut parser = new_sub_parser_from_file(
+            let m = match Parser::parse_file_as_module(
+                self.directory.ownership,
                 self.parse_sess,
                 &actual_path,
-                self.directory.ownership,
-                None,
-                DUMMY_SP,
-            );
-            parser.cfg_mods = false;
-            let lo = parser.token.span;
-            // FIXME(topecongiro) Format inner attributes (#3606).
-            let _mod_attrs = match parse_inner_attributes(&mut parser) {
-                Ok(attrs) => attrs,
-                Err(mut e) => {
-                    e.cancel();
-                    parser.sess.span_diagnostic.reset_err_count();
-                    continue;
-                }
+            ) {
+                Some(m) => m,
+                None => continue,
             };
-            let m = match parse_mod_items(&mut parser, lo) {
-                Ok(m) => m,
-                Err(mut e) => {
-                    e.cancel();
-                    parser.sess.span_diagnostic.reset_err_count();
-                    continue;
-                }
-            };
+
             result.push((
                 actual_path,
                 DirectoryOwnership::Owned { relative: None },
@@ -422,67 +362,11 @@ fn find_path_value(attrs: &[ast::Attribute]) -> Option<Symbol> {
     attrs.iter().flat_map(path_value).next()
 }
 
-// FIXME(topecongiro) Use the method from libsyntax[1] once it become public.
-//
-// [1] https://github.com/rust-lang/rust/blob/master/src/libsyntax/parse/attr.rs
-fn parse_inner_attributes<'a>(parser: &mut parser::Parser<'a>) -> PResult<'a, Vec<ast::Attribute>> {
-    let mut attrs: Vec<ast::Attribute> = vec![];
-    loop {
-        match parser.token.kind {
-            TokenKind::Pound => {
-                // Don't even try to parse if it's not an inner attribute.
-                if !parser.look_ahead(1, |t| t == &TokenKind::Not) {
-                    break;
-                }
-
-                let attr = parser.parse_attribute(true)?;
-                assert_eq!(attr.style, ast::AttrStyle::Inner);
-                attrs.push(attr);
-            }
-            TokenKind::DocComment(s) => {
-                // we need to get the position of this token before we bump.
-                let attr = syntax::attr::mk_doc_comment(
-                    syntax::util::comments::doc_comment_style(&s.as_str()),
-                    s,
-                    parser.token.span,
-                );
-                if attr.style == ast::AttrStyle::Inner {
-                    attrs.push(attr);
-                    parser.bump();
-                } else {
-                    break;
-                }
-            }
-            _ => break,
-        }
-    }
-    Ok(attrs)
-}
-
-fn parse_mod_items<'a>(parser: &mut parser::Parser<'a>, inner_lo: Span) -> PResult<'a, ast::Mod> {
-    let mut items = vec![];
-    while let Some(item) = parser.parse_item()? {
-        items.push(item);
-    }
-
-    let hi = if parser.token.span.is_dummy() {
-        inner_lo
-    } else {
-        parser.prev_token.span
-    };
-
-    Ok(ast::Mod {
-        inner: inner_lo.to(hi),
-        items,
-        inline: false,
-    })
-}
-
 fn is_cfg_if(item: &ast::Item) -> bool {
     match item.kind {
         ast::ItemKind::Mac(ref mac) => {
             if let Some(first_segment) = mac.path.segments.first() {
-                if first_segment.ident.name == Symbol::intern("cfg_if") {
+                if first_segment.ident.name == *CFG_IF {
                     return true;
                 }
             }

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -35,9 +35,9 @@ struct Directory {
 }
 
 impl<'a> Directory {
-    fn to_syntax_directory(&'a self) -> rustc_parse::Directory<'a> {
+    fn to_syntax_directory(&'a self) -> rustc_parse::Directory {
         rustc_parse::Directory {
-            path: Cow::Borrowed(&self.path),
+            path: self.path.clone(),
             ownership: self.ownership.clone(),
         }
     }

--- a/src/modules/visitor.rs
+++ b/src/modules/visitor.rs
@@ -15,11 +15,11 @@ pub(crate) struct ModItem {
 pub(crate) struct CfgIfVisitor<'a> {
     parse_sess: &'a ParseSess,
     mods: Vec<ModItem>,
-    base_dir: Directory<'a>,
+    base_dir: Directory,
 }
 
 impl<'a> CfgIfVisitor<'a> {
-    pub(crate) fn new(parse_sess: &'a ParseSess, base_dir: Directory<'a>) -> CfgIfVisitor<'a> {
+    pub(crate) fn new(parse_sess: &'a ParseSess, base_dir: Directory) -> CfgIfVisitor<'a> {
         CfgIfVisitor {
             mods: vec![],
             parse_sess,

--- a/src/modules/visitor.rs
+++ b/src/modules/visitor.rs
@@ -1,6 +1,6 @@
+use rustc_ast::ast;
+use rustc_ast::visit::Visitor;
 use rustc_span::Symbol;
-use syntax::ast;
-use syntax::visit::Visitor;
 
 use crate::attr::MetaVisitor;
 use crate::syntux::parser::Parser;

--- a/src/modules/visitor.rs
+++ b/src/modules/visitor.rs
@@ -1,11 +1,10 @@
-use rustc_parse::{stream_to_parser_with_base_dir, Directory};
-use rustc_session::parse::ParseSess;
-use rustc_span::{symbol::kw, Symbol};
+use rustc_span::Symbol;
 use syntax::ast;
-use syntax::token::{DelimToken, TokenKind};
 use syntax::visit::Visitor;
 
 use crate::attr::MetaVisitor;
+use crate::syntux::parser::{Directory, Parser};
+use crate::syntux::session::ParseSess;
 
 pub(crate) struct ModItem {
     pub(crate) item: ast::Item,
@@ -15,11 +14,11 @@ pub(crate) struct ModItem {
 pub(crate) struct CfgIfVisitor<'a> {
     parse_sess: &'a ParseSess,
     mods: Vec<ModItem>,
-    base_dir: Directory,
+    base_dir: &'a Directory,
 }
 
 impl<'a> CfgIfVisitor<'a> {
-    pub(crate) fn new(parse_sess: &'a ParseSess, base_dir: Directory) -> CfgIfVisitor<'a> {
+    pub(crate) fn new(parse_sess: &'a ParseSess, base_dir: &'a Directory) -> CfgIfVisitor<'a> {
         CfgIfVisitor {
             mods: vec![],
             parse_sess,
@@ -65,59 +64,9 @@ impl<'a, 'ast: 'a> CfgIfVisitor<'a> {
             }
         };
 
-        let ts = mac.args.inner_tokens();
-        let mut parser =
-            stream_to_parser_with_base_dir(self.parse_sess, ts.clone(), self.base_dir.clone());
-        parser.cfg_mods = false;
-        let mut process_if_cfg = true;
-
-        while parser.token.kind != TokenKind::Eof {
-            if process_if_cfg {
-                if !parser.eat_keyword(kw::If) {
-                    return Err("Expected `if`");
-                }
-                parser
-                    .parse_attribute(false)
-                    .map_err(|_| "Failed to parse attributes")?;
-            }
-
-            if !parser.eat(&TokenKind::OpenDelim(DelimToken::Brace)) {
-                return Err("Expected an opening brace");
-            }
-
-            while parser.token != TokenKind::CloseDelim(DelimToken::Brace)
-                && parser.token.kind != TokenKind::Eof
-            {
-                let item = match parser.parse_item() {
-                    Ok(Some(item_ptr)) => item_ptr.into_inner(),
-                    Ok(None) => continue,
-                    Err(mut err) => {
-                        err.cancel();
-                        parser.sess.span_diagnostic.reset_err_count();
-                        return Err(
-                            "Expected item inside cfg_if block, but failed to parse it as an item",
-                        );
-                    }
-                };
-                if let ast::ItemKind::Mod(..) = item.kind {
-                    self.mods.push(ModItem { item });
-                }
-            }
-
-            if !parser.eat(&TokenKind::CloseDelim(DelimToken::Brace)) {
-                return Err("Expected a closing brace");
-            }
-
-            if parser.eat(&TokenKind::Eof) {
-                break;
-            }
-
-            if !parser.eat_keyword(kw::Else) {
-                return Err("Expected `else`");
-            }
-
-            process_if_cfg = parser.token.is_keyword(kw::If);
-        }
+        let items = Parser::parse_cfg_if(self.parse_sess, mac, &self.base_dir)?;
+        self.mods
+            .append(&mut items.into_iter().map(|item| ModItem { item }).collect());
 
         Ok(())
     }

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -3,9 +3,9 @@
 use std::cmp::min;
 
 use itertools::Itertools;
+use rustc_ast::token::DelimToken;
+use rustc_ast::{ast, ptr};
 use rustc_span::Span;
-use syntax::token::DelimToken;
-use syntax::{ast, ptr};
 
 use crate::closures;
 use crate::config::lists::*;

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -1,4 +1,4 @@
-use syntax::ast;
+use rustc_ast::ast;
 
 use crate::config::lists::*;
 use crate::config::IndentStyle;

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -1,6 +1,6 @@
+use rustc_ast::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax};
+use rustc_ast::ptr;
 use rustc_span::{BytePos, Span};
-use syntax::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax};
-use syntax::ptr;
 
 use crate::comment::{combine_strs_with_missing_comments, FindUncommented};
 use crate::config::lists::*;

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -231,7 +231,9 @@ impl Rewrite for Pat {
             PatKind::Struct(ref path, ref fields, ellipsis) => {
                 rewrite_struct_pat(path, fields, ellipsis, self.span, context, shape)
             }
-            PatKind::MacCall(ref mac) => rewrite_macro(mac, None, context, shape, MacroPosition::Pat),
+            PatKind::MacCall(ref mac) => {
+                rewrite_macro(mac, None, context, shape, MacroPosition::Pat)
+            }
             PatKind::Paren(ref pat) => pat
                 .rewrite(context, shape.offset_left(1)?.sub_width(1)?)
                 .map(|inner_pat| format!("({})", inner_pat)),

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -40,7 +40,7 @@ fn is_short_pattern_inner(pat: &ast::Pat) -> bool {
         ast::PatKind::Rest | ast::PatKind::Wild | ast::PatKind::Lit(_) => true,
         ast::PatKind::Ident(_, _, ref pat) => pat.is_none(),
         ast::PatKind::Struct(..)
-        | ast::PatKind::Mac(..)
+        | ast::PatKind::MacCall(..)
         | ast::PatKind::Slice(..)
         | ast::PatKind::Path(..)
         | ast::PatKind::Range(..) => false,
@@ -231,7 +231,7 @@ impl Rewrite for Pat {
             PatKind::Struct(ref path, ref fields, ellipsis) => {
                 rewrite_struct_pat(path, fields, ellipsis, self.span, context, shape)
             }
-            PatKind::Mac(ref mac) => rewrite_macro(mac, None, context, shape, MacroPosition::Pat),
+            PatKind::MacCall(ref mac) => rewrite_macro(mac, None, context, shape, MacroPosition::Pat),
             PatKind::Paren(ref pat) => pat
                 .rewrite(context, shape.offset_left(1)?.sub_width(1)?)
                 .map(|inner_pat| format!("({})", inner_pat)),

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -8,8 +8,8 @@
 
 use std::cmp::{Ord, Ordering};
 
+use rustc_ast::{ast, attr};
 use rustc_span::{symbol::sym, Span};
-use syntax::{ast, attr};
 
 use crate::config::Config;
 use crate::imports::{merge_use_trees, UseTree};

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -207,13 +207,13 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         item_kind: ReorderableItemKind,
         in_group: bool,
     ) -> usize {
-        let mut last = self.source_map.lookup_line_range(items[0].span());
+        let mut last = self.parse_sess.lookup_line_range(items[0].span());
         let item_length = items
             .iter()
             .take_while(|ppi| {
                 item_kind.is_same_item_kind(&***ppi)
                     && (!in_group || {
-                        let current = self.source_map.lookup_line_range(ppi.span());
+                        let current = self.parse_sess.lookup_line_range(ppi.span());
                         let in_same_group = current.lo < last.hi + 2;
                         last = current;
                         in_same_group

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -3,8 +3,8 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
+use rustc_ast::ptr;
 use rustc_span::Span;
-use syntax::ptr;
 
 use crate::config::{Config, IndentStyle};
 use crate::shape::Shape;

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -3,13 +3,13 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use rustc_session::parse::ParseSess;
-use rustc_span::{source_map::SourceMap, Span};
+use rustc_span::Span;
 use syntax::ptr;
 
 use crate::config::{Config, IndentStyle};
 use crate::shape::Shape;
 use crate::skip::SkipContext;
+use crate::syntux::session::ParseSess;
 use crate::visitor::SnippetProvider;
 use crate::FormatReport;
 
@@ -26,8 +26,7 @@ impl<T: Rewrite> Rewrite for ptr::P<T> {
 
 #[derive(Clone)]
 pub(crate) struct RewriteContext<'a> {
-    pub(crate) parse_session: &'a ParseSess,
-    pub(crate) source_map: &'a SourceMap,
+    pub(crate) parse_sess: &'a ParseSess,
     pub(crate) config: &'a Config,
     pub(crate) inside_macro: Rc<Cell<bool>>,
     // Force block indent style even if we are using visual indent style.
@@ -37,7 +36,7 @@ pub(crate) struct RewriteContext<'a> {
     pub(crate) is_if_else_block: Cell<bool>,
     // When rewriting chain, veto going multi line except the last element
     pub(crate) force_one_line_chain: Cell<bool>,
-    pub(crate) snippet_provider: &'a SnippetProvider<'a>,
+    pub(crate) snippet_provider: &'a SnippetProvider,
     // Used for `format_snippet`
     pub(crate) macro_rewrite_failure: Cell<bool>,
     pub(crate) report: FormatReport,

--- a/src/skip.rs
+++ b/src/skip.rs
@@ -1,7 +1,7 @@
 //! Module that contains skip related stuffs.
 
+use rustc_ast::ast;
 use rustc_ast_pretty::pprust;
-use syntax::ast;
 
 /// Take care of skip name stack. You can update it by attributes slice or
 /// by other context. Query this context to know if you need skip a block.
@@ -56,7 +56,7 @@ fn get_skip_names(kind: &str, attrs: &[ast::Attribute]) -> Vec<String> {
     let mut skip_names = vec![];
     let path = format!("{}::{}::{}", RUSTFMT, SKIP, kind);
     for attr in attrs {
-        // syntax::ast::Path is implemented partialEq
+        // rustc_ast::ast::Path is implemented partialEq
         // but it is designed for segments.len() == 1
         if let ast::AttrKind::Normal(attr_item) = &attr.kind {
             if pprust::path_to_string(&attr_item.path) != path {

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -1,11 +1,10 @@
 //! This module contains utilities that work with the `SourceMap` from `libsyntax`/`syntex_syntax`.
 //! This includes extension traits and methods for looking up spans and line ranges for AST nodes.
 
-use rustc_span::{source_map::SourceMap, BytePos, Span};
+use rustc_span::{BytePos, Span};
 
 use crate::comment::FindUncommented;
 use crate::config::file_lines::LineRange;
-use crate::utils::starts_with_newline;
 use crate::visitor::SnippetProvider;
 
 pub(crate) trait SpanUtils {
@@ -26,7 +25,7 @@ pub(crate) trait LineRangeUtils {
     fn lookup_line_range(&self, span: Span) -> LineRange;
 }
 
-impl<'a> SpanUtils for SnippetProvider<'a> {
+impl SpanUtils for SnippetProvider {
     fn span_after(&self, original: Span, needle: &str) -> BytePos {
         self.opt_span_after(original, needle).unwrap_or_else(|| {
             panic!(
@@ -79,29 +78,5 @@ impl<'a> SpanUtils for SnippetProvider<'a> {
         let offset = snippet.find_uncommented(needle)?;
 
         Some(original.lo() + BytePos(offset as u32))
-    }
-}
-
-impl LineRangeUtils for SourceMap {
-    fn lookup_line_range(&self, span: Span) -> LineRange {
-        let snippet = self.span_to_snippet(span).unwrap_or_default();
-        let lo = self.lookup_line(span.lo()).unwrap();
-        let hi = self.lookup_line(span.hi()).unwrap();
-
-        debug_assert_eq!(
-            lo.sf.name, hi.sf.name,
-            "span crossed file boundary: lo: {:?}, hi: {:?}",
-            lo, hi
-        );
-
-        // in case the span starts with a newline, the line range is off by 1 without the
-        // adjustment below
-        let offset = 1 + if starts_with_newline(&snippet) { 1 } else { 0 };
-        // Line numbers start at 1
-        LineRange {
-            file: lo.sf.clone(),
-            lo: lo.line + offset,
-            hi: hi.line + offset,
-        }
     }
 }

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -66,7 +66,7 @@ impl Spanned for ast::Stmt {
             ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => {
                 mk_sp(expr.span().lo(), self.span.hi())
             }
-            ast::StmtKind::Mac(ref mac) => {
+            ast::StmtKind::MacCall(ref mac) => {
                 let (_, _, ref attrs) = **mac;
                 if attrs.is_empty() {
                     self.span

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -151,11 +151,11 @@ impl Spanned for ast::WherePredicate {
     }
 }
 
-impl Spanned for ast::FunctionRetTy {
+impl Spanned for ast::FnRetTy {
     fn span(&self) -> Span {
         match *self {
-            ast::FunctionRetTy::Default(span) => span,
-            ast::FunctionRetTy::Ty(ref ty) => ty.span,
+            ast::FnRetTy::Default(span) => span,
+            ast::FnRetTy::Ty(ref ty) => ty.span,
         }
     }
 }

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -74,6 +74,7 @@ impl Spanned for ast::Stmt {
                     mk_sp(attrs[0].span.lo(), self.span.hi())
                 }
             }
+            ast::StmtKind::Empty => self.span,
         }
     }
 }

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 
+use rustc_ast::{ast, ptr};
 use rustc_span::{source_map, Span};
-use syntax::{ast, ptr};
 
 use crate::macros::MacroArg;
 use crate::utils::{mk_sp, outer_attributes};

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -106,7 +106,7 @@ fn format_stmt(
             let shape = shape.sub_width(suffix.len())?;
             format_expr(ex, expr_type, context, shape).map(|s| s + suffix)
         }
-        ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => None,
+        ast::StmtKind::MacCall(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => None,
     };
     result.and_then(|res| recover_comment_removed(res, stmt.span(), context))
 }

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -1,5 +1,5 @@
+use rustc_ast::ast;
 use rustc_span::Span;
-use syntax::ast;
 
 use crate::comment::recover_comment_removed;
 use crate::config::Version;

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -106,7 +106,7 @@ fn format_stmt(
             let shape = shape.sub_width(suffix.len())?;
             format_expr(ex, expr_type, context, shape).map(|s| s + suffix)
         }
-        ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) => None,
+        ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => None,
     };
     result.and_then(|res| recover_comment_removed(res, stmt.span(), context))
 }

--- a/src/syntux.rs
+++ b/src/syntux.rs
@@ -1,0 +1,4 @@
+//! This module defines a thin abstract layer on top of the rustc's parser and syntax libraries.
+
+pub(crate) mod parser;
+pub(crate) mod session;

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -1,0 +1,348 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
+
+use rustc_errors::{Diagnostic, PResult};
+use rustc_parse::{new_sub_parser_from_file, parser::Parser as RawParser};
+use rustc_span::{symbol::kw, Span, DUMMY_SP};
+use syntax::ast;
+use syntax::token::{DelimToken, TokenKind};
+
+use crate::syntux::session::ParseSess;
+use crate::{Config, Input};
+
+pub(crate) type DirectoryOwnership = rustc_parse::DirectoryOwnership;
+pub(crate) type ModulePathSuccess = rustc_parse::parser::ModulePathSuccess;
+
+#[derive(Clone)]
+pub(crate) struct Directory {
+    pub(crate) path: PathBuf,
+    pub(crate) ownership: DirectoryOwnership,
+}
+
+impl<'a> Directory {
+    fn to_syntax_directory(&'a self) -> rustc_parse::Directory {
+        rustc_parse::Directory {
+            path: self.path.clone(),
+            ownership: self.ownership,
+        }
+    }
+}
+
+/// A parser for Rust source code.
+pub(crate) struct Parser<'a> {
+    parser: RawParser<'a>,
+    sess: &'a ParseSess,
+}
+
+/// A builder for the `Parser`.
+#[derive(Default)]
+pub(crate) struct ParserBuilder<'a> {
+    config: Option<&'a Config>,
+    sess: Option<&'a ParseSess>,
+    input: Option<Input>,
+    directory_ownership: Option<DirectoryOwnership>,
+}
+
+impl<'a> ParserBuilder<'a> {
+    pub(crate) fn input(mut self, input: Input) -> ParserBuilder<'a> {
+        self.input = Some(input);
+        self
+    }
+
+    pub(crate) fn sess(mut self, sess: &'a ParseSess) -> ParserBuilder<'a> {
+        self.sess = Some(sess);
+        self
+    }
+
+    pub(crate) fn config(mut self, config: &'a Config) -> ParserBuilder<'a> {
+        self.config = Some(config);
+        self
+    }
+
+    pub(crate) fn directory_ownership(
+        mut self,
+        directory_ownership: Option<DirectoryOwnership>,
+    ) -> ParserBuilder<'a> {
+        self.directory_ownership = directory_ownership;
+        self
+    }
+
+    pub(crate) fn build(self) -> Result<Parser<'a>, ParserError> {
+        let config = self.config.ok_or(ParserError::NoConfig)?;
+        let sess = self.sess.ok_or(ParserError::NoParseSess)?;
+        let input = self.input.ok_or(ParserError::NoInput)?;
+
+        let mut parser = match Self::parser(sess.inner(), input, self.directory_ownership) {
+            Ok(p) => p,
+            Err(db) => {
+                sess.emit_diagnostics(db);
+                return Err(ParserError::ParserCreationError);
+            }
+        };
+
+        parser.cfg_mods = false;
+        if config.skip_children() {
+            parser.recurse_into_file_modules = false;
+        }
+
+        Ok(Parser { parser, sess })
+    }
+
+    fn parser(
+        sess: &'a rustc_session::parse::ParseSess,
+        input: Input,
+        directory_ownership: Option<DirectoryOwnership>,
+    ) -> Result<rustc_parse::parser::Parser<'a>, Vec<Diagnostic>> {
+        match input {
+            Input::File(ref file) => Ok(if let Some(directory_ownership) = directory_ownership {
+                rustc_parse::new_sub_parser_from_file(
+                    sess,
+                    file,
+                    directory_ownership,
+                    None,
+                    DUMMY_SP,
+                )
+            } else {
+                rustc_parse::new_parser_from_file(sess, file)
+            }),
+            Input::Text(text) => rustc_parse::maybe_new_parser_from_source_str(
+                sess,
+                rustc_span::FileName::Custom("stdin".to_owned()),
+                text,
+            )
+            .map(|mut parser| {
+                parser.recurse_into_file_modules = false;
+                parser
+            }),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum ParserError {
+    NoConfig,
+    NoParseSess,
+    NoInput,
+    ParserCreationError,
+    ParseError,
+    ParsePanicError,
+}
+
+impl<'a> Parser<'a> {
+    pub(crate) fn submod_path_from_attr(attrs: &[ast::Attribute], path: &Path) -> Option<PathBuf> {
+        rustc_parse::parser::Parser::submod_path_from_attr(attrs, path)
+    }
+
+    // FIXME(topecongiro) Use the method from libsyntax[1] once it become public.
+    //
+    // [1] https://github.com/rust-lang/rust/blob/master/src/libsyntax/parse/attr.rs
+    fn parse_inner_attrs(parser: &mut RawParser<'a>) -> PResult<'a, Vec<ast::Attribute>> {
+        let mut attrs: Vec<ast::Attribute> = vec![];
+        loop {
+            match parser.token.kind {
+                TokenKind::Pound => {
+                    // Don't even try to parse if it's not an inner attribute.
+                    if !parser.look_ahead(1, |t| t == &TokenKind::Not) {
+                        break;
+                    }
+
+                    let attr = parser.parse_attribute(true)?;
+                    assert_eq!(attr.style, ast::AttrStyle::Inner);
+                    attrs.push(attr);
+                }
+                TokenKind::DocComment(s) => {
+                    // we need to get the position of this token before we bump.
+                    let attr = syntax::attr::mk_doc_comment(
+                        syntax::util::comments::doc_comment_style(&s.as_str()),
+                        s,
+                        parser.token.span,
+                    );
+                    if attr.style == ast::AttrStyle::Inner {
+                        attrs.push(attr);
+                        parser.bump();
+                    } else {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+        Ok(attrs)
+    }
+
+    fn parse_mod_items(parser: &mut RawParser<'a>, span: Span) -> PResult<'a, ast::Mod> {
+        let mut items = vec![];
+        while let Some(item) = parser.parse_item()? {
+            items.push(item);
+        }
+
+        let hi = if parser.token.span.is_dummy() {
+            span
+        } else {
+            parser.prev_token.span
+        };
+
+        Ok(ast::Mod {
+            inner: span.to(hi),
+            items,
+            inline: false,
+        })
+    }
+
+    pub(crate) fn parse_file_as_module(
+        directory_ownership: DirectoryOwnership,
+        sess: &'a ParseSess,
+        path: &Path,
+    ) -> Option<ast::Mod> {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut parser =
+                new_sub_parser_from_file(sess.inner(), &path, directory_ownership, None, DUMMY_SP);
+
+            parser.cfg_mods = false;
+            let lo = parser.token.span;
+            // FIXME(topecongiro) Format inner attributes (#3606).
+            match Parser::parse_inner_attrs(&mut parser) {
+                Ok(_attrs) => (),
+                Err(mut e) => {
+                    e.cancel();
+                    sess.reset_errors();
+                    return None;
+                }
+            }
+
+            match Parser::parse_mod_items(&mut parser, lo) {
+                Ok(m) => Some(m),
+                Err(mut db) => {
+                    db.cancel();
+                    sess.reset_errors();
+                    None
+                }
+            }
+        }));
+        match result {
+            Ok(Some(m)) => Some(m),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn parse_crate(
+        config: &'a Config,
+        input: Input,
+        directory_ownership: Option<DirectoryOwnership>,
+        sess: &'a ParseSess,
+    ) -> Result<ast::Crate, ParserError> {
+        let mut parser = ParserBuilder::default()
+            .config(config)
+            .input(input)
+            .directory_ownership(directory_ownership)
+            .sess(sess)
+            .build()?;
+
+        parser.parse_crate_inner()
+    }
+
+    fn parse_crate_inner(&mut self) -> Result<ast::Crate, ParserError> {
+        let mut parser = AssertUnwindSafe(&mut self.parser);
+
+        match catch_unwind(move || parser.parse_crate_mod()) {
+            Ok(Ok(krate)) => {
+                if !self.sess.has_errors() {
+                    return Ok(krate);
+                }
+
+                if self.sess.can_reset_errors() {
+                    self.sess.reset_errors();
+                    return Ok(krate);
+                }
+
+                Err(ParserError::ParseError)
+            }
+            Ok(Err(mut db)) => {
+                db.emit();
+                Err(ParserError::ParseError)
+            }
+            Err(_) => Err(ParserError::ParsePanicError),
+        }
+    }
+
+    pub(crate) fn parse_cfg_if(
+        sess: &'a ParseSess,
+        mac: &'a ast::Mac,
+        base_dir: &Directory,
+    ) -> Result<Vec<ast::Item>, &'static str> {
+        match catch_unwind(AssertUnwindSafe(|| {
+            Parser::parse_cfg_if_inner(sess, mac, base_dir)
+        })) {
+            Ok(Ok(items)) => Ok(items),
+            Ok(err @ Err(_)) => err,
+            Err(..) => Err("failed to parse cfg_if!"),
+        }
+    }
+
+    fn parse_cfg_if_inner(
+        sess: &'a ParseSess,
+        mac: &'a ast::Mac,
+        base_dir: &Directory,
+    ) -> Result<Vec<ast::Item>, &'static str> {
+        let token_stream = mac.args.inner_tokens();
+        let mut parser = rustc_parse::stream_to_parser_with_base_dir(
+            sess.inner(),
+            token_stream.clone(),
+            base_dir.to_syntax_directory(),
+        );
+
+        parser.cfg_mods = false;
+        let mut items = vec![];
+        let mut process_if_cfg = true;
+
+        while parser.token.kind != TokenKind::Eof {
+            if process_if_cfg {
+                if !parser.eat_keyword(kw::If) {
+                    return Err("Expected `if`");
+                }
+                parser
+                    .parse_attribute(false)
+                    .map_err(|_| "Failed to parse attributes")?;
+            }
+
+            if !parser.eat(&TokenKind::OpenDelim(DelimToken::Brace)) {
+                return Err("Expected an opening brace");
+            }
+
+            while parser.token != TokenKind::CloseDelim(DelimToken::Brace)
+                && parser.token.kind != TokenKind::Eof
+            {
+                let item = match parser.parse_item() {
+                    Ok(Some(item_ptr)) => item_ptr.into_inner(),
+                    Ok(None) => continue,
+                    Err(mut err) => {
+                        err.cancel();
+                        parser.sess.span_diagnostic.reset_err_count();
+                        return Err(
+                            "Expected item inside cfg_if block, but failed to parse it as an item",
+                        );
+                    }
+                };
+                if let ast::ItemKind::Mod(..) = item.kind {
+                    items.push(item);
+                }
+            }
+
+            if !parser.eat(&TokenKind::CloseDelim(DelimToken::Brace)) {
+                return Err("Expected a closing brace");
+            }
+
+            if parser.eat(&TokenKind::Eof) {
+                break;
+            }
+
+            if !parser.eat_keyword(kw::Else) {
+                return Err("Expected `else`");
+            }
+
+            process_if_cfg = parser.token.is_keyword(kw::If);
+        }
+
+        Ok(items)
+    }
+}

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -1,11 +1,11 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
+use rustc_ast::ast;
+use rustc_ast::token::{DelimToken, TokenKind};
 use rustc_errors::{Diagnostic, PResult};
 use rustc_parse::{new_parser_from_file, parser::Parser as RawParser};
 use rustc_span::{symbol::kw, Span};
-use syntax::ast;
-use syntax::token::{DelimToken, TokenKind};
 
 use crate::syntux::session::ParseSess;
 use crate::{Config, Input};
@@ -121,8 +121,8 @@ impl<'a> Parser<'a> {
                 }
                 TokenKind::DocComment(s) => {
                     // we need to get the position of this token before we bump.
-                    let attr = syntax::attr::mk_doc_comment(
-                        syntax::util::comments::doc_comment_style(&s.as_str()),
+                    let attr = rustc_ast::attr::mk_doc_comment(
+                        rustc_ast::util::comments::doc_comment_style(&s.as_str()),
                         s,
                         parser.token.span,
                     );

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -168,7 +168,7 @@ impl<'a> Parser<'a> {
         path: &Path,
         span: Span,
     ) -> Option<ast::Mod> {
-            let result = catch_unwind(AssertUnwindSafe(|| {
+        let result = catch_unwind(AssertUnwindSafe(|| {
             let mut parser = new_parser_from_file(sess.inner(), &path, Some(span));
 
             let lo = parser.token.span;
@@ -241,9 +241,7 @@ impl<'a> Parser<'a> {
         sess: &'a ParseSess,
         mac: &'a ast::MacCall,
     ) -> Result<Vec<ast::Item>, &'static str> {
-        match catch_unwind(AssertUnwindSafe(|| {
-            Parser::parse_cfg_if_inner(sess, mac)
-        })) {
+        match catch_unwind(AssertUnwindSafe(|| Parser::parse_cfg_if_inner(sess, mac))) {
             Ok(Ok(items)) => Ok(items),
             Ok(err @ Err(_)) => err,
             Err(..) => Err("failed to parse cfg_if!"),
@@ -255,7 +253,8 @@ impl<'a> Parser<'a> {
         mac: &'a ast::MacCall,
     ) -> Result<Vec<ast::Item>, &'static str> {
         let token_stream = mac.args.inner_tokens();
-        let mut parser = rustc_parse::stream_to_parser(sess.inner(),token_stream.clone(),Some(""));
+        let mut parser =
+            rustc_parse::stream_to_parser(sess.inner(), token_stream.clone(), Some(""));
 
         let mut items = vec![];
         let mut process_if_cfg = true;

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -150,12 +150,13 @@ impl ParseSess {
         id: ast::Ident,
         relative: Option<ast::Ident>,
         dir_path: &Path,
-    ) -> rustc_parse::parser::ModulePath {
-        rustc_parse::parser::Parser::default_submod_path(
+    ) -> rustc_expand::module::ModulePath<'_> {
+        rustc_expand::module::default_submod_path(
+            &self.parse_sess,
             id,
+            rustc_span::DUMMY_SP,
             relative,
             dir_path,
-            self.parse_sess.source_map(),
         )
     }
 

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
 
+use rustc_ast::ast;
 use rustc_data_structures::sync::{Lrc, Send};
 use rustc_errors::emitter::{Emitter, EmitterWriter};
 use rustc_errors::{ColorConfig, Diagnostic, Handler, Level as DiagnosticLevel};
@@ -10,7 +11,6 @@ use rustc_span::{
     source_map::{FilePathMapping, SourceMap},
     BytePos, Span,
 };
-use syntax::ast;
 
 use crate::config::file_lines::LineRange;
 use crate::ignore_path::IgnorePathSet;

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -1,0 +1,440 @@
+use std::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+
+use rustc_data_structures::sync::{Lrc, Send};
+use rustc_errors::emitter::{Emitter, EmitterWriter};
+use rustc_errors::{ColorConfig, Diagnostic, Handler, Level as DiagnosticLevel};
+use rustc_session::parse::ParseSess as RawParseSess;
+use rustc_span::{
+    source_map::{FilePathMapping, SourceMap},
+    BytePos, Span,
+};
+use syntax::ast;
+
+use crate::config::file_lines::LineRange;
+use crate::ignore_path::IgnorePathSet;
+use crate::source_map::LineRangeUtils;
+use crate::utils::starts_with_newline;
+use crate::visitor::SnippetProvider;
+use crate::{Config, ErrorKind, FileName};
+
+/// ParseSess holds structs necessary for constructing a parser.
+pub(crate) struct ParseSess {
+    parse_sess: RawParseSess,
+    ignore_path_set: Rc<IgnorePathSet>,
+    can_reset_errors: Rc<RefCell<bool>>,
+}
+
+/// Emitter which discards every error.
+struct SilentEmitter;
+
+impl Emitter for SilentEmitter {
+    fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+        None
+    }
+    fn emit_diagnostic(&mut self, _db: &Diagnostic) {}
+}
+
+fn silent_emitter() -> Box<dyn Emitter + Send> {
+    Box::new(SilentEmitter {})
+}
+
+/// Emit errors against every files expect ones specified in the `ignore_path_set`.
+struct SilentOnIgnoredFilesEmitter {
+    ignore_path_set: Rc<IgnorePathSet>,
+    source_map: Rc<SourceMap>,
+    emitter: Box<dyn Emitter + Send>,
+    has_non_ignorable_parser_errors: bool,
+    can_reset: Rc<RefCell<bool>>,
+}
+
+impl SilentOnIgnoredFilesEmitter {
+    fn handle_non_ignoreable_error(&mut self, db: &Diagnostic) {
+        self.has_non_ignorable_parser_errors = true;
+        *self.can_reset.borrow_mut() = false;
+        self.emitter.emit_diagnostic(db);
+    }
+}
+
+impl Emitter for SilentOnIgnoredFilesEmitter {
+    fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+        None
+    }
+    fn emit_diagnostic(&mut self, db: &Diagnostic) {
+        if db.level == DiagnosticLevel::Fatal {
+            return self.handle_non_ignoreable_error(db);
+        }
+        if let Some(primary_span) = &db.span.primary_span() {
+            let file_name = self.source_map.span_to_filename(*primary_span);
+            if let rustc_span::FileName::Real(ref path) = file_name {
+                if self
+                    .ignore_path_set
+                    .is_match(&FileName::Real(path.to_path_buf()))
+                {
+                    if !self.has_non_ignorable_parser_errors {
+                        *self.can_reset.borrow_mut() = true;
+                    }
+                    return;
+                }
+            };
+        }
+        self.handle_non_ignoreable_error(db);
+    }
+}
+
+fn default_handler(
+    source_map: Rc<SourceMap>,
+    ignore_path_set: Rc<IgnorePathSet>,
+    can_reset: Rc<RefCell<bool>>,
+    hide_parse_errors: bool,
+) -> Handler {
+    let supports_color = term::stderr().map_or(false, |term| term.supports_color());
+    let color_cfg = if supports_color {
+        ColorConfig::Auto
+    } else {
+        ColorConfig::Never
+    };
+
+    let emitter = if hide_parse_errors {
+        silent_emitter()
+    } else {
+        Box::new(EmitterWriter::stderr(
+            color_cfg,
+            Some(source_map.clone()),
+            false,
+            false,
+            None,
+            false,
+        ))
+    };
+    Handler::with_emitter(
+        true,
+        None,
+        Box::new(SilentOnIgnoredFilesEmitter {
+            has_non_ignorable_parser_errors: false,
+            source_map,
+            emitter,
+            ignore_path_set,
+            can_reset,
+        }),
+    )
+}
+
+impl ParseSess {
+    pub(crate) fn new(config: &Config) -> Result<ParseSess, ErrorKind> {
+        let ignore_path_set = match IgnorePathSet::from_ignore_list(&config.ignore()) {
+            Ok(ignore_path_set) => Rc::new(ignore_path_set),
+            Err(e) => return Err(ErrorKind::InvalidGlobPattern(e)),
+        };
+        let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
+        let can_reset_errors = Rc::new(RefCell::new(false));
+
+        let handler = default_handler(
+            Rc::clone(&source_map),
+            Rc::clone(&ignore_path_set),
+            Rc::clone(&can_reset_errors),
+            config.hide_parse_errors(),
+        );
+        let parse_sess = RawParseSess::with_span_handler(handler, source_map);
+
+        Ok(ParseSess {
+            parse_sess,
+            ignore_path_set,
+            can_reset_errors,
+        })
+    }
+
+    pub(crate) fn default_submod_path(
+        &self,
+        id: ast::Ident,
+        relative: Option<ast::Ident>,
+        dir_path: &Path,
+    ) -> rustc_parse::parser::ModulePath {
+        rustc_parse::parser::Parser::default_submod_path(
+            id,
+            relative,
+            dir_path,
+            self.parse_sess.source_map(),
+        )
+    }
+
+    pub(crate) fn is_file_parsed(&self, path: &Path) -> bool {
+        self.parse_sess
+            .source_map()
+            .get_source_file(&rustc_span::FileName::Real(path.to_path_buf()))
+            .is_some()
+    }
+
+    pub(crate) fn ignore_file(&self, path: &FileName) -> bool {
+        self.ignore_path_set.as_ref().is_match(&path)
+    }
+
+    pub(crate) fn set_silent_emitter(&mut self) {
+        self.parse_sess.span_diagnostic = Handler::with_emitter(true, None, silent_emitter());
+    }
+
+    pub(crate) fn span_to_filename(&self, span: Span) -> FileName {
+        self.parse_sess.source_map().span_to_filename(span).into()
+    }
+
+    pub(crate) fn span_to_first_line_string(&self, span: Span) -> String {
+        let file_lines = self.parse_sess.source_map().span_to_lines(span).ok();
+
+        match file_lines {
+            Some(fl) => fl
+                .file
+                .get_line(fl.lines[0].line_index)
+                .map_or_else(String::new, |s| s.to_string()),
+            None => String::new(),
+        }
+    }
+
+    pub(crate) fn line_of_byte_pos(&self, pos: BytePos) -> usize {
+        self.parse_sess.source_map().lookup_char_pos(pos).line
+    }
+
+    pub(crate) fn span_to_debug_info(&self, span: Span) -> String {
+        self.parse_sess.source_map().span_to_string(span)
+    }
+
+    pub(crate) fn inner(&self) -> &RawParseSess {
+        &self.parse_sess
+    }
+
+    pub(crate) fn snippet_provider(&self, span: Span) -> SnippetProvider {
+        let source_file = self.parse_sess.source_map().lookup_char_pos(span.lo()).file;
+        SnippetProvider::new(
+            source_file.start_pos,
+            source_file.end_pos,
+            Rc::clone(source_file.src.as_ref().unwrap()),
+        )
+    }
+
+    pub(crate) fn get_original_snippet(&self, file_name: &FileName) -> Option<Rc<String>> {
+        self.parse_sess
+            .source_map()
+            .get_source_file(&file_name.into())
+            .and_then(|source_file| source_file.src.clone())
+    }
+}
+
+// Methods that should be restricted within the syntux module.
+impl ParseSess {
+    pub(super) fn emit_diagnostics(&self, diagnostics: Vec<Diagnostic>) {
+        for diagnostic in diagnostics {
+            self.parse_sess.span_diagnostic.emit_diagnostic(&diagnostic);
+        }
+    }
+
+    pub(super) fn can_reset_errors(&self) -> bool {
+        *self.can_reset_errors.borrow()
+    }
+
+    pub(super) fn has_errors(&self) -> bool {
+        self.parse_sess.span_diagnostic.has_errors()
+    }
+
+    pub(super) fn reset_errors(&self) {
+        self.parse_sess.span_diagnostic.reset_err_count();
+    }
+}
+
+impl LineRangeUtils for ParseSess {
+    fn lookup_line_range(&self, span: Span) -> LineRange {
+        let snippet = self
+            .parse_sess
+            .source_map()
+            .span_to_snippet(span)
+            .unwrap_or_default();
+        let lo = self.parse_sess.source_map().lookup_line(span.lo()).unwrap();
+        let hi = self.parse_sess.source_map().lookup_line(span.hi()).unwrap();
+
+        debug_assert_eq!(
+            lo.sf.name, hi.sf.name,
+            "span crossed file boundary: lo: {:?}, hi: {:?}",
+            lo, hi
+        );
+
+        // in case the span starts with a newline, the line range is off by 1 without the
+        // adjustment below
+        let offset = 1 + if starts_with_newline(&snippet) { 1 } else { 0 };
+        // Line numbers start at 1
+        LineRange {
+            file: lo.sf.clone(),
+            lo: lo.line + offset,
+            hi: hi.line + offset,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod emitter {
+        use super::*;
+        use crate::config::IgnoreList;
+        use crate::is_nightly_channel;
+        use crate::utils::mk_sp;
+        use rustc_span::{FileName as SourceMapFileName, MultiSpan, DUMMY_SP};
+        use std::path::PathBuf;
+
+        struct TestEmitter {
+            num_emitted_errors: Rc<RefCell<u32>>,
+        }
+
+        impl Emitter for TestEmitter {
+            fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+                None
+            }
+            fn emit_diagnostic(&mut self, _db: &Diagnostic) {
+                *self.num_emitted_errors.borrow_mut() += 1;
+            }
+        }
+
+        fn build_diagnostic(level: DiagnosticLevel, span: Option<MultiSpan>) -> Diagnostic {
+            Diagnostic {
+                level,
+                code: None,
+                message: vec![],
+                children: vec![],
+                suggestions: vec![],
+                span: span.unwrap_or_else(MultiSpan::new),
+                sort_span: DUMMY_SP,
+            }
+        }
+
+        fn build_emitter(
+            num_emitted_errors: Rc<RefCell<u32>>,
+            can_reset: Rc<RefCell<bool>>,
+            source_map: Option<Rc<SourceMap>>,
+            ignore_list: Option<IgnoreList>,
+        ) -> SilentOnIgnoredFilesEmitter {
+            let emitter_writer = TestEmitter { num_emitted_errors };
+            let source_map =
+                source_map.unwrap_or_else(|| Rc::new(SourceMap::new(FilePathMapping::empty())));
+            let ignore_path_set =
+                Rc::new(IgnorePathSet::from_ignore_list(&ignore_list.unwrap_or_default()).unwrap());
+            SilentOnIgnoredFilesEmitter {
+                has_non_ignorable_parser_errors: false,
+                source_map,
+                emitter: Box::new(emitter_writer),
+                ignore_path_set,
+                can_reset,
+            }
+        }
+
+        fn get_ignore_list(config: &str) -> IgnoreList {
+            Config::from_toml(config, Path::new("")).unwrap().ignore()
+        }
+
+        #[test]
+        fn handles_fatal_parse_error_in_ignored_file() {
+            let num_emitted_errors = Rc::new(RefCell::new(0));
+            let can_reset_errors = Rc::new(RefCell::new(false));
+            let ignore_list = get_ignore_list(r#"ignore = ["foo.rs"]"#);
+            let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
+            let source =
+                String::from(r#"extern "system" fn jni_symbol!( funcName ) ( ... ) -> {} "#);
+            source_map.new_source_file(SourceMapFileName::Real(PathBuf::from("foo.rs")), source);
+            let mut emitter = build_emitter(
+                Rc::clone(&num_emitted_errors),
+                Rc::clone(&can_reset_errors),
+                Some(Rc::clone(&source_map)),
+                Some(ignore_list),
+            );
+            let span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
+            let fatal_diagnostic = build_diagnostic(DiagnosticLevel::Fatal, Some(span));
+            emitter.emit_diagnostic(&fatal_diagnostic);
+            assert_eq!(*num_emitted_errors.borrow(), 1);
+            assert_eq!(*can_reset_errors.borrow(), false);
+        }
+
+        #[test]
+        fn handles_recoverable_parse_error_in_ignored_file() {
+            if !is_nightly_channel!() {
+                return;
+            }
+            let num_emitted_errors = Rc::new(RefCell::new(0));
+            let can_reset_errors = Rc::new(RefCell::new(false));
+            let ignore_list = get_ignore_list(r#"ignore = ["foo.rs"]"#);
+            let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
+            let source = String::from(r#"pub fn bar() { 1x; }"#);
+            source_map.new_source_file(SourceMapFileName::Real(PathBuf::from("foo.rs")), source);
+            let mut emitter = build_emitter(
+                Rc::clone(&num_emitted_errors),
+                Rc::clone(&can_reset_errors),
+                Some(Rc::clone(&source_map)),
+                Some(ignore_list),
+            );
+            let span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
+            let non_fatal_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(span));
+            emitter.emit_diagnostic(&non_fatal_diagnostic);
+            assert_eq!(*num_emitted_errors.borrow(), 0);
+            assert_eq!(*can_reset_errors.borrow(), true);
+        }
+
+        #[test]
+        fn handles_recoverable_parse_error_in_non_ignored_file() {
+            if !is_nightly_channel!() {
+                return;
+            }
+            let num_emitted_errors = Rc::new(RefCell::new(0));
+            let can_reset_errors = Rc::new(RefCell::new(false));
+            let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
+            let source = String::from(r#"pub fn bar() { 1x; }"#);
+            source_map.new_source_file(SourceMapFileName::Real(PathBuf::from("foo.rs")), source);
+            let mut emitter = build_emitter(
+                Rc::clone(&num_emitted_errors),
+                Rc::clone(&can_reset_errors),
+                Some(Rc::clone(&source_map)),
+                None,
+            );
+            let span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
+            let non_fatal_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(span));
+            emitter.emit_diagnostic(&non_fatal_diagnostic);
+            assert_eq!(*num_emitted_errors.borrow(), 1);
+            assert_eq!(*can_reset_errors.borrow(), false);
+        }
+
+        #[test]
+        fn handles_mix_of_recoverable_parse_error() {
+            if !is_nightly_channel!() {
+                return;
+            }
+            let num_emitted_errors = Rc::new(RefCell::new(0));
+            let can_reset_errors = Rc::new(RefCell::new(false));
+            let source_map = Rc::new(SourceMap::new(FilePathMapping::empty()));
+            let ignore_list = get_ignore_list(r#"ignore = ["foo.rs"]"#);
+            let bar_source = String::from(r#"pub fn bar() { 1x; }"#);
+            let foo_source = String::from(r#"pub fn foo() { 1x; }"#);
+            let fatal_source =
+                String::from(r#"extern "system" fn jni_symbol!( funcName ) ( ... ) -> {} "#);
+            source_map
+                .new_source_file(SourceMapFileName::Real(PathBuf::from("bar.rs")), bar_source);
+            source_map
+                .new_source_file(SourceMapFileName::Real(PathBuf::from("foo.rs")), foo_source);
+            source_map.new_source_file(
+                SourceMapFileName::Real(PathBuf::from("fatal.rs")),
+                fatal_source,
+            );
+            let mut emitter = build_emitter(
+                Rc::clone(&num_emitted_errors),
+                Rc::clone(&can_reset_errors),
+                Some(Rc::clone(&source_map)),
+                Some(ignore_list),
+            );
+            let bar_span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
+            let foo_span = MultiSpan::from_span(mk_sp(BytePos(21), BytePos(22)));
+            let bar_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(bar_span));
+            let foo_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(foo_span));
+            let fatal_diagnostic = build_diagnostic(DiagnosticLevel::Fatal, None);
+            emitter.emit_diagnostic(&bar_diagnostic);
+            emitter.emit_diagnostic(&foo_diagnostic);
+            emitter.emit_diagnostic(&fatal_diagnostic);
+            assert_eq!(*num_emitted_errors.borrow(), 2);
+            assert_eq!(*can_reset_errors.borrow(), false);
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -233,14 +233,18 @@ fn rewrite_segment(
 
     if let Some(ref args) = segment.args {
         match **args {
-            ast::GenericArgs::AngleBracketed(ref data)
-                if !data.args.is_empty() || !data.constraints.is_empty() =>
-            {
+            ast::GenericArgs::AngleBracketed(ref data) if !data.args.is_empty() => {
                 let param_list = data
                     .args
                     .iter()
-                    .map(SegmentParam::from_generic_arg)
-                    .chain(data.constraints.iter().map(|x| SegmentParam::Binding(&*x)))
+                    .map(|x| match x {
+                        ast::AngleBracketedArg::Arg(generic_arg) => {
+                            SegmentParam::from_generic_arg(generic_arg)
+                        }
+                        ast::AngleBracketedArg::Constraint(constraint) => {
+                            SegmentParam::Binding(constraint)
+                        }
+                    })
                     .collect::<Vec<_>>();
 
                 // HACK: squeeze out the span between the identifier and the parameters.

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@ use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
 use rustc_span::{symbol::kw, BytePos, Span};
-use syntax::ast::{self, FunctionRetTy, Mutability};
+use syntax::ast::{self, FnRetTy, Mutability};
 
 use crate::config::lists::*;
 use crate::config::{IndentStyle, TypeDensity, Version};
@@ -292,7 +292,7 @@ fn rewrite_segment(
 
 fn format_function_type<'a, I>(
     inputs: I,
-    output: &FunctionRetTy,
+    output: &FnRetTy,
     variadic: bool,
     span: Span,
     context: &RewriteContext<'_>,
@@ -311,11 +311,11 @@ where
         IndentStyle::Visual => shape.block_left(4)?,
     };
     let output = match *output {
-        FunctionRetTy::Ty(ref ty) => {
+        FnRetTy::Ty(ref ty) => {
             let type_str = ty.rewrite(context, ty_shape)?;
             format!(" -> {}", type_str)
         }
-        FunctionRetTy::Default(..) => String::new(),
+        FnRetTy::Default(..) => String::new(),
     };
 
     let list_shape = if context.use_block_indent() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
+use rustc_ast::ast::{self, FnRetTy, Mutability};
 use rustc_span::{symbol::kw, BytePos, Span};
-use syntax::ast::{self, FnRetTy, Mutability};
 
 use crate::config::lists::*;
 use crate::config::{IndentStyle, TypeDensity, Version};
@@ -551,7 +551,7 @@ impl Rewrite for ast::GenericParam {
             _ => (),
         }
 
-        if let syntax::ast::GenericParamKind::Const { ref ty } = &self.kind {
+        if let rustc_ast::ast::GenericParamKind::Const { ref ty } = &self.kind {
             result.push_str("const ");
             result.push_str(rewrite_ident(context, self.ident));
             result.push_str(": ");

--- a/src/types.rs
+++ b/src/types.rs
@@ -732,7 +732,7 @@ impl Rewrite for ast::Ty {
             }
             ast::TyKind::BareFn(ref bare_fn) => rewrite_bare_fn(bare_fn, self.span, context, shape),
             ast::TyKind::Never => Some(String::from("!")),
-            ast::TyKind::Mac(ref mac) => {
+            ast::TyKind::MacCall(ref mac) => {
                 rewrite_macro(mac, None, context, shape, MacroPosition::Expression)
             }
             ast::TyKind::ImplicitSelf => Some(String::from("")),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -104,7 +104,7 @@ pub(crate) fn format_constness(constness: ast::Const) -> &'static str {
 #[inline]
 pub(crate) fn format_defaultness(defaultness: ast::Defaultness) -> &'static str {
     match defaultness {
-        ast::Defaultness::Default => "default ",
+        ast::Defaultness::Default(..) => "default ",
         ast::Defaultness::Final => "",
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -456,7 +456,7 @@ pub(crate) fn first_line_ends_with(s: &str, c: char) -> bool {
 // parens, braces, and brackets in its idiomatic formatting.
 pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr: &str) -> bool {
     match expr.kind {
-        ast::ExprKind::Mac(..)
+        ast::ExprKind::MacCall(..)
         | ast::ExprKind::Call(..)
         | ast::ExprKind::MethodCall(..)
         | ast::ExprKind::Array(..)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -355,7 +355,7 @@ macro_rules! out_of_file_lines_range {
             && !$self
                 .config
                 .file_lines()
-                .intersects(&$self.source_map.lookup_line_range($span))
+                .intersects(&$self.parse_sess.lookup_line_range($span))
     };
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,13 @@
 use std::borrow::Cow;
 
-use rustc_ast_pretty::pprust;
-use rustc_span::{sym, BytePos, ExpnId, Span, Symbol, SyntaxContext};
-use rustc_target::spec::abi;
-use syntax::ast::{
+use rustc_ast::ast::{
     self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem, NodeId, Path, Visibility,
     VisibilityKind,
 };
-use syntax::ptr;
+use rustc_ast::ptr;
+use rustc_ast_pretty::pprust;
+use rustc_span::{sym, BytePos, ExpnId, Span, Symbol, SyntaxContext};
+use rustc_target::spec::abi;
 use unicode_width::UnicodeWidthStr;
 
 use crate::comment::{filter_normal_code, CharClasses, FullCodeCharKind, LineClasses};
@@ -157,7 +157,7 @@ pub(crate) fn format_extern(
 }
 
 #[inline]
-// Transform `Vec<syntax::ptr::P<T>>` into `Vec<&T>`
+// Transform `Vec<rustc_ast::ptr::P<T>>` into `Vec<&T>`
 pub(crate) fn ptr_vec_to_ref_vec<T>(vec: &[ptr::P<T>]) -> Vec<&T> {
     vec.iter().map(|x| &**x).collect::<Vec<_>>()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -490,7 +490,7 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::Continue(..)
         | ast::ExprKind::Err
         | ast::ExprKind::Field(..)
-        | ast::ExprKind::InlineAsm(..)
+        | ast::ExprKind::LlvmInlineAsm(..)
         | ast::ExprKind::Let(..)
         | ast::ExprKind::Path(..)
         | ast::ExprKind::Range(..)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,18 +86,18 @@ pub(crate) fn format_visibility(
 }
 
 #[inline]
-pub(crate) fn format_async(is_async: &ast::IsAsync) -> &'static str {
+pub(crate) fn format_async(is_async: &ast::Async) -> &'static str {
     match is_async {
-        ast::IsAsync::Async { .. } => "async ",
-        ast::IsAsync::NotAsync => "",
+        ast::Async::Yes { .. } => "async ",
+        ast::Async::No => "",
     }
 }
 
 #[inline]
-pub(crate) fn format_constness(constness: ast::Constness) -> &'static str {
+pub(crate) fn format_constness(constness: ast::Const) -> &'static str {
     match constness {
-        ast::Constness::Const => "const ",
-        ast::Constness::NotConst => "",
+        ast::Const::Yes(..) => "const ",
+        ast::Const::No => "",
     }
 }
 
@@ -110,10 +110,10 @@ pub(crate) fn format_defaultness(defaultness: ast::Defaultness) -> &'static str 
 }
 
 #[inline]
-pub(crate) fn format_unsafety(unsafety: ast::Unsafety) -> &'static str {
+pub(crate) fn format_unsafety(unsafety: ast::Unsafe) -> &'static str {
     match unsafety {
-        ast::Unsafety::Unsafe => "unsafe ",
-        ast::Unsafety::Normal => "",
+        ast::Unsafe::Yes(..) => "unsafe ",
+        ast::Unsafe::No => "",
     }
 }
 

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -3,8 +3,8 @@
 use std::cmp;
 
 use itertools::Itertools;
+use rustc_ast::ast;
 use rustc_span::{BytePos, Span};
-use syntax::ast;
 
 use crate::comment::combine_strs_with_missing_comments;
 use crate::config::lists::*;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -151,7 +151,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     self.push_rewrite(stmt.span(), rewrite)
                 }
             }
-            ast::StmtKind::Mac(ref mac) => {
+            ast::StmtKind::MacCall(ref mac) => {
                 let (ref mac, _macro_style, ref attrs) = **mac;
                 if self.visit_attrs(attrs, ast::AttrStyle::Outer) {
                     self.push_skipped_with_span(
@@ -504,7 +504,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     self.format_missing_with_indent(source!(self, item.span).lo());
                     self.format_mod(module, &item.vis, item.span, item.ident, attrs, is_inline);
                 }
-                ast::ItemKind::Mac(ref mac) => {
+                ast::ItemKind::MacCall(ref mac) => {
                     self.visit_mac(mac, Some(item.ident), MacroPosition::Item);
                 }
                 ast::ItemKind::ForeignMod(ref foreign_mod) => {
@@ -619,7 +619,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 );
                 self.push_rewrite(ti.span, rewrite);
             }
-            ast::AssocItemKind::Macro(ref mac) => {
+            ast::AssocItemKind::MacCall(ref mac) => {
                 self.visit_mac(mac, Some(ti.ident), MacroPosition::Item);
             }
         }
@@ -669,7 +669,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         Some(generic_bounds) => rewrite_opaque_impl_type(
                             &self.get_context(),
                             ii.ident,
-                            &generics,
+                            generics,
                             generic_bounds,
                             self.block_indent,
                         ),
@@ -678,13 +678,13 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 };
                 self.push_rewrite(ii.span, rewrite);
             }
-            ast::AssocItemKind::Macro(ref mac) => {
+            ast::AssocItemKind::MacCall(ref mac) => {
                 self.visit_mac(mac, Some(ii.ident), MacroPosition::Item);
             }
         }
     }
 
-    fn visit_mac(&mut self, mac: &ast::Mac, ident: Option<ast::Ident>, pos: MacroPosition) {
+    fn visit_mac(&mut self, mac: &ast::MacCall, ident: Option<ast::Ident>, pos: MacroPosition) {
         skip_out_of_file_lines_range_visitor!(self, mac.span());
 
         // 1 = ;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -133,18 +133,13 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 self.format_missing(stmt.span().hi());
             }
             ast::StmtKind::Local(..) | ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
-                if let Some(attrs) = get_attrs_from_stmt(stmt.as_ast_node()) {
-                    if contains_skip(attrs) {
-                        self.push_skipped_with_span(
-                            attrs,
-                            stmt.span(),
-                            get_span_without_attrs(stmt.as_ast_node()),
-                        );
-                    } else {
-                        let shape = self.shape();
-                        let rewrite = self.with_context(|ctx| stmt.rewrite(&ctx, shape));
-                        self.push_rewrite(stmt.span(), rewrite)
-                    }
+                let attrs = get_attrs_from_stmt(stmt.as_ast_node());
+                if contains_skip(attrs) {
+                    self.push_skipped_with_span(
+                        attrs,
+                        stmt.span(),
+                        get_span_without_attrs(stmt.as_ast_node()),
+                    );
                 } else {
                     let shape = self.shape();
                     let rewrite = self.with_context(|ctx| stmt.rewrite(&ctx, shape));

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -514,7 +514,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 ast::ItemKind::Static(..) | ast::ItemKind::Const(..) => {
                     self.visit_static(&StaticParts::from_item(item));
                 }
-                ast::ItemKind::Fn(defaultness, ref fn_signature, ref generics, ref body) => {
+                ast::ItemKind::Fn(defaultness, ref fn_signature, ref generics, Some(ref body)) => {
                     let inner_attrs = inner_attributes(&item.attrs);
                     let fn_ctxt = match fn_signature.header.ext {
                         ast::Extern::None => visit::FnCtxt::Free,
@@ -526,7 +526,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                             item.ident,
                             &fn_signature,
                             &item.vis,
-                            body.as_deref(),
+                            Some(body),
                         ),
                         generics,
                         &fn_signature.decl,
@@ -534,6 +534,18 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         defaultness,
                         Some(&inner_attrs),
                     )
+                }
+                ast::ItemKind::Fn(_, ref fn_signature, ref generics, None) => {
+                    let indent = self.block_indent;
+                    let rewrite = self.rewrite_required_fn(
+                        indent,
+                        item.ident,
+                        &fn_signature,
+                        generics,
+                        item.span,
+                    );
+
+                    self.push_rewrite(item.span, rewrite);
                 }
                 ast::ItemKind::TyAlias(_, ref generics, ref generic_bounds, ref ty) => match ty {
                     Some(ty) => {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1,9 +1,9 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
+use rustc_ast::token::DelimToken;
+use rustc_ast::{ast, visit};
 use rustc_span::{BytePos, Pos, Span};
-use syntax::token::DelimToken;
-use syntax::{ast, visit};
 
 use crate::attr::*;
 use crate::comment::{rewrite_comment, CodeCharKind, CommentCodeSlices};

--- a/tests/source/imports.rs
+++ b/tests/source/imports.rs
@@ -3,7 +3,7 @@
 // Imports.
 
 // Long import.
-use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
+use rustc_ast::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
 use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA, ItemB};
 use exceedingly::loooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA, ItemB};
 
@@ -15,30 +15,30 @@ use list::{
 
 use test::{  Other          /* C   */  , /*   A   */ self  /*    B     */    };
 
-use syntax::{self};
+use rustc_ast::{self};
 use {/* Pre-comment! */
      Foo, Bar /* comment */};
 use Foo::{Bar, Baz};
-pub use syntax::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath};
+pub use rustc_ast::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath};
 
-use syntax::some::{};
+use rustc_ast::some::{};
 
 use self;
 use std::io::{self};
 use std::io::self;
 
 mod Foo {
-    pub use syntax::ast::{
+    pub use rustc_ast::ast::{
         ItemForeignMod,
-        ItemImpl, 
+        ItemImpl,
         ItemMac,
         ItemMod,
-        ItemStatic, 
+        ItemStatic,
         ItemDefaultImpl
     };
 
     mod Foo2 {
-        pub use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, self, ItemDefaultImpl};
+        pub use rustc_ast::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, self, ItemDefaultImpl};
     }
 }
 

--- a/tests/source/issue_4057.rs
+++ b/tests/source/issue_4057.rs
@@ -1,0 +1,15 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```
+/// # #[rustversion::since(1.36)]
+/// # fn dox() {
+/// # use std::pin::Pin;
+/// # type Projection<'a> = &'a ();
+/// # type ProjectionRef<'a> = &'a ();
+/// # trait Dox {
+/// fn   project_ex (self: Pin<&mut Self>) -> Projection<'_>;
+/// fn   project_ref(self: Pin<&Self>) -> ProjectionRef<'_>;
+/// # }
+/// # }
+/// ```
+struct Foo;

--- a/tests/target/imports.rs
+++ b/tests/target/imports.rs
@@ -9,7 +9,7 @@ use exceedingly::loooooooooooooooooooooooooooooooooooooooooooooooooooooooong::im
 use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{
     ItemA, ItemB,
 };
-use syntax::ast::{ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
+use rustc_ast::ast::{ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
 
 use list::{
     // Another item
@@ -22,8 +22,8 @@ use list::{
 
 use test::{/* A */ self /* B */, Other /* C */};
 
-pub use syntax::ast::{Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath, Expr_};
-use syntax::{self};
+pub use rustc_ast::ast::{Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath, Expr_};
+use rustc_ast::{self};
 use Foo::{Bar, Baz};
 use {Bar /* comment */, /* Pre-comment! */ Foo};
 
@@ -31,12 +31,12 @@ use std::io;
 use std::io::{self};
 
 mod Foo {
-    pub use syntax::ast::{
+    pub use rustc_ast::ast::{
         ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic,
     };
 
     mod Foo2 {
-        pub use syntax::ast::{
+        pub use rustc_ast::ast::{
             self, ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic,
         };
     }

--- a/tests/target/issue-4068.rs
+++ b/tests/target/issue-4068.rs
@@ -1,0 +1,3 @@
+fn main() {
+    extern "C" fn packet_records_options_impl_layout_length_encoding_option_len_multiplier();
+}

--- a/tests/target/issue_4057.rs
+++ b/tests/target/issue_4057.rs
@@ -1,0 +1,15 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```
+/// # #[rustversion::since(1.36)]
+/// # fn dox() {
+/// # use std::pin::Pin;
+/// # type Projection<'a> = &'a ();
+/// # type ProjectionRef<'a> = &'a ();
+/// # trait Dox {
+/// fn project_ex(self: Pin<&mut Self>) -> Projection<'_>;
+/// fn project_ref(self: Pin<&Self>) -> ProjectionRef<'_>;
+/// # }
+/// # }
+/// ```
+struct Foo;


### PR DESCRIPTION
Refs https://github.com/rust-lang/rust/issues/70280

Feel free to change the target branch as needed, just pointing to 1.4.12 for now since that's the only one available with the latest 1.x.

This updates the rustc-ap-* dependencies to v651 which should get rustfmt working again on nightly, and also backports the syntux module from rustfmt 2.x/master to be more consistent and minimize the amount of parser changes required. 

I tried to do only the minimal amount of refactoring to the parser and mod resolver needed to get rustfmt working with the upstream parser/expansion changes. It can certainly be improved and I believe some of these upstream changes will ultimately help us implement some of the mod resolver changes we've been eyeing (like #3930). However, IMO those would be better addressed in follow up PRs since rustfmt has been broken for a while and this PR is a decent size already.

cc @Centril @Manishearth @matthiaskrgr 