### PR TITLE
Fix stable toggle on gh pages configuration site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -155,7 +155,9 @@
                     head: val[0].text,
                     value: val,
                     stable: val.some((elem) => {
-                      return !!elem.text && elem.text.includes("**Stable**: Yes")
+                      return elem.type === "list" &&
+                        !!elem.raw &&
+                        elem.raw.includes("**Stable**: Yes");
                     }),
                     text: val.reduce((result, next) => {
                       return next.text != null


### PR DESCRIPTION
A demonstration of the fix is included in the PR associated with this
commit.

![rustfmt-stable](https://user-images.githubusercontent.com/20735482/83357328-9c03d800-a320-11ea-9304-91254ab02fe4.gif)
