### PR TITLE
bump rustfmt 1.x rustc-ap* crates to v644

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +537,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,83 +719,80 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-ap-arena"
-version = "659.0.0"
+name = "rustc-ap-rustc_arena"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "rustc-ap-graphviz"
-version = "659.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "rustc-ap-rustc_ast"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_ast 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,10 +805,11 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "measureme 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-graphviz 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_graphviz 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -810,15 +821,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "annotate-snippets 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -827,52 +838,57 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_passes 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_passes 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "659.0.0"
+version = "664.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-ap-rustc_graphviz"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,54 +907,62 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_lexer 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_lexer 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "rustc-ap-rustc_serialize"
+version = "664.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-ap-rustc_session"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_feature 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_fs_util 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_target 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_feature 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_fs_util 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_target 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-arena 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_arena 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -946,25 +970,16 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "659.0.0"
+version = "664.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_index 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_macros 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rustc-ap-serialize"
-version = "659.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_index 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_macros 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1042,15 +1057,15 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_ast_pretty 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_attr 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_expand 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_parse 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_session 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_ast_pretty 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_attr 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_expand 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_parse 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_session 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfmt-config_proc_macro 0.2.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1368,6 +1383,7 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7021ce4924a3f25f802b2cccd1af585e39ea1a363a1aa2e72afe54b67a3a7a7"
+"checksum annotate-snippets 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d78ea013094e5ea606b1c05fe35f1dd7ea1eb1ea259908d040b25bd5ec677ee5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
@@ -1431,6 +1447,7 @@ dependencies = [
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+"checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum packed_simd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220"
 "checksum parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
@@ -1451,25 +1468,25 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
-"checksum rustc-ap-arena 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdaf0295fc40b10ec1091aad1a1760b4bb3b4e7c4f77d543d1a2e9d50a01e6b1"
-"checksum rustc-ap-graphviz 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8028e8cdb4eb71810d0c22a5a5e1e3106c81123be63ce7f044b6d4ac100d8941"
-"checksum rustc-ap-rustc_ast 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16e9e502bb3a5568433db1cf2fb1f1e1074934636069cf744ad7c77b58e1428e"
-"checksum rustc-ap-rustc_ast_passes 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "faf35ffecab28f97f7ac01cf6a13afaca6408529d15eb95f317a43b2ffb88933"
-"checksum rustc-ap-rustc_ast_pretty 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3684ed43dc552f1e030e3f7a5a300a7a834bdda4e9e00ab80284be4220d8c603"
-"checksum rustc-ap-rustc_attr 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31b413927daa666983b3b49227f9ac218aa29254546abdb585f20cd71c391870"
-"checksum rustc-ap-rustc_data_structures 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b1c6069e5c522657f1c6f5ab33074e097092f48e804cc896d337e319aacbd60"
-"checksum rustc-ap-rustc_errors 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c374e89b3c9714869ef86076942155383804ba6778c26be2169d324563c31f9"
-"checksum rustc-ap-rustc_expand 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "259d2a7aa7a12f3c99a4ce4123643ec065f1a26f8e89be1f9bedd9757ea53fdc"
-"checksum rustc-ap-rustc_feature 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0296fbc29b629d5ae2ebee1bbf0407bb22de04d26d87216c20899b79579ccb3"
-"checksum rustc-ap-rustc_fs_util 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34734f6cc681399630acd836a14207c6b5b9671a290cc7cad0354b0a4d71b3c9"
-"checksum rustc-ap-rustc_index 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1e4508753d71d3523209c2ca5086db15a1413e71ebf17ad5412bb7ced5e44c2"
-"checksum rustc-ap-rustc_lexer 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "42b9fcd8407e322908a721262fbc0b35b5f3c35bb173a26dd1e0070bde336e33"
-"checksum rustc-ap-rustc_macros 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d104115a689367d2e0bcd99f37e0ebd6b9c8c78bab0d9cbea5bae86323601b5"
-"checksum rustc-ap-rustc_parse 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afaaab91853fc5a3916785ccae727a4433359d9787c260d42b96a2265fe5b287"
-"checksum rustc-ap-rustc_session 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "86e756a57ce6ce1b868e35e64a7e10ab28d49ece80d7c661b07aff5afc6e5d2d"
-"checksum rustc-ap-rustc_span 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "21031c3396ee452f4c6e994b67513a633055c57c86d00336afd9d63149518f34"
-"checksum rustc-ap-rustc_target 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff21badfbead5b0050391eaad8840f2e4fcb03b6b0fc6006f447443529e9ae6e"
-"checksum rustc-ap-serialize 659.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "768b5a305669d934522712bc13502962edfde5128ea63b9e7db4000410be1dc6"
+"checksum rustc-ap-rustc_arena 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c6683b49209f8b132bec33dc6b6c8f9958c8c94eb3586d4cb495e092b61c1da"
+"checksum rustc-ap-rustc_ast 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b21784d92fb2d584800f528866f00fe814f73abda794f406bfd1fbb2f1ca7f7"
+"checksum rustc-ap-rustc_ast_passes 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "820c46fde7ef1df0432073090d775f097b7279ca75ea34ba954081ce4b884d4c"
+"checksum rustc-ap-rustc_ast_pretty 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "013db7dd198fe95962d2cefa5bd0b350cf2028af77c169b17b4baa9c3bbf77d1"
+"checksum rustc-ap-rustc_attr 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "35b5a85c90eb341eec543600ffdd9e262da5ea72a73a23ae4ca2f4ab8cd1a188"
+"checksum rustc-ap-rustc_data_structures 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b92e4c6cb6c43ee9031a71709dc12853b358253c2b41d12a26379994fab625e0"
+"checksum rustc-ap-rustc_errors 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0aa79423260c1b9e2f856e144e040f606b0f5d43644408375becf9d7bcdf86"
+"checksum rustc-ap-rustc_expand 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c07d76ba2a1b7d4325a2ed21d6345ccebd89ddc6666a1535a6edd489fb4cbc11"
+"checksum rustc-ap-rustc_feature 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1bbd625705c1db42a0c7503736292813d7b76ada5da20578fb55c63228c80ab5"
+"checksum rustc-ap-rustc_fs_util 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34cca6e2942fa0b059c582437ead666d5bcf20fa7c242599e2bbea9b609f29ae"
+"checksum rustc-ap-rustc_graphviz 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13d6a029b81f5e02da85763f82c135507f278a4a0c776432c728520563059529"
+"checksum rustc-ap-rustc_index 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bae50852d303e230b2781c994513788136dc6c2fe4ebe032959f0b990a425767"
+"checksum rustc-ap-rustc_lexer 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b7186e74aa2d31bf0e2454325fefcdf0a3da77d9344134592144b9e40d45b15d"
+"checksum rustc-ap-rustc_macros 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc1add04e9d2301164118660ee0bc3266e9a7b1973fc2303fdbe002a12e5401"
+"checksum rustc-ap-rustc_parse 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9cd7fc4968bd60084f2fa4f280fa450b0cf98660a7983d6b93a7ae41b6d1d322"
+"checksum rustc-ap-rustc_serialize 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00bf4c110271d9a2b7dfd2c6eb82e56fd80606a8bad6c102e158c54e44044046"
+"checksum rustc-ap-rustc_session 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "431cf962de71d4c03fb877d54f331ec36eca77350b0539017abc40a4410d6501"
+"checksum rustc-ap-rustc_span 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b912039640597624f4bcb75f1e1fcfa5710267d715a7f73a6336baef341b23d1"
+"checksum rustc-ap-rustc_target 664.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51347a9dadc5ad0b5916cc12d42624b31955285ad13745dbe72f0140038b84e9"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc-rayon 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f32767f90d938f1b7199a174ef249ae1924f6e5bbdb9d112fea141e016f25b3a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,12 +610,26 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.2.6"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-error-attr 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1075,7 +1089,7 @@ dependencies = [
  "rustfmt-config_proc_macro 0.2.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1194,20 +1208,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.3.3"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.3.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1221,6 +1236,16 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1479,7 +1504,8 @@ dependencies = [
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum parking_lot_core 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-"checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
+"checksum proc-macro-error 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e7959c6467d962050d639361f7703b2051c43036d03493c36f01d440fdd3138a"
+"checksum proc-macro-error-attr 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e4002d9f55991d5e019fb940a90e1a95eb80c24e77cb2462dd4dc869604d543a"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum psm 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "659ecfea2142a458893bb7673134bad50b752fea932349c213d6a23874ce3aa7"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -1533,9 +1559,10 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stacker 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "72dd941b456e1c006d6b9f27c526d5b69281288aeea8cba82c19d3843d8ccdd2"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
-"checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
+"checksum structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe43617218c0805c6eb37160119dc3c548110a67786da7218d1c6555212f073"
+"checksum structopt-derive 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c6e79c80e0f4efd86ca960218d4e056249be189ff1c42824dcd9a7f51a56f0bd"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayref"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,13 +1049,13 @@ name = "rustfmt-nightly"
 version = "1.4.17"
 dependencies = [
  "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1072,6 +1077,7 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1263,6 +1269,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1409,7 @@ dependencies = [
 "checksum annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7021ce4924a3f25f802b2cccd1af585e39ea1a363a1aa2e72afe54b67a3a7a7"
 "checksum annotate-snippets 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d78ea013094e5ea606b1c05fe35f1dd7ea1eb1ea259908d040b25bd5ec677ee5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
@@ -1516,6 +1541,8 @@ dependencies = [
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termize 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cc6b305ec0e323c7b6cfff6098a22516e0063d0bb7c3d88660a890217dca099a"
+"checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ env_logger = "0.6"
 getopts = "0.2"
 derive-new = "0.5"
 cargo_metadata = "0.8"
-failure = "0.1.3"
 bytecount = "0.6"
 unicode-width = "0.1.5"
 unicode_categories = "0.1.1"
@@ -57,6 +56,8 @@ annotate-snippets = { version = "0.6", features = ["ansi_term"] }
 structopt = "0.3"
 rustfmt-config_proc_macro = { version = "0.2", path = "config_proc_macro" }
 lazy_static = "1.0.0"
+anyhow = "1.0"
+thiserror = "1.0"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,36 +65,36 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "659.0.0"
+version = "664.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "659.0.0"
+version = "664.0.0"
 
 [dependencies.rustc_attr]
 package = "rustc-ap-rustc_attr"
-version = "659.0.0"
+version = "664.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "659.0.0"
+version = "664.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "659.0.0"
+version = "664.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "659.0.0"
+version = "664.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "659.0.0"
+version = "664.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "659.0.0"
+version = "664.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "659.0.0"
+version = "664.0.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,7 @@
+use anyhow::{format_err, Result};
 use env_logger;
-use failure::{err_msg, format_err, Error as FailureError, Fail};
 use io::Error as IoError;
+use thiserror::Error;
 
 use rustfmt_nightly as rustfmt;
 
@@ -59,27 +60,27 @@ enum Operation {
 }
 
 /// Rustfmt operations errors.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum OperationError {
     /// An unknown help topic was requested.
-    #[fail(display = "Unknown help topic: `{}`.", _0)]
+    #[error("Unknown help topic: `{0}`.")]
     UnknownHelpTopic(String),
     /// An unknown print-config option was requested.
-    #[fail(display = "Unknown print-config option: `{}`.", _0)]
+    #[error("Unknown print-config option: `{0}`.")]
     UnknownPrintConfigTopic(String),
     /// Attempt to generate a minimal config from standard input.
-    #[fail(display = "The `--print-config=minimal` option doesn't work with standard input.")]
+    #[error("The `--print-config=minimal` option doesn't work with standard input.")]
     MinimalPathWithStdin,
     /// An io error during reading or writing.
-    #[fail(display = "io error: {}", _0)]
+    #[error("io error: {0}")]
     IoError(IoError),
     /// Attempt to use --check with stdin, which isn't currently
     /// supported.
-    #[fail(display = "The `--check` option is not supported with standard input.")]
+    #[error("The `--check` option is not supported with standard input.")]
     CheckWithStdin,
     /// Attempt to use --emit=json with stdin, which isn't currently
     /// supported.
-    #[fail(display = "Using `--emit` other than stdout is not supported with standard input.")]
+    #[error("Using `--emit` other than stdout is not supported with standard input.")]
     EmitWithStdin,
 }
 
@@ -192,7 +193,7 @@ fn is_nightly() -> bool {
 }
 
 // Returned i32 is an exit code
-fn execute(opts: &Options) -> Result<i32, FailureError> {
+fn execute(opts: &Options) -> Result<i32> {
     let matches = opts.parse(env::args().skip(1))?;
     let options = GetOptsOptions::from_matches(&matches)?;
 
@@ -214,7 +215,7 @@ fn execute(opts: &Options) -> Result<i32, FailureError> {
             Ok(0)
         }
         Operation::ConfigOutputDefault { path } => {
-            let toml = Config::default().all_options().to_toml().map_err(err_msg)?;
+            let toml = Config::default().all_options().to_toml()?;
             if let Some(path) = path {
                 let mut file = File::create(path)?;
                 file.write_all(toml.as_bytes())?;
@@ -233,7 +234,7 @@ fn execute(opts: &Options) -> Result<i32, FailureError> {
             let file = file.canonicalize().unwrap_or(file);
 
             let (config, _) = load_config(Some(file.parent().unwrap()), Some(options.clone()))?;
-            let toml = config.all_options().to_toml().map_err(err_msg)?;
+            let toml = config.all_options().to_toml()?;
             io::stdout().write_all(toml.as_bytes())?;
 
             Ok(0)
@@ -246,7 +247,7 @@ fn execute(opts: &Options) -> Result<i32, FailureError> {
     }
 }
 
-fn format_string(input: String, options: GetOptsOptions) -> Result<i32, FailureError> {
+fn format_string(input: String, options: GetOptsOptions) -> Result<i32> {
     // try to read config from local directory
     let (mut config, _) = load_config(Some(Path::new(".")), Some(options.clone()))?;
 
@@ -287,7 +288,7 @@ fn format(
     files: Vec<PathBuf>,
     minimal_config_path: Option<String>,
     options: &GetOptsOptions,
-) -> Result<i32, FailureError> {
+) -> Result<i32> {
     options.verify_file_lines(&files);
     let (config, config_path) = load_config(None, Some(options.clone()))?;
 
@@ -335,7 +336,7 @@ fn format(
     // that were used during formatting as TOML.
     if let Some(path) = minimal_config_path {
         let mut file = File::create(path)?;
-        let toml = session.config.used_options().to_toml().map_err(err_msg)?;
+        let toml = session.config.used_options().to_toml()?;
         file.write_all(toml.as_bytes())?;
     }
 
@@ -514,7 +515,7 @@ struct GetOptsOptions {
 }
 
 impl GetOptsOptions {
-    pub fn from_matches(matches: &Matches) -> Result<GetOptsOptions, FailureError> {
+    pub fn from_matches(matches: &Matches) -> Result<GetOptsOptions> {
         let mut options = GetOptsOptions::default();
         options.verbose = matches.opt_present("verbose");
         options.quiet = matches.opt_present("quiet");
@@ -535,7 +536,7 @@ impl GetOptsOptions {
                     options.error_on_unformatted = Some(true);
                 }
                 if let Some(ref file_lines) = matches.opt_str("file-lines") {
-                    options.file_lines = file_lines.parse().map_err(err_msg)?;
+                    options.file_lines = file_lines.parse()?;
                 }
             } else {
                 let mut unstable_options = vec![];
@@ -684,7 +685,7 @@ impl CliOptions for GetOptsOptions {
     }
 }
 
-fn edition_from_edition_str(edition_str: &str) -> Result<Edition, FailureError> {
+fn edition_from_edition_str(edition_str: &str) -> Result<Edition> {
     match edition_str {
         "2015" => Ok(Edition::Edition2015),
         "2018" => Ok(Edition::Edition2018),
@@ -692,7 +693,7 @@ fn edition_from_edition_str(edition_str: &str) -> Result<Edition, FailureError> 
     }
 }
 
-fn emit_mode_from_emit_str(emit_str: &str) -> Result<EmitMode, FailureError> {
+fn emit_mode_from_emit_str(emit_str: &str) -> Result<EmitMode> {
     match emit_str {
         "files" => Ok(EmitMode::Files),
         "stdout" => Ok(EmitMode::Stdout),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -72,7 +72,7 @@ pub enum OperationError {
     #[error("The `--print-config=minimal` option doesn't work with standard input.")]
     MinimalPathWithStdin,
     /// An io error during reading or writing.
-    #[error("io error: {0}")]
+    #[error("{0}")]
     IoError(IoError),
     /// Attempt to use --check with stdin, which isn't currently
     /// supported.

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -529,7 +529,6 @@ impl<'a> CommentRewrite<'a> {
             .checked_sub(closer.len() + opener.len())
             .unwrap_or(1);
         let indent_str = shape.indent.to_string_with_newline(config).to_string();
-        let fmt_indent = shape.indent + (opener.len() - line_start.len());
 
         let mut cr = CommentRewrite {
             result: String::with_capacity(orig.len() * 2),
@@ -540,14 +539,14 @@ impl<'a> CommentRewrite<'a> {
             comment_line_separator: format!("{}{}", indent_str, line_start),
             max_width,
             indent_str,
-            fmt_indent,
+            fmt_indent: shape.indent,
 
             fmt: StringFormat {
                 opener: "",
                 closer: "",
                 line_start,
                 line_end: "",
-                shape: Shape::legacy(max_width, fmt_indent),
+                shape: Shape::legacy(max_width, shape.indent),
                 trim_end: true,
                 config,
             },

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -91,8 +91,9 @@ impl<'a> CommentStyle<'a> {
             | CommentStyle::TripleSlash
             | CommentStyle::Custom(..)
             | CommentStyle::Doc => "",
-            CommentStyle::DoubleBullet => " **/",
-            CommentStyle::SingleBullet | CommentStyle::Exclamation => " */",
+            CommentStyle::SingleBullet | CommentStyle::DoubleBullet | CommentStyle::Exclamation => {
+                " */"
+            }
         }
     }
 
@@ -101,8 +102,9 @@ impl<'a> CommentStyle<'a> {
             CommentStyle::DoubleSlash => "// ",
             CommentStyle::TripleSlash => "/// ",
             CommentStyle::Doc => "//! ",
-            CommentStyle::SingleBullet | CommentStyle::Exclamation => " * ",
-            CommentStyle::DoubleBullet => " ** ",
+            CommentStyle::SingleBullet | CommentStyle::DoubleBullet | CommentStyle::Exclamation => {
+                " * "
+            }
             CommentStyle::Custom(opener) => opener,
         }
     }

--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -27,7 +27,7 @@ pub enum FileName {
 impl From<rustc_span::FileName> for FileName {
     fn from(name: rustc_span::FileName) -> FileName {
         match name {
-            rustc_span::FileName::Real(p) => FileName::Real(p),
+            rustc_span::FileName::Real(p) => FileName::Real(p.into_local_path()),
             rustc_span::FileName::Custom(ref f) if f == "stdin" => FileName::Stdin,
             _ => unreachable!(),
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use regex::Regex;
+use thiserror::Error;
 
 use crate::config::config_type::ConfigType;
 #[allow(unreachable_pub)]
@@ -157,8 +158,12 @@ create_config! {
          files that would be formated when used with `--check` mode. ";
 }
 
+#[derive(Error, Debug)]
+#[error("Could not output config: {0}")]
+pub struct ToTomlError(toml::ser::Error);
+
 impl PartialConfig {
-    pub fn to_toml(&self) -> Result<String, String> {
+    pub fn to_toml(&self) -> Result<String, ToTomlError> {
         // Non-user-facing options can't be specified in TOML
         let mut cloned = self.clone();
         cloned.file_lines = None;
@@ -166,7 +171,7 @@ impl PartialConfig {
         cloned.width_heuristics = None;
         cloned.print_misformatted_file_names = None;
 
-        ::toml::to_string(&cloned).map_err(|e| format!("Could not output config: {}", e))
+        ::toml::to_string(&cloned).map_err(ToTomlError)
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -322,7 +322,11 @@ pub(crate) fn format_expr(
         }
         // We do not format these expressions yet, but they should still
         // satisfy our width restrictions.
-        ast::ExprKind::LlvmInlineAsm(..) => Some(context.snippet(expr.span).to_owned()),
+        // Style Guide RFC for InlineAsm variant pending
+        // https://github.com/rust-dev-tools/fmt-rfcs/issues/152
+        ast::ExprKind::LlvmInlineAsm(..) | ast::ExprKind::InlineAsm(..) => {
+            Some(context.snippet(expr.span).to_owned())
+        }
         ast::ExprKind::TryBlock(ref block) => {
             if let rw @ Some(_) =
                 rewrite_single_line_block(context, "try ", block, Some(&expr.attrs), None, shape)

--- a/src/format-diff/main.rs
+++ b/src/format-diff/main.rs
@@ -6,12 +6,11 @@
 
 use env_logger;
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate log;
 use regex;
 use serde::{Deserialize, Serialize};
 use serde_json as json;
+use thiserror::Error;
 
 use std::collections::HashSet;
 use std::io::{self, BufRead};
@@ -27,32 +26,14 @@ use structopt::StructOpt;
 /// We only want to format rust files by default.
 const DEFAULT_PATTERN: &str = r".*\.rs";
 
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 enum FormatDiffError {
-    #[fail(display = "{}", _0)]
-    IncorrectOptions(#[cause] getopts::Fail),
-    #[fail(display = "{}", _0)]
-    IncorrectFilter(#[cause] regex::Error),
-    #[fail(display = "{}", _0)]
-    IoError(#[cause] io::Error),
-}
-
-impl From<getopts::Fail> for FormatDiffError {
-    fn from(fail: getopts::Fail) -> Self {
-        FormatDiffError::IncorrectOptions(fail)
-    }
-}
-
-impl From<regex::Error> for FormatDiffError {
-    fn from(err: regex::Error) -> Self {
-        FormatDiffError::IncorrectFilter(err)
-    }
-}
-
-impl From<io::Error> for FormatDiffError {
-    fn from(fail: io::Error) -> Self {
-        FormatDiffError::IoError(fail)
-    }
+    #[error("{0}")]
+    IncorrectOptions(#[from] getopts::Fail),
+    #[error("{0}")]
+    IncorrectFilter(#[from] regex::Error),
+    #[error("{0}")]
+    IoError(#[from] io::Error),
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -162,6 +162,7 @@ fn error_kind_to_snippet_annotation_type(error_kind: &ErrorKind) -> AnnotationTy
         ErrorKind::LineOverflow(..)
         | ErrorKind::TrailingWhitespace
         | ErrorKind::IoError(_)
+        | ErrorKind::ModuleResolutionError(_)
         | ErrorKind::ParseError
         | ErrorKind::LostComment
         | ErrorKind::LicenseCheck

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@ use std::panic;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use failure::Fail;
 use ignore;
 use rustc_ast::ast;
 use rustc_span::symbol;
+use thiserror::Error;
 
 use crate::comment::LineClasses;
 use crate::emitter::Emitter;
@@ -84,45 +84,44 @@ pub(crate) mod visitor;
 
 /// The various errors that can occur during formatting. Note that not all of
 /// these can currently be propagated to clients.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum ErrorKind {
     /// Line has exceeded character limit (found, maximum).
-    #[fail(
-        display = "line formatted, but exceeded maximum width \
-                   (maximum: {} (see `max_width` option), found: {})",
-        _1, _0
+    #[error(
+        "line formatted, but exceeded maximum width \
+         (maximum: {1} (see `max_width` option), found: {0})"
     )]
     LineOverflow(usize, usize),
     /// Line ends in whitespace.
-    #[fail(display = "left behind trailing whitespace")]
+    #[error("left behind trailing whitespace")]
     TrailingWhitespace,
     /// TODO or FIXME item without an issue number.
-    #[fail(display = "found {}", _0)]
+    #[error("found {0}")]
     BadIssue(Issue),
     /// License check has failed.
-    #[fail(display = "license check failed")]
+    #[error("license check failed")]
     LicenseCheck,
     /// Used deprecated skip attribute.
-    #[fail(display = "`rustfmt_skip` is deprecated; use `rustfmt::skip`")]
+    #[error("`rustfmt_skip` is deprecated; use `rustfmt::skip`")]
     DeprecatedAttr,
     /// Used a rustfmt:: attribute other than skip or skip::macros.
-    #[fail(display = "invalid attribute")]
+    #[error("invalid attribute")]
     BadAttr,
     /// An io error during reading or writing.
-    #[fail(display = "io error: {}", _0)]
+    #[error("io error: {0}")]
     IoError(io::Error),
     /// Parse error occurred when parsing the input.
-    #[fail(display = "parse error")]
+    #[error("parse error")]
     ParseError,
     /// The user mandated a version and the current version of Rustfmt does not
     /// satisfy that requirement.
-    #[fail(display = "version mismatch")]
+    #[error("version mismatch")]
     VersionMismatch,
     /// If we had formatted the given node, then we would have lost a comment.
-    #[fail(display = "not formatted because a comment would be lost")]
+    #[error("not formatted because a comment would be lost")]
     LostComment,
     /// Invalid glob pattern in `ignore` configuration option.
-    #[fail(display = "Invalid glob pattern found in ignore list: {}", _0)]
+    #[error("Invalid glob pattern found in ignore list: {0}")]
     InvalidGlobPattern(ignore::Error),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use crate::comment::LineClasses;
 use crate::emitter::Emitter;
 use crate::formatting::{FormatErrorMap, FormattingError, ReportedErrors, SourceFile};
 use crate::issues::Issue;
+use crate::modules::ModuleResolutionError;
 use crate::shape::Indent;
 use crate::syntux::parser::DirectoryOwnership;
 use crate::utils::indent_next_line;
@@ -110,6 +111,9 @@ pub enum ErrorKind {
     /// An io error during reading or writing.
     #[error("io error: {0}")]
     IoError(io::Error),
+    /// Error during module resolution.
+    #[error("{0}")]
+    ModuleResolutionError(#[from] ModuleResolutionError),
     /// Parse error occurred when parsing the input.
     #[error("parse error")]
     ParseError,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1204,6 +1204,7 @@ pub(crate) fn convert_try_mac(
             kind: ast::ExprKind::Try(parser.parse_expr().ok()?),
             span: mac.span(), // incorrect span, but shouldn't matter too much
             attrs: ast::AttrVec::new(),
+            tokens: Some(ts),
         })
     } else {
         None

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -36,8 +36,8 @@ pub(crate) struct ModResolver<'ast, 'sess> {
 #[error("failed to resolve mod `{module}`: {kind}")]
 #[derive(Debug, Error)]
 pub struct ModuleResolutionError {
-    module: String,
-    kind: ModuleResolutionErrorKind,
+    pub(crate) module: String,
+    pub(crate) kind: ModuleResolutionErrorKind,
 }
 
 #[derive(Debug, Error)]

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -5,11 +5,14 @@ use std::path::{Path, PathBuf};
 use rustc_ast::ast;
 use rustc_ast::visit::Visitor;
 use rustc_span::symbol::{self, sym, Symbol};
+use thiserror::Error;
 
 use crate::attr::MetaVisitor;
 use crate::config::FileName;
 use crate::items::is_mod_decl;
-use crate::syntux::parser::{Directory, DirectoryOwnership, ModulePathSuccess, Parser};
+use crate::syntux::parser::{
+    Directory, DirectoryOwnership, ModulePathSuccess, Parser, ParserError,
+};
 use crate::syntux::session::ParseSess;
 use crate::utils::contains_skip;
 
@@ -27,6 +30,24 @@ pub(crate) struct ModResolver<'ast, 'sess> {
     directory: Directory,
     file_map: FileModMap<'ast>,
     recursive: bool,
+}
+
+/// Represents errors while trying to resolve modules.
+#[error("failed to resolve mod `{module}`: {kind}")]
+#[derive(Debug, Error)]
+pub struct ModuleResolutionError {
+    module: String,
+    kind: ModuleResolutionErrorKind,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ModuleResolutionErrorKind {
+    /// Find a file that cannot be parsed.
+    #[error("cannot parse {file}")]
+    ParseError { file: PathBuf },
+    /// File cannot be found.
+    #[error("{file} does not exist")]
+    NotFound { file: PathBuf },
 }
 
 #[derive(Clone)]
@@ -63,7 +84,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
     pub(crate) fn visit_crate(
         mut self,
         krate: &'ast ast::Crate,
-    ) -> Result<FileModMap<'ast>, String> {
+    ) -> Result<FileModMap<'ast>, ModuleResolutionError> {
         let root_filename = self.parse_sess.span_to_filename(krate.span);
         self.directory.path = match root_filename {
             FileName::Real(ref p) => p.parent().unwrap_or(Path::new("")).to_path_buf(),
@@ -81,7 +102,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
     }
 
     /// Visit `cfg_if` macro and look for module declarations.
-    fn visit_cfg_if(&mut self, item: Cow<'ast, ast::Item>) -> Result<(), String> {
+    fn visit_cfg_if(&mut self, item: Cow<'ast, ast::Item>) -> Result<(), ModuleResolutionError> {
         let mut visitor = visitor::CfgIfVisitor::new(self.parse_sess);
         visitor.visit_item(&item);
         for module_item in visitor.mods() {
@@ -93,7 +114,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
     }
 
     /// Visit modules defined inside macro calls.
-    fn visit_mod_outside_ast(&mut self, module: ast::Mod) -> Result<(), String> {
+    fn visit_mod_outside_ast(&mut self, module: ast::Mod) -> Result<(), ModuleResolutionError> {
         for item in module.items {
             if is_cfg_if(&item) {
                 self.visit_cfg_if(Cow::Owned(item.into_inner()))?;
@@ -108,7 +129,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
     }
 
     /// Visit modules from AST.
-    fn visit_mod_from_ast(&mut self, module: &'ast ast::Mod) -> Result<(), String> {
+    fn visit_mod_from_ast(&mut self, module: &'ast ast::Mod) -> Result<(), ModuleResolutionError> {
         for item in &module.items {
             if is_cfg_if(item) {
                 self.visit_cfg_if(Cow::Borrowed(item))?;
@@ -125,7 +146,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         &mut self,
         item: &'c ast::Item,
         sub_mod: Cow<'ast, ast::Mod>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ModuleResolutionError> {
         let old_directory = self.directory.clone();
         let sub_mod_kind = self.peek_sub_mod(item, &sub_mod)?;
         if let Some(sub_mod_kind) = sub_mod_kind {
@@ -141,7 +162,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         &self,
         item: &'c ast::Item,
         sub_mod: &Cow<'ast, ast::Mod>,
-    ) -> Result<Option<SubModKind<'c, 'ast>>, String> {
+    ) -> Result<Option<SubModKind<'c, 'ast>>, ModuleResolutionError> {
         if contains_skip(&item.attrs) {
             return Ok(None);
         }
@@ -165,7 +186,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         &mut self,
         sub_mod_kind: SubModKind<'c, 'ast>,
         _sub_mod: Cow<'ast, ast::Mod>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ModuleResolutionError> {
         match sub_mod_kind {
             SubModKind::External(mod_path, _, sub_mod) => {
                 self.file_map
@@ -188,7 +209,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         &mut self,
         sub_mod: Cow<'ast, ast::Mod>,
         sub_mod_kind: SubModKind<'c, 'ast>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ModuleResolutionError> {
         match sub_mod_kind {
             SubModKind::External(mod_path, directory_ownership, sub_mod) => {
                 let directory = Directory {
@@ -226,7 +247,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         &mut self,
         sub_mod: Cow<'ast, ast::Mod>,
         directory: Option<Directory>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ModuleResolutionError> {
         if let Some(directory) = directory {
             self.directory = directory;
         }
@@ -242,7 +263,7 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
         mod_name: symbol::Ident,
         attrs: &[ast::Attribute],
         sub_mod: &Cow<'ast, ast::Mod>,
-    ) -> Result<Option<SubModKind<'c, 'ast>>, String> {
+    ) -> Result<Option<SubModKind<'c, 'ast>>, ModuleResolutionError> {
         let relative = match self.directory.ownership {
             DirectoryOwnership::Owned { relative } => relative,
             DirectoryOwnership::UnownedViaBlock | DirectoryOwnership::UnownedViaMod => None,
@@ -252,16 +273,20 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                 return Ok(None);
             }
             return match Parser::parse_file_as_module(self.parse_sess, &path, sub_mod.inner) {
-                Some((_, ref attrs)) if contains_skip(attrs) => Ok(None),
-                Some((m, _)) => Ok(Some(SubModKind::External(
+                Ok((_, ref attrs)) if contains_skip(attrs) => Ok(None),
+                Ok((m, _)) => Ok(Some(SubModKind::External(
                     path,
                     DirectoryOwnership::Owned { relative: None },
                     Cow::Owned(m),
                 ))),
-                None => Err(format!(
-                    "Failed to find module {} in {:?} {:?}",
-                    mod_name, self.directory.path, relative,
-                )),
+                Err(ParserError::ParseError) => Err(ModuleResolutionError {
+                    module: mod_name.to_string(),
+                    kind: ModuleResolutionErrorKind::ParseError { file: path },
+                }),
+                Err(..) => Err(ModuleResolutionError {
+                    module: mod_name.to_string(),
+                    kind: ModuleResolutionErrorKind::NotFound { file: path },
+                }),
             };
         }
 
@@ -291,22 +316,26 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
                     }
                 }
                 match Parser::parse_file_as_module(self.parse_sess, &path, sub_mod.inner) {
-                    Some((_, ref attrs)) if contains_skip(attrs) => Ok(None),
-                    Some((m, _)) if outside_mods_empty => {
+                    Ok((_, ref attrs)) if contains_skip(attrs) => Ok(None),
+                    Ok((m, _)) if outside_mods_empty => {
                         Ok(Some(SubModKind::External(path, ownership, Cow::Owned(m))))
                     }
-                    Some((m, _)) => {
+                    Ok((m, _)) => {
                         mods_outside_ast.push((path.clone(), ownership, Cow::Owned(m)));
                         if should_insert {
                             mods_outside_ast.push((path, ownership, sub_mod.clone()));
                         }
                         Ok(Some(SubModKind::MultiExternal(mods_outside_ast)))
                     }
-                    None if outside_mods_empty => Err(format!(
-                        "Failed to find module {} in {:?} {:?}",
-                        mod_name, self.directory.path, relative,
-                    )),
-                    None => {
+                    Err(ParserError::ParseError) => Err(ModuleResolutionError {
+                        module: mod_name.to_string(),
+                        kind: ModuleResolutionErrorKind::ParseError { file: path },
+                    }),
+                    Err(..) if outside_mods_empty => Err(ModuleResolutionError {
+                        module: mod_name.to_string(),
+                        kind: ModuleResolutionErrorKind::NotFound { file: path },
+                    }),
+                    Err(..) => {
                         if should_insert {
                             mods_outside_ast.push((path, ownership, sub_mod.clone()));
                         }
@@ -320,10 +349,12 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
             }
             Err(mut e) => {
                 e.cancel();
-                Err(format!(
-                    "Failed to find module {} in {:?} {:?}",
-                    mod_name, self.directory.path, relative,
-                ))
+                Err(ModuleResolutionError {
+                    module: mod_name.to_string(),
+                    kind: ModuleResolutionErrorKind::NotFound {
+                        file: self.directory.path.clone(),
+                    },
+                })
             }
         }
     }
@@ -379,9 +410,9 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
             }
             let m = match Parser::parse_file_as_module(self.parse_sess, &actual_path, sub_mod.inner)
             {
-                Some((_, ref attrs)) if contains_skip(attrs) => continue,
-                Some((m, _)) => m,
-                None => continue,
+                Ok((_, ref attrs)) if contains_skip(attrs) => continue,
+                Ok((m, _)) => m,
+                Err(..) => continue,
             };
 
             result.push((

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -68,7 +68,9 @@ where
     impl From<&FileName> for rustc_span::FileName {
         fn from(filename: &FileName) -> rustc_span::FileName {
             match filename {
-                FileName::Real(path) => rustc_span::FileName::Real(path.to_owned()),
+                FileName::Real(path) => {
+                    rustc_span::FileName::Real(rustc_span::RealFileName::Named(path.to_owned()))
+                }
                 FileName::Stdin => rustc_span::FileName::Custom("stdin".to_owned()),
             }
         }

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -119,7 +119,17 @@ impl<'a> Parser<'a> {
             }
         }));
         match result {
-            Ok(Some(m)) => Ok(m),
+            Ok(Some(m)) => {
+                if !sess.has_errors() {
+                    return Ok(m);
+                }
+
+                if sess.can_reset_errors() {
+                    sess.reset_errors();
+                    return Ok(m);
+                }
+                Err(ParserError::ParseError)
+            }
             Ok(None) => Err(ParserError::ParseError),
             Err(..) if path.exists() => Err(ParserError::ParseError),
             Err(_) => Err(ParserError::ParsePanicError),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -40,6 +40,7 @@ const SKIP_FILE_WHITE_LIST: &[&str] = &[
     "cfg_mod/bar.rs",
     "cfg_mod/foo.rs",
     "cfg_mod/wasm32.rs",
+    "skip/foo.rs",
 ];
 
 fn init_log() {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -11,10 +11,12 @@ use std::thread;
 
 use crate::config::{Color, Config, EmitMode, FileName, NewlineStyle, ReportTactic};
 use crate::formatting::{ReportedErrors, SourceFile};
-use crate::is_nightly_channel;
+use crate::modules::{ModuleResolutionError, ModuleResolutionErrorKind};
 use crate::rustfmt_diff::{make_diff, print_diff, DiffLine, Mismatch, ModifiedChunk, OutputWriter};
 use crate::source_file;
-use crate::{FormatReport, FormatReportFormatterBuilder, Input, Session};
+use crate::{
+    is_nightly_channel, ErrorKind, FormatReport, FormatReportFormatterBuilder, Input, Session,
+};
 
 mod configuration_snippet;
 
@@ -481,6 +483,34 @@ fn format_lines_errors_are_reported_with_tabs() {
     let mut session = Session::<io::Stdout>::new(config, None);
     session.format(input).unwrap();
     assert!(session.has_formatting_errors());
+}
+
+#[test]
+fn parser_errors_in_submods_are_surfaced() {
+    // See also https://github.com/rust-lang/rustfmt/issues/4126
+    let filename = "tests/parser/issue-4126/lib.rs";
+    let input_file = PathBuf::from(filename);
+    let exp_mod_name = "invalid";
+    let config = read_config(&input_file);
+    let mut session = Session::<io::Stdout>::new(config, None);
+    if let Err(ErrorKind::ModuleResolutionError(ModuleResolutionError { module, kind })) =
+        session.format(Input::File(filename.into()))
+    {
+        assert_eq!(&module, exp_mod_name);
+        if let ModuleResolutionErrorKind::ParseError {
+            file: unparseable_file,
+        } = kind
+        {
+            assert_eq!(
+                unparseable_file,
+                PathBuf::from("tests/parser/issue-4126/invalid.rs"),
+            );
+        } else {
+            panic!("Expected parser error");
+        }
+    } else {
+        panic!("Expected ModuleResolution operation error");
+    }
 }
 
 // For each file, run rustfmt and collect the output.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -487,6 +487,7 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::Continue(..)
         | ast::ExprKind::Err
         | ast::ExprKind::Field(..)
+        | ast::ExprKind::InlineAsm(..)
         | ast::ExprKind::LlvmInlineAsm(..)
         | ast::ExprKind::Let(..)
         | ast::ExprKind::Path(..)

--- a/tests/parser/issue-4126/invalid.rs
+++ b/tests/parser/issue-4126/invalid.rs
@@ -1,0 +1,6 @@
+fn foo() {
+    if bar && if !baz {
+        next_is_none = Some(true);
+    }
+    println!("foo");
+}

--- a/tests/parser/issue-4126/lib.rs
+++ b/tests/parser/issue-4126/lib.rs
@@ -1,0 +1,1 @@
+mod invalid;

--- a/tests/source/issue-4079.rs
+++ b/tests/source/issue-4079.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: true
+
+/*!
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia
+ * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem volutpat
+ */
+
+/*! Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem volutpat */

--- a/tests/target/issue-4020.rs
+++ b/tests/target/issue-4020.rs
@@ -1,0 +1,9 @@
+// rustfmt-wrap_comments: true
+
+/** foobar */
+const foo1: u32 = 0;
+
+/**
+ * foobar
+ */
+const foo2: u32 = 0;

--- a/tests/target/issue-4079.rs
+++ b/tests/target/issue-4079.rs
@@ -1,0 +1,11 @@
+// rustfmt-wrap_comments: true
+
+/*!
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia
+ * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem
+ * volutpat
+ */
+
+/*! Lorem ipsum dolor sit amet, consectetur adipiscing elit. In lacinia
+ * ullamcorper lorem, non hendrerit enim convallis ut. Curabitur id sem
+ * volutpat */

--- a/tests/target/skip/foo.rs
+++ b/tests/target/skip/foo.rs
@@ -1,0 +1,5 @@
+#![rustfmt::skip]
+
+fn
+foo()
+{}

--- a/tests/target/skip/main.rs
+++ b/tests/target/skip/main.rs
@@ -1,0 +1,5 @@
+mod foo;
+
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Refs rust-lang/rust#73200, rustfmt 1.x pair to #4252. 

~~There's one last parser bug which has been fixed in source, but that I want to also backport to rustfmt 1.x as part of this~~

* bumps rustc-ap-* crate versions to latest v644.0.0
* cherry-pick backport of switch from `failure` to `anyhow/thiserror` from #3948 (in part because `failure` is deprecated and because our subsequent err handling on master is based on `anyhow` and `thiserror`)
* backports the module resolution error handling from #4198 
* backports the fix for handling of parser errors in non-inline mods from #4200
* also backports some minor bug fixes (from #4080 and #4071) given how small they were and the discussion in https://github.com/rust-lang/rustfmt/pull/4080#issuecomment-615884887