### PR TITLE
rename KeepExisting->Preserve variant for leading match arm pipe config option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1553,7 +1553,7 @@ See also: [`match_block_trailing_comma`](#match_block_trailing_comma).
 Controls whether to include a leading pipe on match arms
 
 - **Default value**: `Never`
-- **Possible values**: `Always`, `Never`, `KeepExisting`
+- **Possible values**: `Always`, `Never`, `Preserve`
 - **Stable**: Yes
 
 #### `Never` (default):
@@ -1610,7 +1610,7 @@ fn foo() {
 }
 ```
 
-#### `KeepExisting`:
+#### `Preserve`:
 ```rust
 fn foo() {
     match foo {

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -355,8 +355,8 @@ pub enum MatchArmLeadingPipe {
     Always,
     /// Never emit leading pipes on match arms
     Never,
-    /// Maintain any existing leading pipes
-    KeepExisting,
+    /// Preserve any existing leading pipes
+    Preserve,
 }
 
 #[cfg(test)]

--- a/src/formatting/matches.rs
+++ b/src/formatting/matches.rs
@@ -244,8 +244,8 @@ fn rewrite_match_arm(
     // 2 = `| `
     let (pipe_offset, pipe_str) = match context.config.match_arm_leading_pipes() {
         MatchArmLeadingPipe::Never => (0, ""),
-        MatchArmLeadingPipe::KeepExisting if !has_leading_pipe => (0, ""),
-        MatchArmLeadingPipe::KeepExisting | MatchArmLeadingPipe::Always => (2, "| "),
+        MatchArmLeadingPipe::Preserve if !has_leading_pipe => (0, ""),
+        MatchArmLeadingPipe::Preserve | MatchArmLeadingPipe::Always => (2, "| "),
     };
 
     // Patterns

--- a/tests/source/configs/match_arm_leading_pipes/preserve.rs
+++ b/tests/source/configs/match_arm_leading_pipes/preserve.rs
@@ -1,26 +1,27 @@
-// rustfmt-match_arm_leading_pipes: KeepExisting
+// rustfmt-match_arm_leading_pipes: Preserve
 
 fn foo() {
     match foo {
-        | "foo" | "bar" => {}
+        | "foo"      | "bar" => {}
         | "baz"
-        | "something relatively long"
+        |                   "something relatively long"
         | "something really really really realllllllllllllly long" => println!("x"),
-        | "qux" => println!("y"),
+        | "qux" =>           println!("y"),
         _ => {}
     }
 }
 
 fn issue_3973() {
     match foo {
-        | "foo" | "bar" => {}
+        | "foo"
+        | "bar" => {}
         _ => {}
     }
 }
 
 fn bar() {
     match baz {
-        "qux" => {}
+        "qux"     => {    }
         "foo" | "bar" => {}
         _ => {}
     }

--- a/tests/target/configs/match_arm_leading_pipes/preserve.rs
+++ b/tests/target/configs/match_arm_leading_pipes/preserve.rs
@@ -1,27 +1,26 @@
-// rustfmt-match_arm_leading_pipes: KeepExisting
+// rustfmt-match_arm_leading_pipes: Preserve
 
 fn foo() {
     match foo {
-        | "foo"      | "bar" => {}
+        | "foo" | "bar" => {}
         | "baz"
-        |                   "something relatively long"
+        | "something relatively long"
         | "something really really really realllllllllllllly long" => println!("x"),
-        | "qux" =>           println!("y"),
+        | "qux" => println!("y"),
         _ => {}
     }
 }
 
 fn issue_3973() {
     match foo {
-        | "foo"
-        | "bar" => {}
+        | "foo" | "bar" => {}
         _ => {}
     }
 }
 
 fn bar() {
     match baz {
-        "qux"     => {    }
+        "qux" => {}
         "foo" | "bar" => {}
         _ => {}
     }


### PR DESCRIPTION
Discussed briefly in https://github.com/rust-lang/rustfmt/pull/4090#issuecomment-650588081, but basically `Preserve` feels like a better variant name than `KeepExisting`. 

It's more succinct and direct, and though not terribly important, another minor benefit is that it also happens to be consistent with the equivalent config option values seen in other code formatting tools 