### PR TITLE
Stabilize binop_separator.

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -47,7 +47,7 @@ Where to put a binary operator when a binary expression goes multiline.
 
 - **Default value**: `"Front"`
 - **Possible values**: `"Front"`, `"Back"`
-- **Stable**: No (tracking issue: [#3368](https://github.com/rust-lang/rustfmt/issues/3368))
+- **Stable**: Yes
 
 #### `"Front"` (default):
 

--- a/rustfmt-core/rustfmt-lib/src/config.rs
+++ b/rustfmt-core/rustfmt-lib/src/config.rs
@@ -92,7 +92,7 @@ create_config! {
     space_around_attr_eq: bool, true, false,
         "Determines if '=' are wrapped in spaces in attributes.";
     spaces_around_ranges: bool, false, false, "Put spaces around the  .. and ..= range operators";
-    binop_separator: SeparatorPlace, SeparatorPlace::Front, false,
+    binop_separator: SeparatorPlace, SeparatorPlace::Front, true,
         "Where to put a binary operator when a binary expression goes multiline";
 
     // Misc.


### PR DESCRIPTION
Servo has used this since forever, and it'd be useful to be able to use
rustfmt stable there so that we can use the same rustfmt version in
both Firefox and Servo.

Feel free to close this if there's any reason it shouldn't be done.

Closes #3368