### PR TITLE
Correctly indent function return types on new lines 

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-# error_on_line_overflow = true
-# error_on_unformatted = true
+error_on_line_overflow = true
+error_on_unformatted = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-error_on_line_overflow = true
-error_on_unformatted = true
+# error_on_line_overflow = true
+# error_on_unformatted = true

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -2330,9 +2330,11 @@ fn rewrite_fn_base(
         _ => false,
     } && !fd.inputs.is_empty();
 
-    let mut params_last_line_contains_comment = false;
-    let mut no_params_and_over_max_width = false;
-    let mut ret_on_nl = false;
+    // Whether the return type should be forced on a newline, disconnected from the closing paren
+    // of the fn params.
+    let mut force_ret_on_nl = false;
+    // Whether the last line of the params string is a single closing paren.
+    let mut last_line_only_closing_paren = put_params_in_block;
 
     if put_params_in_block {
         param_indent = indent.block_indent(context.config);
@@ -2349,19 +2351,18 @@ fn rewrite_fn_base(
             fd.inputs.is_empty() && used_width + 1 > context.config.max_width();
         // If the last line of params contains comment, we cannot put the closing paren
         // on the same line.
-        params_last_line_contains_comment = param_str
+        let params_last_line_contains_comment = param_str
             .lines()
             .last()
             .map_or(false, |last_line| last_line.contains("//"));
 
         if closing_paren_overflow_max_width {
             result.push(')');
-            ret_on_nl = true;
-            no_params_and_over_max_width = true;
+            force_ret_on_nl = true;
         } else if params_last_line_contains_comment {
             result.push_str(&indent.to_string_with_newline(context.config));
             result.push(')');
-            no_params_and_over_max_width = true;
+            last_line_only_closing_paren = true;
         } else {
             result.push(')');
         }
@@ -2369,12 +2370,18 @@ fn rewrite_fn_base(
 
     // Return type.
     if let ast::FnRetTy::Ty(..) = fd.output {
-        let ret_should_indent = match context.config.indent_style() {
-            // If our params are block layout then we surely must have space.
-            IndentStyle::Block if put_params_in_block || fd.inputs.is_empty() => false,
-            _ if params_last_line_contains_comment => false,
-            _ if result.contains('\n') || multi_line_ret_str => true,
-            _ => {
+        // The return type needs to be indented iff it is separated from the function parameters by
+        // a newline. E.g.
+        //   fn foo() -> T   // no indent
+        //
+        //   fn foo(
+        //      a: usize
+        //   ) -> T   // no indent
+        //
+        //   fn super_long_foo()
+        //      -> T   // indent
+        let ret_should_indent = !last_line_only_closing_paren
+            && (force_ret_on_nl || {
                 // If the return type would push over the max width, then put the return type on
                 // a new line. With the +1 for the signature length an additional space between
                 // the closing parenthesis of the param and the arrow '->' is considered.
@@ -2386,10 +2393,8 @@ fn rewrite_fn_base(
                     sig_length += 2;
                 }
 
-                ret_on_nl = sig_length > context.config.max_width();
-                ret_on_nl
-            }
-        } || ret_on_nl;
+                sig_length > context.config.max_width()
+            });
         let ret_shape = if ret_should_indent {
             if context.config.indent_style() == IndentStyle::Visual {
                 let indent = if param_str.is_empty() {
@@ -2406,22 +2411,14 @@ fn rewrite_fn_base(
                 result.push_str(&indent.to_string_with_newline(context.config));
                 Shape::indented(indent, context.config)
             } else {
-                let mut ret_shape = Shape::indented(indent, context.config);
-                if ret_on_nl {
-                    // Aligning with non-existent params looks silly, as does aligning the return
-                    // type when it is on a newline entirely disconnected from the parentheses of
-                    // the parameters.
-                    force_new_line_for_brace = true;
-                    ret_shape = ret_shape.block_indent(4);
-                }
+                force_new_line_for_brace = true;
 
+                let ret_shape = Shape::indented(indent, context.config).block_indent(4);
                 result.push_str(&ret_shape.indent.to_string_with_newline(context.config));
                 ret_shape
             }
         } else {
-            if !param_str.is_empty() || !no_params_and_over_max_width {
-                result.push(' ');
-            }
+            result.push(' ');
 
             let ret_shape = Shape::indented(indent, context.config);
             ret_shape

--- a/tests/target/issue-2672.rs
+++ b/tests/target/issue-2672.rs
@@ -22,13 +22,15 @@ mod asdf {
 
 impl Something {
     fn my_function_name_is_way_to_long_but_used_as_a_case_study_or_an_example_its_fine()
-    -> Result<(), String> {
+        -> Result<(), String>
+    {
     }
 }
 
 impl Something {
     fn my_function_name()
-    -> HashMap<(String, String, (String, String)), (String, String, String, String)> {
+        -> HashMap<(String, String, (String, String)), (String, String, String, String)>
+    {
     }
 }
 
@@ -46,7 +48,7 @@ mod A {
                                             mod L {
                                                 mod M {
                                                     fn setup_happy_path()
-                                                    -> Result<String, CustomTypeA>
+                                                        -> Result<String, CustomTypeA>
                                                     {
                                                     }
                                                 }

--- a/tests/target/issue-3278.rs
+++ b/tests/target/issue-3278.rs
@@ -1,5 +1,5 @@
 pub fn parse_conditional<'a, I: 'a>()
--> impl Parser<Input = I, Output = Expr, PartialState = ()> + 'a
+    -> impl Parser<Input = I, Output = Expr, PartialState = ()> + 'a
 where
     I: Stream<Item = char>,
 {

--- a/tests/target/long-fn-1.rs
+++ b/tests/target/long-fn-1.rs
@@ -16,13 +16,15 @@ impl Foo {
 // #1843
 #[allow(non_snake_case)]
 pub extern "C" fn Java_com_exonum_binding_storage_indices_ValueSetIndexProxy_nativeContainsByHash()
--> bool {
+    -> bool
+{
     false
 }
 
 // #3009
 impl Something {
     fn my_function_name_is_way_to_long_but_used_as_a_case_study_or_an_example_its_fine()
-    -> Result<(), String> {
+        -> Result<(), String>
+    {
     }
 }


### PR DESCRIPTION
There are two commits in this PR. The first fixes the incorrect return type indentation discussed in #4373. The second simplifies the logic of the code ambient to the fix to try lower the number of branches and amount of work needed to reason about what is happening. The biggest change w.r.t. the latter commit is that we can think about indentation of the return type only when the return type should be on its own newline; otherwise, there is no reason to indent it.

There is a blocker that need to be discussed before this could be landed:

- [ ] (cc @topecongiro) that this change is the indented behavior for a return type when the indent style is block

To expand on this, visual indent styles would have the return type inline with the parameter indent:

```rust
fn lorem(ipsum: usize,
         dolor: usize,
         sit: usize,
         amet: usize,
         consectetur: usize,
         adipiscing: usize,
         elit: usize)
         -> usize {
}
```

I think this is a reasonable difference between visual and block indent, but we need to confirm this.

---

tangent: in the process, I discovered what I think is another bug w.r.t. fn signature indentation with the visual indent style. Under this mode, a code would format as

```rust
    fn foo(
        )
        -> BoxFuture<'static,
                     Result<Box<dyn dirents_sink::Sealed>,
                            Status,
                            BoxFuture<'static, Result<Box<dyn dirents_sink::Sealed>, Status>>>>;

```

but I think the desired formatting is more like

```rust
    fn foo() -> BoxFuture<'static,
                          Result<Box<dyn dirents_sink::Sealed>,
                                 Status,
                                 BoxFuture<'static, Result<Box<dyn dirents_sink::Sealed>, Status>>>>;
```

However, this is a rather esoteric case that I don't think should be prioritized until more users begin submitting reports of it in real cases.

---

I think the function formatting function as a whole could use some refactoring for better reasoning and less branches; currently it is [exceptionally large and difficult to understand](https://github.com/rust-lang/rustfmt/blob/master/src/formatting/items.rs#L2210-L2526).