### PR TITLE
Exclude code block delimiters when wrapping comments

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/comment.rs
+++ b/rustfmt-core/rustfmt-lib/src/comment.rs
@@ -290,7 +290,7 @@ fn identify_comment(
     ) -> (bool, usize) {
         let mut first_group_ending = 0;
         let mut hbl = false;
-        let mut in_code_block = false;
+        let mut seen_cb_delimiters = 0;
 
         for (i, line) in orig.lines().enumerate() {
             let trimmed_line = line.trim_start();
@@ -301,10 +301,10 @@ fn identify_comment(
                 || comment_style(trimmed_line, false) == style
             {
                 if line.starts_with(&format!("{}```", line_start)) {
-                    in_code_block |= i == 0;
-                    if !in_code_block {
-                        // Next line is the start of a code block. Stop here to avoid wrapping the
-                        // delimiter up when we format the comment group.
+                    seen_cb_delimiters += 1;
+                    if seen_cb_delimiters % 2 != 0 && i != 0 {
+                        // Next line is the start of a new code block. Stop here to avoid wrapping
+                        // the delimiter up when we format the comment group.
                         break;
                     }
                 }

--- a/rustfmt-core/rustfmt-lib/src/comment.rs
+++ b/rustfmt-core/rustfmt-lib/src/comment.rs
@@ -290,8 +290,9 @@ fn identify_comment(
     ) -> (bool, usize) {
         let mut first_group_ending = 0;
         let mut hbl = false;
+        let mut in_code_block = false;
 
-        for line in orig.lines() {
+        for (i, line) in orig.lines().enumerate() {
             let trimmed_line = line.trim_start();
             if trimmed_line.is_empty() {
                 hbl = true;
@@ -299,6 +300,14 @@ fn identify_comment(
             } else if trimmed_line.starts_with(line_start)
                 || comment_style(trimmed_line, false) == style
             {
+                if line.starts_with(&format!("{}```", line_start)) {
+                    in_code_block |= i == 0;
+                    if !in_code_block {
+                        // Next line is the start of a code block. Stop here to avoid wrapping the
+                        // delimiter up when we format the comment group.
+                        break;
+                    }
+                }
                 first_group_ending += compute_len(&orig[first_group_ending..], line);
             } else {
                 break;

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-4158.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-4158.rs
@@ -7,6 +7,10 @@
 // this is code that won't
 // even if it also is very very very very very very very very very very very very long
 // ```
+// This is a second long line that will be wrapped on the next line.
+// ```
+// this is code that won't
+// ```
 
 /// This is a long line that will be wrapped on the next line.
 /// ```

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-4158.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-4158.rs
@@ -1,0 +1,26 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 50
+
+// This is a long line that will be wrapped on the next line.
+// This line will be wrapped with it.
+// ```
+// this is code that won't
+// even if it also is very very very very very very very very very very very very long
+// ```
+
+/// This is a long line that will be wrapped on the next line.
+/// ```
+/// Should handle code blocks with no end
+fn outer() {
+    //! This is a long line that will be wrapped on the next line.
+    //! ```rust
+    //! assert!(true);
+    //! ```
+    fn inner() {
+        /* This is a long line that will be wrapped on the next line.
+         * ```rust
+         * assert!(true);
+         * ```
+         */
+    }
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4158.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4158.rs
@@ -7,6 +7,11 @@
 // this is code that won't
 // even if it also is very very very very very very very very very very very very long
 // ```
+// This is a second long line that will be wrapped
+// on the next line.
+// ```
+// this is code that won't
+// ```
 
 /// This is a long line that will be wrapped on
 /// the next line.

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4158.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4158.rs
@@ -1,0 +1,29 @@
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 50
+
+// This is a long line that will be wrapped on the
+// next line. This line will be wrapped with it.
+// ```
+// this is code that won't
+// even if it also is very very very very very very very very very very very very long
+// ```
+
+/// This is a long line that will be wrapped on
+/// the next line.
+/// ```
+/// Should handle code blocks with no end
+fn outer() {
+    //! This is a long line that will be wrapped
+    //! on the next line.
+    //! ```rust
+    //! assert!(true);
+    //! ```
+    fn inner() {
+        /* This is a long line that will be
+         * wrapped on the next line.
+         * ```rust
+         * assert!(true);
+         * ```
+         */
+    }
+}


### PR DESCRIPTION
Closes #4158