### PR TITLE
Configuration option to preserve blank lines at start of block

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1809,6 +1809,35 @@ pub enum Foo {}
 pub enum Foo {}
 ```
 
+## `preserve_block_start_blank_lines`
+
+Preserves blanks lines at the start of the block. Note that this will preserve newlines, but strip
+any other whitespace on those lines.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: No
+
+#### `false` (default):
+
+```rust
+fn say_hi() {
+    println!("hi");
+}
+```
+
+#### `true`:
+
+```rust
+fn say_hi() {
+
+
+    println!("hi");
+}
+```
+
+###
+
 ## `overflow_delimited_expr`
 
 When structs, slices, arrays, and block/array-like macros are used as the last

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,8 @@ create_config! {
         "Write an item and its attribute on the same line \
         if their combined width is below a threshold";
     format_generated_files: bool, false, false, "Format generated files";
+    preserve_block_start_blank_lines: bool, false, false, "Preserve blank lines at the start of \
+        blocks.";
 
     // Options that can change the source code beyond whitespace/blocks (somewhat linty things)
     merge_derives: bool, true, true, "Merge multiple `#[derive(...)]` into a single one";
@@ -617,6 +619,7 @@ blank_lines_lower_bound = 0
 edition = "2018"
 inline_attribute_width = 0
 format_generated_files = false
+preserve_block_start_blank_lines = false
 merge_derives = true
 use_try_shorthand = false
 use_field_init_shorthand = false

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -334,7 +334,7 @@ impl<'a> FmtVisitor<'a> {
                 self.push_str(&indent_str);
             } else {
                 let first_non_ws = item.body.first().map(|s| s.span().lo());
-                let opening_nls = &self.trim_spaces_after_opening_brace(first_non_ws);
+                let opening_nls = &self.advance_to_first_block_item(first_non_ws);
                 self.push_str(&opening_nls);
 
                 for item in &item.body {
@@ -863,11 +863,11 @@ pub(crate) fn format_impl(
             visitor.block_indent = item_indent;
             visitor.last_pos = lo + BytePos(open_pos as u32);
 
-            let open_nls = &visitor.trim_spaces_after_opening_brace(
+            let open_nls = &visitor.advance_to_first_block_item(
                 inner_attributes(&item.attrs)
                     .first()
                     .map(|a| a.span.lo())
-                    .or(items.first().map(|i| i.span().lo())),
+                    .or_else(|| items.first().map(|i| i.span().lo())),
             );
 
             visitor.visit_attrs(&item.attrs, ast::AttrStyle::Inner);
@@ -1235,8 +1235,8 @@ pub(crate) fn format_trait(
             visitor.block_indent = offset.block_only().block_indent(context.config);
             visitor.last_pos = block_span.lo() + BytePos(open_pos as u32);
 
-            let open_nls = &visitor
-                .trim_spaces_after_opening_brace(trait_items.first().map(|i| i.span().lo()));
+            let open_nls =
+                &visitor.advance_to_first_block_item(trait_items.first().map(|i| i.span().lo()));
 
             for item in trait_items {
                 visitor.visit_trait_item(item);

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -868,20 +868,16 @@ pub(crate) fn format_impl(
                 .first()
                 .map(|a| a.span.lo())
                 .or_else(|| items.first().map(|i| i.span().lo()));
-            let opening_nls = visitor.advance_to_first_block_item(first_non_ws);
+            if let Some(opening_nls) = visitor.advance_to_first_block_item(first_non_ws) {
+                result.push_str(&opening_nls);
+            }
 
             visitor.visit_attrs(&item.attrs, ast::AttrStyle::Inner);
             visitor.visit_impl_items(items);
 
             visitor.format_missing(item.span.hi() - BytePos(1));
 
-            let inner_indent_str = if let Some(opening_nls) = opening_nls {
-                result.push_str(&opening_nls);
-                visitor.block_indent.to_string(context.config)
-            } else {
-                visitor.block_indent.to_string_with_newline(context.config)
-            };
-
+            let inner_indent_str = visitor.block_indent.to_string_with_newline(context.config);
             let outer_indent_str = offset.block_only().to_string_with_newline(context.config);
 
             result.push_str(&inner_indent_str);
@@ -1235,8 +1231,11 @@ pub(crate) fn format_trait(
             visitor.block_indent = offset.block_only().block_indent(context.config);
             visitor.last_pos = block_span.lo() + BytePos(open_pos as u32);
 
-            let opening_nls =
-                visitor.advance_to_first_block_item(trait_items.first().map(|i| i.span().lo()));
+            if let Some(opening_nls) =
+                visitor.advance_to_first_block_item(trait_items.first().map(|i| i.span().lo()))
+            {
+                result.push_str(&opening_nls);
+            }
 
             for item in trait_items {
                 visitor.visit_trait_item(item);
@@ -1244,12 +1243,7 @@ pub(crate) fn format_trait(
 
             visitor.format_missing(item.span.hi() - BytePos(1));
 
-            let inner_indent_str = if let Some(opening_nls) = opening_nls {
-                result.push_str(&opening_nls);
-                visitor.block_indent.to_string(context.config)
-            } else {
-                visitor.block_indent.to_string_with_newline(context.config)
-            };
+            let inner_indent_str = visitor.block_indent.to_string_with_newline(context.config);
 
             result.push_str(&inner_indent_str);
             result.push_str(visitor.buffer.trim());

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -334,8 +334,9 @@ impl<'a> FmtVisitor<'a> {
                 self.push_str(&indent_str);
             } else {
                 let first_non_ws = item.body.first().map(|s| s.span().lo());
-                let opening_nls = &self.advance_to_first_block_item(first_non_ws);
-                self.push_str(&opening_nls);
+                if let Some(opening_nls) = self.advance_to_first_block_item(first_non_ws) {
+                    self.push_str(&opening_nls);
+                }
 
                 for item in &item.body {
                     self.format_body_element(item);
@@ -863,20 +864,19 @@ pub(crate) fn format_impl(
             visitor.block_indent = item_indent;
             visitor.last_pos = lo + BytePos(open_pos as u32);
 
-            let open_nls = &visitor.advance_to_first_block_item(
-                inner_attributes(&item.attrs)
-                    .first()
-                    .map(|a| a.span.lo())
-                    .or_else(|| items.first().map(|i| i.span().lo())),
-            );
+            let first_non_ws = inner_attributes(&item.attrs)
+                .first()
+                .map(|a| a.span.lo())
+                .or_else(|| items.first().map(|i| i.span().lo()));
+            let opening_nls = visitor.advance_to_first_block_item(first_non_ws);
 
             visitor.visit_attrs(&item.attrs, ast::AttrStyle::Inner);
             visitor.visit_impl_items(items);
 
             visitor.format_missing(item.span.hi() - BytePos(1));
 
-            let inner_indent_str = if !open_nls.is_empty() {
-                result.push_str(open_nls);
+            let inner_indent_str = if let Some(opening_nls) = opening_nls {
+                result.push_str(&opening_nls);
                 visitor.block_indent.to_string(context.config)
             } else {
                 visitor.block_indent.to_string_with_newline(context.config)
@@ -1235,8 +1235,8 @@ pub(crate) fn format_trait(
             visitor.block_indent = offset.block_only().block_indent(context.config);
             visitor.last_pos = block_span.lo() + BytePos(open_pos as u32);
 
-            let open_nls =
-                &visitor.advance_to_first_block_item(trait_items.first().map(|i| i.span().lo()));
+            let opening_nls =
+                visitor.advance_to_first_block_item(trait_items.first().map(|i| i.span().lo()));
 
             for item in trait_items {
                 visitor.visit_trait_item(item);
@@ -1244,8 +1244,8 @@ pub(crate) fn format_trait(
 
             visitor.format_missing(item.span.hi() - BytePos(1));
 
-            let inner_indent_str = if !open_nls.is_empty() {
-                result.push_str(open_nls);
+            let inner_indent_str = if let Some(opening_nls) = opening_nls {
+                result.push_str(&opening_nls);
                 visitor.block_indent.to_string(context.config)
             } else {
                 visitor.block_indent.to_string_with_newline(context.config)

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -229,6 +229,14 @@ enum BodyElement<'a> {
     ForeignItem(&'a ast::ForeignItem),
 }
 
+impl BodyElement<'_> {
+    pub(crate) fn span(&self) -> Span {
+        match self {
+            BodyElement::ForeignItem(fi) => fi.span(),
+        }
+    }
+}
+
 /// Represents a fn's signature.
 pub(crate) struct FnSig<'a> {
     decl: &'a ast::FnDecl,
@@ -325,6 +333,10 @@ impl<'a> FmtVisitor<'a> {
                 let indent_str = self.block_indent.to_string(self.config);
                 self.push_str(&indent_str);
             } else {
+                let first_non_ws = item.body.first().map(|s| s.span().lo());
+                let opening_nls = &self.trim_spaces_after_opening_brace(first_non_ws);
+                self.push_str(&opening_nls);
+
                 for item in &item.body {
                     self.format_body_element(item);
                 }
@@ -851,12 +863,25 @@ pub(crate) fn format_impl(
             visitor.block_indent = item_indent;
             visitor.last_pos = lo + BytePos(open_pos as u32);
 
+            let open_nls = &visitor.trim_spaces_after_opening_brace(
+                inner_attributes(&item.attrs)
+                    .first()
+                    .map(|a| a.span.lo())
+                    .or(items.first().map(|i| i.span().lo())),
+            );
+
             visitor.visit_attrs(&item.attrs, ast::AttrStyle::Inner);
             visitor.visit_impl_items(items);
 
             visitor.format_missing(item.span.hi() - BytePos(1));
 
-            let inner_indent_str = visitor.block_indent.to_string_with_newline(context.config);
+            let inner_indent_str = if !open_nls.is_empty() {
+                result.push_str(open_nls);
+                visitor.block_indent.to_string(context.config)
+            } else {
+                visitor.block_indent.to_string_with_newline(context.config)
+            };
+
             let outer_indent_str = offset.block_only().to_string_with_newline(context.config);
 
             result.push_str(&inner_indent_str);
@@ -1210,13 +1235,21 @@ pub(crate) fn format_trait(
             visitor.block_indent = offset.block_only().block_indent(context.config);
             visitor.last_pos = block_span.lo() + BytePos(open_pos as u32);
 
+            let open_nls = &visitor
+                .trim_spaces_after_opening_brace(trait_items.first().map(|i| i.span().lo()));
+
             for item in trait_items {
                 visitor.visit_trait_item(item);
             }
 
             visitor.format_missing(item.span.hi() - BytePos(1));
 
-            let inner_indent_str = visitor.block_indent.to_string_with_newline(context.config);
+            let inner_indent_str = if !open_nls.is_empty() {
+                result.push_str(open_nls);
+                visitor.block_indent.to_string(context.config)
+            } else {
+                visitor.block_indent.to_string_with_newline(context.config)
+            };
 
             result.push_str(&inner_indent_str);
             result.push_str(visitor.buffer.trim());

--- a/src/formatting/visitor.rs
+++ b/src/formatting/visitor.rs
@@ -230,6 +230,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 if snippet.find('\n') != snippet.rfind('\n') {
                     let mut lines = snippet.lines().map(&str::trim);
                     lines.next(); // Eat block-opening newline
+                    lines.next_back(); // Eat newline before the first item
                     let mut result = String::new();
                     while let Some("") = lines.next() {
                         result.push('\n');
@@ -1001,6 +1002,9 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     .or_else(|| m.items.first().map(|s| s.span().lo()));
                 if let Some(opening_nls) = self.advance_to_first_block_item(first_non_ws) {
                     self.push_str(&opening_nls);
+                    if attrs.is_empty() {
+                        self.push_str("\n");
+                    }
                 }
 
                 self.visit_attrs(attrs, ast::AttrStyle::Inner);

--- a/src/formatting/visitor.rs
+++ b/src/formatting/visitor.rs
@@ -183,18 +183,56 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     }
 
     /// Remove spaces between the opening brace and the first statement or the inner attribute
-    /// of the block.
-    fn trim_spaces_after_opening_brace(
+    /// of the block, fast-forwarding this position of the visitor.
+    /// If `preserve_block_start_blank_lines` is true, the return value contains the newlines that
+    /// should be preserved.
+    pub(crate) fn trim_spaces_after_opening_brace(
         &mut self,
-        b: &ast::Block,
-        inner_attrs: Option<&[ast::Attribute]>,
-    ) {
-        if let Some(first_stmt) = b.stmts.first() {
-            let hi = inner_attrs
-                .and_then(|attrs| inner_attributes(attrs).first().map(|attr| attr.span.lo()))
-                .unwrap_or_else(|| first_stmt.span().lo());
-            let missing_span = self.next_span(hi);
+        first_item_pos: Option<BytePos>,
+    ) -> String {
+        let mut result = String::new();
+        if let Some(first_item_pos) = first_item_pos {
+            let missing_span = self.next_span(first_item_pos);
             let snippet = self.snippet(missing_span);
+
+            if self.config.preserve_block_start_blank_lines() {
+                // First we need to find the span to look for blank lines in. This is either the
+                // - span between the opening brace and first item, or
+                // - span between the opening brace and a comment before the first item
+                // We do this so that we get a span of contiguous whitespace, which makes
+                // processing the blank lines easier.
+                let blank_lines_snippet = if let Some(hi) = self
+                    .snippet_provider
+                    .span_to_snippet(missing_span)
+                    .and_then(|s| s.find('/'))
+                {
+                    self.snippet_provider.span_to_snippet(mk_sp(
+                        missing_span.lo(),
+                        missing_span.lo() + BytePos::from_usize(hi),
+                    ))
+                } else {
+                    self.snippet_provider.span_to_snippet(missing_span)
+                };
+
+                if let Some(snippet) = blank_lines_snippet {
+                    let has_multiple_blank_lines =
+                        if let (Some(l), Some(r)) = (snippet.find('\n'), snippet.rfind('\n')) {
+                            l != r
+                        } else {
+                            false
+                        };
+                    if has_multiple_blank_lines {
+                        let mut lines = snippet.lines().map(&str::trim);
+                        lines.next(); // Eat block-opening newline
+                        while let Some("") = lines.next() {
+                            result.push('\n');
+                        }
+                    }
+                } else {
+                    debug!("Failed to preserve blank lines for {:?}", missing_span);
+                }
+            }
+
             let len = CommentCodeSlices::new(snippet)
                 .next()
                 .and_then(|(kind, _, s)| {
@@ -208,6 +246,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 self.last_pos = self.last_pos + BytePos::from_usize(len);
             }
         }
+        result
     }
 
     pub(crate) fn visit_block(
@@ -227,7 +266,12 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         self.last_pos = self.last_pos + brace_compensation;
         self.block_indent = self.block_indent.block_indent(self.config);
         self.push_str("{");
-        self.trim_spaces_after_opening_brace(b, inner_attrs);
+
+        let first_non_ws = inner_attrs
+            .and_then(|attrs| inner_attributes(attrs).first().map(|attr| attr.span.lo()))
+            .or(b.stmts.first().map(|s| s.span().lo()));
+        let opening_nls = &self.trim_spaces_after_opening_brace(first_non_ws);
+        self.push_str(&opening_nls);
 
         // Format inner attributes if available.
         if let Some(attrs) = inner_attrs {
@@ -953,6 +997,14 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             } else {
                 self.last_pos = mod_lo;
                 self.block_indent = self.block_indent.block_indent(self.config);
+
+                let first_non_ws = inner_attributes(attrs)
+                    .first()
+                    .map(|attr| attr.span.lo())
+                    .or(m.items.first().map(|s| s.span().lo()));
+                let opening_nls = &self.trim_spaces_after_opening_brace(first_non_ws);
+                self.push_str(&opening_nls);
+
                 self.visit_attrs(attrs, ast::AttrStyle::Inner);
                 self.walk_mod_items(m);
                 let missing_span = self.next_span(m.inner.hi() - BytePos(1));

--- a/tests/source/configs/preserve_block_start_blank_lines/false.rs
+++ b/tests/source/configs/preserve_block_start_blank_lines/false.rs
@@ -1,0 +1,208 @@
+// rustfmt-preserve_block_start_blank_lines: false
+
+fn noop() {
+    println!("hi");
+}
+
+fn say_hi() {
+       
+        
+    println!("hi");
+}
+
+fn say_hi() {
+       
+       
+    #![attr]
+    println!("hi");
+}
+
+fn say_hi() {
+       
+       
+    //! Abcdef
+
+    println!("hi");
+}
+
+fn say_hi() {
+       
+       
+    // Abcdef
+
+    println!("hi");
+}
+
+fn say_hi() {
+    // Abcdef
+
+    println!("hi");
+}
+
+fn container() {
+    if true {
+        
+
+        // comment
+        do_work();
+    } else {
+        
+
+        // comment
+        other_work();
+    }
+
+    let val = {
+
+
+        // comment
+        get_val();
+    };
+}
+
+trait Hello {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+
+
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    fn say_hi() -> &str;
+}
+
+impl Hello for &str {
+
+
+    // comment
+
+    fn say_hi() -> &str { "hi" }
+}
+
+impl Hello for &str {
+    // comment
+
+    fn say_hi() -> &str { "hi" }
+}
+
+impl Hello for &str {
+
+
+
+    fn say_hi() -> &str { "hi" }
+}
+
+impl Hello for &str {
+    fn say_hi() -> &str { "hi" }
+}
+
+mod Hi {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+    
+    // comment
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+    
+    // comment
+
+    #![attr]
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+    
+    #![attr]
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    // comment
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    // comment
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    // comment
+
+    #[attr]
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    // comment
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    fn say_hi() -> &str;
+}

--- a/tests/source/configs/preserve_block_start_blank_lines/true.rs
+++ b/tests/source/configs/preserve_block_start_blank_lines/true.rs
@@ -1,0 +1,208 @@
+// rustfmt-preserve_block_start_blank_lines: true
+
+fn noop() {
+    println!("hi");
+}
+
+fn say_hi() {
+       
+        
+    println!("hi");
+}
+
+fn say_hi() {
+       
+       
+    #![attr]
+    println!("hi");
+}
+
+fn say_hi() {
+       
+       
+    //! Abcdef
+
+    println!("hi");
+}
+
+fn say_hi() {
+       
+       
+    // Abcdef
+
+    println!("hi");
+}
+
+fn say_hi() {
+    // Abcdef
+
+    println!("hi");
+}
+
+fn container() {
+    if true {
+        
+
+        // comment
+        do_work();
+    } else {
+        
+
+        // comment
+        other_work();
+    }
+
+    let val = {
+
+
+        // comment
+        get_val();
+    };
+}
+
+trait Hello {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+
+
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    fn say_hi() -> &str;
+}
+
+impl Hello for &str {
+
+
+    // comment
+
+    fn say_hi() -> &str { "hi" }
+}
+
+impl Hello for &str {
+    // comment
+
+    fn say_hi() -> &str { "hi" }
+}
+
+impl Hello for &str {
+
+
+
+    fn say_hi() -> &str { "hi" }
+}
+
+impl Hello for &str {
+    fn say_hi() -> &str { "hi" }
+}
+
+mod Hi {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+    
+    // comment
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+    
+    // comment
+
+    #![attr]
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+    
+    #![attr]
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    // comment
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+    
+    // comment
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+    
+    // comment
+
+    #[attr]
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    // comment
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    fn say_hi() -> &str;
+}

--- a/tests/target/configs/preserve_block_start_blank_lines/false.rs
+++ b/tests/target/configs/preserve_block_start_blank_lines/false.rs
@@ -1,0 +1,172 @@
+// rustfmt-preserve_block_start_blank_lines: false
+
+fn noop() {
+    println!("hi");
+}
+
+fn say_hi() {
+    println!("hi");
+}
+
+fn say_hi() {
+    #![attr]
+    println!("hi");
+}
+
+fn say_hi() {
+    //! Abcdef
+
+    println!("hi");
+}
+
+fn say_hi() {
+    // Abcdef
+
+    println!("hi");
+}
+
+fn say_hi() {
+    // Abcdef
+
+    println!("hi");
+}
+
+fn container() {
+    if true {
+        // comment
+        do_work();
+    } else {
+        // comment
+        other_work();
+    }
+
+    let val = {
+        // comment
+        get_val();
+    };
+}
+
+trait Hello {
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    fn say_hi() -> &str;
+}
+
+impl Hello for &str {
+    // comment
+
+    fn say_hi() -> &str {
+        "hi"
+    }
+}
+
+impl Hello for &str {
+    // comment
+
+    fn say_hi() -> &str {
+        "hi"
+    }
+}
+
+impl Hello for &str {
+    fn say_hi() -> &str {
+        "hi"
+    }
+}
+
+impl Hello for &str {
+    fn say_hi() -> &str {
+        "hi"
+    }
+}
+
+mod Hi {
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    // comment
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    // comment
+
+    #![attr]
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    #![attr]
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    // comment
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    /// comment
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    // comment
+
+    /// comment
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    // comment
+
+    #[attr]
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    // comment
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    fn say_hi() -> &str;
+}

--- a/tests/target/configs/preserve_block_start_blank_lines/true.rs
+++ b/tests/target/configs/preserve_block_start_blank_lines/true.rs
@@ -1,0 +1,214 @@
+// rustfmt-preserve_block_start_blank_lines: true
+
+fn noop() {
+    println!("hi");
+}
+
+fn say_hi() {
+
+
+    println!("hi");
+}
+
+fn say_hi() {
+
+
+    #![attr]
+    println!("hi");
+}
+
+fn say_hi() {
+
+
+    //! Abcdef
+
+    println!("hi");
+}
+
+fn say_hi() {
+
+
+    // Abcdef
+
+    println!("hi");
+}
+
+fn say_hi() {
+    // Abcdef
+
+    println!("hi");
+}
+
+fn container() {
+    if true {
+
+
+        // comment
+        do_work();
+    } else {
+
+
+        // comment
+        other_work();
+    }
+
+    let val = {
+
+
+        // comment
+        get_val();
+    };
+}
+
+trait Hello {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+
+
+
+    fn say_hi() -> &str;
+}
+
+trait Hello {
+    fn say_hi() -> &str;
+}
+
+impl Hello for &str {
+
+
+    // comment
+
+    fn say_hi() -> &str {
+        "hi"
+    }
+}
+
+impl Hello for &str {
+    // comment
+
+    fn say_hi() -> &str {
+        "hi"
+    }
+}
+
+impl Hello for &str {
+
+
+
+    fn say_hi() -> &str {
+        "hi"
+    }
+}
+
+impl Hello for &str {
+    fn say_hi() -> &str {
+        "hi"
+    }
+}
+
+mod Hi {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+
+    // comment
+
+    /// comment
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+
+    // comment
+
+    #![attr]
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+
+
+    #![attr]
+
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    // comment
+    fn say_hi() -> &str;
+}
+
+mod Hi {
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    // comment
+
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    /// comment
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    // comment
+
+    /// comment
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+
+
+    // comment
+
+    #[attr]
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    // comment
+    fn say_hi() -> &str;
+}
+
+extern "C" {
+    fn say_hi() -> &str;
+}


### PR DESCRIPTION
Adds the option for

- Functions
- Control flow blocks
- Expression statements (i.e. `let x = { ... };`)
- Traits
- Trait Impls
- Mods
- Foreign Mods

If I am missing a kind of item, let me know :)

Closes #2868