### PR TITLE
Issue #4059 - comments handling before and after long attrs or list

### DIFF
--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -1604,7 +1604,17 @@ pub(crate) fn recover_comment_removed(
     let snippet = context.snippet(span);
     let includes_comment = contains_comment(snippet);
     if snippet != new && includes_comment && changed_comment_content(snippet, &new) {
-        Some(snippet.to_owned())
+        /* >>>>>>> #2896 [DBO] ADD/CHANGE */
+        /* Trim whitespace at end of lines */
+        let mut c = String::from("");
+        for line in snippet.to_owned().split('\n') {
+            if !c.is_empty() {
+                c.push('\n')
+            };
+            c.push_str(line.trim_end());
+        }
+        Some(c.to_owned())
+    /* <<<<<<< [DBO] ADD/CHANGE */
     } else {
         Some(new)
     }

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -2082,17 +2082,6 @@ impl Rewrite for ast::Param {
             let pat_str = &self
                 .pat
                 .rewrite(context, Shape::legacy(shape.width, shape.indent))?;
-        
-            let mut result = combine_strs_with_missing_comments(
-                context,
-                &param_attrs_result,
-                &self
-                    .pat
-                    .rewrite(context, Shape::legacy(shape.width, shape.indent))?,
-                span,
-                shape,
-                !has_multiple_attr_lines,
-            )?;
 
             let mut param_type_str = String::from(pat_str);
 

--- a/src/formatting/lists.rs
+++ b/src/formatting/lists.rs
@@ -504,6 +504,13 @@ where
             if formatted_comment.contains('\n') {
                 item_max_width = None;
             }
+            
+            /* If adding the comment will exceed max length - add new line */
+            if indent_str.len() + result.len() + formatted_comment.len() > formatting.shape.width {
+                result.push('\n');
+                result.push_str(indent_str);
+            }
+            
             result.push_str(&formatted_comment);
         } else {
             item_max_width = None;


### PR DESCRIPTION
Resolve issue #4059  formatting when comments are before/after long attribute or at the end of long list or list, like:

`fn a1 /* comment */ (#[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa] a: u8) {}`
`fn a1(#[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa] /* comment */ a: u8) {}`

Also partly fixed following example.  Will be fully fixed with #2896 resolution:

```
fn main() {
use crate::formatting::{
    comment::{collect_comment_contents, combine_strs_with_missing_comments, rewrite_comment
	},/* COMMENT <<<<*/
}; }
```