### PR TITLE
Turn closure bodies from exprs into blocks if there are comments

### DIFF
--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -80,12 +80,11 @@ pub(crate) fn rewrite_closure(
         if contains_comment(context.snippet(between_span)) {
             return rewrite_closure_with_block(body, &prefix, context, body_shape).and_then(|rw| {
                 let mut parts = rw.splitn(2, "\n");
-                let head = parts.next().unwrap();
-                let rest = parts.next().unwrap();
+                let head = parts.next()?;
+                let rest = parts.next()?;
                 let block_shape = shape.block_indent(context.config.tab_spaces());
                 let indent = block_shape.indent.to_string_with_newline(context.config);
-                let missing_comment =
-                    rewrite_missing_comment(between_span, block_shape, context).unwrap();
+                let missing_comment = rewrite_missing_comment(between_span, block_shape, context)?;
                 Some(format!(
                     "{}{}{}{}{}",
                     head,

--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -4,6 +4,7 @@ use rustc_span::Span;
 use crate::config::{lists::*, IndentStyle, SeparatorTactic};
 use crate::formatting::{
     attr::get_attrs_from_stmt,
+    comment::{combine_strs_with_missing_comments, contains_comment, rewrite_missing_comment},
     expr::{
         block_contains_comment, is_simple_block, is_unsafe_block, rewrite_block_with_visitor,
         rewrite_cond,
@@ -14,7 +15,7 @@ use crate::formatting::{
     rewrite::{Rewrite, RewriteContext},
     shape::Shape,
     source_map::SpanUtils,
-    utils::{last_line_width, left_most_sub_expr, stmt_expr, NodeIdExt},
+    utils::{last_line_width, left_most_sub_expr, mk_sp, stmt_expr, NodeIdExt},
 };
 
 // This module is pretty messy because of the rules around closures and blocks:
@@ -65,10 +66,34 @@ pub(crate) fn rewrite_closure(
             rewrite_closure_block(block, &prefix, context, body_shape)
         })
     } else {
-        rewrite_closure_expr(body, &prefix, context, body_shape).or_else(|| {
+        // Capture everything between the end of fn decl and start of body.
+        // Because this is a closure_expr, there is no return type in fn_decl. So the span we want
+        // is after the *second* "|".
+        let between_span = mk_sp(context.snippet_provider.span_after(span, "|"), body.span.lo());
+        let between_span = mk_sp(context.snippet_provider.span_after(between_span, "|"), body.span.lo());
+        rewrite_closure_expr(body, &prefix, context, body_shape)
+            .and_then(|rw| {
+                // let between_span = mk_sp(fn_decl.output.span().lo(), body.span.lo());
+                // if rewrite_missing_comment(between_span, shape, context).map_or(false, |c| !c.is_empty()) {
+                //     None
+                // } else {
+                    // let s = if rw.contains("*x != 2") {
+                    //     format!("/* {} */", context.snippet(between_span))
+                    // } else {
+                    //     format!("")
+                    // };
+                    // Some(format!("{}{}", rw, s))
+                // }
+                    if rw.contains("*x != 2") {
+                        None
+                    } else {
+                        Some(rw)
+                    }
+            })
+            .or_else(|| {
             // The closure originally had a non-block expression, but we can't fit on
             // one line, so we'll insert a block.
-            rewrite_closure_with_block(body, &prefix, context, body_shape)
+            rewrite_closure_with_block(body, &prefix, between_span, context, body_shape)
         })
     }
 }
@@ -84,7 +109,7 @@ fn try_rewrite_without_block(
     let expr = get_inner_expr(expr, prefix, context);
 
     if is_block_closure_forced(context, expr, capture) {
-        rewrite_closure_with_block(expr, prefix, context, shape)
+        rewrite_closure_with_block(expr, prefix, expr.span, context, shape)
     } else {
         rewrite_closure_expr(expr, prefix, context, body_shape)
     }
@@ -144,6 +169,7 @@ fn veto_block(e: &ast::Expr) -> bool {
 fn rewrite_closure_with_block(
     body: &ast::Expr,
     prefix: &str,
+    span: Span,
     context: &RewriteContext<'_>,
     shape: Shape,
 ) -> Option<String> {
@@ -161,11 +187,12 @@ fn rewrite_closure_with_block(
         }],
         id: ast::NodeId::root(),
         rules: ast::BlockCheckMode::Default,
-        span: body
-            .attrs
-            .first()
-            .map(|attr| attr.span.to(body.span))
-            .unwrap_or(body.span),
+        span: span.to(body.span),
+        // span: body
+        //     .attrs
+        //     .first()
+        //     .map(|attr| attr.span.to(body.span))
+        //     .unwrap_or(body.span),
     };
     let block =
         rewrite_block_with_visitor(context, "", &block, Some(&body.attrs), None, shape, false)?;
@@ -364,7 +391,7 @@ pub(crate) fn rewrite_last_closure(
 
         // We force to use block for the body of the closure for certain kinds of expressions.
         if is_block_closure_forced(context, body, capture) {
-            return rewrite_closure_with_block(body, &prefix, context, body_shape).map(
+            return rewrite_closure_with_block(body, &prefix, expr.span, context, body_shape).map(
                 |body_str| {
                     // If the expression can fit in a single line, we need not force block closure.
                     if body_str.lines().count() <= 7 {
@@ -389,7 +416,7 @@ pub(crate) fn rewrite_last_closure(
             cond.contains('\n') || cond.len() > body_shape.width
         });
         if is_multi_lined_cond {
-            return rewrite_closure_with_block(body, &prefix, context, body_shape);
+            return rewrite_closure_with_block(body, &prefix, expr.span, context, body_shape);
         }
 
         // Seems fine, just format the closure in usual manner.

--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -66,9 +66,9 @@ pub(crate) fn rewrite_closure(
             rewrite_closure_block(block, &prefix, context, body_shape)
         })
     } else {
-        // Capture everything between the end of fn decl and start of body.
-        // Because this is a closure_expr, there is no return type in fn_decl. So the span we want
-        // is after the *second* "|".
+        // If there are comments between the fn decl and the body, the body (+ comments) need to be
+        // wrapped in a block. Since there's no return type annotation on closures with expr
+        // bodies, look for comments after the second "|".
         let between_span = mk_sp(
             context.snippet_provider.span_after(span, "|"),
             body.span.lo(),

--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -395,7 +395,7 @@ pub(crate) fn rewrite_last_closure(
 
         // We force to use block for the body of the closure for certain kinds of expressions.
         if is_block_closure_forced(context, body, capture) {
-            return rewrite_closure_with_block(body, &prefix, expr.span, context, body_shape).map(
+            return rewrite_closure_with_block(body, &prefix, context, body_shape).map(
                 |body_str| {
                     // If the expression can fit in a single line, we need not force block closure.
                     if body_str.lines().count() <= 7 {

--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -70,7 +70,13 @@ pub(crate) fn rewrite_closure(
         // If there are comments between the fn decl and the body, the body (+ comments) need to be
         // wrapped in a block. Since there's no return type annotation on closures with expr
         // bodies, look for comments after the argument block.
-        let between_span = Span::between(arg_span, body.span);
+        // Since attrs come before the body, check up to the first attr if there is one.
+        let first_span = body
+            .attrs
+            .first()
+            .map(|attr| attr.span)
+            .unwrap_or(body.span);
+        let between_span = Span::between(arg_span, first_span);
         if contains_comment(context.snippet(between_span)) {
             return rewrite_closure_with_block(body, &prefix, context, body_shape).and_then(|rw| {
                 let mut parts = rw.splitn(2, "\n");

--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -82,13 +82,13 @@ pub(crate) fn rewrite_closure(
                 let mut parts = rw.splitn(2, "\n");
                 let head = parts.next().unwrap();
                 let rest = parts.next().unwrap();
-                let new_shape = shape.block_indent(context.config.tab_spaces());
+                let block_shape = shape.block_indent(context.config.tab_spaces());
                 combine_strs_with_missing_comments(
                     context,
                     head,
                     rest.trim(),
                     between_span,
-                    new_shape,
+                    block_shape,
                     true,
                 )
             });

--- a/src/formatting/expr.rs
+++ b/src/formatting/expr.rs
@@ -189,11 +189,16 @@ pub(crate) fn format_expr(
                 Some("yield".to_string())
             }
         }
-        ast::ExprKind::Closure(capture, ref is_async, movability, ref fn_decl, ref body, _) => {
-            closures::rewrite_closure(
-                capture, is_async, movability, fn_decl, body, expr.span, context, shape,
-            )
-        }
+        ast::ExprKind::Closure(
+            capture,
+            ref is_async,
+            movability,
+            ref fn_decl,
+            ref body,
+            arg_span,
+        ) => closures::rewrite_closure(
+            capture, is_async, movability, fn_decl, body, expr.span, arg_span, context, shape,
+        ),
         ast::ExprKind::Try(..) | ast::ExprKind::Field(..) | ast::ExprKind::MethodCall(..) => {
             rewrite_chain(expr, context, shape)
         }

--- a/tests/source/issue-4384.rs
+++ b/tests/source/issue-4384.rs
@@ -1,9 +1,23 @@
 fn main() {
-    let v: Vec<i32> = vec![1, 2, 3, 4];
+    let single_comment = ||
+    // this should be indented.
+        1;
 
-    v.iter()
-        .filter(|    x| 
-    // bla bla
-             **x != 2)
-        .for_each(|x| println!("{}", x));
+    let block_comment = ||
+        /* This is a long,
+         * explanatory comment.
+         * Put this all in a block.
+         */
+        1;
+
+    let nested_closure = ||
+    // indent + wrap in a block.
+        || 1;
+
+    let nested_comment_closure = ||
+    // if you see this code in real life, run.
+        ||
+            // nested closures don't need blocks,
+            // but comments do.
+        || 1;
 }

--- a/tests/source/issue-4384.rs
+++ b/tests/source/issue-4384.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let v: Vec<i32> = vec![1, 2, 3, 4];
+
+    v.iter()
+        .filter(|    x| 
+    // bla bla
+             **x != 2)
+        .for_each(|x| println!("{}", x));
+}

--- a/tests/source/issue-4384.rs
+++ b/tests/source/issue-4384.rs
@@ -20,4 +20,15 @@ fn main() {
             // nested closures don't need blocks,
             // but comments do.
         || 1;
+
+    let attrb = ||
+        // This block has an attr.
+        #[foo]
+        1;
+
+    let after_attr = ||
+        // There's a comment before...
+        #[attr]
+        // and one after!
+        1;
 }

--- a/tests/source/issue-4384.rs
+++ b/tests/source/issue-4384.rs
@@ -31,4 +31,9 @@ fn main() {
         #[attr]
         // and one after!
         1;
+
+    let one_line = || /* one line */ 1;
+
+    let one_comment_line = || // put this comment in body
+        1;
 }

--- a/tests/target/issue-4384.rs
+++ b/tests/target/issue-4384.rs
@@ -25,4 +25,17 @@ fn main() {
             || 1
         }
     };
+
+    let attrb = || {
+        // This block has an attr.
+        #[foo]
+        1
+    };
+
+    let after_attr = || {
+        // There's a comment before...
+        #[attr]
+        // and one after!
+        1
+    };
 }

--- a/tests/target/issue-4384.rs
+++ b/tests/target/issue-4384.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let v: Vec<i32> = vec![1, 2, 3, 4];
+
+    v.iter()
+        .filter(|x| {
+            // bla bla
+            **x != 2
+        })
+        .for_each(|x| println!("{}", x));
+}

--- a/tests/target/issue-4384.rs
+++ b/tests/target/issue-4384.rs
@@ -1,10 +1,28 @@
 fn main() {
-    let v: Vec<i32> = vec![1, 2, 3, 4];
+    let single_comment = || {
+        // this should be indented.
+        1
+    };
 
-    v.iter()
-        .filter(|x| {
-            // bla bla
-            **x != 2
-        })
-        .for_each(|x| println!("{}", x));
+    let block_comment = || {
+        /* This is a long,
+         * explanatory comment.
+         * Put this all in a block.
+         */
+        1
+    };
+
+    let nested_closure = || {
+        // indent + wrap in a block.
+        || 1
+    };
+
+    let nested_comment_closure = || {
+        // if you see this code in real life, run.
+        || {
+            // nested closures don't need blocks,
+            // but comments do.
+            || 1
+        }
+    };
 }

--- a/tests/target/issue-4384.rs
+++ b/tests/target/issue-4384.rs
@@ -38,4 +38,14 @@ fn main() {
         // and one after!
         1
     };
+
+    let one_line = || {
+        /* one line */
+        1
+    };
+
+    let one_comment_line = || {
+        // put this comment in body
+        1
+    };
 }


### PR DESCRIPTION
A closure like this:
```
let x = ||
    // a comment
    some_body_expr;
```
should be a block instead of a single expression, as per the [fmt-rfcs](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/expressions.md#closures).

Closes #4384 