### PR TITLE
Clarify conditionals for clippy

### DIFF
--- a/src/formatting/expr.rs
+++ b/src/formatting/expr.rs
@@ -80,12 +80,10 @@ pub(crate) fn format_expr(
         ast::ExprKind::Lit(ref l) => {
             if let Some(expr_rw) = rewrite_literal(context, l, shape) {
                 Some(expr_rw)
+            } else if let LitKind::StrRaw(_) = l.token.kind {
+                Some(context.snippet(l.span).trim().into())
             } else {
-                if let LitKind::StrRaw(_) = l.token.kind {
-                    Some(context.snippet(l.span).trim().into())
-                } else {
-                    None
-                }
+                None
             }
         }
         ast::ExprKind::Call(ref callee, ref args) => {

--- a/src/formatting/imports.rs
+++ b/src/formatting/imports.rs
@@ -626,12 +626,10 @@ fn merge_use_trees_inner(trees: &mut Vec<UseTree>, use_tree: UseTree) {
                 return;
             }
         }
-    } else {
-        if let Some(tree) = similar_trees.max_by_key(|tree| tree.path.len()) {
-            if tree.path.len() > 1 {
-                tree.merge(&use_tree);
-                return;
-            }
+    } else if let Some(tree) = similar_trees.max_by_key(|tree| tree.path.len()) {
+        if tree.path.len() > 1 {
+            tree.merge(&use_tree);
+            return;
         }
     }
     trees.push(use_tree);

--- a/src/formatting/types.rs
+++ b/src/formatting/types.rs
@@ -625,10 +625,12 @@ impl Rewrite for ast::Ty {
                 let shape = if is_dyn { shape.offset_left(4)? } else { shape };
                 let mut res = bounds.rewrite(context, shape)?;
                 // We may have falsely removed a trailing `+` inside macro call.
-                if context.inside_macro() && bounds.len() == 1 {
-                    if context.snippet(self.span).ends_with('+') && !res.ends_with('+') {
-                        res.push('+');
-                    }
+                if context.inside_macro()
+                    && bounds.len() == 1
+                    && context.snippet(self.span).ends_with('+')
+                    && !res.ends_with('+')
+                {
+                    res.push('+');
                 }
                 if is_dyn {
                     Some(format!("dyn {}", res))

--- a/src/formatting/utils.rs
+++ b/src/formatting/utils.rs
@@ -154,7 +154,7 @@ pub(crate) fn format_extern(
 ) -> Cow<'static, str> {
     let format_explicit_abi = |abi: &str| Cow::from(format!(r#"extern "{}" "#, abi));
     let explicit_conversion_preserves_semantics =
-        || !is_mod || (is_mod && attrs.map_or(true, |a| a.is_empty()));
+        || !is_mod || attrs.map_or(true, |a| a.is_empty());
 
     match ext {
         ast::Extern::None if !is_mod => Cow::from(""),


### PR DESCRIPTION
Remove double-check of is_mod in format_extern
Collapse nested if in is_block_closure_forced
Use map instead of and_then in rewrite_last_closure
Collapse nested if in impl Rewrite for ast::Ty
Collapse nested if in format_expr
Collapse nested if in merge_use_trees_inner

This is basically to resolve a bunch of clippy's lamentations, or at least the ones that are trivial fixes, so the less-trivial ones become more obvious. No functional changes should be implied.