### PR TITLE
Adds query param for version no

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -82,6 +82,7 @@
             const queryParams = new URLSearchParams(window.location.search);
             const searchParam = queryParams.get('search');
             const searchTerm = null !== searchParam ? searchParam : '';
+            const versionNumber = null !== queryParams.get('version') ? 'v' + queryParams.get('version') : 'master';
             new Vue({
               el: '#app',
               data: {
@@ -90,7 +91,7 @@
                 configurationDescriptions: [],
                 searchCondition: searchTerm,
                 shouldStable: false,
-                version: 'master',
+                version: versionNumber,
                 oldVersion: undefined,
                 versionOptions: ['master']
               },

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,16 +100,20 @@
                   if (this.version !== this.oldVersion) {
                     const ConfigurationMdUrl =
                       `https://raw.githubusercontent.com/rust-lang/rustfmt/${this.version}/Configurations.md`;
-                    const res = await axios.get(ConfigurationMdUrl);
-                    const {
-                      about,
-                      configurationAbout,
-                      configurationDescriptions
-                    } = parseMarkdownAst(res.data);
-                    this.aboutHtml = marked.parser(about);
-                    this.configurationAboutHtml = marked.parser(configurationAbout);
-                    this.configurationDescriptions = configurationDescriptions;
-                    this.oldVersion = this.version;
+                    try {
+                      const res = await axios.get(ConfigurationMdUrl);
+                      const {
+                        about,
+                        configurationAbout,
+                        configurationDescriptions
+                      } = parseMarkdownAst(res.data);
+                      this.aboutHtml = marked.parser(about);
+                      this.configurationAboutHtml = marked.parser(configurationAbout);
+                      this.configurationDescriptions = configurationDescriptions;
+                      this.oldVersion = this.version;
+                    } catch(error) {
+                        this.aboutHtml = "<p>Failed to get configuration options for this version, please select the version from the dropdown above.</p>";
+                    }
                   }
 
                   const ast = this.configurationDescriptions

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,7 +82,13 @@
             const queryParams = new URLSearchParams(window.location.search);
             const searchParam = queryParams.get('search');
             const searchTerm = null !== searchParam ? searchParam : '';
-            const versionNumber = null !== queryParams.get('version') ? 'v' + queryParams.get('version') : 'master';
+            const versionParam = queryParams.get('version');
+            const parseVersionParam = (version) => {
+              if (version === 'master') return 'master';
+              if (version.startsWith('v')) return version;
+              return `v${version}`;
+            };
+            const versionNumber = null !== versionParam ? parseVersionParam(versionParam) : 'master';
             new Vue({
               el: '#app',
               data: {


### PR DESCRIPTION
Fixes #4260 

This adds support for using a query parameter to select the version no.

Note: If the provided version number in the query string cannot be found then the page is shown as blank since the axios get call returns a 404 and isn't being caught. If this is a concern then a proper 404 message can be shown something like `No such version number found`.