### PR TITLE
fix newline width calc in combine w/ comments

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/comment.rs
+++ b/rustfmt-core/rustfmt-lib/src/comment.rs
@@ -188,7 +188,7 @@ pub(crate) fn combine_strs_with_missing_comments(
     let missing_comment = rewrite_missing_comment(span, shape, context)?;
 
     if missing_comment.is_empty() {
-        if allow_extend && prev_str.len() + first_sep.len() + next_str.len() <= shape.width {
+        if allow_extend && one_line_width <= shape.width {
             result.push_str(first_sep);
         } else if !prev_str.is_empty() {
             result.push_str(&indent.to_string_with_newline(config))

--- a/rustfmt-core/rustfmt-lib/tests/target/issue_4031.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue_4031.rs
@@ -1,0 +1,21 @@
+fn foo() {
+    with_woff2_glyf_table("tests/fonts/woff2/SFNT-TTF-Composite.woff2", |glyf| {
+        let actual = glyf
+            .records
+            .iter()
+            .map(|glyph| match glyph {
+                GlyfRecord::Parsed(
+                    found @ Glyph {
+                        data: GlyphData::Composite { .. },
+                        ..
+                    },
+                ) => Some(found),
+                _ => None,
+            })
+            .find(|candidate| candidate.is_some())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(*actual, expected)
+    });
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/issue_4110.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue_4110.rs
@@ -1,0 +1,55 @@
+fn bindings() {
+    let err = match (place_desc, explanation) {
+        (
+            Some(ref name),
+            BorrowExplanation::MustBeValidFor {
+                category:
+                    category @ (ConstraintCategory::Return
+                    | ConstraintCategory::CallArgument
+                    | ConstraintCategory::OpaqueType),
+                from_closure: false,
+                ref region_name,
+                span,
+                ..
+            },
+        ) if borrow_spans.for_generator() | borrow_spans.for_closure() => self
+            .report_escaping_closure_capture(
+                borrow_spans,
+                borrow_span,
+                region_name,
+                category,
+                span,
+                &format!("`{}`", name),
+            ),
+        (
+            ref name,
+            BorrowExplanation::MustBeValidFor {
+                category: ConstraintCategory::Assignment,
+                from_closure: false,
+                region_name:
+                    RegionName {
+                        source: RegionNameSource::AnonRegionFromUpvar(upvar_span, ref upvar_name),
+                        ..
+                    },
+                span,
+                ..
+            },
+        ) => self.report_escaping_data(borrow_span, name, upvar_span, upvar_name, span),
+        (Some(name), explanation) => self.report_local_value_does_not_live_long_enough(
+            location,
+            &name,
+            &borrow,
+            drop_span,
+            borrow_spans,
+            explanation,
+        ),
+        (None, explanation) => self.report_temporary_value_does_not_live_long_enough(
+            location,
+            &borrow,
+            drop_span,
+            borrow_spans,
+            proper_span,
+            explanation,
+        ),
+    };
+}


### PR DESCRIPTION
Resolves #4031, refs #4110 

This address the binding formatting in #4110, but doesn't include any updates for the sub pattern formatting 