### PR TITLE
Pick up comments between trait where clause and open block

### DIFF
--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -1155,24 +1155,28 @@ pub(crate) fn format_trait(
                 result.push_str(&where_indent.to_string_with_newline(context.config));
             }
             result.push_str(&where_clause_str);
+        }
+        let pre_block_span = if !generics.where_clause.predicates.is_empty() {
+            mk_sp(generics.where_clause.span.hi(), item.span.hi())
         } else {
-            let item_snippet = context.snippet(item.span);
-            if let Some(lo) = item_snippet.find('/') {
-                // 1 = `{`
-                let comment_hi = body_lo - BytePos(1);
-                let comment_lo = item.span.lo() + BytePos(lo as u32);
-                if comment_lo < comment_hi {
-                    match recover_missing_comment_in_span(
-                        mk_sp(comment_lo, comment_hi),
-                        Shape::indented(offset, context.config),
-                        context,
-                        last_line_width(&result),
-                    ) {
-                        Some(ref missing_comment) if !missing_comment.is_empty() => {
-                            result.push_str(missing_comment);
-                        }
-                        _ => {}
+            item.span
+        };
+        let pre_block_snippet = context.snippet(pre_block_span);
+        if let Some(lo) = pre_block_snippet.find('/') {
+            // 1 = `{`
+            let comment_hi = body_lo - BytePos(1);
+            let comment_lo = pre_block_span.lo() + BytePos(lo as u32);
+            if comment_lo < comment_hi {
+                match recover_missing_comment_in_span(
+                    mk_sp(comment_lo, comment_hi),
+                    Shape::indented(offset, context.config),
+                    context,
+                    last_line_width(&result),
+                ) {
+                    Some(ref missing_comment) if !missing_comment.is_empty() => {
+                        result.push_str(missing_comment);
                     }
+                    _ => {}
                 }
             }
         }

--- a/tests/source/issue-4289.rs
+++ b/tests/source/issue-4289.rs
@@ -1,0 +1,8 @@
+trait MyTrait
+where
+    Self: Clone, // comment on first constraint
+    Self: Eq, // comment on last constraint
+{
+}
+
+trait MyTrait2 where Self: Clone, /* another comment */ {}

--- a/tests/target/issue-4289.rs
+++ b/tests/target/issue-4289.rs
@@ -1,0 +1,12 @@
+trait MyTrait
+where
+    Self: Clone, // comment on first constraint
+    Self: Eq, // comment on last constraint
+{
+}
+
+trait MyTrait2
+where
+    Self: Clone, /* another comment */
+{
+}


### PR DESCRIPTION
Previously rustfmt only picked up comments between a trait "signature"
and its block when there was no `where` clause on the trait. Amending
this to work for comments following a `where` clause and preceding the
trait block is straightforward; we simply get rid of the branch and
adjust the span to search for a comment in accordingly.

Closes #4289