### PR TITLE
update GitHub label references in Contributing guide

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -125,8 +125,8 @@ There are a lot of open issues on the backlog for those interested in hacking on
 
 Here are some good starting issues:
 
-[![GitHub good-first-issue](https://img.shields.io/github/issues/rust-lang/rustfmt/good-first-issue?style=flat-square)](https://github.com/rust-lang/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3Agood%20first%20issue)
-[![GitHub help-wanted](https://img.shields.io/github/issues/rust-lang/rustfmt/help-wanted?style=flat-square)](https://github.com/rust-lang/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted)
+[![GitHub good-first-issue](https://img.shields.io/github/issues/rust-lang/rustfmt/good%20first%20issue?style=flat-square)](https://github.com/rust-lang/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3Agood%20first%20issue)
+[![GitHub help-wanted](https://img.shields.io/github/issues/rust-lang/rustfmt/help%20wanted?style=flat-square)](https://github.com/rust-lang/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted)
 
 
 If you've found areas which need polish and don't have issues, please submit a


### PR DESCRIPTION
Apparently the GitHub feature that identities issues needing help in a repo requires spaces between the label words (e.g. `help wanted` vs `help-wanted`) in order to actually work. I've updated the label names so that these types of issues will be recognized properly for rustfmt, and this PR updates the label references to reflect the rename accordingly