### PR TITLE
Permit ranges on multiple lines in closures, without an enclosing block

### DIFF
--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -121,6 +121,8 @@ fn needs_block(block: &ast::Block, prefix: &str, context: &RewriteContext<'_>) -
         || prefix.contains('\n')
 }
 
+// TODO: The expressions "veto"ed here should align with expressions that are permitted on multiple
+// lines in rewrite_closure_expr#allow_multi_line. Consider refactoring to avoid this disparity.
 fn veto_block(e: &ast::Expr) -> bool {
     match e.kind {
         ast::ExprKind::Call(..)
@@ -179,7 +181,8 @@ fn rewrite_closure_expr(
             | ast::ExprKind::Block(..)
             | ast::ExprKind::TryBlock(..)
             | ast::ExprKind::Loop(..)
-            | ast::ExprKind::Struct(..) => true,
+            | ast::ExprKind::Struct(..)
+            | ast::ExprKind::Range(..) => true,
 
             ast::ExprKind::AddrOf(_, _, ref expr)
             | ast::ExprKind::Box(ref expr)

--- a/tests/source/issue-4308.rs
+++ b/tests/source/issue-4308.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let requires_multiline = 7;
+
+    let _ = {
+        || if true {
+            requires_multiline
+        } else {
+            requires_multiline
+        } 
+        ..19;
+    };
+}

--- a/tests/target/issue-4308.rs
+++ b/tests/target/issue-4308.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let requires_multiline = 7;
+
+    let _ = {
+        || if true {
+            requires_multiline
+        } else {
+            requires_multiline
+        }..19;
+    };
+}


### PR DESCRIPTION
The problem here was that if an expression in a closure fails to be
formatted without an enclosing block, as in the case of a multiline
range prior to this commit, we try to put the expression in the block.
But then we try to check what expressions should be "vetoed" from being
in a block, which includes ranges. The non-breaking fix is to let
multiline ranges be formatted without a block.

On the big picture, though, it may be the case that there is no need for
a "veto" check when formatting expressions in a closure block, or that
there is a better way to structure the work being done here. I added a
todo for this, since it's relatively low priority (IMO).

Closes #4308