### PR TITLE
Add test for generic bounds on associated types

### DIFF
--- a/tests/source/where-clause.rs
+++ b/tests/source/where-clause.rs
@@ -56,3 +56,8 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         // ...
     }
 }
+
+// #4315
+pub trait AsUnindented {
+    type Output<'ast> where Self: 'ast;
+}

--- a/tests/target/where-clause.rs
+++ b/tests/target/where-clause.rs
@@ -105,3 +105,8 @@ impl<'a, 'gcx, 'tcx> ProbeContext<'a, 'gcx, 'tcx> {
         // ...
     }
 }
+
+// #4315
+pub trait AsUnindented {
+    type Output<'ast> where Self: 'ast;
+}


### PR DESCRIPTION
This was fixed in 1e9af9fa2eb6ba4e0ad1e2e275003ada7e5a27e2 but it seems
that a test was never added.

Closes #4315