### PR TITLE
Indent return types separated from params by newline

### DIFF
--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -2368,6 +2368,7 @@ fn rewrite_fn_base(
 
     // Return type.
     if let ast::FnRetTy::Ty(..) = fd.output {
+        let mut ret_on_nl = false;
         let ret_should_indent = match context.config.indent_style() {
             // If our params are block layout then we surely must have space.
             IndentStyle::Block if put_params_in_block || fd.inputs.is_empty() => false,
@@ -2385,7 +2386,8 @@ fn rewrite_fn_base(
                     sig_length += 2;
                 }
 
-                sig_length > context.config.max_width()
+                ret_on_nl = sig_length > context.config.max_width();
+                ret_on_nl
             }
         };
         let ret_shape = if ret_should_indent {
@@ -2405,15 +2407,13 @@ fn rewrite_fn_base(
                 Shape::indented(indent, context.config)
             } else {
                 let mut ret_shape = Shape::indented(indent, context.config);
-                if param_str.is_empty() {
-                    // Aligning with non-existent params looks silly.
+                if param_str.is_empty() || ret_on_nl {
+                    // Aligning with non-existent params looks silly, as does aligning the return
+                    // type when it is on a newline entirely disconnected from the parentheses of
+                    // the parameters.
                     force_new_line_for_brace = true;
-                    ret_shape = if context.use_block_indent() {
-                        ret_shape.offset_left(4).unwrap_or(ret_shape)
-                    } else {
-                        ret_shape.indent = ret_shape.indent + 4;
-                        ret_shape
-                    };
+
+                    ret_shape.indent = ret_shape.indent + 4;
                 }
 
                 result.push_str(&ret_shape.indent.to_string_with_newline(context.config));

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -2412,8 +2412,12 @@ fn rewrite_fn_base(
                     // type when it is on a newline entirely disconnected from the parentheses of
                     // the parameters.
                     force_new_line_for_brace = true;
-
-                    ret_shape.indent = ret_shape.indent + 4;
+                    ret_shape = if context.use_block_indent() && !ret_on_nl {
+                        ret_shape.offset_left(4).unwrap_or(ret_shape)
+                    } else {
+                        ret_shape.indent = ret_shape.indent + 4;
+                        ret_shape
+                    };
                 }
 
                 result.push_str(&ret_shape.indent.to_string_with_newline(context.config));

--- a/tests/target/configs/space_before_fn_sig_paren/max_width.rs
+++ b/tests/target/configs/space_before_fn_sig_paren/max_width.rs
@@ -4,7 +4,7 @@
 
 trait Story {
     fn swap_context<T: 'static + Context + Send + Sync> (&mut self, context: T)
-    -> Option<Box<Context + Send + Sync>>;
+        -> Option<Box<Context + Send + Sync>>;
 }
 
 impl Story for () {

--- a/tests/target/issue-4306.rs
+++ b/tests/target/issue-4306.rs
@@ -1,0 +1,6 @@
+// rustfmt-max_width: 80
+
+trait GetMetadata {
+    fn metadata(loc: ApiEndpointParameterLocation)
+        -> Vec<ApiEndpointParameter>;
+}


### PR DESCRIPTION
 #3891 removed Version One formatting that did this correctly (https://github.com/rust-lang/rustfmt/pull/3891/files#diff-5db152a52bdaeae9dacd35f43a4a78ddL2342-L2344),
but at seemingly at the time there were no tests to catch the
regression.

This commit fix-forwards the formatting regression, though via a different
implementation because the original implementation would muddle the branch
for visual indentation and this fix, which is probably not preferrable
giving the existing complexity of the rewrite_required_fn method.

Closes #4366
