### PR TITLE
Skip formatting generated files

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -964,6 +964,14 @@ fn add_one(x: i32) -> i32 {
 }
 ```
 
+## `format_generated_files`
+
+Format generated files. A file is considered as generated if the file starts with `// @generated`.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: No
+
 ## `format_macro_matchers`
 
 Format the metavariable matching patterns in macros.

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,7 @@ create_config! {
     inline_attribute_width: usize, 0, false,
         "Write an item and its attribute on the same line \
         if their combined width is below a threshold";
+    format_generated_files: bool, false, false, "Format generated files";
 
     // Options that can change the source code beyond whitespace/blocks (somewhat linty things)
     merge_derives: bool, true, true, "Merge multiple `#[derive(...)]` into a single one";
@@ -615,6 +616,7 @@ blank_lines_upper_bound = 1
 blank_lines_lower_bound = 0
 edition = "2018"
 inline_attribute_width = 0
+format_generated_files = false
 merge_derives = true
 use_try_shorthand = false
 use_field_init_shorthand = false

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -10,6 +10,7 @@ pub(crate) use syntux::session::ParseSess;
 use crate::config::{Config, FileName};
 use crate::formatting::{
     comment::{CharClasses, FullCodeCharKind},
+    generated::is_generated_file,
     modules::{FileModMap, Module},
     newline_style::apply_newline_style,
     report::NonFormattedRange,
@@ -30,6 +31,7 @@ mod chains;
 mod closures;
 mod comment;
 mod expr;
+mod generated;
 mod imports;
 mod items;
 mod lists;
@@ -125,7 +127,10 @@ fn format_project(
     parse_session.set_silent_emitter();
 
     for (path, module) in &files {
-        let should_ignore = !input_is_stdin && parse_session.ignore_file(&path);
+        let should_ignore = (!input_is_stdin && parse_session.ignore_file(&path))
+            || (!config.format_generated_files()
+                && is_generated_file(&path, original_snippet.as_ref()));
+
         if (!operation_setting.recursive && path != &main_file) || should_ignore {
             continue;
         }

--- a/src/formatting/generated.rs
+++ b/src/formatting/generated.rs
@@ -1,0 +1,40 @@
+use std::{
+    fs,
+    io::{self, BufRead},
+};
+
+use crate::config::file_lines::FileName;
+use crate::formatting::comment::contains_comment;
+
+/// Returns `true` if the given span is a part of generated files.
+pub(super) fn is_generated_file(file_name: &FileName, original_snippet: Option<&String>) -> bool {
+    let first_line = match file_name {
+        FileName::Stdin => original_snippet
+            .and_then(|s| s.lines().next())
+            .map(str::to_owned)
+            .unwrap_or("".to_owned()),
+        FileName::Real(ref path) => fs::File::open(path)
+            .ok()
+            .and_then(|f| io::BufReader::new(f).lines().next()?.ok())
+            .unwrap_or("".to_owned()),
+    };
+
+    is_comment_with_generated_notation(&first_line)
+}
+
+fn is_comment_with_generated_notation(s: &str) -> bool {
+    contains_comment(&s) && s.contains("@generated")
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn is_comment_with_generated_notation() {
+        use super::is_comment_with_generated_notation;
+
+        assert!(is_comment_with_generated_notation("// @generated"));
+        assert!(is_comment_with_generated_notation("//@generated\n\n"));
+        assert!(is_comment_with_generated_notation("\n// @generated"));
+        assert!(is_comment_with_generated_notation("/* @generated"));
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -744,7 +744,7 @@ fn read_significant_comments(file_name: &Path) -> HashMap<String, String> {
     reader
         .lines()
         .map(|line| line.expect("failed getting line"))
-        .take_while(|line| line_regex.is_match(line))
+        .filter(|line| line_regex.is_match(line))
         .filter_map(|line| {
             regex.captures_iter(&line).next().map(|capture| {
                 (

--- a/tests/source/configs/format_generated_files/false.rs
+++ b/tests/source/configs/format_generated_files/false.rs
@@ -1,0 +1,8 @@
+// @generated
+// rustfmt-format_generated_files: false
+
+fn main()
+{
+    println!("hello, world")
+    ;
+}

--- a/tests/source/configs/format_generated_files/true.rs
+++ b/tests/source/configs/format_generated_files/true.rs
@@ -1,0 +1,8 @@
+// @generated
+// rustfmt-format_generated_files: true
+
+fn main()
+{
+    println!("hello, world")
+    ;
+}

--- a/tests/target/configs/format_generated_files/false.rs
+++ b/tests/target/configs/format_generated_files/false.rs
@@ -1,0 +1,8 @@
+// @generated
+// rustfmt-format_generated_files: false
+
+fn main()
+{
+    println!("hello, world")
+    ;
+}

--- a/tests/target/configs/format_generated_files/true.rs
+++ b/tests/target/configs/format_generated_files/true.rs
@@ -1,0 +1,6 @@
+// @generated
+// rustfmt-format_generated_files: true
+
+fn main() {
+    println!("hello, world");
+}


### PR DESCRIPTION
This PR adds `format_generated_files`. When this value is `false`, rustfmt skips formatting generated files. If the value is `true`, rustfmt formats generated files. `format_generated_files` is set to `false` by default.

rustfmt considers files as generated if the file starts with a comment which includes `@generated` ( e.g., `// @generated`).

Close #3958.