### PR TITLE
Fix CFG_RELEASE value

### DIFF
--- a/.cargo/Makefile.toml
+++ b/.cargo/Makefile.toml
@@ -1,8 +1,8 @@
 # This Makefile.toml defines common tasks and settings used in the rustfmt project.
 
 [env]
-CFG_RELEASE = { value = "nightly", condition = { env_not_set = ["CFG_RELEASE"] } }
-CFG_RELEASE_CHANNEL = { value = "nightly", condition = { env_not_set = ["CFG_RELEASE_CHANNEL"] } }
+CFG_RELEASE = { value = "${CARGO_MAKE_RUST_VERSION}", condition = { env_not_set = ["CFG_RELEASE"] } }
+CFG_RELEASE_CHANNEL = { value = "${CARGO_MAKE_RUST_CHANNEL}", condition = { env_not_set = ["CFG_RELEASE_CHANNEL"] } }
 
 [tasks.b]
 alias = "build"


### PR DESCRIPTION
I ran into an issue while using rustfmt and found rust-lang/rust#72423
I saw how you solved it locally and decided to do the same as well, but the actual values provided are not accurate.
I believe CFG_RELEASE should hold the rustc version number and not channel.
so this should hopefully provide a more accurate value.