### PR TITLE
Use rewrite buffer to determine if comment should be on a newline

### DIFF
--- a/tests/source/issue-4227.rs
+++ b/tests/source/issue-4227.rs
@@ -1,0 +1,6 @@
+fn main() {
+    /*
+    Block comment
+    */ // Line comment
+    println!("Hello");
+}

--- a/tests/target/issue-4227.rs
+++ b/tests/target/issue-4227.rs
@@ -1,0 +1,7 @@
+fn main() {
+    /*
+    Block comment
+    */
+    // Line comment
+    println!("Hello");
+}


### PR DESCRIPTION
Rewriting may change the context of a later item (in this case, a
comment), so looking at the original snippet to determine the context
may not be correct. Since for any given item, all previous items should
already be rewritten, it is enough to determine the item's context in
the new source but looking back at the rewrite buffer.

This commit also gets rid of variables no longer used due to the change.

Closes #4227