### PR TITLE
Stabilize match_block_trailing_comma.

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1514,7 +1514,7 @@ Put a trailing comma after a block based match arm (non-block arms are not affec
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
-- **Stable**: No (tracking issue: [#3380](https://github.com/rust-lang/rustfmt/issues/3380))
+- **Stable**: Yes
 
 #### `false` (default):
 

--- a/rustfmt-core/rustfmt-lib/src/config.rs
+++ b/rustfmt-core/rustfmt-lib/src/config.rs
@@ -117,7 +117,7 @@ create_config! {
         "Add trailing semicolon after break, continue and return";
     trailing_comma: SeparatorTactic, SeparatorTactic::Vertical, false,
         "How to handle trailing commas for lists";
-    match_block_trailing_comma: bool, false, false,
+    match_block_trailing_comma: bool, false, true,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
     blank_lines_upper_bound: usize, 1, false,
         "Maximum number of blank lines which can be put between items";


### PR DESCRIPTION
Servo has used this since forever, and it'd be useful to be able to use
rustfmt stable there so that we can use the same rustfmt version in
both Firefox and Servo.

Feel free to close this if there's any reason it shouldn't be done.

Closes #3380