### PR TITLE
Align string type for edition

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -519,8 +519,8 @@ fn main() {
 
 Specifies which edition is used by the parser.
 
-- **Default value**: `2015`
-- **Possible values**: `2015`, `2018`
+- **Default value**: `"2015"`
+- **Possible values**: `"2015"`, `"2018"`
 - **Stable**: Yes
 
 Rustfmt is able to pick up the edition used by reading the `Cargo.toml` file if executed


### PR DESCRIPTION
Writing `2018` for the edition, like it suggests it results in
```
Error: Decoding config file failed:
invalid type: integer `2018`, expected string for key `edition`
Please check your config file.
```

So just like other strings, make it sure it has to be a string