### PR TITLE
Correctly create artificial span for formatting closure body

### DIFF
--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -140,6 +140,7 @@ fn veto_block(e: &ast::Expr) -> bool {
 }
 
 // Rewrite closure with a single expression wrapping its body with block.
+// || { #[attr] foo() } -> Block { #[attr] foo() }
 fn rewrite_closure_with_block(
     body: &ast::Expr,
     prefix: &str,
@@ -160,7 +161,11 @@ fn rewrite_closure_with_block(
         }],
         id: ast::NodeId::root(),
         rules: ast::BlockCheckMode::Default,
-        span: body.span,
+        span: body
+            .attrs
+            .first()
+            .map(|attr| attr.span.to(body.span))
+            .unwrap_or(body.span),
     };
     let block =
         rewrite_block_with_visitor(context, "", &block, Some(&body.attrs), None, shape, false)?;

--- a/src/formatting/expr.rs
+++ b/src/formatting/expr.rs
@@ -525,17 +525,7 @@ pub(crate) fn rewrite_block_with_visitor(
             let open_pos = snippet.find_uncommented("{")?;
             visitor.last_pos = block.span.lo() + BytePos(open_pos as u32)
         }
-        (ast::BlockCheckMode::Default, None) => {
-            visitor.last_pos = block.span.lo();
-            if let Some(attrs) = attrs {
-                if let Some(first) = attrs.first() {
-                    let first_lo_span = first.span.lo();
-                    if first_lo_span < visitor.last_pos {
-                        visitor.last_pos = first_lo_span;
-                    }
-                }
-            }
-        }
+        (ast::BlockCheckMode::Default, None) => visitor.last_pos = block.span.lo(),
     }
 
     let inner_attrs = attrs.map(inner_attributes);

--- a/tests/source/issue-4382.rs
+++ b/tests/source/issue-4382.rs
@@ -1,0 +1,4 @@
+pub const NAME_MAX: usize = {
+    #[cfg(target_os = "linux")]   { 1024 }
+    #[cfg(target_os = "freebsd")] {  255 }
+};

--- a/tests/target/issue-4382.rs
+++ b/tests/target/issue-4382.rs
@@ -1,0 +1,10 @@
+pub const NAME_MAX: usize = {
+    #[cfg(target_os = "linux")]
+    {
+        1024
+    }
+    #[cfg(target_os = "freebsd")]
+    {
+        255
+    }
+};


### PR DESCRIPTION
This commit partially reverts #3934, opting to create a span that covers
the entire body of a closure when formatting a closure body with a
block-formatting strategy, rather than having the block-formatting code
determine if the visitor pointer should be rewound. The problem with
rewinding the visitor pointer is it may be incorrect for other (i.e.
non-artificial) AST nodes, as in the case of #4382.

Closes #4382
