### PR TITLE
bump rustc-ap-* crates to v651

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c144addf28721384a516382f1f7b7c518ebb87a330623dc9e2427b4ed01512"
+checksum = "f7ba8774d4d5c8d42727c74836f478c51e0a16daeeee80017c133f9e1ebf4f6f"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.1.0",
@@ -709,15 +709,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bdd6f563273576220a075afefae7b9e20953c70e7cfe4b664ce1c240f88841"
+checksum = "feba68cc05f42d227b258e07a84df7d690d1f20200593754a789ab39acb581e5"
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4b7aa06b8d9d6bf02075f91cdaf027cbce34aedd6ab5a6f4759de4c05de099"
+checksum = "989d221c292a3c777fc4921f87e4962d8d89633cf52a3a82f6f34d5b3d66efc7"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",
@@ -731,10 +731,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-ap-rustc_ast_pretty"
-version = "647.0.0"
+name = "rustc-ap-rustc_ast_passes"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb9a73b0f1c632fd09dd02444efe753445de17da8ffb1df28adc5766a581ada"
+checksum = "865c0bddabe735c8f8116cf14239b41d5789e5c38d1c503888779721b98bdd9e"
+dependencies = [
+ "log",
+ "rustc-ap-rustc_ast",
+ "rustc-ap-rustc_ast_pretty",
+ "rustc-ap-rustc_attr",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_feature",
+ "rustc-ap-rustc_parse",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
+]
+
+[[package]]
+name = "rustc-ap-rustc_ast_pretty"
+version = "650.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595c0092a2fa00dd0e572739279f771d96242f7626fc3999b4b027f08664417f"
 dependencies = [
  "log",
  "rustc-ap-rustc_ast",
@@ -744,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a420a672006a07f51cfc603ab394a066ccaf51323862c6b6b44bb673812df32"
+checksum = "3be021d73b25feb33dc0aa91f91ff37b939a0ef54f9620684bc2846278b5e637"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -762,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f224fd21a3c82b84e9914b4b1de31b0099e2083345c739285130017f5b2882"
+checksum = "a41551e5393a1abb4401e82f4e4bb64e097facb7d0362a1736b117186c0966dd"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -789,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312120a27c404bae22ed957b8d4e9cca2b872998558d227130aca9f3ff4edce9"
+checksum = "8715e95fd29d92a7799f9c65cb5583485bbf902dda17900c884fbb7956d593d8"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -806,10 +824,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-ap-rustc_feature"
-version = "647.0.0"
+name = "rustc-ap-rustc_expand"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7615aa561db78b1acacbedfa475e3ba5ed7071a33e5ede30d9660069be7b5e"
+checksum = "7ecc53789a88bb89caf81a6572db077b8679450b384fc03bf797d8453f86354b"
+dependencies = [
+ "log",
+ "rustc-ap-rustc_ast",
+ "rustc-ap-rustc_ast_passes",
+ "rustc-ap-rustc_ast_pretty",
+ "rustc-ap-rustc_attr",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_feature",
+ "rustc-ap-rustc_lexer",
+ "rustc-ap-rustc_parse",
+ "rustc-ap-rustc_session",
+ "rustc-ap-rustc_span",
+ "rustc-ap-serialize",
+ "smallvec 1.1.0",
+]
+
+[[package]]
+name = "rustc-ap-rustc_feature"
+version = "650.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf6304d5df6f803f43d15a71d1c4b4aa6b68a01fe587ad62fcdfb83049e3ec77"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -818,15 +858,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad7d6ee7fe47355214989c1638d9353344dfd2ac46eda5ac971533c543468d0"
+checksum = "c7c05da9f8dfd5c086465ad0263749453c13739226233c0354de5fc93b20204a"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a570533637a35eb7ed51de75a819a9f290fbd45b6cd4ca21e4ffe35ee2fcdf5"
+checksum = "b1c292880ff00cd1e61710396f9379b2c99a533cfb1bc9c3274d566ada2c6027"
 dependencies = [
  "rustc-ap-serialize",
  "smallvec 1.1.0",
@@ -834,18 +874,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a9df68feec956275dfd12cdeadc46fc55e48859417e4301f2b330d680de96e"
+checksum = "51e5ac7071163642ff52dda1bc41ff7464fcd832b5ea3fabf162569d26969410"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623e619c676c376f079c4504a6047f76630bb3d23d1a6c4a4beee79158082c74"
+checksum = "2e147f23b65b716b58bd8687170914d3e2d2bfd004ec3fc8d2749e9d601482c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -855,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465685a06a0a897cacd3c6bc6e0f50c79e1347cca9eb061361b5fa90ce46fb62"
+checksum = "c5e12622f831b7344899229f2f776ff2cdd14f7f82b257d6bbcb79c850996298"
 dependencies = [
  "bitflags",
  "log",
@@ -876,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf21db47cebe929bcac82f66da0faa1f38ace2091d6a887acdd87dcdfb7a823d"
+checksum = "18fb72a26080a34d35c8dd7ba5ac593812c1c3f97edffe6f1bf30c1ef5c4c550"
 dependencies = [
  "log",
  "num_cpus",
@@ -895,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bb21edcd0e2603efee36ffb1bc4c08b7288478fe107159dbffed0ec8a894a1"
+checksum = "fe2d8db305496f9dc5f43408044735a942eadeeb2a28d6da8dd6b23b5ef60f93"
 dependencies = [
  "cfg-if",
  "log",
@@ -912,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8cb1a2d38583099f392c6ea8d3f77b1fc8368e4edfce1978d94c249dc9a828"
+checksum = "e2797ddd7911ba6681f500fa0d5af651635bdc74813363a1216bafc6156cb3d2"
 dependencies = [
  "bitflags",
  "log",
@@ -927,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "647.0.0"
+version = "650.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25317d226bf1d0243d4df231edcc9bf1c0e40c503ef0290cc7aa5658d3819915"
+checksum = "e8567212bd0f0a93bbf3675e1ae819937e4a57d48b705522462c31ff8efc0604"
 dependencies = [
  "indexmap",
  "smallvec 1.1.0",
@@ -1059,6 +1099,7 @@ dependencies = [
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
+ "rustc-ap-rustc_expand",
  "rustc-ap-rustc_parse",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "fef709d3257013bba7cff14fc504e07e80631d3fe0f6d38ce63b8f6510ccb932"
 dependencies = [
  "byteorder",
  "memmap",
- "parking_lot",
+ "parking_lot 0.9.0",
  "rustc-hash",
 ]
 
@@ -543,8 +543,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.6.2",
  "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.7.0",
 ]
 
 [[package]]
@@ -559,6 +569,20 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.1.0",
  "winapi",
 ]
 
@@ -699,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ba8774d4d5c8d42727c74836f478c51e0a16daeeee80017c133f9e1ebf4f6f"
+checksum = "632704fb93ca8148957191e5d2d827082f93c4aa20cdd242fb46d8cca57029da"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.1.0",
@@ -709,15 +733,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feba68cc05f42d227b258e07a84df7d690d1f20200593754a789ab39acb581e5"
+checksum = "bdd4689b814859c9f1b3e314ed2bde596acac428a256a16894635f600bed46b4"
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d221c292a3c777fc4921f87e4962d8d89633cf52a3a82f6f34d5b3d66efc7"
+checksum = "101c1517d3fd19d083aaca5b113f9965e6ae353a0bb09c49959b0f62b95b75d9"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",
@@ -732,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865c0bddabe735c8f8116cf14239b41d5789e5c38d1c503888779721b98bdd9e"
+checksum = "3ab3f5a7e939b37c99d8ca371f09b10bb5b5c85ad5d5b8d1d736ce8248c71be0"
 dependencies = [
  "log",
  "rustc-ap-rustc_ast",
@@ -750,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595c0092a2fa00dd0e572739279f771d96242f7626fc3999b4b027f08664417f"
+checksum = "05046d3a2b8de22b20bcda9a1c063dc5c1f2f721f042b6c2809df2d23c64a13e"
 dependencies = [
  "log",
  "rustc-ap-rustc_ast",
@@ -762,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be021d73b25feb33dc0aa91f91ff37b939a0ef54f9620684bc2846278b5e637"
+checksum = "f00b7ccad6fc3628fb44950435772945a425575f9ea0b3708c536fe75623a6e8"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -780,20 +804,20 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41551e5393a1abb4401e82f4e4bb64e097facb7d0362a1736b117186c0966dd"
+checksum = "4c6121ab6766644fa76b711f65d4c39f2e335488ab768324567fed0ed191166e"
 dependencies = [
  "bitflags",
  "cfg-if",
- "crossbeam-utils 0.6.6",
+ "crossbeam-utils 0.7.0",
  "ena",
  "indexmap",
  "jobserver",
  "lazy_static",
  "log",
  "measureme",
- "parking_lot",
+ "parking_lot 0.10.0",
  "rustc-ap-graphviz",
  "rustc-ap-rustc_index",
  "rustc-ap-serialize",
@@ -807,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8715e95fd29d92a7799f9c65cb5583485bbf902dda17900c884fbb7956d593d8"
+checksum = "adab84c842003ad1c8435fd71b8d0cc19bf0d702a8a2147d5be06e083db2d207"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -825,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc53789a88bb89caf81a6572db077b8679450b384fc03bf797d8453f86354b"
+checksum = "bb001df541ea02b65c8e294252530010c6f90e3c6a5716e8e24e58c12dd1cd86"
 dependencies = [
  "log",
  "rustc-ap-rustc_ast",
@@ -847,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6304d5df6f803f43d15a71d1c4b4aa6b68a01fe587ad62fcdfb83049e3ec77"
+checksum = "446cc60613cc3b05d0bdbcab7feb02305790b5617fa43c532d51ae3223d677a4"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -858,15 +882,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c05da9f8dfd5c086465ad0263749453c13739226233c0354de5fc93b20204a"
+checksum = "9ac99d6f67e7db3bb300895630e769ed41bd3e336c0e725870c70e676c1a5ff1"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c292880ff00cd1e61710396f9379b2c99a533cfb1bc9c3274d566ada2c6027"
+checksum = "5608c1cf50d2251b7e10a138cf6dd388e97f139b21c00b06a22d06f89c6591f6"
 dependencies = [
  "rustc-ap-serialize",
  "smallvec 1.1.0",
@@ -874,18 +898,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e5ac7071163642ff52dda1bc41ff7464fcd832b5ea3fabf162569d26969410"
+checksum = "74e9c1c6f5dc85977b3adb6fb556b2ff23354d1a12021da15eb1d36353458bde"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e147f23b65b716b58bd8687170914d3e2d2bfd004ec3fc8d2749e9d601482c0"
+checksum = "3226b5ec864312a5d23eb40a5d621ee06bdc0754228d20d6eb76d4ddc4f2d4a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -895,15 +919,14 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e12622f831b7344899229f2f776ff2cdd14f7f82b257d6bbcb79c850996298"
+checksum = "ba3b042344c2280b50d5df0058d11379028a8f016a407e575bb3ea8b6c798049"
 dependencies = [
  "bitflags",
  "log",
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
- "rustc-ap-rustc_attr",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_feature",
@@ -916,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb72a26080a34d35c8dd7ba5ac593812c1c3f97edffe6f1bf30c1ef5c4c550"
+checksum = "ff35ef4b5d9fbcb2fd539c7c908eb3cdd1f68ddbccd042945ef50ae65564f941"
 dependencies = [
  "log",
  "num_cpus",
@@ -935,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2d8db305496f9dc5f43408044735a942eadeeb2a28d6da8dd6b23b5ef60f93"
+checksum = "e323b1f4a824039886eed8e33cad20ea4f492a9f9b3c9441009797c91de3e87a"
 dependencies = [
  "cfg-if",
  "log",
@@ -952,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2797ddd7911ba6681f500fa0d5af651635bdc74813363a1216bafc6156cb3d2"
+checksum = "e161eb7b3a5b7993c6b480135296dc61476db80041d49dd446422742426e390b"
 dependencies = [
  "bitflags",
  "log",
@@ -967,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "650.0.0"
+version = "651.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8567212bd0f0a93bbf3675e1ae819937e4a57d48b705522462c31ff8efc0604"
+checksum = "af510a659098d8c45a7303fb882fa780f4a87ec5f5d7a2053521e7d5d7f332c4"
 dependencies = [
  "indexmap",
  "smallvec 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea82fa3d9a8add7422228ca1a2cbba0784fa8861f56148ff64da08b3c7921b03"
+checksum = "80a4f7385e1a0bd8869b1c49738eb6a5c552d66cbea1b880d0481048588fc565"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.1.0",
@@ -709,15 +709,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638d0b2b3bcf99824e0cb5a25dbc547b61dc20942e11daf6a97e981918aa18e5"
+checksum = "da134a8459132ec83aba664fbc791c5e409539534bcdeb9df3d29b6ca7c37a76"
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38bab04dd676dee6d2f9670506a18c31bfce38bf7f8420aa83eb1140ecde049"
+checksum = "41b1280428ae4a3e6b944f2045578a4737cf367db1ac1bdcf66e6e3f886ec981"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b843ba8b1ed43739133047673b9f6a54d3b3b4d328d69c6ea89ff971395f35"
+checksum = "b3f27b42985109679eadcf07e0b0f227b9ba3d203173766b2c1a9ee0bbda05e4"
 dependencies = [
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_data_structures",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3d1c6d0a80ab0c1df76405377cec0f3d5423fb5b0953a8eac70a2ad6c44df2"
+checksum = "c8d3f4519ec1dad0b704129a4f891e7c75239850fa683765a63f163ea8ffa7b9"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4909a1eca29331332257230f29120a8ff68c9e37d868c564fcd599e430cf8914"
+checksum = "4e870484235e89654b66b10467862f3d60a698c0d5983aa51b42563733b77f71"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ab887a181d795cf5fd3edadf367760deafb90aefb844f168ab5255266e3478"
+checksum = "03e3e31e687890adfbc606e8f41e460408bc5b7a94c785d36e7cebc4c9193d00"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -801,15 +801,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70814116df3c5fbec8f06f6a1d013ca481f620fd22a9475754e9bf3ee9ba70d8"
+checksum = "23e0f0111c0b6ce58385784ecb4945f6b02c449591c13087dba5e82bbd900ac1"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1bf1d3cf3d119d41353d6fd229ef7272d5097bc0924de021c0294bf86d48bf"
+checksum = "808d42ae6e32607870710ff7ac0faa89b4ce8f8a4aa0a0d875e8ea62e4911a6c"
 dependencies = [
  "rustc-ap-serialize",
  "smallvec 1.1.0",
@@ -817,20 +817,19 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cda21a32cebdc11ec4f5393aa2fcde5ed1b2f673a8571e5a4dcdf07e4ae9cac"
+checksum = "f1494650ca657dd164503e03ebe5a3172fdfe1750e427aa7e139fbda4460817e"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c47b48ea51910ecfd853c9248a9bf4c767bc823449ab6a1d864dff65fbae16"
+checksum = "df5ad90674b7aac5606fc923d1aa8b804a11a4e65bf2fe850447b28a2bd9a011"
 dependencies = [
- "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -839,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd88e89cd5b5d28dcd3a347a3d534c08627d9455570dc1a2d402cb8437b9d30"
+checksum = "cb47830cfbb7b05eba5d5ec7c53dfb57dd76d09977e9a78eb7798a2b606bfec6"
 dependencies = [
  "bitflags",
  "log",
@@ -860,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8487b4575fbb2d1fc6f1cd61225efd108a4d36817e6fb9b643d57fcae9cb12"
+checksum = "d44935089371d9e4c91eb90c9a3358b44c0b59ef1b4552f05cecb8025b1971f0"
 dependencies = [
  "log",
  "num_cpus",
@@ -879,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69746c0d4c21bf20a5bb2bd247261a1aa8631f04202d7303352942dde70d987"
+checksum = "ccd71ce20995448afe2af68c32d06b01ee160d55ef9e5eebe81a7ca085324dd0"
 dependencies = [
  "cfg-if",
  "log",
@@ -896,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbc6ae09b5d42ec66edd520e8412e0615c53a7c93607fe33dc4abab60ba7c8b"
+checksum = "9bf8ba8d508f3e4e9e625566295bc1437d0327e7cd3c821e08f65e5801da6904"
 dependencies = [
  "bitflags",
  "log",
@@ -911,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13a1ead0252fc3d96da4c336a95950be6795f2b00c84a67ccadf26142f8cb41"
+checksum = "e7b029cc11516918c37b55230edbfc693dabbe1481013cadc506bdd345e63587"
 dependencies = [
  "indexmap",
  "smallvec 1.1.0",
@@ -921,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "642.0.0"
+version = "644.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f59f48ca3a2ec16a7e82e718ed5aadf9c9e08cf63015d28b4e774767524a6a"
+checksum = "478155ef59211e934a79bd1ed4dbbbb5d1226bd8921e2aa7edb23d8f5f8d1080"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a4f7385e1a0bd8869b1c49738eb6a5c552d66cbea1b880d0481048588fc565"
+checksum = "a0c144addf28721384a516382f1f7b7c518ebb87a330623dc9e2427b4ed01512"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.1.0",
@@ -709,28 +709,46 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da134a8459132ec83aba664fbc791c5e409539534bcdeb9df3d29b6ca7c37a76"
+checksum = "c4bdd6f563273576220a075afefae7b9e20953c70e7cfe4b664ce1c240f88841"
 
 [[package]]
-name = "rustc-ap-rustc_ast_pretty"
-version = "644.0.0"
+name = "rustc-ap-rustc_ast"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b1280428ae4a3e6b944f2045578a4737cf367db1ac1bdcf66e6e3f886ec981"
+checksum = "2b4b7aa06b8d9d6bf02075f91cdaf027cbce34aedd6ab5a6f4759de4c05de099"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_index",
+ "rustc-ap-rustc_lexer",
+ "rustc-ap-rustc_macros",
  "rustc-ap-rustc_span",
- "rustc-ap-syntax",
+ "rustc-ap-serialize",
+ "scoped-tls",
+ "smallvec 1.1.0",
+]
+
+[[package]]
+name = "rustc-ap-rustc_ast_pretty"
+version = "647.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb9a73b0f1c632fd09dd02444efe753445de17da8ffb1df28adc5766a581ada"
+dependencies = [
+ "log",
+ "rustc-ap-rustc_ast",
+ "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_span",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f27b42985109679eadcf07e0b0f227b9ba3d203173766b2c1a9ee0bbda05e4"
+checksum = "4a420a672006a07f51cfc603ab394a066ccaf51323862c6b6b44bb673812df32"
 dependencies = [
+ "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
@@ -739,15 +757,14 @@ dependencies = [
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
  "rustc-ap-serialize",
- "rustc-ap-syntax",
  "smallvec 1.1.0",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d3f4519ec1dad0b704129a4f891e7c75239850fa683765a63f163ea8ffa7b9"
+checksum = "43f224fd21a3c82b84e9914b4b1de31b0099e2083345c739285130017f5b2882"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -772,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e870484235e89654b66b10467862f3d60a698c0d5983aa51b42563733b77f71"
+checksum = "312120a27c404bae22ed957b8d4e9cca2b872998558d227130aca9f3ff4edce9"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -790,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e3e31e687890adfbc606e8f41e460408bc5b7a94c785d36e7cebc4c9193d00"
+checksum = "0e7615aa561db78b1acacbedfa475e3ba5ed7071a33e5ede30d9660069be7b5e"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -801,15 +818,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e0f0111c0b6ce58385784ecb4945f6b02c449591c13087dba5e82bbd900ac1"
+checksum = "6ad7d6ee7fe47355214989c1638d9353344dfd2ac46eda5ac971533c543468d0"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808d42ae6e32607870710ff7ac0faa89b4ce8f8a4aa0a0d875e8ea62e4911a6c"
+checksum = "3a570533637a35eb7ed51de75a819a9f290fbd45b6cd4ca21e4ffe35ee2fcdf5"
 dependencies = [
  "rustc-ap-serialize",
  "smallvec 1.1.0",
@@ -817,18 +834,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1494650ca657dd164503e03ebe5a3172fdfe1750e427aa7e139fbda4460817e"
+checksum = "47a9df68feec956275dfd12cdeadc46fc55e48859417e4301f2b330d680de96e"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5ad90674b7aac5606fc923d1aa8b804a11a4e65bf2fe850447b28a2bd9a011"
+checksum = "623e619c676c376f079c4504a6047f76630bb3d23d1a6c4a4beee79158082c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -838,12 +855,13 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb47830cfbb7b05eba5d5ec7c53dfb57dd76d09977e9a78eb7798a2b606bfec6"
+checksum = "465685a06a0a897cacd3c6bc6e0f50c79e1347cca9eb061361b5fa90ce46fb62"
 dependencies = [
  "bitflags",
  "log",
+ "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_attr",
  "rustc-ap-rustc_data_structures",
@@ -852,19 +870,19 @@ dependencies = [
  "rustc-ap-rustc_lexer",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
- "rustc-ap-syntax",
  "smallvec 1.1.0",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44935089371d9e4c91eb90c9a3358b44c0b59ef1b4552f05cecb8025b1971f0"
+checksum = "bf21db47cebe929bcac82f66da0faa1f38ace2091d6a887acdd87dcdfb7a823d"
 dependencies = [
  "log",
  "num_cpus",
+ "rustc-ap-rustc_ast",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_feature",
@@ -873,14 +891,13 @@ dependencies = [
  "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
  "rustc-ap-serialize",
- "rustc-ap-syntax",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd71ce20995448afe2af68c32d06b01ee160d55ef9e5eebe81a7ca085324dd0"
+checksum = "d7bb21edcd0e2603efee36ffb1bc4c08b7288478fe107159dbffed0ec8a894a1"
 dependencies = [
  "cfg-if",
  "log",
@@ -895,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf8ba8d508f3e4e9e625566295bc1437d0327e7cd3c821e08f65e5801da6904"
+checksum = "9e8cb1a2d38583099f392c6ea8d3f77b1fc8368e4edfce1978d94c249dc9a828"
 dependencies = [
  "bitflags",
  "log",
@@ -910,28 +927,11 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "644.0.0"
+version = "647.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b029cc11516918c37b55230edbfc693dabbe1481013cadc506bdd345e63587"
+checksum = "25317d226bf1d0243d4df231edcc9bf1c0e40c503ef0290cc7aa5658d3819915"
 dependencies = [
  "indexmap",
- "smallvec 1.1.0",
-]
-
-[[package]]
-name = "rustc-ap-syntax"
-version = "644.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478155ef59211e934a79bd1ed4dbbbb5d1226bd8921e2aa7edb23d8f5f8d1080"
-dependencies = [
- "log",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_index",
- "rustc-ap-rustc_lexer",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_span",
- "rustc-ap-serialize",
- "scoped-tls",
  "smallvec 1.1.0",
 ]
 
@@ -1055,13 +1055,13 @@ dependencies = [
  "lazy_static",
  "log",
  "regex",
+ "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_parse",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
- "rustc-ap-syntax",
  "rustfmt_configuration",
  "rustfmt_emitter",
  "term",

--- a/rustfmt-core/rustfmt-config/Cargo.toml
+++ b/rustfmt-core/rustfmt-config/Cargo.toml
@@ -19,5 +19,5 @@ toml = "0.5"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "650.0.0"
+version = "651.0.0"
 

--- a/rustfmt-core/rustfmt-config/Cargo.toml
+++ b/rustfmt-core/rustfmt-config/Cargo.toml
@@ -19,5 +19,5 @@ toml = "0.5"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "647.0.0"
+version = "650.0.0"
 

--- a/rustfmt-core/rustfmt-config/Cargo.toml
+++ b/rustfmt-core/rustfmt-config/Cargo.toml
@@ -19,5 +19,5 @@ toml = "0.5"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "644.0.0"
+version = "647.0.0"
 

--- a/rustfmt-core/rustfmt-config/Cargo.toml
+++ b/rustfmt-core/rustfmt-config/Cargo.toml
@@ -19,5 +19,5 @@ toml = "0.5"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "642.0.0"
+version = "644.0.0"
 

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -32,32 +32,32 @@ env_logger = "0.7"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "650.0.0"
+version = "651.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "650.0.0"
+version = "651.0.0"

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -30,6 +30,10 @@ unicode-width = "0.1.5"
 [dev-dependencies]
 env_logger = "0.7"
 
+[dependencies.rustc_ast]
+package = "rustc-ap-rustc_ast"
+version = "647.0.0"
+
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
 version = "647.0.0"
@@ -53,8 +57,3 @@ version = "647.0.0"
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
 version = "647.0.0"
-
-[dependencies.syntax]
-package = "rustc-ap-rustc_ast"
-version = "647.0.0"
-

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -32,29 +32,29 @@ env_logger = "0.7"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "642.0.0"
+version = "644.0.0"
 
 [dependencies.syntax]
 package = "rustc-ap-syntax"
-version = "642.0.0"
+version = "644.0.0"
 

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -32,29 +32,29 @@ env_logger = "0.7"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "644.0.0"
+version = "647.0.0"
 
 [dependencies.syntax]
-package = "rustc-ap-syntax"
-version = "644.0.0"
+package = "rustc-ap-rustc_ast"
+version = "647.0.0"
 

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -32,28 +32,32 @@ env_logger = "0.7"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "647.0.0"
+version = "650.0.0"
+
+[dependencies.rustc_expand]
+package = "rustc-ap-rustc_expand"
+version = "650.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "647.0.0"
+version = "650.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "647.0.0"
+version = "650.0.0"

--- a/rustfmt-core/rustfmt-lib/src/attr.rs
+++ b/rustfmt-core/rustfmt-lib/src/attr.rs
@@ -28,7 +28,7 @@ pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
         ast::StmtKind::Local(ref local) => local.span,
         ast::StmtKind::Item(ref item) => item.span,
         ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => expr.span,
-        ast::StmtKind::Mac(ref mac) => {
+        ast::StmtKind::MacCall(ref mac) => {
             let (ref mac, _, _) = **mac;
             mac.span()
         }

--- a/rustfmt-core/rustfmt-lib/src/attr.rs
+++ b/rustfmt-core/rustfmt-lib/src/attr.rs
@@ -1,8 +1,8 @@
 //! Format attributes and meta items.
 
+use rustc_ast::ast;
+use rustc_ast::attr::HasAttrs;
 use rustc_span::{symbol::sym, BytePos, Span, DUMMY_SP};
-use syntax::ast;
-use syntax::attr::HasAttrs;
 
 use self::doc_comment::DocCommentFormatter;
 use crate::comment::{contains_comment, rewrite_doc_comment, CommentStyle};

--- a/rustfmt-core/rustfmt-lib/src/attr.rs
+++ b/rustfmt-core/rustfmt-lib/src/attr.rs
@@ -2,6 +2,7 @@
 
 use rustc_span::{symbol::sym, BytePos, Span, DUMMY_SP};
 use syntax::ast;
+use syntax::attr::HasAttrs;
 
 use self::doc_comment::DocCommentFormatter;
 use crate::comment::{contains_comment, rewrite_doc_comment, CommentStyle};
@@ -19,12 +20,7 @@ mod doc_comment;
 
 /// Returns attributes on the given statement.
 pub(crate) fn get_attrs_from_stmt(stmt: &ast::Stmt) -> &[ast::Attribute] {
-    match stmt.kind {
-        ast::StmtKind::Local(ref local) => &local.attrs,
-        ast::StmtKind::Item(ref item) => &item.attrs,
-        ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => &expr.attrs,
-        ast::StmtKind::Mac(ref mac) => &mac.2,
-    }
+    stmt.attrs()
 }
 
 pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
@@ -36,6 +32,7 @@ pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
             let (ref mac, _, _) = **mac;
             mac.span()
         }
+        ast::StmtKind::Empty => stmt.span,
     }
 }
 

--- a/rustfmt-core/rustfmt-lib/src/chains.rs
+++ b/rustfmt-core/rustfmt-lib/src/chains.rs
@@ -396,7 +396,7 @@ impl Chain {
 
     fn convert_try(expr: &ast::Expr, context: &RewriteContext<'_>) -> ast::Expr {
         match expr.kind {
-            ast::ExprKind::Mac(ref mac) if context.config.use_try_shorthand() => {
+            ast::ExprKind::MacCall(ref mac) if context.config.use_try_shorthand() => {
                 if let Some(subexpr) = convert_try_mac(mac, context) {
                     subexpr
                 } else {

--- a/rustfmt-core/rustfmt-lib/src/chains.rs
+++ b/rustfmt-core/rustfmt-lib/src/chains.rs
@@ -58,8 +58,8 @@
 use std::borrow::Cow;
 use std::cmp::min;
 
+use rustc_ast::{ast, ptr};
 use rustc_span::{BytePos, Span};
-use syntax::{ast, ptr};
 
 use crate::comment::{rewrite_comment, CharClasses, FullCodeCharKind, RichChar};
 use crate::config::IndentStyle;

--- a/rustfmt-core/rustfmt-lib/src/chains.rs
+++ b/rustfmt-core/rustfmt-lib/src/chains.rs
@@ -148,7 +148,15 @@ impl ChainItemKind {
             ast::ExprKind::MethodCall(ref segment, ref expressions) => {
                 let types = if let Some(ref generic_args) = segment.args {
                     if let ast::GenericArgs::AngleBracketed(ref data) = **generic_args {
-                        data.args.clone()
+                        data.args
+                            .iter()
+                            .filter_map(|x| match x {
+                                ast::AngleBracketedArg::Arg(ref generic_arg) => {
+                                    Some(generic_arg.clone())
+                                }
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
                     } else {
                         vec![]
                     }

--- a/rustfmt-core/rustfmt-lib/src/closures.rs
+++ b/rustfmt-core/rustfmt-lib/src/closures.rs
@@ -25,7 +25,7 @@ use crate::utils::{last_line_width, left_most_sub_expr, stmt_expr, NodeIdExt};
 
 pub(crate) fn rewrite_closure(
     capture: ast::CaptureBy,
-    is_async: &ast::IsAsync,
+    is_async: &ast::Async,
     movability: ast::Movability,
     fn_decl: &ast::FnDecl,
     body: &ast::Expr,
@@ -50,7 +50,7 @@ pub(crate) fn rewrite_closure(
         }
 
         let result = match fn_decl.output {
-            ast::FunctionRetTy::Default(_) if !context.inside_macro() => {
+            ast::FnRetTy::Default(_) if !context.inside_macro() => {
                 try_rewrite_without_block(body, &prefix, capture, context, shape, body_shape)
             }
             _ => None,
@@ -222,7 +222,7 @@ fn rewrite_closure_block(
 // Return type is (prefix, extra_offset)
 fn rewrite_closure_fn_decl(
     capture: ast::CaptureBy,
-    asyncness: &ast::IsAsync,
+    asyncness: &ast::Async,
     movability: ast::Movability,
     fn_decl: &ast::FnDecl,
     body: &ast::Expr,

--- a/rustfmt-core/rustfmt-lib/src/closures.rs
+++ b/rustfmt-core/rustfmt-lib/src/closures.rs
@@ -1,5 +1,5 @@
+use rustc_ast::{ast, ptr};
 use rustc_span::Span;
-use syntax::{ast, ptr};
 
 use crate::attr::get_attrs_from_stmt;
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -1192,14 +1192,18 @@ pub(crate) fn is_simple_block_stmt(
 
 fn block_has_statements(block: &ast::Block) -> bool {
     block.stmts.iter().any(|stmt| {
-        if let ast::StmtKind::Semi(ref expr) = stmt.kind {
-            if let ast::ExprKind::Tup(ref tup_exprs) = expr.kind {
-                if tup_exprs.is_empty() {
-                    return false;
+        match stmt.kind {
+            ast::StmtKind::Semi(ref expr) => {
+                if let ast::ExprKind::Tup(ref tup_exprs) = expr.kind {
+                    if tup_exprs.is_empty() {
+                        return false;
+                    }
                 }
+                true
             }
+            ast::StmtKind::Empty => false,
+            _ => true,
         }
-        true
     })
 }
 

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::cmp::min;
 
 use itertools::Itertools;
+use rustc_ast::token::{DelimToken, LitKind};
+use rustc_ast::{ast, ptr};
 use rustc_span::{BytePos, Span};
-use syntax::token::{DelimToken, LitKind};
-use syntax::{ast, ptr};
 
 use crate::chains::rewrite_chain;
 use crate::closures;
@@ -1191,19 +1191,17 @@ pub(crate) fn is_simple_block_stmt(
 }
 
 fn block_has_statements(block: &ast::Block) -> bool {
-    block.stmts.iter().any(|stmt| {
-        match stmt.kind {
-            ast::StmtKind::Semi(ref expr) => {
-                if let ast::ExprKind::Tup(ref tup_exprs) = expr.kind {
-                    if tup_exprs.is_empty() {
-                        return false;
-                    }
+    block.stmts.iter().any(|stmt| match stmt.kind {
+        ast::StmtKind::Semi(ref expr) => {
+            if let ast::ExprKind::Tup(ref tup_exprs) = expr.kind {
+                if tup_exprs.is_empty() {
+                    return false;
                 }
-                true
             }
-            ast::StmtKind::Empty => false,
-            _ => true,
+            true
         }
+        ast::StmtKind::Empty => false,
+        _ => true,
     })
 }
 
@@ -1355,7 +1353,7 @@ pub(crate) fn can_be_overflowed_expr(
         }
         ast::ExprKind::Mac(ref mac) => {
             match (
-                syntax::ast::MacDelimiter::from_token(mac.args.delim()),
+                rustc_ast::ast::MacDelimiter::from_token(mac.args.delim()),
                 context.config.overflow_delimited_expr(),
             ) {
                 (Some(ast::MacDelimiter::Bracket), true)

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -320,7 +320,7 @@ pub(crate) fn format_expr(
         }
         // We do not format these expressions yet, but they should still
         // satisfy our width restrictions.
-        ast::ExprKind::InlineAsm(..) => Some(context.snippet(expr.span).to_owned()),
+        ast::ExprKind::LlvmInlineAsm(..) => Some(context.snippet(expr.span).to_owned()),
         ast::ExprKind::TryBlock(ref block) => {
             if let rw @ Some(_) =
                 rewrite_single_line_block(context, "try ", block, Some(&expr.attrs), None, shape)

--- a/rustfmt-core/rustfmt-lib/src/expr.rs
+++ b/rustfmt-core/rustfmt-lib/src/expr.rs
@@ -197,7 +197,7 @@ pub(crate) fn format_expr(
         ast::ExprKind::Try(..) | ast::ExprKind::Field(..) | ast::ExprKind::MethodCall(..) => {
             rewrite_chain(expr, context, shape)
         }
-        ast::ExprKind::Mac(ref mac) => {
+        ast::ExprKind::MacCall(ref mac) => {
             rewrite_macro(mac, None, context, shape, MacroPosition::Expression).or_else(|| {
                 wrap_str(
                     context.snippet(expr.span).to_owned(),
@@ -1351,7 +1351,7 @@ pub(crate) fn can_be_overflowed_expr(
             context.config.overflow_delimited_expr()
                 || (context.use_block_indent() && args_len == 1)
         }
-        ast::ExprKind::Mac(ref mac) => {
+        ast::ExprKind::MacCall(ref mac) => {
             match (
                 rustc_ast::ast::MacDelimiter::from_token(mac.args.delim()),
                 context.config.overflow_delimited_expr(),
@@ -1379,7 +1379,7 @@ pub(crate) fn can_be_overflowed_expr(
 
 pub(crate) fn is_nested_call(expr: &ast::Expr) -> bool {
     match expr.kind {
-        ast::ExprKind::Call(..) | ast::ExprKind::Mac(..) => true,
+        ast::ExprKind::Call(..) | ast::ExprKind::MacCall(..) => true,
         ast::ExprKind::AddrOf(_, _, ref expr)
         | ast::ExprKind::Box(ref expr)
         | ast::ExprKind::Try(ref expr)

--- a/rustfmt-core/rustfmt-lib/src/formatting.rs
+++ b/rustfmt-core/rustfmt-lib/src/formatting.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 use std::time::{Duration, Instant};
 
+use rustc_ast::ast;
 use rustc_span::Span;
-use syntax::ast;
 
 use self::newline_style::apply_newline_style;
 use crate::comment::{CharClasses, FullCodeCharKind};
@@ -29,7 +29,7 @@ impl<'b, T: Write + 'b> Session<'b, T> {
             return Err(ErrorKind::VersionMismatch);
         }
 
-        syntax::with_globals(self.config.edition().into(), || {
+        rustc_ast::with_globals(self.config.edition().into(), || {
             if self.config.disable_all_formatting() {
                 // When the input is from stdin, echo back the input.
                 if let Input::Text(ref buf) = input {

--- a/rustfmt-core/rustfmt-lib/src/imports.rs
+++ b/rustfmt-core/rustfmt-lib/src/imports.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt;
 
+use rustc_ast::ast::{self, UseTreeKind};
 use rustc_span::{source_map, symbol::sym, BytePos, Span, DUMMY_SP};
-use syntax::ast::{self, UseTreeKind};
 
 use crate::comment::combine_strs_with_missing_comments;
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -356,7 +356,7 @@ impl<'a> FmtVisitor<'a> {
 
     fn format_foreign_item(&mut self, item: &ast::ForeignItem) {
         let rewrite = item.rewrite(&self.get_context(), self.shape());
-        self.push_rewrite(item.span(), rewrite);
+        self.push_rewrite(item.span, rewrite);
         self.last_pos = item.span.hi();
     }
 
@@ -681,7 +681,7 @@ impl<'a> FmtVisitor<'a> {
             use crate::ast::AssocItemKind::*;
             fn need_empty_line(a: &ast::AssocItemKind, b: &ast::AssocItemKind) -> bool {
                 match (a, b) {
-                    (TyAlias(_, ref lty), TyAlias(_, ref rty))
+                    (TyAlias(_, _, _, ref lty), TyAlias(_, _, _, ref rty))
                         if both_type(lty, rty) || both_opaque(lty, rty) =>
                     {
                         false
@@ -692,7 +692,7 @@ impl<'a> FmtVisitor<'a> {
             }
 
             buffer.sort_by(|(_, a), (_, b)| match (&a.kind, &b.kind) {
-                (TyAlias(_, ref lty), TyAlias(_, ref rty))
+                (TyAlias(_, _, _, ref lty), TyAlias(_, _, _, ref rty))
                     if both_type(lty, rty) || both_opaque(lty, rty) =>
                 {
                     a.ident.as_str().cmp(&b.ident.as_str())
@@ -701,8 +701,8 @@ impl<'a> FmtVisitor<'a> {
                     a.ident.as_str().cmp(&b.ident.as_str())
                 }
                 (Fn(..), Fn(..)) => a.span.lo().cmp(&b.span.lo()),
-                (TyAlias(_, ref ty), _) if is_type(ty) => Ordering::Less,
-                (_, TyAlias(_, ref ty)) if is_type(ty) => Ordering::Greater,
+                (TyAlias(_, _, _, ref ty), _) if is_type(ty) => Ordering::Less,
+                (_, TyAlias(_, _, _, ref ty)) if is_type(ty) => Ordering::Greater,
                 (TyAlias(..), _) => Ordering::Less,
                 (_, TyAlias(..)) => Ordering::Greater,
                 (Const(..), _) => Ordering::Less,
@@ -1760,9 +1760,13 @@ pub(crate) struct StaticParts<'a> {
 
 impl<'a> StaticParts<'a> {
     pub(crate) fn from_item(item: &'a ast::Item) -> Self {
-        let (prefix, ty, mutability, expr) = match item.kind {
-            ast::ItemKind::Static(ref ty, mutability, ref expr) => ("static", ty, mutability, expr),
-            ast::ItemKind::Const(ref ty, ref expr) => ("const", ty, ast::Mutability::Not, expr),
+        let (defaultness, prefix, ty, mutability, expr) = match item.kind {
+            ast::ItemKind::Static(ref ty, mutability, ref expr) => {
+                (None, "static", ty, mutability, expr)
+            }
+            ast::ItemKind::Const(defaultness, ref ty, ref expr) => {
+                (Some(defaultness), "const", ty, ast::Mutability::Not, expr)
+            }
             _ => unreachable!(),
         };
         StaticParts {
@@ -1771,15 +1775,17 @@ impl<'a> StaticParts<'a> {
             ident: item.ident,
             ty,
             mutability,
-            expr_opt: Some(expr),
-            defaultness: None,
+            expr_opt: expr.as_ref(),
+            defaultness,
             span: item.span,
         }
     }
 
     pub(crate) fn from_trait_item(ti: &'a ast::AssocItem) -> Self {
-        let (ty, expr_opt) = match ti.kind {
-            ast::AssocItemKind::Const(ref ty, ref expr_opt) => (ty, expr_opt),
+        let (defaultness, ty, expr_opt) = match ti.kind {
+            ast::AssocItemKind::Const(defaultness, ref ty, ref expr_opt) => {
+                (defaultness, ty, expr_opt)
+            }
             _ => unreachable!(),
         };
         StaticParts {
@@ -1789,14 +1795,14 @@ impl<'a> StaticParts<'a> {
             ty,
             mutability: ast::Mutability::Not,
             expr_opt: expr_opt.as_ref(),
-            defaultness: None,
+            defaultness: Some(defaultness),
             span: ti.span,
         }
     }
 
     pub(crate) fn from_impl_item(ii: &'a ast::AssocItem) -> Self {
-        let (ty, expr) = match ii.kind {
-            ast::AssocItemKind::Const(ref ty, ref expr) => (ty, expr),
+        let (defaultness, ty, expr) = match ii.kind {
+            ast::AssocItemKind::Const(defaultness, ref ty, ref expr) => (defaultness, ty, expr),
             _ => unreachable!(),
         };
         StaticParts {
@@ -1806,7 +1812,7 @@ impl<'a> StaticParts<'a> {
             ty,
             mutability: ast::Mutability::Not,
             expr_opt: expr.as_ref(),
-            defaultness: Some(ii.defaultness),
+            defaultness: Some(defaultness),
             span: ii.span,
         }
     }
@@ -1970,7 +1976,7 @@ pub(crate) fn rewrite_associated_impl_type(
     let result = rewrite_associated_type(ident, ty_opt, generics, None, context, indent)?;
 
     match defaultness {
-        ast::Defaultness::Default => Some(format!("default {}", result)),
+        ast::Defaultness::Default(..) => Some(format!("default {}", result)),
         _ => Some(result),
     }
 }
@@ -3121,7 +3127,7 @@ impl Rewrite for ast::ForeignItem {
         let span = mk_sp(self.span.lo(), self.span.hi() - BytePos(1));
 
         let item_str = match self.kind {
-            ast::ForeignItemKind::Fn(ref fn_sig, ref generics, _) => rewrite_fn_base(
+            ast::ForeignItemKind::Fn(_, ref fn_sig, ref generics, _) => rewrite_fn_base(
                 context,
                 shape.indent,
                 self.ident,
@@ -3130,7 +3136,7 @@ impl Rewrite for ast::ForeignItem {
                 FnBraceStyle::None,
             )
             .map(|(s, _)| format!("{};", s)),
-            ast::ForeignItemKind::Static(ref ty, mutability) => {
+            ast::ForeignItemKind::Static(ref ty, mutability, _) => {
                 // FIXME(#21): we're dropping potential comments in between the
                 // function kw here.
                 let vis = format_visibility(context, &self.vis);
@@ -3144,7 +3150,7 @@ impl Rewrite for ast::ForeignItem {
                 // 1 = ;
                 rewrite_assign_rhs(context, prefix, &**ty, shape.sub_width(1)?).map(|s| s + ";")
             }
-            ast::ForeignItemKind::Ty => {
+            ast::ForeignItemKind::TyAlias(..) => {
                 let vis = format_visibility(context, &self.vis);
                 Some(format!(
                     "{}type {};",

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -223,10 +223,10 @@ pub(crate) struct FnSig<'a> {
     decl: &'a ast::FnDecl,
     generics: &'a ast::Generics,
     ext: ast::Extern,
-    is_async: Cow<'a, ast::IsAsync>,
-    constness: ast::Constness,
+    is_async: Cow<'a, ast::Async>,
+    constness: ast::Const,
     defaultness: ast::Defaultness,
-    unsafety: ast::Unsafety,
+    unsafety: ast::Unsafe,
     visibility: ast::Visibility,
 }
 
@@ -240,10 +240,10 @@ impl<'a> FnSig<'a> {
             decl,
             generics,
             ext: ast::Extern::None,
-            is_async: Cow::Owned(ast::IsAsync::NotAsync),
-            constness: ast::Constness::NotConst,
+            is_async: Cow::Owned(ast::Async::No),
+            constness: ast::Const::No,
             defaultness: ast::Defaultness::Final,
-            unsafety: ast::Unsafety::Normal,
+            unsafety: ast::Unsafe::No,
             visibility: vis,
         }
     }
@@ -254,8 +254,8 @@ impl<'a> FnSig<'a> {
     ) -> FnSig<'a> {
         FnSig {
             unsafety: method_sig.header.unsafety,
-            is_async: Cow::Borrowed(&method_sig.header.asyncness.node),
-            constness: method_sig.header.constness.node,
+            is_async: Cow::Borrowed(&method_sig.header.asyncness),
+            constness: method_sig.header.constness,
             defaultness: ast::Defaultness::Final,
             ext: method_sig.header.ext,
             decl: &*method_sig.decl,
@@ -282,8 +282,8 @@ impl<'a> FnSig<'a> {
                     decl,
                     generics,
                     ext: fn_sig.header.ext,
-                    constness: fn_sig.header.constness.node,
-                    is_async: Cow::Borrowed(&fn_sig.header.asyncness.node),
+                    constness: fn_sig.header.constness,
+                    is_async: Cow::Borrowed(&fn_sig.header.asyncness),
                     defaultness,
                     unsafety: fn_sig.header.unsafety,
                     visibility: vis.clone(),
@@ -1975,11 +1975,11 @@ pub(crate) fn rewrite_associated_impl_type(
     }
 }
 
-impl Rewrite for ast::FunctionRetTy {
+impl Rewrite for ast::FnRetTy {
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
         match *self {
-            ast::FunctionRetTy::Default(_) => Some(String::new()),
-            ast::FunctionRetTy::Ty(ref ty) => {
+            ast::FnRetTy::Default(_) => Some(String::new()),
+            ast::FnRetTy::Ty(ref ty) => {
                 if context.config.indent_style() == IndentStyle::Visual {
                     let inner_width = shape.width.checked_sub(3)?;
                     return ty
@@ -2348,7 +2348,7 @@ fn rewrite_fn_base(
     }
 
     // Return type.
-    if let ast::FunctionRetTy::Ty(..) = fd.output {
+    if let ast::FnRetTy::Ty(..) = fd.output {
         let ret_should_indent = match context.config.indent_style() {
             // If our params are block layout then we surely must have space.
             IndentStyle::Block if put_params_in_block || fd.inputs.is_empty() => false,
@@ -2448,8 +2448,8 @@ fn rewrite_fn_base(
     }
 
     let pos_before_where = match fd.output {
-        ast::FunctionRetTy::Default(..) => params_span.hi(),
-        ast::FunctionRetTy::Ty(ref ty) => ty.span.hi(),
+        ast::FnRetTy::Default(..) => params_span.hi(),
+        ast::FnRetTy::Ty(ref ty) => ty.span.hi(),
     };
 
     let is_params_multi_lined = param_str.contains('\n');
@@ -2477,7 +2477,7 @@ fn rewrite_fn_base(
     // If there are neither where-clause nor return type, we may be missing comments between
     // params and `{`.
     if where_clause_str.is_empty() {
-        if let ast::FunctionRetTy::Default(ret_span) = fd.output {
+        if let ast::FnRetTy::Default(ret_span) = fd.output {
             match recover_missing_comment_in_span(
                 mk_sp(params_span.hi(), ret_span.hi()),
                 shape,

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -356,8 +356,14 @@ impl<'a> FmtVisitor<'a> {
 
     fn format_foreign_item(&mut self, item: &ast::ForeignItem) {
         let rewrite = item.rewrite(&self.get_context(), self.shape());
-        self.push_rewrite(item.span, rewrite);
-        self.last_pos = item.span.hi();
+        let hi = item.span.hi();
+        let span = if item.attrs.is_empty() {
+            item.span
+        } else {
+            mk_sp(item.attrs[0].span.lo(), hi)
+        };
+        self.push_rewrite(span, rewrite);
+        self.last_pos = hi;
     }
 
     pub(crate) fn rewrite_fn_before_block(

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -703,7 +703,7 @@ impl<'a> FmtVisitor<'a> {
                 {
                     a.ident.as_str().cmp(&b.ident.as_str())
                 }
-                (Const(..), Const(..)) | (Macro(..), Macro(..)) => {
+                (Const(..), Const(..)) | (MacCall(..), MacCall(..)) => {
                     a.ident.as_str().cmp(&b.ident.as_str())
                 }
                 (Fn(..), Fn(..)) => a.span.lo().cmp(&b.span.lo()),
@@ -713,8 +713,8 @@ impl<'a> FmtVisitor<'a> {
                 (_, TyAlias(..)) => Ordering::Greater,
                 (Const(..), _) => Ordering::Less,
                 (_, Const(..)) => Ordering::Greater,
-                (Macro(..), _) => Ordering::Less,
-                (_, Macro(..)) => Ordering::Greater,
+                (MacCall(..), _) => Ordering::Less,
+                (_, MacCall(..)) => Ordering::Greater,
             });
             let mut prev_kind = None;
             for (buf, item) in buffer {
@@ -918,10 +918,9 @@ fn format_impl_ref_and_type(
         let generics_str = rewrite_generics(context, "impl", generics, shape)?;
         result.push_str(&generics_str);
 
-        let polarity_str = if polarity == ast::ImplPolarity::Negative {
-            "!"
-        } else {
-            ""
+        let polarity_str = match polarity {
+            ast::ImplPolarity::Negative(_) => "!",
+            ast::ImplPolarity::Positive => "",
         };
 
         if let Some(ref trait_ref) = *trait_ref {
@@ -3164,7 +3163,7 @@ impl Rewrite for ast::ForeignItem {
                     rewrite_ident(context, self.ident)
                 ))
             }
-            ast::ForeignItemKind::Macro(ref mac) => {
+            ast::ForeignItemKind::MacCall(ref mac) => {
                 rewrite_macro(mac, None, context, shape, MacroPosition::Item)
             }
         }?;

--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -4,9 +4,9 @@ use std::borrow::Cow;
 use std::cmp::{max, min, Ordering};
 
 use regex::Regex;
+use rustc_ast::visit;
+use rustc_ast::{ast, ptr};
 use rustc_span::{source_map, symbol, BytePos, Span, DUMMY_SP};
-use syntax::visit;
-use syntax::{ast, ptr};
 
 use crate::attr::filter_inline_attrs;
 use crate::comment::{
@@ -652,14 +652,14 @@ impl<'a> FmtVisitor<'a> {
                 self.buffer.clear();
             }
 
-            fn is_type(ty: &Option<syntax::ptr::P<ast::Ty>>) -> bool {
+            fn is_type(ty: &Option<rustc_ast::ptr::P<ast::Ty>>) -> bool {
                 match ty {
                     None => true,
                     Some(lty) => lty.kind.opaque_top_hack().is_none(),
                 }
             }
 
-            fn is_opaque(ty: &Option<syntax::ptr::P<ast::Ty>>) -> bool {
+            fn is_opaque(ty: &Option<rustc_ast::ptr::P<ast::Ty>>) -> bool {
                 match ty {
                     None => false,
                     Some(lty) => lty.kind.opaque_top_hack().is_some(),
@@ -667,15 +667,15 @@ impl<'a> FmtVisitor<'a> {
             }
 
             fn both_type(
-                a: &Option<syntax::ptr::P<ast::Ty>>,
-                b: &Option<syntax::ptr::P<ast::Ty>>,
+                a: &Option<rustc_ast::ptr::P<ast::Ty>>,
+                b: &Option<rustc_ast::ptr::P<ast::Ty>>,
             ) -> bool {
                 is_type(a) && is_type(b)
             }
 
             fn both_opaque(
-                a: &Option<syntax::ptr::P<ast::Ty>>,
-                b: &Option<syntax::ptr::P<ast::Ty>>,
+                a: &Option<rustc_ast::ptr::P<ast::Ty>>,
+                b: &Option<rustc_ast::ptr::P<ast::Ty>>,
             ) -> bool {
                 is_opaque(a) && is_opaque(b)
             }

--- a/rustfmt-core/rustfmt-lib/src/lib.rs
+++ b/rustfmt-core/rustfmt-lib/src/lib.rs
@@ -15,8 +15,8 @@ use std::panic;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use rustc_ast::ast;
 use rustfmt_configuration as config;
-use syntax::ast;
 use thiserror::Error;
 
 use crate::comment::LineClasses;

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -230,7 +230,7 @@ fn check_keyword<'a, 'b: 'a>(parser: &'a mut Parser<'b>) -> Option<MacroArg> {
             parser.bump();
             return Some(MacroArg::Keyword(
                 ast::Ident::with_dummy_span(keyword),
-                parser.prev_span,
+                parser.prev_token.span,
             ));
         }
     }
@@ -1492,7 +1492,8 @@ fn format_lazy_static(
         )?);
         result.push(';');
         if parser.token.kind != TokenKind::Eof {
-            let snippet = context.snippet(mk_sp(parser.prev_span.hi(), parser.token.span.lo()));
+            let snippet =
+                context.snippet(mk_sp(parser.prev_token.span.hi(), parser.token.span.lo()));
             if count_newlines(snippet) >= 2 {
                 result.push('\n');
             }

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -12,12 +12,12 @@
 use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
+use rustc_ast::token::{BinOpToken, DelimToken, Token, TokenKind};
+use rustc_ast::tokenstream::{Cursor, TokenStream, TokenTree};
+use rustc_ast::{ast, ptr};
 use rustc_ast_pretty::pprust;
 use rustc_parse::{new_parser_from_tts, parser::Parser};
 use rustc_span::{symbol::kw, BytePos, Span, Symbol, DUMMY_SP};
-use syntax::token::{BinOpToken, DelimToken, Token, TokenKind};
-use syntax::tokenstream::{Cursor, TokenStream, TokenTree};
-use syntax::{ast, ptr};
 
 use crate::comment::{
     contains_comment, CharClasses, FindUncommented, FullCodeCharKind, LineClasses,

--- a/rustfmt-core/rustfmt-lib/src/macros.rs
+++ b/rustfmt-core/rustfmt-lib/src/macros.rs
@@ -187,7 +187,7 @@ fn return_macro_parse_failure_fallback(
 }
 
 pub(crate) fn rewrite_macro(
-    mac: &ast::Mac,
+    mac: &ast::MacCall,
     extra_ident: Option<ast::Ident>,
     context: &RewriteContext<'_>,
     shape: Shape,
@@ -238,7 +238,7 @@ fn check_keyword<'a, 'b: 'a>(parser: &'a mut Parser<'b>) -> Option<MacroArg> {
 }
 
 fn rewrite_macro_inner(
-    mac: &ast::Mac,
+    mac: &ast::MacCall,
     extra_ident: Option<ast::Ident>,
     context: &RewriteContext<'_>,
     shape: Shape,
@@ -493,7 +493,7 @@ pub(crate) fn rewrite_macro_def(
         None => return snippet,
     };
 
-    let mut result = if def.legacy {
+    let mut result = if def.macro_rules {
         String::from("macro_rules!")
     } else {
         format!("{}macro", format_visibility(context, vis))
@@ -502,7 +502,7 @@ pub(crate) fn rewrite_macro_def(
     result += " ";
     result += rewrite_ident(context, ident);
 
-    let multi_branch_style = def.legacy || parsed_def.branches.len() != 1;
+    let multi_branch_style = def.macro_rules || parsed_def.branches.len() != 1;
 
     let arm_shape = if multi_branch_style {
         shape
@@ -535,7 +535,7 @@ pub(crate) fn rewrite_macro_def(
     .collect::<Vec<_>>();
 
     let fmt = ListFormatting::new(arm_shape, context.config)
-        .separator(if def.legacy { ";" } else { "" })
+        .separator(if def.macro_rules { ";" } else { "" })
         .trailing_separator(SeparatorTactic::Always)
         .preserve_newline(true);
 
@@ -1184,7 +1184,10 @@ fn next_space(tok: &TokenKind) -> SpaceState {
 /// Tries to convert a macro use into a short hand try expression. Returns `None`
 /// when the macro is not an instance of `try!` (or parsing the inner expression
 /// failed).
-pub(crate) fn convert_try_mac(mac: &ast::Mac, context: &RewriteContext<'_>) -> Option<ast::Expr> {
+pub(crate) fn convert_try_mac(
+    mac: &ast::MacCall,
+    context: &RewriteContext<'_>,
+) -> Option<ast::Expr> {
     // The `try!` macro was deprecated in Rust 1.39.0 and `try` is a
     // reserved keyword in the 2018 Edition so the raw identifier
     // `r#try!` must be used in the 2018 Edition.
@@ -1210,7 +1213,7 @@ pub(crate) fn convert_try_mac(mac: &ast::Mac, context: &RewriteContext<'_>) -> O
     }
 }
 
-pub(crate) fn macro_style(mac: &ast::Mac, context: &RewriteContext<'_>) -> DelimToken {
+pub(crate) fn macro_style(mac: &ast::MacCall, context: &RewriteContext<'_>) -> DelimToken {
     let snippet = context.snippet(mac.span());
     let paren_pos = snippet.find_uncommented("(").unwrap_or(usize::max_value());
     let bracket_pos = snippet.find_uncommented("[").unwrap_or(usize::max_value());

--- a/rustfmt-core/rustfmt-lib/src/matches.rs
+++ b/rustfmt-core/rustfmt-lib/src/matches.rs
@@ -2,8 +2,8 @@
 
 use std::iter::repeat;
 
+use rustc_ast::{ast, ptr};
 use rustc_span::{BytePos, Span};
-use syntax::{ast, ptr};
 
 use crate::comment::{combine_strs_with_missing_comments, rewrite_comment};
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/matches.rs
+++ b/rustfmt-core/rustfmt-lib/src/matches.rs
@@ -572,7 +572,7 @@ fn can_flatten_block_around_this(body: &ast::Expr) -> bool {
         | ast::ExprKind::Array(..)
         | ast::ExprKind::Call(..)
         | ast::ExprKind::MethodCall(..)
-        | ast::ExprKind::Mac(..)
+        | ast::ExprKind::MacCall(..)
         | ast::ExprKind::Struct(..)
         | ast::ExprKind::Tup(..) => true,
         ast::ExprKind::AddrOf(_, _, ref expr)

--- a/rustfmt-core/rustfmt-lib/src/modules.rs
+++ b/rustfmt-core/rustfmt-lib/src/modules.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use rustc_ast::ast;
+use rustc_ast::visit::Visitor;
 use rustc_span::symbol::{sym, Symbol};
-use syntax::ast;
-use syntax::visit::Visitor;
 
 use crate::attr::MetaVisitor;
 use crate::config::FileName;

--- a/rustfmt-core/rustfmt-lib/src/modules.rs
+++ b/rustfmt-core/rustfmt-lib/src/modules.rs
@@ -32,7 +32,7 @@ pub(crate) struct ModResolver<'ast, 'sess> {
 #[derive(Clone)]
 enum SubModKind<'a, 'ast> {
     /// `mod foo;`
-    External(PathBuf, DirectoryOwnership),
+    External(PathBuf, DirectoryOwnership, Cow<'ast, ast::Mod>),
     /// `mod foo;` with multiple sources.
     MultiExternal(Vec<(PathBuf, DirectoryOwnership, Cow<'ast, ast::Mod>)>),
     /// `#[path = "..."] mod foo {}`
@@ -82,7 +82,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
 
     /// Visit `cfg_if` macro and look for module declarations.
     fn visit_cfg_if(&mut self, item: Cow<'ast, ast::Item>) -> Result<(), String> {
-        let mut visitor = visitor::CfgIfVisitor::new(self.parse_sess, &self.directory);
+        let mut visitor = visitor::CfgIfVisitor::new(self.parse_sess);
         visitor.visit_item(&item);
         for module_item in visitor.mods() {
             if let ast::ItemKind::Mod(ref sub_mod) = module_item.item.kind {
@@ -150,7 +150,6 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
             // mod foo;
             // Look for an extern file.
             self.find_external_module(item.ident, &item.attrs, sub_mod)
-                .map(Some)
         } else {
             // An internal module (`mod foo { /* ... */ }`);
             if let Some(path) = find_path_value(&item.attrs) {
@@ -165,15 +164,19 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
     fn insert_sub_mod(
         &mut self,
         sub_mod_kind: SubModKind<'c, 'ast>,
-        sub_mod: Cow<'ast, ast::Mod>,
+        _sub_mod: Cow<'ast, ast::Mod>,
     ) -> Result<(), String> {
         match sub_mod_kind {
-            SubModKind::External(mod_path, _) => {
-                self.file_map.insert(FileName::Real(mod_path), sub_mod);
+            SubModKind::External(mod_path, _, sub_mod) => {
+                self.file_map
+                    .entry(FileName::Real(mod_path))
+                    .or_insert(sub_mod);
             }
             SubModKind::MultiExternal(mods) => {
                 for (mod_path, _, sub_mod) in mods {
-                    self.file_map.insert(FileName::Real(mod_path), sub_mod);
+                    self.file_map
+                        .entry(FileName::Real(mod_path))
+                        .or_insert(sub_mod);
                 }
             }
             _ => (),
@@ -187,7 +190,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         sub_mod_kind: SubModKind<'c, 'ast>,
     ) -> Result<(), String> {
         match sub_mod_kind {
-            SubModKind::External(mod_path, directory_ownership) => {
+            SubModKind::External(mod_path, directory_ownership, sub_mod) => {
                 let directory = Directory {
                     path: mod_path.parent().unwrap().to_path_buf(),
                     ownership: directory_ownership,
@@ -239,50 +242,87 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         mod_name: ast::Ident,
         attrs: &[ast::Attribute],
         sub_mod: &Cow<'ast, ast::Mod>,
-    ) -> Result<SubModKind<'c, 'ast>, String> {
+    ) -> Result<Option<SubModKind<'c, 'ast>>, String> {
+        let relative = match self.directory.ownership {
+            DirectoryOwnership::Owned { relative } => relative,
+            DirectoryOwnership::UnownedViaBlock | DirectoryOwnership::UnownedViaMod => None,
+        };
         if let Some(path) = Parser::submod_path_from_attr(attrs, &self.directory.path) {
-            return Ok(SubModKind::External(
-                path,
-                DirectoryOwnership::Owned { relative: None },
-            ));
+            if self.parse_sess.is_file_parsed(&path) {
+                return Ok(None);
+            }
+            return match Parser::parse_file_as_module(self.parse_sess, &path, sub_mod.inner) {
+                Some(m) => Ok(Some(SubModKind::External(
+                    path,
+                    DirectoryOwnership::Owned { relative: None },
+                    Cow::Owned(m),
+                ))),
+                None => Err(format!(
+                    "Failed to find module {} in {:?} {:?}",
+                    mod_name, self.directory.path, relative,
+                )),
+            };
         }
 
         // Look for nested path, like `#[cfg_attr(feature = "foo", path = "bar.rs")]`.
         let mut mods_outside_ast = self.find_mods_outside_of_ast(attrs, sub_mod);
 
-        let relative = match self.directory.ownership {
-            DirectoryOwnership::Owned { relative } => relative,
-            DirectoryOwnership::UnownedViaBlock | DirectoryOwnership::UnownedViaMod => None,
-        };
         match self
             .parse_sess
             .default_submod_path(mod_name, relative, &self.directory.path)
             .result
         {
             Ok(ModulePathSuccess {
-                path,
-                directory_ownership,
-                ..
+                path, ownership, ..
             }) => {
-                if mods_outside_ast.is_empty() {
-                    Ok(SubModKind::External(path, directory_ownership))
-                } else {
-                    let should_insert = !mods_outside_ast
-                        .iter()
-                        .any(|(outside_path, _, _)| outside_path == &path);
-                    if should_insert {
-                        mods_outside_ast.push((path, directory_ownership, sub_mod.clone()));
+                let outside_mods_empty = mods_outside_ast.is_empty();
+                let should_insert = !mods_outside_ast
+                    .iter()
+                    .any(|(outside_path, _, _)| outside_path == &path);
+                if self.parse_sess.is_file_parsed(&path) {
+                    if outside_mods_empty {
+                        return Ok(None);
+                    } else {
+                        if should_insert {
+                            mods_outside_ast.push((path, ownership, sub_mod.clone()));
+                        }
+                        return Ok(Some(SubModKind::MultiExternal(mods_outside_ast)));
                     }
-                    Ok(SubModKind::MultiExternal(mods_outside_ast))
+                }
+                match Parser::parse_file_as_module(self.parse_sess, &path, sub_mod.inner) {
+                    Some(m) if outside_mods_empty => {
+                        Ok(Some(SubModKind::External(path, ownership, Cow::Owned(m))))
+                    }
+                    Some(m) => {
+                        mods_outside_ast.push((path.clone(), ownership, Cow::Owned(m)));
+                        if should_insert {
+                            mods_outside_ast.push((path, ownership, sub_mod.clone()));
+                        }
+                        Ok(Some(SubModKind::MultiExternal(mods_outside_ast)))
+                    }
+                    None if outside_mods_empty => Err(format!(
+                        "Failed to find module {} in {:?} {:?}",
+                        mod_name, self.directory.path, relative,
+                    )),
+                    None => {
+                        if should_insert {
+                            mods_outside_ast.push((path, ownership, sub_mod.clone()));
+                        }
+                        Ok(Some(SubModKind::MultiExternal(mods_outside_ast)))
+                    }
                 }
             }
-            Err(_) if !mods_outside_ast.is_empty() => {
-                Ok(SubModKind::MultiExternal(mods_outside_ast))
+            Err(mut e) if !mods_outside_ast.is_empty() => {
+                e.cancel();
+                Ok(Some(SubModKind::MultiExternal(mods_outside_ast)))
             }
-            Err(_) => Err(format!(
-                "Failed to find module {} in {:?} {:?}",
-                mod_name, self.directory.path, relative,
-            )),
+            Err(mut e) => {
+                e.cancel();
+                Err(format!(
+                    "Failed to find module {} in {:?} {:?}",
+                    mod_name, self.directory.path, relative,
+                ))
+            }
         }
     }
 
@@ -338,11 +378,8 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                 continue;
             }
 
-            let m = match Parser::parse_file_as_module(
-                self.directory.ownership,
-                self.parse_sess,
-                &actual_path,
-            ) {
+            let m = match Parser::parse_file_as_module(self.parse_sess, &actual_path, sub_mod.inner)
+            {
                 Some(m) => m,
                 None => continue,
             };
@@ -374,7 +411,7 @@ fn find_path_value(attrs: &[ast::Attribute]) -> Option<Symbol> {
 
 fn is_cfg_if(item: &ast::Item) -> bool {
     match item.kind {
-        ast::ItemKind::Mac(ref mac) => {
+        ast::ItemKind::MacCall(ref mac) => {
             if let Some(first_segment) = mac.path.segments.first() {
                 if first_segment.ident.name == *CFG_IF {
                     return true;

--- a/rustfmt-core/rustfmt-lib/src/modules/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/modules/visitor.rs
@@ -1,6 +1,6 @@
+use rustc_ast::ast;
+use rustc_ast::visit::Visitor;
 use rustc_span::Symbol;
-use syntax::ast;
-use syntax::visit::Visitor;
 
 use crate::attr::MetaVisitor;
 use crate::syntux::parser::{Directory, Parser};

--- a/rustfmt-core/rustfmt-lib/src/modules/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/modules/visitor.rs
@@ -3,7 +3,7 @@ use rustc_ast::visit::Visitor;
 use rustc_span::Symbol;
 
 use crate::attr::MetaVisitor;
-use crate::syntux::parser::{Directory, Parser};
+use crate::syntux::parser::Parser;
 use crate::syntux::session::ParseSess;
 
 pub(crate) struct ModItem {
@@ -14,15 +14,13 @@ pub(crate) struct ModItem {
 pub(crate) struct CfgIfVisitor<'a> {
     parse_sess: &'a ParseSess,
     mods: Vec<ModItem>,
-    base_dir: &'a Directory,
 }
 
 impl<'a> CfgIfVisitor<'a> {
-    pub(crate) fn new(parse_sess: &'a ParseSess, base_dir: &'a Directory) -> CfgIfVisitor<'a> {
+    pub(crate) fn new(parse_sess: &'a ParseSess) -> CfgIfVisitor<'a> {
         CfgIfVisitor {
             mods: vec![],
             parse_sess,
-            base_dir,
         }
     }
 
@@ -32,7 +30,7 @@ impl<'a> CfgIfVisitor<'a> {
 }
 
 impl<'a, 'ast: 'a> Visitor<'ast> for CfgIfVisitor<'a> {
-    fn visit_mac(&mut self, mac: &'ast ast::Mac) {
+    fn visit_mac(&mut self, mac: &'ast ast::MacCall) {
         match self.visit_mac_inner(mac) {
             Ok(()) => (),
             Err(e) => debug!("{}", e),
@@ -41,7 +39,7 @@ impl<'a, 'ast: 'a> Visitor<'ast> for CfgIfVisitor<'a> {
 }
 
 impl<'a, 'ast: 'a> CfgIfVisitor<'a> {
-    fn visit_mac_inner(&mut self, mac: &'ast ast::Mac) -> Result<(), &'static str> {
+    fn visit_mac_inner(&mut self, mac: &'ast ast::MacCall) -> Result<(), &'static str> {
         // Support both:
         // ```
         // extern crate cfg_if;
@@ -64,7 +62,7 @@ impl<'a, 'ast: 'a> CfgIfVisitor<'a> {
             }
         };
 
-        let items = Parser::parse_cfg_if(self.parse_sess, mac, &self.base_dir)?;
+        let items = Parser::parse_cfg_if(self.parse_sess, mac)?;
         self.mods
             .append(&mut items.into_iter().map(|item| ModItem { item }).collect());
 

--- a/rustfmt-core/rustfmt-lib/src/overflow.rs
+++ b/rustfmt-core/rustfmt-lib/src/overflow.rs
@@ -3,9 +3,9 @@
 use std::cmp::min;
 
 use itertools::Itertools;
+use rustc_ast::token::DelimToken;
+use rustc_ast::{ast, ptr};
 use rustc_span::Span;
-use syntax::token::DelimToken;
-use syntax::{ast, ptr};
 
 use crate::closures;
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/pairs.rs
+++ b/rustfmt-core/rustfmt-lib/src/pairs.rs
@@ -1,4 +1,4 @@
-use syntax::ast;
+use rustc_ast::ast;
 
 use crate::config::lists::*;
 use crate::config::IndentStyle;

--- a/rustfmt-core/rustfmt-lib/src/patterns.rs
+++ b/rustfmt-core/rustfmt-lib/src/patterns.rs
@@ -40,7 +40,7 @@ fn is_short_pattern_inner(pat: &ast::Pat) -> bool {
         ast::PatKind::Rest | ast::PatKind::Wild | ast::PatKind::Lit(_) => true,
         ast::PatKind::Ident(_, _, ref pat) => pat.is_none(),
         ast::PatKind::Struct(..)
-        | ast::PatKind::Mac(..)
+        | ast::PatKind::MacCall(..)
         | ast::PatKind::Slice(..)
         | ast::PatKind::Path(..)
         | ast::PatKind::Range(..) => false,
@@ -247,7 +247,9 @@ impl Rewrite for Pat {
             PatKind::Struct(ref path, ref fields, ellipsis) => {
                 rewrite_struct_pat(path, fields, ellipsis, self.span, context, shape)
             }
-            PatKind::Mac(ref mac) => rewrite_macro(mac, None, context, shape, MacroPosition::Pat),
+            PatKind::MacCall(ref mac) => {
+                rewrite_macro(mac, None, context, shape, MacroPosition::Pat)
+            }
             PatKind::Paren(ref pat) => pat
                 .rewrite(context, shape.offset_left(1)?.sub_width(1)?)
                 .map(|inner_pat| format!("({})", inner_pat)),

--- a/rustfmt-core/rustfmt-lib/src/patterns.rs
+++ b/rustfmt-core/rustfmt-lib/src/patterns.rs
@@ -1,6 +1,6 @@
+use rustc_ast::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax};
+use rustc_ast::ptr;
 use rustc_span::{BytePos, Span};
-use syntax::ast::{self, BindingMode, FieldPat, Pat, PatKind, RangeEnd, RangeSyntax};
-use syntax::ptr;
 
 use crate::comment::{combine_strs_with_missing_comments, FindUncommented};
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/reorder.rs
+++ b/rustfmt-core/rustfmt-lib/src/reorder.rs
@@ -8,8 +8,8 @@
 
 use std::cmp::{Ord, Ordering};
 
+use rustc_ast::{ast, attr};
 use rustc_span::{symbol::sym, Span};
-use syntax::{ast, attr};
 
 use crate::config::Config;
 use crate::imports::{merge_use_trees, UseTree};

--- a/rustfmt-core/rustfmt-lib/src/rewrite.rs
+++ b/rustfmt-core/rustfmt-lib/src/rewrite.rs
@@ -3,8 +3,8 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
+use rustc_ast::ptr;
 use rustc_span::Span;
-use syntax::ptr;
 
 use crate::config::{Config, IndentStyle};
 use crate::shape::Shape;

--- a/rustfmt-core/rustfmt-lib/src/skip.rs
+++ b/rustfmt-core/rustfmt-lib/src/skip.rs
@@ -1,7 +1,7 @@
 //! Module that contains skip related stuffs.
 
+use rustc_ast::ast::{Attribute, PathSegment};
 use rustc_span::symbol::{sym, Symbol};
-use syntax::ast::{Attribute, PathSegment};
 
 macro_rules! sym {
     ($tt:tt) => {
@@ -29,7 +29,7 @@ impl SkipContext {
             }
         }
         for attr in attrs {
-            if let syntax::ast::AttrKind::Normal(ref attr_item) = &attr.kind {
+            if let rustc_ast::ast::AttrKind::Normal(ref attr_item) = &attr.kind {
                 if is_skip_attr_with(&attr_item.path.segments, |s| s == sym!(macros)) {
                     get_skip_names(&mut self.macros, attr)
                 } else if is_skip_attr_with(&attr_item.path.segments, |s| s == sym::attributes) {

--- a/rustfmt-core/rustfmt-lib/src/spanned.rs
+++ b/rustfmt-core/rustfmt-lib/src/spanned.rs
@@ -66,7 +66,7 @@ impl Spanned for ast::Stmt {
             ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => {
                 mk_sp(expr.span().lo(), self.span.hi())
             }
-            ast::StmtKind::Mac(ref mac) => {
+            ast::StmtKind::MacCall(ref mac) => {
                 let (_, _, ref attrs) = **mac;
                 if attrs.is_empty() {
                     self.span

--- a/rustfmt-core/rustfmt-lib/src/spanned.rs
+++ b/rustfmt-core/rustfmt-lib/src/spanned.rs
@@ -151,11 +151,11 @@ impl Spanned for ast::WherePredicate {
     }
 }
 
-impl Spanned for ast::FunctionRetTy {
+impl Spanned for ast::FnRetTy {
     fn span(&self) -> Span {
         match *self {
-            ast::FunctionRetTy::Default(span) => span,
-            ast::FunctionRetTy::Ty(ref ty) => ty.span,
+            ast::FnRetTy::Default(span) => span,
+            ast::FnRetTy::Ty(ref ty) => ty.span,
         }
     }
 }

--- a/rustfmt-core/rustfmt-lib/src/spanned.rs
+++ b/rustfmt-core/rustfmt-lib/src/spanned.rs
@@ -74,6 +74,7 @@ impl Spanned for ast::Stmt {
                     mk_sp(attrs[0].span.lo(), self.span.hi())
                 }
             }
+            ast::StmtKind::Empty => self.span,
         }
     }
 }

--- a/rustfmt-core/rustfmt-lib/src/spanned.rs
+++ b/rustfmt-core/rustfmt-lib/src/spanned.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 
+use rustc_ast::{ast, ptr};
 use rustc_span::{source_map, Span};
-use syntax::{ast, ptr};
 
 use crate::macros::MacroArg;
 use crate::utils::{mk_sp, outer_attributes};

--- a/rustfmt-core/rustfmt-lib/src/stmt.rs
+++ b/rustfmt-core/rustfmt-lib/src/stmt.rs
@@ -105,7 +105,7 @@ fn format_stmt(
             let shape = shape.sub_width(suffix.len())?;
             format_expr(ex, expr_type, context, shape).map(|s| s + suffix)
         }
-        ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) => None,
+        ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => None,
     };
     result.and_then(|res| recover_comment_removed(res, stmt.span(), context))
 }

--- a/rustfmt-core/rustfmt-lib/src/stmt.rs
+++ b/rustfmt-core/rustfmt-lib/src/stmt.rs
@@ -105,7 +105,7 @@ fn format_stmt(
             let shape = shape.sub_width(suffix.len())?;
             format_expr(ex, expr_type, context, shape).map(|s| s + suffix)
         }
-        ast::StmtKind::Mac(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => None,
+        ast::StmtKind::MacCall(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => None,
     };
     result.and_then(|res| recover_comment_removed(res, stmt.span(), context))
 }

--- a/rustfmt-core/rustfmt-lib/src/stmt.rs
+++ b/rustfmt-core/rustfmt-lib/src/stmt.rs
@@ -1,5 +1,5 @@
+use rustc_ast::ast;
 use rustc_span::Span;
-use syntax::ast;
 
 use crate::comment::recover_comment_removed;
 use crate::expr::{format_expr, ExprType};

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -21,9 +21,9 @@ pub(crate) struct Directory {
 }
 
 impl<'a> Directory {
-    fn to_syntax_directory(&'a self) -> rustc_parse::Directory<'a> {
+    fn to_syntax_directory(&'a self) -> rustc_parse::Directory {
         rustc_parse::Directory {
-            path: Cow::Borrowed(&self.path),
+            path: self.path.clone(),
             ownership: self.ownership,
         }
     }

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
@@ -178,7 +177,7 @@ impl<'a> Parser<'a> {
         let hi = if parser.token.span.is_dummy() {
             span
         } else {
-            parser.prev_span
+            parser.prev_token.span
         };
 
         Ok(ast::Mod {

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -4,28 +4,19 @@ use std::path::{Path, PathBuf};
 use rustc_ast::ast;
 use rustc_ast::token::{DelimToken, TokenKind};
 use rustc_errors::{Diagnostic, PResult};
-use rustc_parse::{new_sub_parser_from_file, parser::Parser as RawParser};
-use rustc_span::{symbol::kw, Span, DUMMY_SP};
+use rustc_parse::{new_parser_from_file, parser::Parser as RawParser};
+use rustc_span::{symbol::kw, Span};
 
 use crate::syntux::session::ParseSess;
 use crate::{Config, Input};
 
-pub(crate) type DirectoryOwnership = rustc_parse::DirectoryOwnership;
-pub(crate) type ModulePathSuccess = rustc_parse::parser::ModulePathSuccess;
+pub(crate) type DirectoryOwnership = rustc_expand::module::DirectoryOwnership;
+pub(crate) type ModulePathSuccess = rustc_expand::module::ModulePathSuccess;
 
 #[derive(Clone)]
 pub(crate) struct Directory {
     pub(crate) path: PathBuf,
     pub(crate) ownership: DirectoryOwnership,
-}
-
-impl<'a> Directory {
-    fn to_syntax_directory(&'a self) -> rustc_parse::Directory {
-        rustc_parse::Directory {
-            path: self.path.clone(),
-            ownership: self.ownership,
-        }
-    }
 }
 
 /// A parser for Rust source code.
@@ -68,11 +59,10 @@ impl<'a> ParserBuilder<'a> {
     }
 
     pub(crate) fn build(self) -> Result<Parser<'a>, ParserError> {
-        let config = self.config.ok_or(ParserError::NoConfig)?;
         let sess = self.sess.ok_or(ParserError::NoParseSess)?;
         let input = self.input.ok_or(ParserError::NoInput)?;
 
-        let mut parser = match Self::parser(sess.inner(), input, self.directory_ownership) {
+        let parser = match Self::parser(sess.inner(), input) {
             Ok(p) => p,
             Err(db) => {
                 sess.emit_diagnostics(db);
@@ -80,45 +70,26 @@ impl<'a> ParserBuilder<'a> {
             }
         };
 
-        parser.cfg_mods = false;
-        parser.recurse_into_file_modules = config.recursive();
-
         Ok(Parser { parser, sess })
     }
 
     fn parser(
         sess: &'a rustc_session::parse::ParseSess,
         input: Input,
-        directory_ownership: Option<DirectoryOwnership>,
     ) -> Result<rustc_parse::parser::Parser<'a>, Vec<Diagnostic>> {
         match input {
-            Input::File(ref file) => Ok(if let Some(directory_ownership) = directory_ownership {
-                rustc_parse::new_sub_parser_from_file(
-                    sess,
-                    file,
-                    directory_ownership,
-                    None,
-                    DUMMY_SP,
-                )
-            } else {
-                rustc_parse::new_parser_from_file(sess, file)
-            }),
+            Input::File(ref file) => Ok(new_parser_from_file(sess, file, None)),
             Input::Text(text) => rustc_parse::maybe_new_parser_from_source_str(
                 sess,
                 rustc_span::FileName::Custom("stdin".to_owned()),
                 text,
-            )
-            .map(|mut parser| {
-                parser.recurse_into_file_modules = false;
-                parser
-            }),
+            ),
         }
     }
 }
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum ParserError {
-    NoConfig,
     NoParseSess,
     NoInput,
     ParserCreationError,
@@ -128,7 +99,7 @@ pub(crate) enum ParserError {
 
 impl<'a> Parser<'a> {
     pub(crate) fn submod_path_from_attr(attrs: &[ast::Attribute], path: &Path) -> Option<PathBuf> {
-        rustc_parse::parser::Parser::submod_path_from_attr(attrs, path)
+        rustc_expand::module::submod_path_from_attr(attrs, path)
     }
 
     // FIXME(topecongiro) Use the method from libsyntax[1] once it become public.
@@ -174,6 +145,11 @@ impl<'a> Parser<'a> {
             items.push(item);
         }
 
+        // Handle extern mods that are empty files/files with only comments.
+        if items.is_empty() {
+            parser.parse_mod(&TokenKind::Eof)?;
+        }
+
         let hi = if parser.token.span.is_dummy() {
             span
         } else {
@@ -188,15 +164,13 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn parse_file_as_module(
-        directory_ownership: DirectoryOwnership,
         sess: &'a ParseSess,
         path: &Path,
+        span: Span,
     ) -> Option<ast::Mod> {
         let result = catch_unwind(AssertUnwindSafe(|| {
-            let mut parser =
-                new_sub_parser_from_file(sess.inner(), &path, directory_ownership, None, DUMMY_SP);
+            let mut parser = new_parser_from_file(sess.inner(), &path, Some(span));
 
-            parser.cfg_mods = false;
             let lo = parser.token.span;
             // FIXME(topecongiro) Format inner attributes (#3606).
             match Parser::parse_inner_attrs(&mut parser) {
@@ -265,12 +239,9 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn parse_cfg_if(
         sess: &'a ParseSess,
-        mac: &'a ast::Mac,
-        base_dir: &Directory,
+        mac: &'a ast::MacCall,
     ) -> Result<Vec<ast::Item>, &'static str> {
-        match catch_unwind(AssertUnwindSafe(|| {
-            Parser::parse_cfg_if_inner(sess, mac, base_dir)
-        })) {
+        match catch_unwind(AssertUnwindSafe(|| Parser::parse_cfg_if_inner(sess, mac))) {
             Ok(Ok(items)) => Ok(items),
             Ok(err @ Err(_)) => err,
             Err(..) => Err("failed to parse cfg_if!"),
@@ -279,17 +250,11 @@ impl<'a> Parser<'a> {
 
     fn parse_cfg_if_inner(
         sess: &'a ParseSess,
-        mac: &'a ast::Mac,
-        base_dir: &Directory,
+        mac: &'a ast::MacCall,
     ) -> Result<Vec<ast::Item>, &'static str> {
         let token_stream = mac.args.inner_tokens();
-        let mut parser = rustc_parse::stream_to_parser_with_base_dir(
-            sess.inner(),
-            token_stream,
-            base_dir.to_syntax_directory(),
-        );
-
-        parser.cfg_mods = false;
+        let mut parser =
+            rustc_parse::stream_to_parser(sess.inner(), token_stream.clone(), Some(""));
         let mut items = vec![];
         let mut process_if_cfg = true;
 

--- a/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/parser.rs
@@ -1,11 +1,11 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 
+use rustc_ast::ast;
+use rustc_ast::token::{DelimToken, TokenKind};
 use rustc_errors::{Diagnostic, PResult};
 use rustc_parse::{new_sub_parser_from_file, parser::Parser as RawParser};
 use rustc_span::{symbol::kw, Span, DUMMY_SP};
-use syntax::ast;
-use syntax::token::{DelimToken, TokenKind};
 
 use crate::syntux::session::ParseSess;
 use crate::{Config, Input};
@@ -150,8 +150,8 @@ impl<'a> Parser<'a> {
                 }
                 TokenKind::DocComment(s) => {
                     // we need to get the position of this token before we bump.
-                    let attr = syntax::attr::mk_doc_comment(
-                        syntax::util::comments::doc_comment_style(&s.as_str()),
+                    let attr = rustc_ast::attr::mk_doc_comment(
+                        rustc_ast::util::comments::doc_comment_style(&s.as_str()),
                         s,
                         parser.token.span,
                     );

--- a/rustfmt-core/rustfmt-lib/src/syntux/session.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/session.rs
@@ -150,12 +150,13 @@ impl ParseSess {
         id: ast::Ident,
         relative: Option<ast::Ident>,
         dir_path: &Path,
-    ) -> rustc_parse::parser::ModulePath {
-        rustc_parse::parser::Parser::default_submod_path(
+    ) -> rustc_expand::module::ModulePath<'_> {
+        rustc_expand::module::default_submod_path(
+            &self.parse_sess,
             id,
+            rustc_span::DUMMY_SP,
             relative,
             dir_path,
-            self.parse_sess.source_map(),
         )
     }
 

--- a/rustfmt-core/rustfmt-lib/src/syntux/session.rs
+++ b/rustfmt-core/rustfmt-lib/src/syntux/session.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
 
+use rustc_ast::ast;
 use rustc_data_structures::sync::{Lrc, Send};
 use rustc_errors::emitter::{Emitter, EmitterWriter};
 use rustc_errors::{ColorConfig, Diagnostic, Handler, Level as DiagnosticLevel};
@@ -10,7 +11,6 @@ use rustc_span::{
     source_map::{FilePathMapping, SourceMap},
     BytePos, Span,
 };
-use syntax::ast;
 
 use crate::config::file_lines::LineRange;
 use crate::ignore_path::IgnorePathSet;

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -1,8 +1,8 @@
 use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
+use rustc_ast::ast::{self, FnRetTy, Mutability};
 use rustc_span::{symbol::kw, BytePos, Span};
-use syntax::ast::{self, FnRetTy, Mutability};
 
 use crate::config::lists::*;
 use crate::config::{IndentStyle, TypeDensity};
@@ -556,7 +556,7 @@ impl Rewrite for ast::GenericParam {
             _ => (),
         }
 
-        if let syntax::ast::GenericParamKind::Const { ref ty } = &self.kind {
+        if let rustc_ast::ast::GenericParamKind::Const { ref ty } = &self.kind {
             result.push_str("const ");
             result.push_str(rewrite_ident(context, self.ident));
             result.push_str(": ");

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -233,14 +233,18 @@ fn rewrite_segment(
 
     if let Some(ref args) = segment.args {
         match **args {
-            ast::GenericArgs::AngleBracketed(ref data)
-                if !data.args.is_empty() || !data.constraints.is_empty() =>
-            {
+            ast::GenericArgs::AngleBracketed(ref data) if !data.args.is_empty() => {
                 let param_list = data
                     .args
                     .iter()
-                    .map(SegmentParam::from_generic_arg)
-                    .chain(data.constraints.iter().map(|x| SegmentParam::Binding(&*x)))
+                    .map(|x| match x {
+                        ast::AngleBracketedArg::Arg(generic_arg) => {
+                            SegmentParam::from_generic_arg(generic_arg)
+                        }
+                        ast::AngleBracketedArg::Constraint(constraint) => {
+                            SegmentParam::Binding(constraint)
+                        }
+                    })
                     .collect::<Vec<_>>();
 
                 // HACK: squeeze out the span between the identifier and the parameters.

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -2,7 +2,7 @@ use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
 use rustc_span::{symbol::kw, BytePos, Span};
-use syntax::ast::{self, FunctionRetTy, Mutability};
+use syntax::ast::{self, FnRetTy, Mutability};
 
 use crate::config::lists::*;
 use crate::config::{IndentStyle, TypeDensity};
@@ -292,7 +292,7 @@ fn rewrite_segment(
 
 fn format_function_type<'a, I>(
     inputs: I,
-    output: &FunctionRetTy,
+    output: &FnRetTy,
     variadic: bool,
     span: Span,
     context: &RewriteContext<'_>,
@@ -311,11 +311,11 @@ where
         IndentStyle::Visual => shape.block_left(4)?,
     };
     let output = match *output {
-        FunctionRetTy::Ty(ref ty) => {
+        FnRetTy::Ty(ref ty) => {
             let type_str = ty.rewrite(context, ty_shape)?;
             format!(" -> {}", type_str)
         }
-        FunctionRetTy::Default(..) => String::new(),
+        FnRetTy::Default(..) => String::new(),
     };
 
     let list_shape = if context.use_block_indent() {

--- a/rustfmt-core/rustfmt-lib/src/types.rs
+++ b/rustfmt-core/rustfmt-lib/src/types.rs
@@ -735,7 +735,7 @@ impl Rewrite for ast::Ty {
             }
             ast::TyKind::BareFn(ref bare_fn) => rewrite_bare_fn(bare_fn, self.span, context, shape),
             ast::TyKind::Never => Some(String::from("!")),
-            ast::TyKind::Mac(ref mac) => {
+            ast::TyKind::MacCall(ref mac) => {
                 rewrite_macro(mac, None, context, shape, MacroPosition::Expression)
             }
             ast::TyKind::ImplicitSelf => Some(String::from("")),

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -452,7 +452,7 @@ pub(crate) fn first_line_ends_with(s: &str, c: char) -> bool {
 // parens, braces, and brackets in its idiomatic formatting.
 pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr: &str) -> bool {
     match expr.kind {
-        ast::ExprKind::Mac(..)
+        ast::ExprKind::MacCall(..)
         | ast::ExprKind::Call(..)
         | ast::ExprKind::MethodCall(..)
         | ast::ExprKind::Array(..)

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -486,7 +486,7 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::Continue(..)
         | ast::ExprKind::Err
         | ast::ExprKind::Field(..)
-        | ast::ExprKind::InlineAsm(..)
+        | ast::ExprKind::LlvmInlineAsm(..)
         | ast::ExprKind::Let(..)
         | ast::ExprKind::Path(..)
         | ast::ExprKind::Range(..)

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 
-use rustc_ast_pretty::pprust;
-use rustc_span::{sym, BytePos, ExpnId, Span, Symbol, SyntaxContext};
-use syntax::ast::{
+use rustc_ast::ast::{
     self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem, NodeId, Path, Visibility,
     VisibilityKind,
 };
-use syntax::ptr;
+use rustc_ast::ptr;
+use rustc_ast_pretty::pprust;
+use rustc_span::{sym, BytePos, ExpnId, Span, Symbol, SyntaxContext};
 use unicode_width::UnicodeWidthStr;
 
 use crate::comment::{filter_normal_code, CharClasses, FullCodeCharKind, LineClasses};
@@ -154,7 +154,7 @@ pub(crate) fn format_extern(
 }
 
 #[inline]
-// Transform `Vec<syntax::ptr::P<T>>` into `Vec<&T>`
+// Transform `Vec<rustc_ast::ptr::P<T>>` into `Vec<&T>`
 pub(crate) fn ptr_vec_to_ref_vec<T>(vec: &[ptr::P<T>]) -> Vec<&T> {
     vec.iter().map(|x| &**x).collect::<Vec<_>>()
 }

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -103,7 +103,7 @@ pub(crate) fn format_constness(constness: ast::Const) -> &'static str {
 #[inline]
 pub(crate) fn format_defaultness(defaultness: ast::Defaultness) -> &'static str {
     match defaultness {
-        ast::Defaultness::Default => "default ",
+        ast::Defaultness::Default(..) => "default ",
         ast::Defaultness::Final => "",
     }
 }

--- a/rustfmt-core/rustfmt-lib/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/src/utils.rs
@@ -85,18 +85,18 @@ pub(crate) fn format_visibility(
 }
 
 #[inline]
-pub(crate) fn format_async(is_async: ast::IsAsync) -> &'static str {
+pub(crate) fn format_async(is_async: ast::Async) -> &'static str {
     match is_async {
-        ast::IsAsync::Async { .. } => "async ",
-        ast::IsAsync::NotAsync => "",
+        ast::Async::Yes { .. } => "async ",
+        ast::Async::No => "",
     }
 }
 
 #[inline]
-pub(crate) fn format_constness(constness: ast::Constness) -> &'static str {
+pub(crate) fn format_constness(constness: ast::Const) -> &'static str {
     match constness {
-        ast::Constness::Const => "const ",
-        ast::Constness::NotConst => "",
+        ast::Const::Yes(..) => "const ",
+        ast::Const::No => "",
     }
 }
 
@@ -109,10 +109,10 @@ pub(crate) fn format_defaultness(defaultness: ast::Defaultness) -> &'static str 
 }
 
 #[inline]
-pub(crate) fn format_unsafety(unsafety: ast::Unsafety) -> &'static str {
+pub(crate) fn format_unsafety(unsafety: ast::Unsafe) -> &'static str {
     match unsafety {
-        ast::Unsafety::Unsafe => "unsafe ",
-        ast::Unsafety::Normal => "",
+        ast::Unsafe::Yes(..) => "unsafe ",
+        ast::Unsafe::No => "",
     }
 }
 

--- a/rustfmt-core/rustfmt-lib/src/vertical.rs
+++ b/rustfmt-core/rustfmt-lib/src/vertical.rs
@@ -3,8 +3,8 @@
 use std::cmp;
 
 use itertools::Itertools;
+use rustc_ast::ast;
 use rustc_span::{BytePos, Span};
-use syntax::ast;
 
 use crate::comment::combine_strs_with_missing_comments;
 use crate::config::lists::*;

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -147,7 +147,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     self.push_rewrite(stmt.span(), rewrite)
                 }
             }
-            ast::StmtKind::Mac(ref mac) => {
+            ast::StmtKind::MacCall(ref mac) => {
                 let (ref mac, _macro_style, ref attrs) = **mac;
                 if self.visit_attrs(attrs, ast::AttrStyle::Outer) {
                     self.push_skipped_with_span(
@@ -495,7 +495,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     self.format_missing_with_indent(source!(self, item.span).lo());
                     self.format_mod(module, &item.vis, item.span, item.ident, attrs, is_inline);
                 }
-                ast::ItemKind::Mac(ref mac) => {
+                ast::ItemKind::MacCall(ref mac) => {
                     self.visit_mac(mac, Some(item.ident), MacroPosition::Item);
                 }
                 ast::ItemKind::ForeignMod(ref foreign_mod) => {
@@ -621,7 +621,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 );
                 self.push_rewrite(ti.span, rewrite);
             }
-            ast::AssocItemKind::Macro(ref mac) => {
+            ast::AssocItemKind::MacCall(ref mac) => {
                 self.visit_mac(mac, Some(ti.ident), MacroPosition::Item);
             }
         }
@@ -680,13 +680,13 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 };
                 self.push_rewrite(ii.span, rewrite);
             }
-            ast::AssocItemKind::Macro(ref mac) => {
+            ast::AssocItemKind::MacCall(ref mac) => {
                 self.visit_mac(mac, Some(ii.ident), MacroPosition::Item);
             }
         }
     }
 
-    fn visit_mac(&mut self, mac: &ast::Mac, ident: Option<ast::Ident>, pos: MacroPosition) {
+    fn visit_mac(&mut self, mac: &ast::MacCall, ident: Option<ast::Ident>, pos: MacroPosition) {
         skip_out_of_file_lines_range_visitor!(self, mac.span());
 
         // 1 = ;

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -1,8 +1,8 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
+use rustc_ast::{ast, token::DelimToken, visit};
 use rustc_span::{BytePos, Pos, Span};
-use syntax::{ast, token::DelimToken, visit};
 
 use crate::attr::*;
 use crate::comment::{rewrite_comment, CodeCharKind, CommentCodeSlices};

--- a/rustfmt-core/rustfmt-lib/src/visitor.rs
+++ b/rustfmt-core/rustfmt-lib/src/visitor.rs
@@ -160,6 +160,9 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 }
                 self.format_missing(stmt.span().hi());
             }
+            ast::StmtKind::Empty => {
+                // println!("inside visitor with empty statement");
+            }
         }
     }
 
@@ -502,7 +505,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 ast::ItemKind::Static(..) | ast::ItemKind::Const(..) => {
                     self.visit_static(&StaticParts::from_item(item));
                 }
-                ast::ItemKind::Fn(ref fn_signature, ref generics, Some(ref body)) => {
+                ast::ItemKind::Fn(defaultness, ref fn_signature, ref generics, Some(ref body)) => {
                     let inner_attrs = inner_attributes(&item.attrs);
                     let fn_ctxt = match fn_signature.header.ext {
                         ast::Extern::None => visit::FnCtxt::Free,
@@ -519,11 +522,11 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         generics,
                         &fn_signature.decl,
                         item.span,
-                        ast::Defaultness::Final,
+                        defaultness,
                         Some(&inner_attrs),
                     )
                 }
-                ast::ItemKind::Fn(ref fn_signature, ref generics, None) => {
+                ast::ItemKind::Fn(_, ref fn_signature, ref generics, None) => {
                     let indent = self.block_indent;
                     let rewrite = self.rewrite_required_fn(
                         indent,
@@ -534,19 +537,19 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     );
                     self.push_rewrite(item.span, rewrite);
                 }
-                ast::ItemKind::TyAlias(ref ty, ref generics) => match ty.kind.opaque_top_hack() {
-                    None => {
+                ast::ItemKind::TyAlias(_, ref generics, ref generic_bounds, ref ty) => match ty {
+                    Some(ty) => {
                         let rewrite = rewrite_type_alias(
                             &self.get_context(),
                             self.block_indent,
                             item.ident,
-                            ty,
+                            &*ty,
                             generics,
                             &item.vis,
                         );
                         self.push_rewrite(item.span, rewrite);
                     }
-                    Some(generic_bounds) => {
+                    None => {
                         let rewrite = rewrite_opaque_type(
                             &self.get_context(),
                             self.block_indent,
@@ -589,30 +592,29 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
 
         match ti.kind {
             ast::AssocItemKind::Const(..) => self.visit_static(&StaticParts::from_trait_item(ti)),
-            ast::AssocItemKind::Fn(ref sig, None) => {
+            ast::AssocItemKind::Fn(_, ref sig, ref generics, None) => {
                 let indent = self.block_indent;
-                let rewrite =
-                    self.rewrite_required_fn(indent, ti.ident, sig, &ti.generics, ti.span);
+                let rewrite = self.rewrite_required_fn(indent, ti.ident, sig, generics, ti.span);
                 self.push_rewrite(ti.span, rewrite);
             }
-            ast::AssocItemKind::Fn(ref sig, Some(ref body)) => {
+            ast::AssocItemKind::Fn(defaultness, ref sig, ref generics, Some(ref body)) => {
                 let inner_attrs = inner_attributes(&ti.attrs);
                 let vis = rustc_span::source_map::dummy_spanned(ast::VisibilityKind::Inherited);
                 let fn_ctxt = visit::FnCtxt::Assoc(visit::AssocCtxt::Trait);
                 self.visit_fn(
                     visit::FnKind::Fn(fn_ctxt, ti.ident, sig, &vis, Some(body)),
-                    &ti.generics,
+                    generics,
                     &sig.decl,
                     ti.span,
-                    ast::Defaultness::Final,
+                    defaultness,
                     Some(&inner_attrs),
                 );
             }
-            ast::AssocItemKind::TyAlias(ref generic_bounds, ref type_default) => {
+            ast::AssocItemKind::TyAlias(_, ref generics, ref generic_bounds, ref type_default) => {
                 let rewrite = rewrite_associated_type(
                     ti.ident,
                     type_default.as_ref(),
-                    &ti.generics,
+                    generics,
                     Some(generic_bounds),
                     &self.get_context(),
                     self.block_indent,
@@ -634,32 +636,31 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         }
 
         match ii.kind {
-            ast::AssocItemKind::Fn(ref sig, Some(ref body)) => {
+            ast::AssocItemKind::Fn(defaultness, ref sig, ref generics, Some(ref body)) => {
                 let inner_attrs = inner_attributes(&ii.attrs);
                 let fn_ctxt = visit::FnCtxt::Assoc(visit::AssocCtxt::Impl);
                 self.visit_fn(
                     visit::FnKind::Fn(fn_ctxt, ii.ident, sig, &ii.vis, Some(body)),
-                    &ii.generics,
+                    generics,
                     &sig.decl,
                     ii.span,
-                    ii.defaultness,
+                    defaultness,
                     Some(&inner_attrs),
                 );
             }
-            ast::AssocItemKind::Fn(ref sig, None) => {
+            ast::AssocItemKind::Fn(_, ref sig, ref generics, None) => {
                 let indent = self.block_indent;
-                let rewrite =
-                    self.rewrite_required_fn(indent, ii.ident, sig, &ii.generics, ii.span);
+                let rewrite = self.rewrite_required_fn(indent, ii.ident, sig, generics, ii.span);
                 self.push_rewrite(ii.span, rewrite);
             }
             ast::AssocItemKind::Const(..) => self.visit_static(&StaticParts::from_impl_item(ii)),
-            ast::AssocItemKind::TyAlias(_, ref ty) => {
+            ast::AssocItemKind::TyAlias(defaultness, ref generics, _, ref ty) => {
                 let rewrite_associated = || {
                     rewrite_associated_impl_type(
                         ii.ident,
-                        ii.defaultness,
+                        defaultness,
                         ty.as_ref(),
-                        &ii.generics,
+                        generics,
                         &self.get_context(),
                         self.block_indent,
                     )
@@ -670,7 +671,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         Some(generic_bounds) => rewrite_opaque_impl_type(
                             &self.get_context(),
                             ii.ident,
-                            &ii.generics,
+                            generics,
                             generic_bounds,
                             self.block_indent,
                         ),

--- a/rustfmt-core/rustfmt-lib/tests/source/imports.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/imports.rs
@@ -3,7 +3,7 @@
 // Imports.
 
 // Long import.
-use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
+use rustc_ast::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
 use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA, ItemB};
 use exceedingly::loooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA, ItemB};
 
@@ -15,13 +15,13 @@ use list::{
 
 use test::{  Other          /* C   */  , /*   A   */ self  /*    B     */    };
 
-use syntax::{self};
+use rustc_ast::{self};
 use {/* Pre-comment! */
      Foo, Bar /* comment */};
 use Foo::{Bar, Baz};
-pub use syntax::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath};
+pub use rustc_ast::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath};
 
-use syntax::some::{};
+use rustc_ast::some::{};
 
 use self;
 use std::io::{self};
@@ -31,7 +31,7 @@ use a::{/* comment */ item};
 use a::{item /* comment */};
 
 mod Foo {
-    pub use syntax::ast::{
+    pub use rustc_ast::ast::{
         ItemForeignMod,
         ItemImpl, 
         ItemMac,
@@ -41,7 +41,7 @@ mod Foo {
     };
 
     mod Foo2 {
-        pub use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, self, ItemDefaultImpl};
+        pub use rustc_ast::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, self, ItemDefaultImpl};
     }
 }
 

--- a/rustfmt-core/rustfmt-lib/tests/source/imports_2015_edition.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/imports_2015_edition.rs
@@ -4,7 +4,7 @@
 // Imports.
 
 // Long import.
-use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
+use rustc_ast::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
 use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA, ItemB};
 use exceedingly::loooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA, ItemB};
 
@@ -16,20 +16,20 @@ use list::{
 
 use test::{  Other          /* C   */  , /*   A   */ self  /*    B     */    };
 
-use syntax::{self};
+use rustc_ast::{self};
 use {/* Pre-comment! */
      Foo, Bar /* comment */};
 use Foo::{Bar, Baz};
-pub use syntax::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath};
+pub use rustc_ast::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath};
 
-use syntax::some::{};
+use rustc_ast::some::{};
 
 use self;
 use std::io::{self};
 use std::io::self;
 
 mod Foo {
-    pub use syntax::ast::{
+    pub use rustc_ast::ast::{
         ItemForeignMod,
         ItemImpl, 
         ItemMac,
@@ -39,7 +39,7 @@ mod Foo {
     };
 
     mod Foo2 {
-        pub use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, self, ItemDefaultImpl};
+        pub use rustc_ast::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, self, ItemDefaultImpl};
     }
 }
 

--- a/rustfmt-core/rustfmt-lib/tests/target/imports.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/imports.rs
@@ -9,7 +9,7 @@ use exceedingly::loooooooooooooooooooooooooooooooooooooooooooooooooooooooong::im
 use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{
     ItemA, ItemB,
 };
-use syntax::ast::{ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
+use rustc_ast::ast::{ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
 
 use list::{
     // Another item
@@ -22,8 +22,8 @@ use list::{
 
 use test::{/* A */ self /* B */, Other /* C */};
 
-pub use syntax::ast::{Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath, Expr_};
-use syntax::{self};
+pub use rustc_ast::ast::{Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath, Expr_};
+use rustc_ast::{self};
 use Foo::{Bar, Baz};
 use {Bar /* comment */, /* Pre-comment! */ Foo};
 
@@ -34,12 +34,12 @@ use a::{/* comment */ item};
 use a::{item /* comment */};
 
 mod Foo {
-    pub use syntax::ast::{
+    pub use rustc_ast::ast::{
         ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic,
     };
 
     mod Foo2 {
-        pub use syntax::ast::{
+        pub use rustc_ast::ast::{
             self, ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic,
         };
     }

--- a/rustfmt-core/rustfmt-lib/tests/target/imports_2015_edition.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/imports_2015_edition.rs
@@ -10,7 +10,7 @@ use exceedingly::loooooooooooooooooooooooooooooooooooooooooooooooooooooooong::im
 use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{
     ItemA, ItemB,
 };
-use syntax::ast::{ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
+use rustc_ast::ast::{ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
 
 use list::{
     // Another item
@@ -23,8 +23,8 @@ use list::{
 
 use test::{/* A */ self /* B */, Other /* C */};
 
-pub use syntax::ast::{Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath, Expr_};
-use syntax::{self};
+pub use rustc_ast::ast::{Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath, Expr_};
+use rustc_ast::{self};
 use Foo::{Bar, Baz};
 use {Bar /* comment */, /* Pre-comment! */ Foo};
 
@@ -32,12 +32,12 @@ use std::io;
 use std::io::{self};
 
 mod Foo {
-    pub use syntax::ast::{
+    pub use rustc_ast::ast::{
         ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic,
     };
 
     mod Foo2 {
-        pub use syntax::ast::{
+        pub use rustc_ast::ast::{
             self, ItemDefaultImpl, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic,
         };
     }


### PR DESCRIPTION
2.x version/pair of #4100 that bumps the version of the rustc-ap* crates on master.

We can go ahead and close #4013 too as those upstream parser changes have now been incorporated