### PR TITLE
Parse comma-separated branches in macro definitions

### DIFF
--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4111.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4111.rs
@@ -1,0 +1,21 @@
+// rustfmt-format_macro_bodies: true
+// rustfmt-format_macro_matchers: true
+
+pub macro scalar($m:ident, $t:ident) {
+    pub macro $m {
+        () => {
+            Val::$t($t::default())
+        },
+        ($v: expr) => {
+            Val::$t($t::new($v))
+        },
+    }
+    pub macro a {
+        () => {
+            Val::$t($t::default())
+        },
+        ($v: expr) => {
+            Val::$t($t::new($v))
+        },
+    }
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/macro_rules.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/macro_rules.rs
@@ -102,21 +102,21 @@ macro m2 {
     ($expr:expr, $($func:ident)*) => {{
         let x = $expr;
         $func(x)
-    }}
+    }},
 
     /* b */
     () => {
         /* c */
-    }
+    },
 
-    (@tag) => {}
+    (@tag) => {},
 
     // d
     ($item:ident) => {
         mod macro_item {
             struct $item;
         }
-    }
+    },
 }
 
 // #2438, #2476


### PR DESCRIPTION
A "macro" definition like

```rust
macro m {
    () => {},
    ($a:expr) => {$a},
}
```

has its branches separated by commas. Previously rustfmt only parsed
branches separated by semicolons, which is applicable only to
"macro_rules" definitions.

Closes #4111