### PR TITLE
Do not remove fn headers (e.g., async) on extern fn items

### DIFF
--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -185,6 +185,7 @@ impl Rewrite for ast::Local {
 // FIXME convert to using rewrite style rather than visitor
 // FIXME format modules in this style
 #[allow(dead_code)]
+#[derive(Debug)]
 struct Item<'a> {
     keyword: &'static str,
     abi: Cow<'static, str>,
@@ -213,6 +214,7 @@ impl<'a> Item<'a> {
     }
 }
 
+#[derive(Debug)]
 enum BodyElement<'a> {
     // Stmt(&'a ast::Stmt),
     // Field(&'a ast::Field),
@@ -234,26 +236,10 @@ pub(crate) struct FnSig<'a> {
 }
 
 impl<'a> FnSig<'a> {
-    pub(crate) fn new(
-        decl: &'a ast::FnDecl,
-        generics: &'a ast::Generics,
-        vis: ast::Visibility,
-    ) -> FnSig<'a> {
-        FnSig {
-            decl,
-            generics,
-            ext: ast::Extern::None,
-            is_async: Cow::Owned(ast::Async::No),
-            constness: ast::Const::No,
-            defaultness: ast::Defaultness::Final,
-            unsafety: ast::Unsafe::No,
-            visibility: vis,
-        }
-    }
-
     pub(crate) fn from_method_sig(
         method_sig: &'a ast::FnSig,
         generics: &'a ast::Generics,
+        visibility: ast::Visibility,
     ) -> FnSig<'a> {
         FnSig {
             unsafety: method_sig.header.unsafety,
@@ -263,7 +249,7 @@ impl<'a> FnSig<'a> {
             ext: method_sig.header.ext,
             decl: &*method_sig.decl,
             generics,
-            visibility: DEFAULT_VISIBILITY,
+            visibility,
         }
     }
 
@@ -276,9 +262,8 @@ impl<'a> FnSig<'a> {
         match *fn_kind {
             visit::FnKind::Fn(fn_ctxt, _, fn_sig, vis, _) => match fn_ctxt {
                 visit::FnCtxt::Assoc(..) => {
-                    let mut fn_sig = FnSig::from_method_sig(fn_sig, generics);
+                    let mut fn_sig = FnSig::from_method_sig(fn_sig, generics, vis.clone());
                     fn_sig.defaultness = defaultness;
-                    fn_sig.visibility = vis.clone();
                     fn_sig
                 }
                 _ => FnSig {
@@ -409,7 +394,7 @@ impl<'a> FmtVisitor<'a> {
             &context,
             indent,
             ident,
-            &FnSig::from_method_sig(sig, generics),
+            &FnSig::from_method_sig(sig, generics, DEFAULT_VISIBILITY),
             span,
             FnBraceStyle::None,
         )?;
@@ -3137,7 +3122,7 @@ impl Rewrite for ast::ForeignItem {
                 context,
                 shape.indent,
                 self.ident,
-                &FnSig::new(&fn_sig.decl, generics, self.vis.clone()),
+                &FnSig::from_method_sig(&fn_sig, generics, self.vis.clone()),
                 span,
                 FnBraceStyle::None,
             )

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -58,6 +58,25 @@ libc::c_long;
                                , mode3: *const c_char,
                                file: *mut FILE)
                               -> *mut FILE;
+
+
+       async fn foo(
+
+       ) -> *mut
+       Bar;
+       const fn foo(
+
+       ) ->
+                            *mut Bar;
+       unsafe fn foo(
+
+       ) -> *
+       mut
+       Bar;
+
+       pub async fn foo() -> *mut Bar;
+       pub(super) const fn foo() -> *mut Bar;
+       pub(crate) unsafe fn foo() -> *mut Bar;
    }
 
 extern {

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -73,6 +73,14 @@ extern "C" {
         mode3: *const c_char,
         file: *mut FILE,
     ) -> *mut FILE;
+
+    async fn foo() -> *mut Bar;
+    const fn foo() -> *mut Bar;
+    unsafe fn foo() -> *mut Bar;
+
+    pub async fn foo() -> *mut Bar;
+    pub(super) const fn foo() -> *mut Bar;
+    pub(crate) unsafe fn foo() -> *mut Bar;
 }
 
 extern "C" {}


### PR DESCRIPTION
Close #4288.