### PR TITLE
ssue #2896 - trim extra whitespaces with comment at end of line

### DIFF
--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -1604,7 +1604,15 @@ pub(crate) fn recover_comment_removed(
     let snippet = context.snippet(span);
     let includes_comment = contains_comment(snippet);
     if snippet != new && includes_comment && changed_comment_content(snippet, &new) {
-        Some(snippet.to_owned())
+        /* Trim white spaces at end of lines */
+        let mut c = String::from("");
+        for line in snippet.to_owned().split('\n') {
+            if c != "" {
+                c.push('\n')
+            };
+            c.push_str(line.trim_end());
+        }
+        Some(c.to_owned())
     } else {
         Some(new)
     }

--- a/tests/source/issue-2896.rs
+++ b/tests/source/issue-2896.rs
@@ -159,3 +159,24 @@ fn main() {
     }
   }).unwrap();
 }
+
+
+
+/*******************************************************************************************
+ * Added test cases for related issues that are supposed to be solved by Pull request #4391
+ * ******************************************************************************************/
+
+// ** Note the extra blank at the end of the 2nd line
+fn main() {
+  if 0 == 1 
+  /* x */ as i32 {} }
+
+// ** Note the extra blank at the end of the 2nd line
+fn main() {
+  if 0 == ' ' 
+  as i32 {} }
+
+// ** Note the extra blank at the end of the 3rd line
+fn main() {
+  if 0 == ' ' /* x */ 
+  as i32 {} }


### PR DESCRIPTION
Should resolve issue #2896 when trailing whitespaces remain because a comment at the end of the line was moved to a new line.
Example resolved:

```
fn main() {
    if 0 == 1 
    /* x */ as i32 {} }
```

```
fn main() {
    if 0 == ' ' /* x */ 
    as i32 {} }
```