### PR TITLE
Do not normalize vertical spaces unless they are between items

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -164,14 +164,11 @@ fn bar() {
 #### `1`
 ```rust
 fn foo() {
-
     println!("a");
 }
 
 fn bar() {
-
     println!("b");
-
     println!("c");
 }
 ```

--- a/src/formatting/macros.rs
+++ b/src/formatting/macros.rs
@@ -75,7 +75,7 @@ impl Rewrite for ast::Item {
         let mut visitor = FmtVisitor::from_context(context);
         visitor.block_indent = shape.indent;
         visitor.last_pos = self.span().lo();
-        visitor.visit_item(self);
+        visitor.visit_item(self, false);
         Some(visitor.buffer.to_owned())
     }
 }
@@ -1562,7 +1562,7 @@ fn rewrite_macro_with_items(
             MacroArg::Item(item) => item,
             _ => return None,
         };
-        visitor.visit_item(&item);
+        visitor.visit_item(&item, false);
     }
 
     let mut result = String::with_capacity(256);

--- a/src/formatting/reorder.rs
+++ b/src/formatting/reorder.rs
@@ -351,6 +351,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             .any(|item| !out_of_file_lines_range!(self, item.span));
 
         if at_least_one_in_file_lines && !items.is_empty() {
+            self.normalize_vertical_spaces = true;
             let lo = items.first().unwrap().span().lo();
             let hi = items.last().unwrap().span().hi();
             let span = mk_sp(lo, hi);
@@ -382,7 +383,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 // Reaching here means items were not reordered. There must be at least
                 // one item left in `items`, so calling `unwrap()` here is safe.
                 let (item, rest) = items.split_first().unwrap();
-                self.visit_item(item);
+                self.visit_item(item, true);
                 items = rest;
             }
         }

--- a/tests/source/configs/blank_lines_lower_bound/2.rs
+++ b/tests/source/configs/blank_lines_lower_bound/2.rs
@@ -1,0 +1,26 @@
+// rustfmt-blank_lines_lower_bound: 2
+// rustfmt-blank_lines_upper_bound: 3
+
+#[foo]
+fn foo() {
+    println!("a");
+}
+#[bar]
+#[barbar]
+fn bar() {
+    println!("b");
+    println!("c");
+}
+struct Foo {}
+enum Bar {}
+use std::io;
+extern crate foobar;
+extern crate foo;
+extern crate bar;
+trait Foo = Bar;
+impl Foo {}
+mac!();
+#[temp]
+use std::fs;
+use std::alloc;
+use std::ascii;

--- a/tests/target/assignment.rs
+++ b/tests/target/assignment.rs
@@ -16,6 +16,7 @@ fn main() {
     single_line_fit = 5;
     single_lit_fit >>= 10;
 
+
     // #2791
     let x = 2;
 }

--- a/tests/target/configs/blank_lines_lower_bound/2.rs
+++ b/tests/target/configs/blank_lines_lower_bound/2.rs
@@ -1,0 +1,45 @@
+// rustfmt-blank_lines_lower_bound: 2
+// rustfmt-blank_lines_upper_bound: 3
+
+
+#[foo]
+fn foo() {
+    println!("a");
+}
+
+
+#[bar]
+#[barbar]
+fn bar() {
+    println!("b");
+    println!("c");
+}
+
+
+struct Foo {}
+
+
+enum Bar {}
+
+
+use std::io;
+
+
+extern crate bar;
+extern crate foo;
+extern crate foobar;
+
+
+trait Foo = Bar;
+
+
+impl Foo {}
+
+
+mac!();
+
+
+use std::alloc;
+use std::ascii;
+#[temp]
+use std::fs;

--- a/tests/target/control-brace-style-always-next-line.rs
+++ b/tests/target/control-brace-style-always-next-line.rs
@@ -7,11 +7,13 @@ fn main() {
         let bar = ();
     }
 
+
     'label: loop
     // loop comment
     {
         let foo = ();
     }
+
 
     cond = true;
     while cond
@@ -19,11 +21,13 @@ fn main() {
         let foo = ();
     }
 
+
     'while_label: while cond
     {
         // while comment
         let foo = ();
     }
+
 
     for obj in iter
     {

--- a/tests/target/control-brace-style-always-same-line.rs
+++ b/tests/target/control-brace-style-always-same-line.rs
@@ -4,21 +4,25 @@ fn main() {
         let bar = ();
     }
 
+
     'label: loop
     // loop comment
     {
         let foo = ();
     }
 
+
     cond = true;
     while cond {
         let foo = ();
     }
 
+
     'while_label: while cond {
         // while comment
         let foo = ();
     }
+
 
     for obj in iter {
         for sub_obj in obj {

--- a/tests/target/else-if-brace-style-always-next-line.rs
+++ b/tests/target/else-if-brace-style-always-next-line.rs
@@ -14,7 +14,9 @@ fn main() {
         let bar = ();
     }
 
+
     let a = if 0 > 1 { unreachable!() } else { 0x0 };
+
 
     if true
     {

--- a/tests/target/else-if-brace-style-always-same-line.rs
+++ b/tests/target/else-if-brace-style-always-same-line.rs
@@ -11,7 +11,9 @@ fn main() {
         let bar = ();
     }
 
+
     let a = if 0 > 1 { unreachable!() } else { 0x0 };
+
 
     if true {
         let foo = ();

--- a/tests/target/else-if-brace-style-closing-next-line.rs
+++ b/tests/target/else-if-brace-style-closing-next-line.rs
@@ -13,7 +13,9 @@ fn main() {
         let bar = ();
     }
 
+
     let a = if 0 > 1 { unreachable!() } else { 0x0 };
+
 
     if true {
         let foo = ();

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -74,6 +74,7 @@ extern "C" {
         file: *mut FILE,
     ) -> *mut FILE;
 
+
     async fn foo() -> *mut Bar;
     const fn foo() -> *mut Bar;
     unsafe fn foo() -> *mut Bar;

--- a/tests/target/multiple.rs
+++ b/tests/target/multiple.rs
@@ -129,6 +129,7 @@ fn main() {
         println!("{}", i);
     }
 
+
     while true {
         hello();
     }

--- a/tests/target/remove_blank_lines.rs
+++ b/tests/target/remove_blank_lines.rs
@@ -1,7 +1,9 @@
 fn main() {
     let x = 1;
 
+
     let y = 2;
+
 
     println!("x + y = {}", x + y);
 }
@@ -20,9 +22,11 @@ fn bar() {
     let x = 1;
     // comment after statement
 
+
     // comment before statement
     let y = 2;
     let z = 3;
+
 
     println!("x + y + z = {}", x + y + z);
 }


### PR DESCRIPTION
With this PR, we no longer normalize the number of vertical lines unless those are in between items.

Since this PR changes the default formatting style, I would like to include this PR to the 2.0 release.

Close #2954.

