### PR TITLE
Merge configs from parent directories

### DIFF
--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -71,25 +71,27 @@ function show_head {
     echo "Head commit of ${INTEGRATION}: $head"
 }
 
+tempdir=$(mktemp -d)
+
 case ${INTEGRATION} in
     cargo)
-        git clone --depth=1 https://github.com/rust-lang/${INTEGRATION}.git
-        cd ${INTEGRATION}
+        git clone --depth=1 https://github.com/rust-lang/${INTEGRATION}.git ${tempdir}
+        cd ${tempdir}
         show_head
         export CFG_DISABLE_CROSS_TESTS=1
         check_fmt_with_all_tests
         cd -
         ;;
     crater)
-        git clone --depth=1 https://github.com/rust-lang-nursery/${INTEGRATION}.git
-        cd ${INTEGRATION}
+        git clone --depth=1 https://github.com/rust-lang-nursery/${INTEGRATION}.git ${tempdir}
+        cd ${tempdir}
         show_head
         check_fmt_with_lib_tests
         cd -
         ;;
     *)
-        git clone --depth=1 https://github.com/rust-lang-nursery/${INTEGRATION}.git
-        cd ${INTEGRATION}
+        git clone --depth=1 https://github.com/rust-lang-nursery/${INTEGRATION}.git ${tempdir}
+        cd ${tempdir}
         show_head
         check_fmt_with_all_tests
         cd -

--- a/rustfmt-core/rustfmt-bin/src/bin/main.rs
+++ b/rustfmt-core/rustfmt-bin/src/bin/main.rs
@@ -488,7 +488,7 @@ fn format(opt: Opt) -> Result<i32> {
     if opt.verbose {
         if let Some(paths) = config_paths.as_ref() {
             println!(
-                "Using rustfmt config files {}",
+                "Using rustfmt config file(s) {}",
                 paths
                     .into_iter()
                     .map(|p| p.display().to_string())

--- a/rustfmt-core/rustfmt-bin/src/bin/main.rs
+++ b/rustfmt-core/rustfmt-bin/src/bin/main.rs
@@ -488,13 +488,12 @@ fn format(opt: Opt) -> Result<i32> {
     if opt.verbose {
         if let Some(paths) = config_paths.as_ref() {
             println!(
-                "Using rustfmt config files {} for {}",
+                "Using rustfmt config files {}",
                 paths
                     .into_iter()
                     .map(|p| p.display().to_string())
                     .collect::<Vec<_>>()
                     .join(","),
-                file.display()
             );
         }
     }

--- a/rustfmt-core/rustfmt-lib/src/config.rs
+++ b/rustfmt-core/rustfmt-lib/src/config.rs
@@ -301,17 +301,6 @@ impl Config {
         match resolve_project_files(dir)? {
             None => Ok((Config::default(), None)),
             Some(paths) => {
-                // If this branch is hit, there must be at least one config file available.
-                let most_local_path = &paths[0];
-                if let Ok(partial_config) = PartialConfig::from_toml_path(most_local_path) {
-                    let config =
-                        Config::default().fill_from_parsed_config(partial_config, most_local_path);
-                    if config.version() == Version::One {
-                        // In v1, don't merge transient config files. Just use the most local one.
-                        return Ok((config, Some(vec![most_local_path.clone()])));
-                    }
-                }
-
                 let mut config = Config::default();
                 let mut used_paths = Vec::with_capacity(paths.len());
                 for path in paths.into_iter().rev() {

--- a/rustfmt-core/rustfmt-lib/src/config.rs
+++ b/rustfmt-core/rustfmt-lib/src/config.rs
@@ -273,14 +273,10 @@ impl Config {
 
             // List of closest -> most distant rustfmt config from the current directory.
             let config_paths: Option<Vec<_>> = paths.into_iter().filter(|p| p.is_some()).collect();
-            let has_paths = config_paths.as_ref().and_then(|paths| {
-                if paths.is_empty() {
-                    None
-                } else {
-                    Some(paths.len())
-                }
-            });
-            if has_paths.is_some() {
+            let has_paths = config_paths
+                .as_ref()
+                .map_or(false, |paths| !paths.is_empty());
+            if has_paths {
                 return Ok(config_paths);
             }
 

--- a/rustfmt-core/rustfmt-lib/src/config.rs
+++ b/rustfmt-core/rustfmt-lib/src/config.rs
@@ -293,9 +293,7 @@ impl Config {
             Ok(None)
         }
 
-        let files = resolve_project_files(dir);
-
-        match files? {
+        match resolve_project_files(dir)? {
             None => Ok((Config::default(), None)),
             Some(paths) => {
                 let mut config = Config::default();

--- a/rustfmt-core/rustfmt-lib/src/config/config_type.rs
+++ b/rustfmt-core/rustfmt-lib/src/config/config_type.rs
@@ -50,19 +50,19 @@ impl ConfigType for IgnoreList {
     }
 }
 
-macro_rules! update {
-    ($self:ident, ignore = $val:ident, $dir:ident) => {
-        $self.ignore.1 = true;
+macro_rules! update_config {
+    ($config:ident, ignore = $val:ident, $dir:ident) => {
+        $config.ignore.1 = true;
 
         let mut new_ignored = $val;
         new_ignored.add_prefix($dir);
-        let old_ignored = $self.ignore.2;
-        $self.ignore.2 = old_ignored.merge_into(new_ignored);
+        let old_ignored = $config.ignore.2;
+        $config.ignore.2 = old_ignored.merge_into(new_ignored);
     };
 
-    ($self:ident, $i:ident = $val:ident, $dir:ident) => {
-        $self.$i.1 = true;
-        $self.$i.2 = $val;
+    ($config:ident, $i:ident = $val:ident, $dir:ident) => {
+        $config.$i.1 = true;
+        $config.$i.2 = $val;
     };
 }
 
@@ -165,10 +165,10 @@ macro_rules! create_config {
             $(
                 if let Some(val) = parsed.$i {
                     if self.$i.3 {
-                        update!(self, $i = val, dir);
+                        update_config!(self, $i = val, dir);
                     } else {
                         if is_nightly_channel!() {
-                            update!(self, $i = val, dir);
+                            update_config!(self, $i = val, dir);
                         } else {
                             eprintln!("Warning: can't set `{} = {:?}`, unstable features are only \
                                        available in nightly channel.", stringify!($i), val);

--- a/rustfmt-core/rustfmt-lib/src/config/config_type.rs
+++ b/rustfmt-core/rustfmt-lib/src/config/config_type.rs
@@ -50,6 +50,22 @@ impl ConfigType for IgnoreList {
     }
 }
 
+macro_rules! update {
+    ($self:ident, ignore = $val:ident, $dir:ident) => {
+        $self.ignore.1 = true;
+
+        let mut new_ignored = $val;
+        new_ignored.add_prefix($dir);
+        let old_ignored = $self.ignore.2;
+        $self.ignore.2 = old_ignored.merge_into(new_ignored);
+    };
+
+    ($self:ident, $i:ident = $val:ident, $dir:ident) => {
+        $self.$i.1 = true;
+        $self.$i.2 = $val;
+    };
+}
+
 macro_rules! create_config {
     ($($i:ident: $Ty:ty, $def:expr, $is_stable:literal, $dstring:literal;)+) => (
         use std::io::Write;
@@ -149,12 +165,10 @@ macro_rules! create_config {
             $(
                 if let Some(val) = parsed.$i {
                     if self.$i.3 {
-                        self.$i.1 = true;
-                        self.$i.2 = val;
+                        update!(self, $i = val, dir);
                     } else {
                         if is_nightly_channel!() {
-                            self.$i.1 = true;
-                            self.$i.2 = val;
+                            update!(self, $i = val, dir);
                         } else {
                             eprintln!("Warning: can't set `{} = {:?}`, unstable features are only \
                                        available in nightly channel.", stringify!($i), val);
@@ -164,7 +178,6 @@ macro_rules! create_config {
             )+
                 self.set_heuristics();
                 self.set_license_template();
-                self.set_ignore(dir);
                 self
             }
 
@@ -395,10 +408,6 @@ macro_rules! create_config {
                         }
                     }
                 }
-            }
-
-            fn set_ignore(&mut self, dir: &Path) {
-                self.ignore.2.add_prefix(dir);
             }
 
             #[allow(unreachable_pub)]

--- a/rustfmt-core/rustfmt-lib/src/config/options.rs
+++ b/rustfmt-core/rustfmt-lib/src/config/options.rs
@@ -277,14 +277,18 @@ impl IgnoreList {
         &self.rustfmt_toml_path
     }
 
+    /// Merges `self` into `other`, returning a new `IgnoreList`. The resulting `IgnoreList` uses
+    /// the `rustfmt_toml_path` of `other`, and only contains paths that are in `other`'s
+    /// `rustfmt_toml_path`.
     pub fn merge_into(self, other: Self) -> Self {
         let old_rustfmt_toml_path = self.rustfmt_toml_path;
-        let new_rustfmt_toml_path = other.rustfmt_toml_path.clone();
+        let new_rustfmt_toml_path = other.rustfmt_toml_path;
         let relocalized_old_paths: HashSet<PathBuf> = self
             .path_set
             .into_iter()
             .map(|p| old_rustfmt_toml_path.parent().unwrap().join(p))
             .map(|p| {
+                // Only keep old paths that are also in the new config path
                 p.strip_prefix(new_rustfmt_toml_path.parent().unwrap())
                     .map(PathBuf::from)
             })

--- a/rustfmt-core/rustfmt-lib/src/config/options.rs
+++ b/rustfmt-core/rustfmt-lib/src/config/options.rs
@@ -292,8 +292,7 @@ impl IgnoreList {
                 p.strip_prefix(new_rustfmt_toml_path.parent().unwrap())
                     .map(PathBuf::from)
             })
-            .filter(|p| p.is_ok())
-            .map(|p| p.unwrap())
+            .flatten()
             .collect();
 
         let mut path_set = other.path_set;


### PR DESCRIPTION
Currently, `rustfmt` stops building its configuration after one
configuration file is found. However, users may expect that `rustfmt`
includes configuration options inhereted by configuration files in
parent directories of the directory `rustfmt` is run in.

The motivation for this commit is for a use case involving files that
should be ignored by `rustfmt`. Consider the directory structure

```
a
|-- rustfmt.toml
|-- b
    |-- rustfmt.toml
    |-- main.rs
```

Suppose `a/rustfmt.toml` has the option `ignore = ["b/main.rs"]`. A user
may expect that running `rusfmt` in either directory `a/` or `b/` will
ignore `main.rs`. Today, though, if `rustfmt` is run in `b/`, `main.rs`
will be formatted because only `b/rustfmt.toml` will be used for
configuration.

Although motivated by the use case for ignored files, this change sets
up `rustfmt` to incrementally populate all configuration options from
parent config files. The priority of population is closest config file
to most transient config file.

To avoid churn of the existing implementation for ignoring files,
populating the ignored files config option with multiple config files is
done by computing a join. Given config files "outer" and "inner", where
"inner" is of higher priority (nested in the directory of) "outer", we
merge their `ignore` configurations by finding the ignore files
specified in "outer" that are present in the "inner" directory, and
appending this to the files ignored by "inner".

This means that printing an `ignore` configuration may not be entirely
accurate, as it could be missing files that are not in the current
directory specified by transient configurations. These files are out of
the scope the `rustfmt` instance's operation, though, so for practical
purposes I don't think this matters.

Closes #3881