### PR TITLE
Exclude where kw from comment following fn return type

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/items.rs
+++ b/rustfmt-core/rustfmt-lib/src/items.rs
@@ -2432,9 +2432,11 @@ fn rewrite_fn_base(
             result.push_str(&ret_str);
         }
 
-        // Comment between return type and the end of the decl.
-        let snippet_lo = fd.output.span().hi();
         if where_clause.predicates.is_empty() {
+            // Comment between return type and the end of the decl.
+            // Even if there are no predicates in the where clause, the "where" kw may be present,
+            // so start the snippet after it.
+            let snippet_lo = where_clause.span.hi();
             let snippet_hi = span.hi();
             let snippet = context.snippet(mk_sp(snippet_lo, snippet_hi));
             // Try to preserve the layout of the original snippet.

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-4001.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-4001.rs
@@ -1,0 +1,3 @@
+fn unit() -> () where     /* comment */ {
+    ()
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4001.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4001.rs
@@ -1,0 +1,3 @@
+fn unit() -> () /* comment */ {
+    ()
+}


### PR DESCRIPTION
rustfmt tries to preserve the comment between a fn return type and the
start of the fn body if there are no where clauses following the return
type. However, even if there are no where clauses present, the "where"
keyword may be. To elide the "where" keyword in this context, just get
the comment snippet starting after the where clause span, which always
includes the "where" keyword if present.

Closes #4001