### PR TITLE
#4099: trailing_comma + struct_field_align_threshold -> removing a struct's commas

### DIFF
--- a/rustfmt-core/rustfmt-lib/src/formatting/vertical.rs
+++ b/rustfmt-core/rustfmt-lib/src/formatting/vertical.rs
@@ -109,11 +109,6 @@ impl AlignedItem for ast::Field {
     }
 }
 
-// This is the code that reformats struct declarations
-// It looks to me that the problem is that struct declarations are formatted by 'groups'
-// i.e, the code formats a single group of fields each time, each group separated by empty lines
-// This means that it thinks the end of a single group is also the end of the struct declaration
-// So it won't insert commas when there aren't supposed to be any trailing commas
 pub(crate) fn rewrite_with_alignment<T: AlignedItem>(
     fields: &[T],
     context: &RewriteContext<'_>,

--- a/rustfmt-core/rustfmt-lib/tests/source/issue-4099.rs
+++ b/rustfmt-core/rustfmt-lib/tests/source/issue-4099.rs
@@ -1,0 +1,30 @@
+// rustfmt-struct_field_align_threshold: 127
+// rustfmt-trailing_comma: Never
+
+struct S {
+    aaa: f32,
+
+    bbb: f32,
+
+    ccc: f32,
+}
+
+struct S2 {
+    aaa: f32,
+    bbb: f32,
+    ccc: f32,
+}
+
+struct S3 {
+    aaa: f32,
+    bbb: f32,
+
+    ccc: f32,
+}
+
+struct S4 {
+    aaa: f32,
+
+    bbb: f32,
+    ccc: f32,
+}

--- a/rustfmt-core/rustfmt-lib/tests/target/issue-4099.rs
+++ b/rustfmt-core/rustfmt-lib/tests/target/issue-4099.rs
@@ -1,0 +1,30 @@
+// rustfmt-struct_field_align_threshold: 127
+// rustfmt-trailing_comma: Never
+
+struct S {
+    aaa: f32,
+
+    bbb: f32,
+
+    ccc: f32
+}
+
+struct S2 {
+    aaa: f32,
+    bbb: f32,
+    ccc: f32
+}
+
+struct S3 {
+    aaa: f32,
+    bbb: f32,
+
+    ccc: f32
+}
+
+struct S4 {
+    aaa: f32,
+
+    bbb: f32,
+    ccc: f32
+}


### PR DESCRIPTION
This PR addresses https://github.com/rust-lang/rustfmt/issues/4099. 

It looks to me that fields are separated into groups based on newlines. However, the trailing comma for each group may be removed. I added code that ensures that only the final group of fields can have their trailing comma removed.