### PR TITLE
Pick up comments between visibility modifier and item name

### DIFF
--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -2998,16 +2998,20 @@ fn format_header(
 
     // Check for a missing comment between the visibility and the item name.
     let after_vis = vis.span.hi();
-    let before_item_name = context
+    if let Some(before_item_name) = context
         .snippet_provider
-        .span_before(mk_sp(vis.span().lo(), ident.span.hi()), item_name.trim());
-    if let Some(cmt) = rewrite_missing_comment(mk_sp(after_vis, before_item_name), shape, context) {
-        result.push_str(&cmt);
-        let need_newline = last_line_contains_single_line_comment(&result);
-        if need_newline {
-            result.push_str(&offset.to_string_with_newline(context.config));
-        } else if cmt.len() > 0 {
-            result.push(' ');
+        .opt_span_before(mk_sp(vis.span().lo(), ident.span.hi()), item_name.trim())
+    {
+        if let Some(cmt) =
+            rewrite_missing_comment(mk_sp(after_vis, before_item_name), shape, context)
+        {
+            result.push_str(&cmt);
+            let need_newline = last_line_contains_single_line_comment(&result);
+            if need_newline {
+                result.push_str(&offset.to_string_with_newline(context.config));
+            } else if cmt.len() > 0 {
+                result.push(' ');
+            }
         }
     }
 

--- a/tests/source/issue-2781.rs
+++ b/tests/source/issue-2781.rs
@@ -1,0 +1,11 @@
+pub      // Oh, no. A line comment.
+struct Foo {}
+
+pub     /* Oh, no. A block comment. */     struct Foo {}
+
+mod inner {
+pub      // Oh, no. A line comment.
+struct Foo {}
+
+pub     /* Oh, no. A block comment. */     struct Foo {}
+}

--- a/tests/target/issue-2781.rs
+++ b/tests/target/issue-2781.rs
@@ -1,0 +1,11 @@
+pub // Oh, no. A line comment.
+struct Foo {}
+
+pub /* Oh, no. A block comment. */ struct Foo {}
+
+mod inner {
+    pub // Oh, no. A line comment.
+    struct Foo {}
+
+    pub /* Oh, no. A block comment. */ struct Foo {}
+}


### PR DESCRIPTION
I don't think this hurts to fix. #2781, which surfaced this issue, has
a number of comments relating to similar but slightly different issues
(i.e. dropped comments in other places). I can mark #2781 as closed and
then will open new issues for the comments that are not already resolved
or tracked.

Closes #2781