### PR TITLE
Format error and typeof types

### DIFF
--- a/src/formatting/types.rs
+++ b/src/formatting/types.rs
@@ -6,7 +6,10 @@ use rustc_span::{symbol::kw, BytePos, Span};
 
 use crate::config::{lists::*, IndentStyle, TypeDensity};
 use crate::formatting::{
-    expr::{format_expr, rewrite_assign_rhs, rewrite_tuple, rewrite_unary_prefix, ExprType},
+    expr::{
+        format_expr, rewrite_assign_rhs, rewrite_call, rewrite_tuple, rewrite_unary_prefix,
+        ExprType,
+    },
     lists::{definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator},
     macros::{rewrite_macro, MacroPosition},
     overflow,
@@ -756,7 +759,14 @@ impl Rewrite for ast::Ty {
                 })
             }
             ast::TyKind::CVarArgs => Some("...".to_owned()),
-            ast::TyKind::Err | ast::TyKind::Typeof(..) => unreachable!(),
+            ast::TyKind::Err => Some(context.snippet(self.span).to_owned()),
+            ast::TyKind::Typeof(ref anon_const) => rewrite_call(
+                context,
+                "typeof",
+                &[anon_const.value.clone()],
+                self.span,
+                shape,
+            ),
         }
     }
 }

--- a/tests/source/type.rs
+++ b/tests/source/type.rs
@@ -166,3 +166,9 @@ impl<T:   ?  const Trait> Foo<T> {
         Self(t)
     }
 }
+
+// #4357
+type T = typeof(
+1);
+impl T for  .. {
+}

--- a/tests/target/type.rs
+++ b/tests/target/type.rs
@@ -177,3 +177,7 @@ impl<T: ?const Trait> Foo<T> {
         Self(t)
     }
 }
+
+// #4357
+type T = typeof(1);
+impl T for .. {}


### PR DESCRIPTION
These two cases are simple enough; I might as well support it instead of panicking.

Also, in a bit extreme case the current implementation can panic against valid Rust code when macro is involved:

```rust
macro_rules! foo {
    (typeof($e:expr)) => {}
}

fn main() {
    foo!(typeof(3));
}
```

Close #4357.