### PR TITLE
don't convert implict ABI when doing so could fail to preserve semantics

### DIFF
--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -194,13 +194,19 @@ struct Item<'a> {
 }
 
 impl<'a> Item<'a> {
-    fn from_foreign_mod(fm: &'a ast::ForeignMod, span: Span, config: &Config) -> Item<'a> {
+    fn from_foreign_mod(
+        fm: &'a ast::ForeignMod,
+        span: Span,
+        config: &Config,
+        attrs: &[ast::Attribute],
+    ) -> Item<'a> {
         Item {
             keyword: "",
             abi: format_extern(
                 ast::Extern::from_abi(fm.abi),
                 config.force_explicit_abi(),
                 true,
+                Some(attrs),
             ),
             vis: None,
             body: fm
@@ -308,6 +314,7 @@ impl<'a> FnSig<'a> {
             self.ext,
             context.config.force_explicit_abi(),
             false,
+            None,
         ));
         result
     }
@@ -352,8 +359,13 @@ impl<'a> FmtVisitor<'a> {
         }
     }
 
-    pub(crate) fn format_foreign_mod(&mut self, fm: &ast::ForeignMod, span: Span) {
-        let item = Item::from_foreign_mod(fm, span, self.config);
+    pub(crate) fn format_foreign_mod(
+        &mut self,
+        fm: &ast::ForeignMod,
+        span: Span,
+        attrs: &[ast::Attribute],
+    ) {
+        let item = Item::from_foreign_mod(fm, span, self.config, attrs);
         self.format_item(&item);
     }
 

--- a/src/formatting/types.rs
+++ b/src/formatting/types.rs
@@ -785,6 +785,7 @@ fn rewrite_bare_fn(
         bare_fn.ext,
         context.config.force_explicit_abi(),
         false,
+        None,
     ));
 
     result.push_str("fn");

--- a/src/formatting/visitor.rs
+++ b/src/formatting/visitor.rs
@@ -513,7 +513,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 }
                 ast::ItemKind::ForeignMod(ref foreign_mod) => {
                     self.format_missing_with_indent(source!(self, item.span).lo());
-                    self.format_foreign_mod(foreign_mod, item.span);
+                    self.format_foreign_mod(foreign_mod, item.span, item.attrs());
                 }
                 ast::ItemKind::Static(..) | ast::ItemKind::Const(..) => {
                     self.visit_static(&StaticParts::from_item(item));

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -63,3 +63,20 @@ libc::c_long;
 extern {
 
 }
+
+// #2908 - https://github.com/rust-lang/rustfmt/issues/2908
+#[wasm_bindgen(module = "child_process", version = "*")]
+extern {
+     #[wasm_bindgen(js_name = execSync)]
+     fn exec_sync(cmd: &str) -> Buffer;
+
+     fn foo() -> Bar;
+ }
+
+// Users that have an existing explicit ABI would need to convert to implicit
+// manually, as rustfmt will be conservative and not attempt to convert explicit
+// to implicit in the wasm case.
+#[wasm_bindgen]
+extern "C" {
+       fn foo() -> Bar;
+}

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -76,3 +76,20 @@ extern "C" {
 }
 
 extern "C" {}
+
+// #2908 - https://github.com/rust-lang/rustfmt/issues/2908
+#[wasm_bindgen(module = "child_process", version = "*")]
+extern {
+    #[wasm_bindgen(js_name = execSync)]
+    fn exec_sync(cmd: &str) -> Buffer;
+
+    fn foo() -> Bar;
+}
+
+// Users that have an existing explicit ABI would need to convert to implicit
+// manually, as rustfmt will be conservative and not attempt to convert explicit
+// to implicit in the wasm case.
+#[wasm_bindgen]
+extern "C" {
+    fn foo() -> Bar;
+}


### PR DESCRIPTION
Fixes #2908 (option 3 from https://github.com/rust-lang/rustfmt/issues/2908#issuecomment-650588865)

Happy to open a separate/alternative PR with option 2 if we'd rather go that route :+1: 