### PR TITLE
Do not add trailing space to empty lines in comment code blocks

### DIFF
--- a/tests/source/issue-4251.rs
+++ b/tests/source/issue-4251.rs
@@ -1,0 +1,6 @@
+// rustfmt-wrap_comments: true
+
+//! ```
+//! 
+//! use something;
+//! ```

--- a/tests/target/issue-4251.rs
+++ b/tests/target/issue-4251.rs
@@ -1,0 +1,6 @@
+// rustfmt-wrap_comments: true
+
+//! ```
+//!
+//! use something;
+//! ```


### PR DESCRIPTION
Currently, the first line pushed in a code block is a comment line
delimiter that includes a trailing space, even if the content of that
line is empty. Later lines are handled correctly because their content
is checked before adding the comment line delimiter. So, just apply the
same logic as is done for later lines to the first line.

Closes #4251