### PR TITLE
Issue4392 resolution - No new line after operation

### DIFF
--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -1604,7 +1604,15 @@ pub(crate) fn recover_comment_removed(
     let snippet = context.snippet(span);
     let includes_comment = contains_comment(snippet);
     if snippet != new && includes_comment && changed_comment_content(snippet, &new) {
-        Some(snippet.to_owned())
+        /* Trim white spaces at end of lines */
+        let mut c = String::from("");
+        for line in snippet.to_owned().split('\n') {
+            if c != "" {
+                c.push('\n')
+            };
+            c.push_str(line.trim_end());
+        }
+        Some(c.to_owned())
     } else {
         Some(new)
     }

--- a/tests/source/issue-4392.rs
+++ b/tests/source/issue-4392.rs
@@ -1,0 +1,47 @@
+/* No new line should be added after the operation ('==', etc.) */
+
+fn main() {
+    if 'a' == b /* x */
+    as char {}
+}
+
+fn main() {
+    if 'a' == 0
+    /* x */ as char {} }
+
+fn main() {
+    if 1234 == 0
+    /* x */ & cc & dd {} }
+
+fn main() {
+    if 1234 == 'a'
+    /* x */ as i32 {} }
+
+fn main() {
+    if 0 == 'a'
+    /* x */ as i32 {} }
+
+fn main() {
+    if 'a' == b /* x */ as char { println!("Match"); }
+}
+
+fn main() {
+	while aaaaaa < bbbbb
+	as char /* x */ {} }
+	
+fn main() {
+    if 'a' == b // x
+    as char {}
+}
+
+fn main() {
+    if 'a' == /* x */ b
+    as char {}
+}
+
+fn main() {
+    if 'a' == b
+	as char {}
+	
+	let a = 5;	// inline
+}


### PR DESCRIPTION
For issue #4392 resolution - not adding new line after operation ('==', etc.).
Also test cases file is added.

An issue in the code changes is that "transmute" is used. Hopefully there is better way to implement.