### PR TITLE
Drop trailing semicolons on item statements

### DIFF
--- a/src/formatting/visitor.rs
+++ b/src/formatting/visitor.rs
@@ -144,8 +144,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         match stmt.as_ast_node().kind {
             ast::StmtKind::Item(ref item) => {
                 self.visit_item(item);
-                // Handle potential `;` after the item.
-                self.format_missing(stmt.span().hi());
+                // If the item requires a trailing ";" (like `struct Foo;`), we should have already
+                // handled it. Otherwise there still may be a trailing ";", but it is unnecessary.
+                // Drop it by fast-forwarding the visitor to the end of the item.
+                self.last_pos = stmt.span().hi();
             }
             ast::StmtKind::Local(..) | ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
                 let attrs = get_attrs_from_stmt(stmt.as_ast_node());

--- a/tests/source/issue-4222.rs
+++ b/tests/source/issue-4222.rs
@@ -1,6 +1,6 @@
 fn first_function() {
     struct inner_item {
         field: u32,
-    }
+    };
     struct Foo;
 }

--- a/tests/source/issue-4222.rs
+++ b/tests/source/issue-4222.rs
@@ -1,0 +1,6 @@
+fn first_function() {
+    struct inner_item {
+        field: u32,
+    }
+    struct Foo;
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -94,7 +94,7 @@ fn foo() -> bool {
             const fn get(&self) -> usize {
                 5
             }
-        };
+        }
         Foo.get()
     }];
 }

--- a/tests/target/issue-4222.rs
+++ b/tests/target/issue-4222.rs
@@ -1,0 +1,6 @@
+fn first_function() {
+    struct inner_item {
+        field: u32,
+    }
+    struct Foo;
+}


### PR DESCRIPTION
Per the Rust grammar, trailing semicolons on an item statement may be
optional (i.e. if the statement is a block). Keeping the semicolon in
such cases is unnecessary and may be confusing (does the semicolon
terminate the last statement, or is it an empty statement?), so just
drop it.

Closes #4222