### PR TITLE
Fix makefile

### DIFF
--- a/.cargo/Makefile.toml
+++ b/.cargo/Makefile.toml
@@ -4,8 +4,21 @@
 CFG_RELEASE = { value = "${CARGO_MAKE_RUST_VERSION}", condition = { env_not_set = ["CFG_RELEASE"] } }
 CFG_RELEASE_CHANNEL = { value = "${CARGO_MAKE_RUST_CHANNEL}", condition = { env_not_set = ["CFG_RELEASE_CHANNEL"] } }
 
+[tasks.build-bin]
+workspace = false
+command = "cargo"
+args = [
+  "build",
+  "--bin",
+  "rustfmt",
+  "--all-features",
+]
+
 [tasks.b]
 alias = "build"
+
+[tasks.bb]
+alias = "build-bin"
 
 [tasks.c]
 alias = "check"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,15 +1,5 @@
 extend = ".cargo/Makefile.toml"
 
-[tasks.build]
-clear = true
-command = "cargo"
-args = [
-  "build",
-  "--manifest-path",
-  "rustfmt-core/Cargo.toml",
-  "--workspace",
-]
-
 [tasks.install]
 command = "cargo"
 args = [

--- a/rustfmt-core/rustfmt-lib/config_proc_macro/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/config_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustfmt-config_proc_macro"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["topecongiro <seuchida@gmail.com>"]
 edition = "2018"
 description = "A collection of procedural macros for rustfmt"

--- a/rustfmt-core/rustfmt-lib/config_proc_macro/Cargo.toml
+++ b/rustfmt-core/rustfmt-lib/config_proc_macro/Cargo.toml
@@ -21,4 +21,3 @@ serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = []
-debug-with-rustfmt = []

--- a/rustfmt-core/rustfmt-lib/config_proc_macro/src/lib.rs
+++ b/rustfmt-core/rustfmt-lib/config_proc_macro/src/lib.rs
@@ -18,8 +18,7 @@ pub fn config_type(_args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::Item);
     let output = config_type::define_config_type(&input);
 
-    #[cfg(feature = "debug-with-rustfmt")]
-    {
+    if std::env::var("RUSTFMT_DEV_DEBUG_PROC_MACRO").is_ok() {
         utils::debug_with_rustfmt(&output);
     }
 

--- a/rustfmt-core/rustfmt-lib/config_proc_macro/src/utils.rs
+++ b/rustfmt-core/rustfmt-lib/config_proc_macro/src/utils.rs
@@ -19,9 +19,8 @@ pub fn is_unit(v: &syn::Variant) -> bool {
     }
 }
 
-#[cfg(feature = "debug-with-rustfmt")]
 /// Pretty-print the output of proc macro using rustfmt.
-pub fn debug_with_rustfmt(input: &TokenStream) {
+pub(crate) fn debug_with_rustfmt(input: &TokenStream) {
     use std::io::Write;
     use std::process::{Command, Stdio};
 


### PR DESCRIPTION
In this PR, I'm going to make a few changes to the Makefile configuration.

- Add a `cargo make bb`. This task builds only the `rustfmt` binary.
- Remove a feature used by config_proc_macro for debugging. Replace it with the environment variable instead.