### PR TITLE
bump rustc-ap crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,15 +550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
-dependencies = [
- "parking_lot 0.10.2",
-]
-
-[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8cf08094be6d414e18b63c6a7b4e67af12ebc4cd53e8f494cd034ba291995a"
+checksum = "2958af0d6e0458434a25cd3a96f6e19f24f71bf50b900add520dec52e212866b"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.4.0",
@@ -788,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fca3205094b69deaa6b46a710ee4ef5334d0239182a3c8a4f66a4ad4846842"
+checksum = "0c82c2510460f2133548e62399e5acd30c25ae6ece30245baab3d1e00c2fefac"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -805,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14822e385bfdb567bf56ba836a83429f366797c55d2fdeb6ecb1b0a03bb06a64"
+checksum = "83977da57f81c6edd89bad47e49136680eaa33288de4abb702e95358c2a0fc6c"
 dependencies = [
  "itertools",
  "rustc-ap-rustc_ast",
@@ -824,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ecf1928ecde47c0a7361c6a358c0c5601993b5d01e6e6340b0c3ba51952e40"
+checksum = "becf4ca1638b214694c71a8752192683048ab8bd47947cc481f57bd48157eeb9"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
@@ -836,15 +827,16 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303737c455baaddea493dbac5fe9422bc3276d80fc3e5dc6ae73dccb8b860201"
+checksum = "0f21ca5dadce8a40d75a2756b77eab75b4c2d827f645c622dd93ee2285599640"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_feature",
+ "rustc-ap-rustc_lexer",
  "rustc-ap-rustc_macros",
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_session",
@@ -854,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a574533429da41799344e3b9923e8a24ead05ceb19a2fa7087eaf2c444fd35a"
+checksum = "a4cd204764727fde9abf75333eb661f058bfc7242062d91019440fe1b240688b"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -867,10 +859,10 @@ dependencies = [
  "lazy_static",
  "libc",
  "measureme",
- "once_cell",
  "parking_lot 0.10.2",
  "rustc-ap-rustc_graphviz",
  "rustc-ap-rustc_index",
+ "rustc-ap-rustc_macros",
  "rustc-ap-rustc_serialize",
  "rustc-hash",
  "rustc-rayon",
@@ -885,13 +877,14 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd8464f7a94c5d2b0c95781be833a71f0ba429c92afabe4e0356c096510d805"
+checksum = "58116f119e37f14c029f99077b347069621118e048a69df74695b98204e7c136"
 dependencies = [
  "annotate-snippets",
  "atty",
  "rustc-ap-rustc_data_structures",
+ "rustc-ap-rustc_macros",
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_span",
  "termcolor",
@@ -903,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fe258f0c5e5d8cd3908730305b4e8c210fd49b8e432a63324fa25eea1c55e7"
+checksum = "48e3c4bda9b64b92805bebe7431fdb8e24fd112b35a8c6d2174827441f10a6b2"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_passes",
@@ -915,6 +908,7 @@ dependencies = [
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_feature",
  "rustc-ap-rustc_lexer",
+ "rustc-ap-rustc_macros",
  "rustc-ap-rustc_parse",
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_session",
@@ -925,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b69d30fedc30b09d860e7f713262b2a7cc90ab3f404e6d91e58856bf9895fb"
+checksum = "4b612bb67d3fc49f395b03fc4ea4384a0145b05afbadab725803074ec827632b"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -936,40 +930,41 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc22a99d2cff4ec83f83a15821c4f0bdf967664fbd9747a7add65b541ed9302"
+checksum = "7630ad1a73a8434ee920676148cb5440ac57509bd20e94ec41087fb0b1d11c28"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf58ebc2d96377e4f201cce875d3f160f548fad8d82efb831918577363d7c7d"
+checksum = "a603fca4817062eb4fb23ff129d475bd66a69fb32f34ed4362ae950cf814b49d"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9fd6db5f0467dd9d5ed4223fc95f20c633779a4b60e5228f4c1698a4ba42bb"
+checksum = "9850c4a5d7c341513e10802bca9588bf8f452ceea2d5cfa87b934246a52622bc"
 dependencies = [
  "arrayvec",
+ "rustc-ap-rustc_macros",
  "rustc-ap-rustc_serialize",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b71fa1285bdefe5fb61e59b63d6cc246abf337f4acafdd620d721bc488e671"
+checksum = "6d86722e5a1a615b198327d0d794cd9cbc8b9db4542276fc51fe078924de68ea"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634c5155defd0288c1171c47ae0cadf8060669084e2bb5ce6eb22a878a7c5db5"
+checksum = "b3fc8482e44cabdda7ac9a8e224aef62ebdf95274d629dac8db3b42321025fea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -979,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd507233a7e70fc2733b61a540940cb5519920021ae0df0a668418596ad78ba7"
+checksum = "3716cdcd978a91dbd4a2788400e90e809527f841426fbeb92f882f9b8582f3ab"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_ast",
@@ -999,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb9d060a496e632afd6799c54db9f2798b24b34fa5e1927ab378e6dda1defd8"
+checksum = "c68046d07988b349b2e1c8bc1c9664a1d06519354aa677b9df358c5c5c058da0"
 dependencies = [
  "indexmap",
  "smallvec 1.4.0",
@@ -1009,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b8682f3989efc2b9217d334720f6777a1f1748f35a619839f98b93b51fa76d"
+checksum = "85735553501a4de0c8904e37b7ccef79cc1c585a7d7f2cfa02cc38e0d149f982"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1021,6 +1016,7 @@ dependencies = [
  "rustc-ap-rustc_errors",
  "rustc-ap-rustc_feature",
  "rustc-ap-rustc_fs_util",
+ "rustc-ap-rustc_macros",
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
@@ -1029,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3620042dbe0a2f8aaa463812fe6264253bfeaffab1ccacc809a732d36b4799b9"
+checksum = "1c49ae8a0d3b9e27c6ffe8febeaa30f899294fff012de70625f9ee81c54fda85"
 dependencies = [
  "cfg-if",
  "md-5",
@@ -1048,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "673.0.0"
+version = "677.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab855d271ed80ef090fac4a8bcbc910b0f300d56a44f5ed6239675b33991cf6b"
+checksum = "1765f447594740c501c7b666b87639aa7c1dae2bf8c3166d5d2dca16646fd034"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -1271,9 +1267,9 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "stacker"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd941b456e1c006d6b9f27c526d5b69281288aeea8cba82c19d3843d8ccdd2"
+checksum = "a92bc346006ae78c539d6ab2cf1a1532bc657b8339c464877a990ec82073c66f"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,11 +423,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.3.2"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+checksum = "4e47a3566dd4fd4eec714ae6ceabdee0caec795be835c223d92c2d40f1e8cf1c"
 dependencies = [
  "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -605,6 +615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +680,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d014a30376e84a36f01c68a1386044571b14e75de14877d272142795da4024c5"
+checksum = "8d8cf08094be6d414e18b63c6a7b4e67af12ebc4cd53e8f494cd034ba291995a"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.4.0",
@@ -722,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e74889abc8ffe55885933943c90b04af8801955d47c118a3529ed16b3943578"
+checksum = "67fca3205094b69deaa6b46a710ee4ef5334d0239182a3c8a4f66a4ad4846842"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -733,16 +799,15 @@ dependencies = [
  "rustc-ap-rustc_macros",
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_span",
- "scoped-tls",
  "smallvec 1.4.0",
  "tracing",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e56708a0e774acd0ba1c56c4eabf48139b4cfbdbbc486d507cb8cea38a0f72"
+checksum = "14822e385bfdb567bf56ba836a83429f366797c55d2fdeb6ecb1b0a03bb06a64"
 dependencies = [
  "itertools",
  "rustc-ap-rustc_ast",
@@ -759,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57a874e6dba1f7d4c87de70bdcad1b15ea74d4e231007e1fe18997217c58bcc"
+checksum = "c5ecf1928ecde47c0a7361c6a358c0c5601993b5d01e6e6340b0c3ba51952e40"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
@@ -771,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc89801730ad78380175d41e6bedd9223209db993c2d03210e99972e307eb674"
+checksum = "303737c455baaddea493dbac5fe9422bc3276d80fc3e5dc6ae73dccb8b860201"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -789,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f18fb0a1385d84ab6f49d1769ca166451117ec80876efc11c2dbec42bd84bf"
+checksum = "1a574533429da41799344e3b9923e8a24ead05ceb19a2fa7087eaf2c444fd35a"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -813,15 +878,16 @@ dependencies = [
  "smallvec 1.4.0",
  "stable_deref_trait",
  "stacker",
+ "tempfile",
  "tracing",
  "winapi",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fedc37e3bb6d85cc874e5d634aa64e07f7bb66e9eeb13bb9dadf9dabc4d617"
+checksum = "2bd8464f7a94c5d2b0c95781be833a71f0ba429c92afabe4e0356c096510d805"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -837,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9e6185b77b83c9d0684546d7d60f4ba56eea25dca4e9c0dec8e42d8ee38424"
+checksum = "11fe258f0c5e5d8cd3908730305b4e8c210fd49b8e432a63324fa25eea1c55e7"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_passes",
@@ -859,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea8df315724e0a8a1e2075bb5a50d2abd807e4506db3bbfdf77c2c5ad5e222a"
+checksum = "12b69d30fedc30b09d860e7f713262b2a7cc90ab3f404e6d91e58856bf9895fb"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -870,21 +936,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19673036a2c932af16a339c233957fcc2d06525f1f9bfb23c99198f715680e50"
+checksum = "0cc22a99d2cff4ec83f83a15821c4f0bdf967664fbd9747a7add65b541ed9302"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ec959426514b5a868b407a25b4f0ad14b51f512b3ea05dc76877c47830ef36"
+checksum = "9bf58ebc2d96377e4f201cce875d3f160f548fad8d82efb831918577363d7c7d"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cec39860362c156c0b76a14169f9d801329fad4742297204969a6493ec53ef8"
+checksum = "4e9fd6db5f0467dd9d5ed4223fc95f20c633779a4b60e5228f4c1698a4ba42bb"
 dependencies = [
  "arrayvec",
  "rustc-ap-rustc_serialize",
@@ -892,18 +958,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9829d5d33bafe9a3020c08b913f847c353456f734f5ac3bd58ae0eeead381a96"
+checksum = "f6b71fa1285bdefe5fb61e59b63d6cc246abf337f4acafdd620d721bc488e671"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8f887d758a4aea3db0352a1bc97ae316dcea8604d64b29f6225a0dd7502649"
+checksum = "634c5155defd0288c1171c47ae0cadf8060669084e2bb5ce6eb22a878a7c5db5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -913,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ab2411011df24ba92f6b85c002c20e1dc12ab5af61880f2a48ce89f3cef42d"
+checksum = "bd507233a7e70fc2733b61a540940cb5519920021ae0df0a668418596ad78ba7"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_ast",
@@ -933,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be9e2ff3e3e424c3a9faecfd94ffb68c0a4f569d9f1c599e624388c9d1935c9"
+checksum = "dfb9d060a496e632afd6799c54db9f2798b24b34fa5e1927ab378e6dda1defd8"
 dependencies = [
  "indexmap",
  "smallvec 1.4.0",
@@ -943,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe999cfa5a54e251fa009723b691b4b0c6e5a3e741281c7ca6d336802e2a457"
+checksum = "b4b8682f3989efc2b9217d334720f6777a1f1748f35a619839f98b93b51fa76d"
 dependencies = [
  "bitflags",
  "getopts",
@@ -963,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b3ab33f4bd27ca8df5fbea78713e2ac26a26df46a7beefa680c16cc7218e11"
+checksum = "3620042dbe0a2f8aaa463812fe6264253bfeaffab1ccacc809a732d36b4799b9"
 dependencies = [
  "cfg-if",
  "md-5",
@@ -982,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "672.0.0"
+version = "673.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c803ab67b63e5344f893d1d7c4bce2af26f9da245dc5b416a404da819454ff99"
+checksum = "ab855d271ed80ef090fac4a8bcbc910b0f300d56a44f5ed6239675b33991cf6b"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -1278,6 +1344,20 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3941333c39ffa778611a34692244052fc9ba0f6b02dcf019c8d24925707dd6"
+checksum = "d014a30376e84a36f01c68a1386044571b14e75de14877d272142795da4024c5"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.4.0",
@@ -722,12 +722,11 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c579f7d89e6fc971b433e92bb2b8c65b716d7c797b21de8685945be9455610"
+checksum = "8e74889abc8ffe55885933943c90b04af8801955d47c118a3529ed16b3943578"
 dependencies = [
  "bitflags",
- "log",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_index",
  "rustc-ap-rustc_lexer",
@@ -736,16 +735,16 @@ dependencies = [
  "rustc-ap-rustc_span",
  "scoped-tls",
  "smallvec 1.4.0",
+ "tracing",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9914fadee461568d19ca2ebaec8699ff898f8ffec9928154659a57ee018e5fd"
+checksum = "e7e56708a0e774acd0ba1c56c4eabf48139b4cfbdbbc486d507cb8cea38a0f72"
 dependencies = [
  "itertools",
- "log",
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_attr",
@@ -755,25 +754,26 @@ dependencies = [
  "rustc-ap-rustc_parse",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
+ "tracing",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a78c5cc50a2f294d3c4e9131a15676724c9f136d3ed54e9ba419850b6025cb3"
+checksum = "a57a874e6dba1f7d4c87de70bdcad1b15ea74d4e231007e1fe18997217c58bcc"
 dependencies = [
- "log",
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
+ "tracing",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78ce08227d146949755175c0cf710280a4b5bf6ee504c0e3f7ccc30d66fbfd9"
+checksum = "cc89801730ad78380175d41e6bedd9223209db993c2d03210e99972e307eb674"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5ac3735c38d2d0e95991ebcd7eb1618b60e784194a738e0ce2e8d39c39b809"
+checksum = "33f18fb0a1385d84ab6f49d1769ca166451117ec80876efc11c2dbec42bd84bf"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -801,7 +801,6 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "libc",
- "log",
  "measureme",
  "once_cell",
  "parking_lot 0.10.2",
@@ -814,34 +813,34 @@ dependencies = [
  "smallvec 1.4.0",
  "stable_deref_trait",
  "stacker",
+ "tracing",
  "winapi",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5166a95afa6e3b78ccbece4c2f1e163634854297f1147c6fd90e2712ed3fede5"
+checksum = "c2fedc37e3bb6d85cc874e5d634aa64e07f7bb66e9eeb13bb9dadf9dabc4d617"
 dependencies = [
  "annotate-snippets",
  "atty",
- "log",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_span",
  "termcolor",
  "termize",
+ "tracing",
  "unicode-width",
  "winapi",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0586e83bdfe70eda8393429a8a38ecb529525dd252d787e479af075d3cab08"
+checksum = "df9e6185b77b83c9d0684546d7d60f4ba56eea25dca4e9c0dec8e42d8ee38424"
 dependencies = [
- "log",
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_passes",
  "rustc-ap-rustc_ast_pretty",
@@ -855,13 +854,14 @@ dependencies = [
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
  "smallvec 1.4.0",
+ "tracing",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fc3aa8de0737a8c5a4353e6948548f469150d2b5d3eac391843de32c6c6ca2"
+checksum = "5ea8df315724e0a8a1e2075bb5a50d2abd807e4506db3bbfdf77c2c5ad5e222a"
 dependencies = [
  "lazy_static",
  "rustc-ap-rustc_data_structures",
@@ -870,21 +870,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fd3380f4029020b693bbfd5a14ec8c893ec33c5c0063ad2e68e46d3fbd6a1f"
+checksum = "19673036a2c932af16a339c233957fcc2d06525f1f9bfb23c99198f715680e50"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b54bd98f70e04291bf611151d1fcd4d7770b35f7ec603d301c4aee0d1979cca4"
+checksum = "23ec959426514b5a868b407a25b4f0ad14b51f512b3ea05dc76877c47830ef36"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335bfb187a2489a59ee8c67fcf5d1760e9dcdbe0f02025c199a74caa05096b15"
+checksum = "1cec39860362c156c0b76a14169f9d801329fad4742297204969a6493ec53ef8"
 dependencies = [
  "arrayvec",
  "rustc-ap-rustc_serialize",
@@ -892,18 +892,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1221f3bfa2943c942cf8da319ab2346887f8757778c29c7f1822cd27b521f"
+checksum = "9829d5d33bafe9a3020c08b913f847c353456f734f5ac3bd58ae0eeead381a96"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b774df26c4ef513555b3a303cb209f44cf68a9e6a5481b41ac832301c6487cb"
+checksum = "2b8f887d758a4aea3db0352a1bc97ae316dcea8604d64b29f6225a0dd7502649"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -913,12 +913,11 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065e632101bdd57a271f38ee7a4d72b5a3d0467ec845104346c284b2c6c69960"
+checksum = "e0ab2411011df24ba92f6b85c002c20e1dc12ab5af61880f2a48ce89f3cef42d"
 dependencies = [
  "bitflags",
- "log",
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_data_structures",
@@ -927,14 +926,16 @@ dependencies = [
  "rustc-ap-rustc_lexer",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
+ "smallvec 1.4.0",
+ "tracing",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8c0b704e3dedb97cbb1ac566bbc0ab397ec4a4743098326a8f2230463fd9f9"
+checksum = "0be9e2ff3e3e424c3a9faecfd94ffb68c0a4f569d9f1c599e624388c9d1935c9"
 dependencies = [
  "indexmap",
  "smallvec 1.4.0",
@@ -942,13 +943,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda99ede4e6e260712754f8548b0a175b615686ad393653a3bd11f6c5e41a04e"
+checksum = "cbe999cfa5a54e251fa009723b691b4b0c6e5a3e741281c7ca6d336802e2a457"
 dependencies = [
  "bitflags",
  "getopts",
- "log",
  "num_cpus",
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_data_structures",
@@ -958,16 +958,16 @@ dependencies = [
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_span",
  "rustc-ap-rustc_target",
+ "tracing",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53453791c2c0b501a921927ce8e305a801eef130920873f8da92d83dad595236"
+checksum = "b0b3ab33f4bd27ca8df5fbea78713e2ac26a26df46a7beefa680c16cc7218e11"
 dependencies = [
  "cfg-if",
- "log",
  "md-5",
  "rustc-ap-rustc_arena",
  "rustc-ap-rustc_data_structures",
@@ -976,22 +976,23 @@ dependencies = [
  "rustc-ap-rustc_serialize",
  "scoped-tls",
  "sha-1",
+ "tracing",
  "unicode-width",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "671.0.0"
+version = "672.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac82006fdb31ef44e24e1623f8b72ac2b404ef15ba20b7ebec0df35e5d20bbef"
+checksum = "c803ab67b63e5344f893d1d7c4bce2af26f9da245dc5b416a404da819454ff99"
 dependencies = [
  "bitflags",
- "log",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_index",
  "rustc-ap-rustc_macros",
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_span",
+ "tracing",
 ]
 
 [[package]]
@@ -1353,6 +1354,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f0e00789804e99b20f12bc7003ca416309d28a6f495d6af58d1e2c2842461b5"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,32 +107,32 @@ lazy_static = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "672.0.0"
+version = "673.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "672.0.0"
+version = "673.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "672.0.0"
+version = "673.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "672.0.0"
+version = "673.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "672.0.0"
+version = "673.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "672.0.0"
+version = "673.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "672.0.0"
+version = "673.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "672.0.0"
+version = "673.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,32 +107,32 @@ lazy_static = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "671.0.0"
+version = "672.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "671.0.0"
+version = "672.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "671.0.0"
+version = "672.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "671.0.0"
+version = "672.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "671.0.0"
+version = "672.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "671.0.0"
+version = "672.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "671.0.0"
+version = "672.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "671.0.0"
+version = "672.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,32 +107,32 @@ lazy_static = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "673.0.0"
+version = "677.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "673.0.0"
+version = "677.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "673.0.0"
+version = "677.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "673.0.0"
+version = "677.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "673.0.0"
+version = "677.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "673.0.0"
+version = "677.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "673.0.0"
+version = "677.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "673.0.0"
+version = "677.0.0"

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -67,7 +67,7 @@ pub(crate) fn format_input_inner(
         return Err(OperationError::VersionMismatch);
     }
 
-    rustc_ast::with_session_globals(config.edition().into(), || {
+    rustc_span::with_session_globals(config.edition().into(), || {
         format_project(input, config, operation_setting)
     })
 }

--- a/src/formatting/attr.rs
+++ b/src/formatting/attr.rs
@@ -339,7 +339,7 @@ impl Rewrite for ast::Attribute {
 
             if let Some(ref meta) = self.meta() {
                 // This attribute is possibly a doc attribute needing normalization to a doc comment
-                if context.config.normalize_doc_attributes() && meta.check_name(sym::doc) {
+                if context.config.normalize_doc_attributes() && meta.has_name(sym::doc) {
                     if let Some(ref literal) = meta.value_str() {
                         let comment_style = match self.style {
                             ast::AttrStyle::Inner => CommentStyle::Doc,

--- a/src/formatting/attr.rs
+++ b/src/formatting/attr.rs
@@ -2,7 +2,7 @@
 
 use rustc_ast::ast;
 use rustc_ast::attr::HasAttrs;
-use rustc_span::{symbol::sym, Span};
+use rustc_span::{symbol::sym, Span, Symbol};
 
 use crate::config::{lists::*, IndentStyle};
 use doc_comment::DocCommentFormatter;
@@ -21,6 +21,14 @@ use crate::formatting::{
 };
 
 mod doc_comment;
+
+pub(crate) fn contains_name(attrs: &[ast::Attribute], name: Symbol) -> bool {
+    attrs.iter().any(|attr| attr.has_name(name))
+}
+
+pub(crate) fn first_attr_value_str_by_name(attrs: &[ast::Attribute], name: Symbol) -> Option<Symbol> {
+    attrs.iter().find(|attr| attr.has_name(name)).and_then(|attr| attr.value_str())
+}
 
 /// Returns attributes on the given statement.
 pub(crate) fn get_attrs_from_stmt(stmt: &ast::Stmt) -> &[ast::Attribute] {
@@ -53,7 +61,7 @@ pub(crate) fn filter_inline_attrs(
 }
 
 fn is_derive(attr: &ast::Attribute) -> bool {
-    attr.check_name(sym::derive)
+    attr.has_name(sym::derive)
 }
 
 // The shape of the arguments to a function-like attribute.

--- a/src/formatting/attr.rs
+++ b/src/formatting/attr.rs
@@ -26,8 +26,14 @@ pub(crate) fn contains_name(attrs: &[ast::Attribute], name: Symbol) -> bool {
     attrs.iter().any(|attr| attr.has_name(name))
 }
 
-pub(crate) fn first_attr_value_str_by_name(attrs: &[ast::Attribute], name: Symbol) -> Option<Symbol> {
-    attrs.iter().find(|attr| attr.has_name(name)).and_then(|attr| attr.value_str())
+pub(crate) fn first_attr_value_str_by_name(
+    attrs: &[ast::Attribute],
+    name: Symbol,
+) -> Option<Symbol> {
+    attrs
+        .iter()
+        .find(|attr| attr.has_name(name))
+        .and_then(|attr| attr.value_str())
 }
 
 /// Returns attributes on the given statement.

--- a/src/formatting/modules.rs
+++ b/src/formatting/modules.rs
@@ -514,7 +514,7 @@ impl<'ast, 'sess> ModResolver<'ast, 'sess> {
 }
 
 fn path_value(attr: &ast::Attribute) -> Option<Symbol> {
-    if attr.check_name(sym::path) {
+    if attr.has_name(sym::path) {
         attr.value_str()
     } else {
         None

--- a/src/formatting/modules/visitor.rs
+++ b/src/formatting/modules/visitor.rs
@@ -83,7 +83,7 @@ impl PathVisitor {
 
 impl<'ast> MetaVisitor<'ast> for PathVisitor {
     fn visit_meta_name_value(&mut self, meta_item: &'ast ast::MetaItem, lit: &'ast ast::Lit) {
-        if meta_item.check_name(Symbol::intern("path")) && lit.kind.is_str() {
+        if meta_item.has_name(Symbol::intern("path")) && lit.kind.is_str() {
             self.paths.push(lit_to_str(lit));
         }
     }

--- a/src/formatting/reorder.rs
+++ b/src/formatting/reorder.rs
@@ -8,7 +8,7 @@
 
 use std::cmp::{Ord, Ordering};
 
-use rustc_ast::{ast, attr};
+use rustc_ast::ast;
 use rustc_span::{symbol::sym, Span};
 
 use crate::config::Config;
@@ -265,7 +265,7 @@ fn rewrite_reorderable_items(
 }
 
 fn contains_macro_use_attr(attrs: &[ast::Attribute]) -> bool {
-    attr::contains_name(attrs, sym::macro_use)
+    crate::formatting::attr::contains_name(attrs, sym::macro_use)
 }
 
 /// A simplified version of `ast::ItemKind`.

--- a/src/formatting/syntux/parser.rs
+++ b/src/formatting/syntux/parser.rs
@@ -5,7 +5,7 @@ use rustc_ast::ast;
 use rustc_ast::token::{DelimToken, TokenKind};
 use rustc_errors::Diagnostic;
 use rustc_parse::{new_parser_from_file, parser::Parser as RawParser};
-use rustc_span::{symbol::kw, sym, Span};
+use rustc_span::{sym, symbol::kw, Span};
 
 use crate::formatting::attr::first_attr_value_str_by_name;
 use crate::formatting::syntux::session::ParseSess;

--- a/src/formatting/syntux/parser.rs
+++ b/src/formatting/syntux/parser.rs
@@ -5,8 +5,9 @@ use rustc_ast::ast;
 use rustc_ast::token::{DelimToken, TokenKind};
 use rustc_errors::Diagnostic;
 use rustc_parse::{new_parser_from_file, parser::Parser as RawParser};
-use rustc_span::{symbol::kw, Span};
+use rustc_span::{symbol::kw, sym, Span};
 
+use crate::formatting::attr::first_attr_value_str_by_name;
 use crate::formatting::syntux::session::ParseSess;
 use crate::{Config, Input};
 
@@ -99,7 +100,15 @@ pub(crate) enum ParserError {
 
 impl<'a> Parser<'a> {
     pub(crate) fn submod_path_from_attr(attrs: &[ast::Attribute], path: &Path) -> Option<PathBuf> {
-        rustc_expand::module::submod_path_from_attr(attrs, path)
+        let path_string = first_attr_value_str_by_name(attrs, sym::path)?.as_str();
+        // On windows, the base path might have the form
+        // `\\?\foo\bar` in which case it does not tolerate
+        // mixed `/` and `\` separators, so canonicalize
+        // `/` to `\`.
+        #[cfg(windows)]
+        let path_string = path_string.replace("/", "\\");
+
+        Some(path.join(&*path_string))
     }
 
     pub(crate) fn parse_file_as_module(

--- a/src/formatting/utils.rs
+++ b/src/formatting/utils.rs
@@ -277,7 +277,7 @@ fn is_skip(meta_item: &MetaItem) -> bool {
             path_str == *skip_annotation().as_str() || path_str == *depr_skip_annotation().as_str()
         }
         MetaItemKind::List(ref l) => {
-            meta_item.check_name(sym::cfg_attr) && l.len() == 2 && is_skip_nested(&l[1])
+            meta_item.has_name(sym::cfg_attr) && l.len() == 2 && is_skip_nested(&l[1])
         }
         _ => false,
     }

--- a/src/formatting/visitor.rs
+++ b/src/formatting/visitor.rs
@@ -887,7 +887,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     // Returns true if we should skip the following item.
     pub(crate) fn visit_attrs(&mut self, attrs: &[ast::Attribute], style: ast::AttrStyle) -> bool {
         for attr in attrs {
-            if attr.check_name(depr_skip_annotation()) {
+            if attr.has_name(depr_skip_annotation()) {
                 let file_name = self.parse_sess.span_to_filename(attr.span);
                 self.report.add_format_error(
                     file_name,


### PR DESCRIPTION
This needs a new nightly to be published for the checks to pass, will re-run the workflows once it is