### PR TITLE
Remove spaces added by comment opener when creating itemized block

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/comment.rs
+++ b/rustfmt-core/rustfmt-lib/src/comment.rs
@@ -704,6 +704,9 @@ impl<'a> CommentRewrite<'a> {
         } else if self.fmt.config.wrap_comments() && ItemizedBlock::is_itemized_line(&line) {
             let ib = ItemizedBlock::new(&line);
             self.item_block = Some(ib);
+            if self.result.ends_with(' ') {
+                self.result.pop();
+            }
             return false;
         }
 

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4104.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4104.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments: true
+// rustfmt-normalize_comments: true
+
+///
+/// - item 1
+
+fn main() {}


### PR DESCRIPTION
I'm not sure there's a better way to do this without a larger refactor
of this method.

Closes #4104