### PR TITLE
refactor: rename some private whitelist naming

### DIFF
--- a/src/formatting/overflow.rs
+++ b/src/formatting/overflow.rs
@@ -36,7 +36,7 @@ const SHORT_ITEM_THRESHOLD: usize = 10;
 /// Organized as a list of `(&str, usize)` tuples, giving the name of the macro and the number of
 /// arguments before the format string (none for `format!("format", ...)`, one for `assert!(result,
 /// "format", ...)`, two for `assert_eq!(left, right, "format", ...)`).
-const SPECIAL_MACRO_WHITELIST: &[(&str, usize)] = &[
+const SPECIAL_CASE_MACROS: &[(&str, usize)] = &[
     // format! like macros
     // From the Rust Standard Library.
     ("eprint!", 0),
@@ -64,7 +64,7 @@ const SPECIAL_MACRO_WHITELIST: &[(&str, usize)] = &[
     ("debug_assert_ne!", 2),
 ];
 
-const SPECIAL_ATTR_WHITELIST: &[(&str, usize)] = &[
+const SPECIAL_CASE_ATTR: &[(&str, usize)] = &[
     // From the `failure` crate.
     ("fail", 0),
 ];
@@ -190,10 +190,10 @@ impl<'a> OverflowableItem<'a> {
         }
     }
 
-    fn whitelist(&self) -> &'static [(&'static str, usize)] {
+    fn special_cases(&self) -> &'static [(&'static str, usize)] {
         match self {
-            OverflowableItem::MacroArg(..) => SPECIAL_MACRO_WHITELIST,
-            OverflowableItem::NestedMetaItem(..) => SPECIAL_ATTR_WHITELIST,
+            OverflowableItem::MacroArg(..) => SPECIAL_CASE_MACROS,
+            OverflowableItem::NestedMetaItem(..) => SPECIAL_CASE_ATTR,
             _ => &[],
         }
     }
@@ -764,7 +764,7 @@ pub(crate) fn maybe_get_args_offset(
 ) -> Option<(bool, usize)> {
     if let Some(&(_, num_args_before)) = args
         .get(0)?
-        .whitelist()
+        .special_cases()
         .iter()
         .find(|&&(s, _)| s == callee_str)
     {


### PR DESCRIPTION
There's obviously been a lot of discussion within the tech industry about various terms and language, and I'm in agreement with ensuring communities are inclusive and use inclusive language. 

Some of the specific terms that are being revisited and renamed are `whitelist` and `blacklist`, including in the [Linux kernel](https://www.zdnet.com/article/linux-team-approves-new-terminology-bans-terms-like-blacklist-and-slave/) and in the [main Rust repo](https://github.com/rust-lang/rust/pull/74127). 

We didn't have much usage of those terms within rustfmt (couple private variables and function names), but this PR renames those handful of instances with what I feel are genuinely better names that more clearly convey their purpose.

For example, we previously used `SKIP_FILE_WHITE_LIST` for the collection of files that should be skipped during system and idempotence tests, which I always felt was a little contradictory and confused me when I first started working on rustfmt :smile: 
