### PR TITLE
Preserve Markdown line breaks in inner and outer block doc comments

### DIFF
--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -368,9 +368,7 @@ fn identify_comment(
 
     let (first_group, rest) = orig.split_at(first_group_ending);
     let rewritten_first_group =
-        if !config.normalize_comments() && has_bare_lines && style.is_block_comment()
-        // && !is_doc_comment
-        {
+        if !config.normalize_comments() && has_bare_lines && style.is_block_comment() {
             trim_left_preserve_layout(first_group, shape.indent, config, is_doc_comment)?
         } else if !config.normalize_comments()
             && !config.wrap_comments()

--- a/src/formatting/macros.rs
+++ b/src/formatting/macros.rs
@@ -180,7 +180,12 @@ fn return_macro_parse_failure_fallback(
         })
         .unwrap_or(false);
     if is_like_block_indent_style {
-        return trim_left_preserve_layout(context.snippet(span), indent, &context.config);
+        return trim_left_preserve_layout(
+            context.snippet(span),
+            indent,
+            &context.config,
+            /* inside_doc_comment */ false,
+        );
     }
 
     context
@@ -432,7 +437,12 @@ fn rewrite_macro_inner(
             // the `macro_name!` and `{ /* macro_body */ }` but skip modifying
             // anything in between the braces (for now).
             let snippet = context.snippet(mac.span()).trim_start_matches(|c| c != '{');
-            match trim_left_preserve_layout(snippet, shape.indent, &context.config) {
+            match trim_left_preserve_layout(
+                snippet,
+                shape.indent,
+                &context.config,
+                /* inside_doc_comment */ false,
+            ) {
                 Some(macro_body) => Some(format!("{} {}", macro_name, macro_body)),
                 None => Some(format!("{} {}", macro_name, snippet)),
             }

--- a/tests/target/issue-3659.rs
+++ b/tests/target/issue-3659.rs
@@ -1,0 +1,8 @@
+/*! multiline doc-comment  
+with trailing double space  
+*/
+
+/** multiline doc-comment  
+with trailing double space  
+*/
+fn foo() {}


### PR DESCRIPTION
Rust has a lot of doc comment types, perhaps too many. This adds outer
block (`/**`) and inner block (`/*!`) doc comments and ensures their
trailing whitespace is preserved in cases it makes a difference in the
output Markdown.

Closes #3659