### PR TITLE
Remove 'search' url query parameter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -89,8 +89,6 @@
             const RusfmtTagsUrl = 'https://api.github.com/repos/rust-lang/rustfmt/tags';
             const UrlHash = window.location.hash.replace(/^#/, '');
             const queryParams = new URLSearchParams(window.location.search);
-            const searchParam = queryParams.get('search');
-            const searchTerm = null !== searchParam ? searchParam : '';
             const versionParam = queryParams.get('version');
             const parseVersionParam = (version) => {
               if (version === 'master') return 'master';
@@ -104,7 +102,7 @@
                 aboutHtml: '',
                 configurationAboutHtml: '',
                 configurationDescriptions: [],
-                searchCondition: searchTerm,
+                searchCondition: '',
                 shouldStable: false,
                 version: versionNumber,
                 oldVersion: undefined,
@@ -147,7 +145,6 @@
                   ast.links = {};
 
                   queryParams.set('version', this.version);
-                  queryParams.set('search', this.searchCondition);
                   const curUrl = window.location.pathname +
                     '?' + queryParams.toString() + window.location.hash;
                   history.pushState(null, '', curUrl);

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.css" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/github-gist.min.css">
       <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/vue@2.6.10/dist/vue.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/vue@2.6.10"></script>
       <script src="https://unpkg.com/vue-async-computed@3.8.1"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/highlight.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"></script>


### PR DESCRIPTION
This PR removes the `search` query parameter from the GitHub page.

Currently, when we type in the search box, the URL gets kept in sync with the input. This is a bit annoying as it keeps adding each URL to the history.

Since the value of the search box is managed by `vue-async-computed`, we do not need the query parameter to pass around the value of the search box.

@ayazhafiz @calebcartwright If I understand correctly this PR does not go against the motivation discussed at #4261, though please let me know if I am missing something.