### PR TITLE
Do not emit file name on stdin mode

### DIFF
--- a/src/rustfmt/main.rs
+++ b/src/rustfmt/main.rs
@@ -131,10 +131,10 @@ struct Opt {
 
 impl Opt {
     fn verbosity(&self) -> Verbosity {
-        if self.verbose {
-            Verbosity::Verbose
-        } else if self.quiet {
+        if self.quiet || self.files.is_empty() {
             Verbosity::Quiet
+        } else if self.verbose {
+            Verbosity::Verbose
         } else {
             Verbosity::Normal
         }


### PR DESCRIPTION
Currently, rustfmt emits `stdin:` prefix unnecessarily on stdin mode:

```
$ rustfmt
fn main()
{}^D
stdin:

fn main() {}
```

This PR fixes it so that rustfmt no longer emits the prefix.