### PR TITLE
update to rustc 656

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
@@ -581,7 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.7.1",
+ "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -601,15 +601,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "winapi",
 ]
 
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
  "unicode-xid",
 ]
@@ -656,9 +656,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -712,25 +712,25 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-arena"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfcfbb0ddfd533abf8c076e3b49d1e5042d1962526a12ce2c66d514b24cca3"
+checksum = "fb6df19dd0afdfda2ff7e1dc33c23ac5e77be2298dfce76b0be90df852fde281"
 dependencies = [
  "rustc-ap-rustc_data_structures",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
 name = "rustc-ap-graphviz"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490bb07b014a7f9531bde33c905a805e08095dbefdb4c9988a1b19fe6d019fd"
+checksum = "c7771196b6eb99a166cf1dd8deb974b492fdf96e090d5a55db6cb5cf9f517afa"
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189f16dbb8dd11089274c9ced58b0cae9e1ea3e434a58f3db683817eda849e58"
+checksum = "edc1cfea59f901244ab488cfd4615da786208e5bd75d782abdbf5c94eccb6280"
 dependencies = [
  "log",
  "rustc-ap-rustc_data_structures",
@@ -740,14 +740,14 @@ dependencies = [
  "rustc-ap-rustc_span",
  "rustc-ap-serialize",
  "scoped-tls",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe619609b56a617fa986332b066d53270093c816d8ff8281fc90e1dbe74c1cc"
+checksum = "fe14bcea3dd2a44f89e2d5ca453838e8d71ebaaede2c265eaed3fa044ce7358e"
 dependencies = [
  "itertools",
  "log",
@@ -764,21 +764,20 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ab1495f7b420e937688749c1da5763aaabd6ebe8cacb758665a0b8481da094"
+checksum = "83c4ea460aa09e592f89ddab2efcfde050bd963bf02740347293294a40c1c757"
 dependencies = [
  "log",
  "rustc-ap-rustc_ast",
- "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_span",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e057495724c60729c1d1d9d49374e0b3ebd6d3481cd161b2871f52fe017b7b5"
+checksum = "f0a2f931847e5967f69622bc9ffd47d4d4ce5444f5165a036c2eda0000ff4eeb"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -789,14 +788,13 @@ dependencies = [
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
  "rustc-ap-serialize",
- "smallvec 1.3.0",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2130997667833692f4bec4681d0e73b066d5a01dac1d8a68f22068b82bf173a"
+checksum = "e105049018a06b05bcab026d751b5ccfa320cb6b078d1aaf2884121dbc939df3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -815,16 +813,16 @@ dependencies = [
  "rustc-hash",
  "rustc-rayon",
  "rustc-rayon-core",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
  "stable_deref_trait",
  "winapi",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908e1ea187c6bb368af4ba6db980001e920515e67371ddc4086e749baabe6080"
+checksum = "b3fb69cb302869dd8398a268c4dae19cfcaf39eaeb121374237d393232ab9ca8"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -840,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50066a75bca872ff933b0ee8a582d18ef1876c8054a392f60c39e538446bfb00"
+checksum = "25d47c4dac84f583e36c6fabb60f7cbf12fae90aa77d45593f71f24b13b006d3"
 dependencies = [
  "log",
  "rustc-ap-rustc_ast",
@@ -857,14 +855,14 @@ dependencies = [
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
  "rustc-ap-serialize",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb53e1710e6de7c2e371ca56c857b79f9b399aba58aa6b6fbed6e2f677d3f6"
+checksum = "298f0c625a922d4675b91db3fac7d3b587849667a166c19eee2596e7edef9712"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -873,34 +871,34 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f91357e5e468fc2729211571d769723c728a34e200d90a70164e945f881e09"
+checksum = "b16f794f99d7a115ee9d5e73dada35d9cb553b0c6c34b3549f38960c9c301c62"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32220c3e6cdf226f38e4474b747dca15f3106bb680c74f10b299af3f6cdb1663"
+checksum = "59edea7fb099ca9589268aa8676b741f43db5c6f1bc1ced231db9d56e2aa9f94"
 dependencies = [
  "rustc-ap-serialize",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b324d2a2bacad344e53e182e5ca04ffb74745b932849aa074f8f7fec8177da5"
+checksum = "9cbba98ec46e96a4663197dfa8c0378752de2006e314e5400c0ca74929d6692f"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59686c56d5f1b3ed47d0f070c257ed35caf24ecf2d744dd11fe44b1014baee0f"
+checksum = "73f36ca24a130773044800e6806bf890365afb6175df8ab32efa59c577a11d4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -910,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfb0c11c591ec5f87bbadb10819795abc9035ff79a26703c1b6c9487ac51f49"
+checksum = "f7ec08a2f8e98799a668e24578cb6e1b37ddca25132badd4b07ebb2cb6412b90"
 dependencies = [
  "bitflags",
  "log",
@@ -924,15 +922,14 @@ dependencies = [
  "rustc-ap-rustc_lexer",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
- "smallvec 1.3.0",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1a194b1a81d7233ee492847638dc9ebdb7d084300e5ade8dea0ceaa98f95b9"
+checksum = "1661cc89ec2e1992d686955aa24fa358ee5af11fdd91ecacb63575ae33c0c6b4"
 dependencies = [
  "getopts",
  "log",
@@ -950,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a648146050fed6b58e681ec22488e728f60e16036bb7497c9815e3debd1e4242"
+checksum = "2afe35ea88a8f61198ff08f627fa3c5ef925e8d4ba23e678d8ab07d76b2999bb"
 dependencies = [
  "cfg-if",
  "log",
@@ -969,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf28798f0988b808e3616713630e4098d68c6f1f41052a2f7e922e094da744"
+checksum = "00835074c37fc7cb377477c24dc8ca3cbaab7e3451925f8844e1a13eea5ec8cc"
 dependencies = [
  "bitflags",
  "log",
@@ -984,12 +981,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "654.0.0"
+version = "656.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756e8f526ec7906e132188bf25e3c10a6ee42ab77294ecb3b3602647f0508eef"
+checksum = "5b2ca2e47af678242e35e38518a64b97bc61b83b6e833c3ae734400f836679a6"
 dependencies = [
  "indexmap",
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -1103,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "same-file"
@@ -1166,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1198,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1216,9 +1213,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
+checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1227,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
+checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1240,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1312,18 +1309,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1360,7 +1357,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.3.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -1434,9 +1431,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi",
 ]

--- a/rustfmt-core/rustfmt-lib/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/Cargo.toml
@@ -59,32 +59,32 @@ env_logger = "0.7"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "654.0.0"
+version = "656.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "654.0.0"
+version = "656.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "654.0.0"
+version = "656.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "654.0.0"
+version = "656.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "654.0.0"
+version = "656.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "654.0.0"
+version = "656.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "654.0.0"
+version = "656.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "654.0.0"
+version = "656.0.0"


### PR DESCRIPTION
I gets past the error in #4132 🎉 

But compiling my app, I end up with this error:
```
   Compiling rustc-ap-rustc_data_structures v656.0.0
   Compiling rustc-ap-arena v656.0.0
   Compiling synstructure v0.12.3
   Compiling wasm-bindgen-backend v0.2.62
   Compiling wasm-bindgen-macro-support v0.2.62
   Compiling rustc-ap-rustc_macros v656.0.0
   Compiling serde_derive v1.0.106
   Compiling thiserror-impl v1.0.16
   Compiling rustfmt-config_proc_macro v0.5.0 (/Users/cameron/rs/rustfmt/rustfmt-core/rustfmt-lib/config_proc_macro)
   Compiling wasm-bindgen-macro v0.2.62
   Compiling thiserror v1.0.16
   Compiling rustc-ap-rustc_span v656.0.0
thread 'rustc' panicked at 'src/librustc_resolve/imports.rs:906: inconsistent resolution for an import', /rustc/2454a68cfbb63aa7b8e09fe05114d5f98b2f9740/src/libstd/macros.rs:13:23
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: rustc 1.45.0-nightly (2454a68cf 2020-05-04) running on x86_64-apple-darwin

note: compiler flags: -C debuginfo=2 --crate-type lib

note: some of the compiler flags provided by cargo are hidden

error: could not compile `rustc-ap-rustc_span`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
Camerons-MacBook-Pro cameron$ rustc --version
rustc 1.45.0-nightly (2454a68cf 2020-05-04)
```