### PR TITLE
Improve support for wasm32-wasi

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -263,7 +263,7 @@ impl Config {
                 dir.to_path_buf()
             };
 
-            current = dunce::canonicalize(current)?;
+            current = dunce::canonicalize(&current).unwrap_or(current);
             let mut paths = Vec::new();
 
             loop {

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -245,7 +245,7 @@ enum Timer {
 
 impl Timer {
     fn start() -> Timer {
-        if cfg!(target_arch = "wasm32") {
+        if cfg!(all(target_arch = "wasm32", not(target_os = "wasi"))) {
             Timer::Disabled
         } else {
             Timer::Initialized(Instant::now())


### PR DESCRIPTION
This commit has a few tweaks necessary to get a wasi binary of `rustfmt`
working. Timers were flagged as being allowed on wasi targets (but still
not allowed on wasm32), and path canonicalization errors are now also
ignored. This is also somewhat beneficial for other filesystems as well
where canonicalization sometimes does not work in esoteric situations.