### PR TITLE
Compare code block line indentation with config whitespace

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/lib.rs
+++ b/rustfmt-core/rustfmt-lib/src/lib.rs
@@ -350,6 +350,7 @@ fn format_code_block(code_snippet: &str, config: &Config) -> Option<FormattedSni
         .rfind('}')
         .unwrap_or_else(|| formatted.snippet.len());
     let mut is_indented = true;
+    let indent_str = Indent::from_width(config, config.tab_spaces()).to_string(config);
     for (kind, ref line) in LineClasses::new(&formatted.snippet[FN_MAIN_PREFIX.len()..block_len]) {
         if !is_first {
             result.push('\n');
@@ -364,9 +365,8 @@ fn format_code_block(code_snippet: &str, config: &Config) -> Option<FormattedSni
             // are too long, or we have failed to format code block. We will be
             // conservative and just return `None` in this case.
             return None;
-        } else if line.len() > config.tab_spaces() {
+        } else if line.len() > indent_str.len() {
             // Make sure that the line has leading whitespaces.
-            let indent_str = Indent::from_width(config, config.tab_spaces()).to_string(config);
             if line.starts_with(indent_str.as_ref()) {
                 let offset = if config.hard_tabs() {
                     1

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4152.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4152.rs
@@ -1,0 +1,18 @@
+// rustfmt-hard_tabs: true
+
+macro_rules! bit {
+	($bool:expr) => {
+		if $bool {
+			1;
+			1
+		} else {
+			0;
+			0
+		}
+	};
+}
+macro_rules! add_one {
+	($vec:expr) => {{
+		$vec.push(1);
+	}};
+}


### PR DESCRIPTION
Previously the indetation of a line was compared with the configured
number of spaces per tab, which could cause lines that were formatted
with hard tabs not to be recognized as indented ("\t".len() < "    ".len()).

Closes #4152