### PR TITLE
feat: conditionally allow unstable opts on stable/beta

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,10 +15,7 @@ jobs:
       matrix:
         integration: [
           bitflags,
-          chalk,
-          crater,
           error-chain,
-          glob,
           log,
           mdbook,
           packed_simd,
@@ -37,6 +34,15 @@ jobs:
           # Instead, leverage `continue-on-error`
           # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error
           #
+          # Failing due to breaking changes in rustfmt 2.0 where empty
+          # match blocks have trailing commas removed
+          # https://github.com/rust-lang/rustfmt/pull/4226
+          - integration: chalk
+            allow-failure: true
+          - integration: crater
+            allow-failure: true
+          - integration: glob
+            allow-failure: true
           # Using old rustfmt configuration option
           - integration: rand
             allow-failure: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,7 @@ matrix:
     - env: CFG_RELEASE_CHANNEL=beta
     - os: osx
     - env: INTEGRATION=bitflags
-    - env: INTEGRATION=chalk
-    - env: INTEGRATION=crater
     - env: INTEGRATION=error-chain
-    - env: INTEGRATION=glob
     - env: INTEGRATION=log
     - env: INTEGRATION=mdbook
     - env: INTEGRATION=packed_simd
@@ -30,6 +27,12 @@ matrix:
     - env: INTEGRATION=tempdir
     - env: INTEGRATION=futures-rs
   allow_failures:
+    # Failing due to breaking changes in rustfmt 2.0 where empty
+    # match blocks have trailing commas removed
+    # https://github.com/rust-lang/rustfmt/pull/4226
+    - env: INTEGRATION=chalk
+    - env: INTEGRATION=crater
+    - env: INTEGRATION=glob
     # Using old configuration option
     - env: INTEGRATION=rand
     # Doesn't build - keep this in allow_failures as it's fragile to breaking changes of rustc.

--- a/Configurations.md
+++ b/Configurations.md
@@ -2395,11 +2395,18 @@ fn lorem<Ipsum: Dolor+Sit=Amet>() {
 
 ## `unstable_features`
 
-Enable unstable features on the unstable channel.
+Enable unstable features on stable and beta channels (unstable features are available by default on nightly).
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
-- **Stable**: No (tracking issue: [#3387](https://github.com/rust-lang/rustfmt/issues/3387))
+- **Stable**: Yes
+
+**Note** - if you are setting unstable configuration options via the CLI instead of the configuration file, then you should include a `unstable_features=true` item before any of the unstable items.
+
+For example:
+```bash
+rustfmt src/lib.rs --config unstable_features=true merge_imports=true
+```
 
 ## `use_field_init_shorthand`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,8 +142,9 @@ create_config! {
     // Control options (changes the operation of rustfmt, rather than the formatting)
     required_version: String, env!("CARGO_PKG_VERSION").to_owned(), false,
         "Require a specific version of rustfmt";
-    unstable_features: bool, false, false,
-            "Enables unstable features. Only available on nightly channel";
+    unstable_features: bool, false, true,
+            "Enables unstable features on stable and beta channels (unstable features are enabled \
+             by default on nightly channel)";
     hide_parse_errors: bool, false, false, "Hide errors from the parser";
     error_on_line_overflow: bool, false, false, "Error if unable to get all lines within max_width";
     error_on_unformatted: bool, false, false,
@@ -436,6 +437,10 @@ mod test {
             chain_width: usize, 60, true, "Maximum length of a chain to fit on a single line.";
             single_line_if_else_max_width: usize, 50, true, "Maximum line length for single \
                 line if-else expressions. A value of zero means always break if-else expressions.";
+
+            unstable_features: bool, false, true,
+                "Enables unstable features on stable and beta channels (unstable features are enabled \
+                 by default on nightly channel)";
 
             // Options that are used by the tests
             stable_option: bool, false, true, "A stable option";

--- a/src/config.rs
+++ b/src/config.rs
@@ -698,13 +698,31 @@ ignore = []
         }
 
         #[test]
-        fn test_from_toml_not_nightly() {
+        fn test_from_toml_not_nightly_unstable_set() {
             if is_nightly_channel!() {
                 // This test requires non-nightly
                 return;
             }
-            let config = Config::from_toml("unstable_features = true", Path::new("")).unwrap();
-            assert_eq!(config.was_set().unstable_features(), false);
+            let toml = r#"
+                unstable_features = true
+                merge_imports = true
+            "#;
+            let config = Config::from_toml(toml, Path::new("")).unwrap();
+            assert_eq!(config.was_set().unstable_features(), true);
+            assert_eq!(config.was_set().merge_imports(), true);
+            assert_eq!(config.unstable_features(), true);
+            assert_eq!(config.merge_imports(), true);
+        }
+
+        #[test]
+        fn test_from_toml_not_nightly_unstable_not_set() {
+            if is_nightly_channel!() {
+                // This test requires non-nightly
+                return;
+            }
+            let config = Config::from_toml("merge_imports = true", Path::new("")).unwrap();
+            assert_eq!(config.was_set().merge_imports(), false);
+            assert_eq!(config.merge_imports(), false);
         }
 
         #[test]
@@ -749,8 +767,12 @@ ignore = []
             }
             let mut config = Config::default();
             assert_eq!(config.unstable_features(), false);
+            config.override_value("merge_imports", "true");
+            assert_eq!(config.merge_imports(), false);
             config.override_value("unstable_features", "true");
             assert_eq!(config.unstable_features(), true);
+            config.override_value("merge_imports", "true");
+            assert_eq!(config.merge_imports(), true);
         }
 
         #[test]

--- a/src/test/configuration_snippet.rs
+++ b/src/test/configuration_snippet.rs
@@ -96,6 +96,9 @@ impl ConfigCodeBlock {
 
     fn get_block_config(&self) -> Config {
         let mut config = Config::default();
+        if !crate::is_nightly_channel!() {
+            config.override_value("unstable_features", "true");
+        }
         if self.config_name.is_some() && self.config_value.is_some() {
             config.override_value(
                 self.config_name.as_ref().unwrap(),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -629,6 +629,10 @@ fn read_config(filename: &Path) -> (Config, OperationSetting, EmitterConfig) {
         get_config(filename.with_extension("toml").file_name().map(Path::new))
     };
 
+    if !config.was_set().unstable_features() && !is_nightly_channel!() {
+        config.override_value("unstable_features", "true");
+    }
+
     let mut operation_setting = OperationSetting::default();
     let mut emitter_config = EmitterConfig::default();
     for (key, val) in &sig_comments {

--- a/tests/config/small_tabs.toml
+++ b/tests/config/small_tabs.toml
@@ -1,3 +1,4 @@
+unstable_features = true
 max_width = 100
 comment_width = 80
 tab_spaces = 2


### PR DESCRIPTION
One of two possible approaches to resolve #4081, and my vote would be for this approach.

AIUI, `unstable_features` is basically an no-op configuration item today that rustfmt doesn't actually use. With config options set in the configuration file, all unstable options are already allowed on nightly and disallowed on stable/beta. For config options specified/overriden via the CLI, rustfmt doesn't do any stability/channel checks whatsoever (unstable config opts can be used on stable even with `unstable_features` not set/set to false, see #4081) 


With the changes in this PR:
* unstable options are still always available on nightly
* unstable options on stable/beta can be leveraged, but _only_ when `unstable_features` is set to true (regardless of whether the unstable config options are set via the CLI and/or config file)

The other approach would be to completely remove `unstable_features` and completely disable the ability to opt-in to unstable rustfmt config options on stable/beta. IMHO rustfmt users have articulated some valid use cases when it would be beneficial for them to be able to opt-in to using unstable rustfmt opts on stable, which is why I prefer this approach over that alternative.

Also refs https://github.com/rust-lang/rustfmt/pull/4064#issue-380003069 and #3387