### PR TITLE
BinOp Comments Handling

### DIFF
--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -805,6 +805,22 @@ impl<'a> CommentRewrite<'a> {
     }
 }
 
+/* Returns the required indentation depending on 'orig'last line:
+ * If last line includes one line comment: 'indent_str' (that should include new line)
+ * othewise: space
+*/
+pub(crate) fn indent_str_by_last_line_comment<'a>(
+    orig: &'a str,
+    indent_str: &'a str,
+    space: &'a str,
+) -> &'a str {
+    if orig.trim_start().starts_with("//") {
+        indent_str
+    } else {
+        space
+    }
+}
+
 fn rewrite_comment_inner(
     orig: &str,
     block_style: bool,

--- a/src/formatting/pairs.rs
+++ b/src/formatting/pairs.rs
@@ -66,6 +66,8 @@ fn rewrite_pairs_one_line<T: Rewrite>(
     let mut result = String::new();
     let base_shape = shape.block();
 
+    let mut prefix_iter = list.sep_prefixes.iter();
+    let mut suffix_iter = list.sep_suffixes.iter();
     for ((_, rewrite), s) in list.list.iter().zip(list.separators.iter()) {
         if let Some(rewrite) = rewrite {
             if !is_single_line(&rewrite) || result.len() > shape.width {
@@ -74,14 +76,14 @@ fn rewrite_pairs_one_line<T: Rewrite>(
 
             result.push_str(&rewrite);
             result.push(' ');
-            let c = list.sep_prefixes.iter().next()?.trim();
+            let c = prefix_iter.next()?.trim();
             if !c.is_empty() {
                 result.push_str(c);
                 result.push(' ');
             };
             result.push_str(s);
             result.push(' ');
-            let c = list.sep_suffixes.iter().next()?.trim();
+            let c = suffix_iter.next()?.trim();
             if !c.is_empty() {
                 result.push_str(c);
                 result.push(' ');

--- a/src/formatting/pairs.rs
+++ b/src/formatting/pairs.rs
@@ -3,7 +3,7 @@ use rustc_ast::ast;
 use crate::config::lists::*;
 use crate::config::IndentStyle;
 use crate::formatting::{
-    comment::{rewrite_comment, rewrite_missing_comment},
+    comment::{indent_str_by_last_line_comment, rewrite_comment, rewrite_missing_comment},
     rewrite::{Rewrite, RewriteContext},
     shape::Shape,
     utils::{
@@ -78,15 +78,23 @@ fn rewrite_pairs_one_line<T: Rewrite>(
             result.push(' ');
             let c = prefix_iter.next()?.trim();
             if !c.is_empty() {
-                result.push_str(c);
-                result.push(' ');
+                if c.starts_with("//") {
+                    return None;
+                } else {
+                    result.push_str(c);
+                    result.push(' ');
+                };
             };
             result.push_str(s);
             result.push(' ');
             let c = suffix_iter.next()?.trim();
             if !c.is_empty() {
-                result.push_str(c);
-                result.push(' ');
+                if c.starts_with("//") {
+                    return None;
+                } else {
+                    result.push_str(c);
+                    result.push(' ');
+                };
             };
         } else {
             return None;
@@ -183,7 +191,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
                             ),
                             context.config,
                         )?);
-                        result.push(' ');
+                        result.push_str(indent_str_by_last_line_comment(&prefix, &indent_str, " "));
                     };
                     result.push_str(s);
                     result.push(' ');
@@ -197,7 +205,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
                             ),
                             context.config,
                         )?);
-                        result.push(' ');
+                        result.push_str(indent_str_by_last_line_comment(&suffix, &indent_str, " "));
                     };
                     result.push_str(&rewrite);
                     continue;

--- a/src/formatting/pairs.rs
+++ b/src/formatting/pairs.rs
@@ -193,7 +193,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
                             true,
                             shape.block_indent(
                                 last_line_used_width(&result, shape.offset)
-                                    - shape.indent.block_indent,
+                                    - multiline_align_overhead,
                             ),
                             context.config,
                         )?);

--- a/src/formatting/pairs.rs
+++ b/src/formatting/pairs.rs
@@ -7,8 +7,8 @@ use crate::formatting::{
     rewrite::{Rewrite, RewriteContext},
     shape::Shape,
     utils::{
-        first_line_width, is_single_line, last_line_used_width, last_line_width, mk_sp,
-        trimmed_last_line_width, wrap_str,
+        first_line_width, is_single_line, last_line_used_width, last_line_width,
+        longest_line_width, mk_sp, trimmed_last_line_width, wrap_str,
     },
 };
 
@@ -152,12 +152,12 @@ fn rewrite_pairs_multiline<T: Rewrite>(
         let prelen = if prefix.is_empty() {
             0
         } else {
-            first_line_width(&prefix) + 1 /* +1 if for separator suffix */
+            longest_line_width(&prefix) + 1 /* +1 if for separator suffix */
         };
         let suflen = if suffix.is_empty() {
             0
         } else {
-            first_line_width(&suffix) + 1 /* +1 if for separator suffix */
+            longest_line_width(&suffix) + 1 /* +1 if for separator suffix */
         };
         let offset = if result.contains('\n') {
             0

--- a/src/formatting/utils.rs
+++ b/src/formatting/utils.rs
@@ -229,6 +229,15 @@ pub(crate) fn first_line_width(s: &str) -> usize {
     unicode_str_width(s.splitn(2, '\n').next().unwrap_or(""))
 }
 
+/// The width of the longest line in s.
+#[inline]
+pub(crate) fn longest_line_width(s: &str) -> usize {
+    s.split("\n")
+        .map(|l| unicode_str_width(l))
+        .max()
+        .unwrap_or(0)
+}
+
 /// The width of the last line in s.
 #[inline]
 pub(crate) fn last_line_width(s: &str) -> usize {

--- a/tests/source/issue-binop-comments/binop-comments-back.rs
+++ b/tests/source/issue-binop-comments/binop-comments-back.rs
@@ -88,14 +88,14 @@ fn main() {
 }
 
 
-// Test 17.1
+// Test 21.1
 fn main() {
     let x = 2        /* v */
 	/* w */        *       /* x */
 	        4   ;
 }
 
-// Test 17.2 
+// Test 21.2 
 fn main() {
     let x = 2        /* v */
 	/* w */        *       /* x */
@@ -103,7 +103,7 @@ fn main() {
 }
 
 
-// Test 18.1 - Multi separators - One line Pre-comments
+// Test 22.1 - Multi separators - One line Pre-comments
 fn main() {
 /* comments before the if statement */
     if context1()   /* condition 1 explanations */
@@ -114,7 +114,7 @@ fn main() {
     {a + b}
 }
 
-// Test 18.2 - Multi separators - One line Post-comments
+// Test 22.2 - Multi separators - One line Post-comments
 fn main() {
 	     /* comments before the if statement */
     if context1() &&   /* condition 1 explanations */
@@ -125,7 +125,7 @@ fn main() {
     {a + b}
 }
 
-// Test 19.1 - Multi separators - Multi line Pre-comments
+// Test 23.1 - Multi separators - Multi line Pre-comments
 fn main() {
 	/* comments before the if statement
 	 * with some explanations about the if */
@@ -142,7 +142,7 @@ fn main() {
     {a + b}
 }
 
-// Test 19.2 - Multi separators - Multi line Post-comments
+// Test 23.2 - Multi separators - Multi line Post-comments
 fn main() {
 	/* comments before the if statement
 	 * with some explanations about the if */
@@ -156,5 +156,29 @@ fn main() {
 		                   * with some added details about condition 4 */
 	/* comments to the executed block
 	 * with some explanations about the executed block */
+    {a + b}
+}
+
+// Test 24.1 - Multi separators - Multi line Pre-comments with long line
+fn main() {
+    if context1()   /* condition 1 explanations longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+		            * with some added details about condition 1 */
+        && bounds.len() == 1    /* condition 2 explanations
+		                   * with some added details about condition 2 longggggggggggggggggggggg */
+        && context3 /* condition 3 explanations longgggggggggggggggggggggggggggggggggggggggg
+		                * with some added details about condition 3 longgggggggggggggggggggggggggg */
+    {a + b}
+}
+
+// Test 24.2 - Multi separators - Multi line Post-comments with long line
+fn main() {
+    if context1() /* pre condition1 longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ &&  /* condition 1 explanations
+		              * with some added details about condition 1 */
+        bounds.len() == 1 &&   /* condition 2 explanations longgggggggggggggggggggggggggggggggggggggg
+		                   * with some added details about condition 2 */
+        context3 && /* condition 3 explanations
+		                * with some added details about condition 3 longggggggggggggggggggggggggggggggggggggg */
+        !res.ends('+') /* condition 4 explanations longgggggggggggggggggggggggggggggggggggggggggggggg
+		                   * with some added details about condition 4 longgggggggggggggggggggggggggggggggggggg*/
     {a + b}
 }

--- a/tests/source/issue-binop-comments/binop-comments-back.rs
+++ b/tests/source/issue-binop-comments/binop-comments-back.rs
@@ -186,3 +186,36 @@ fn main() {
 		                   * with some added details about condition 4 longgggggggggggggggggggggggggggggggggggg*/
     {a + b}
 }
+
+// Test 25.1 - binop with one line comment
+fn main() {
+if
+a // comment1
+| bbbbbb    |    cccccc
+{}
+}
+
+// Test 25.2 - binop with one line comment
+fn main() {
+if
+a // comment1
+	// comment2
+| b
+{}
+}
+
+// Test 25.3 - binop with one line comment
+fn main() {
+if a
+|  // comment3
+b
+{}
+}
+
+// Test 25.4 - binop with one line comment
+fn main() {
+if a     // comment1
+|           // comment3
+b   |   c
+{}
+}

--- a/tests/source/issue-binop-comments/binop-comments-back.rs
+++ b/tests/source/issue-binop-comments/binop-comments-back.rs
@@ -35,6 +35,10 @@ fn main() {
 fn main() {
 	if context() /* cond 1 */        &&            bounds.len() == 1 /* cond 2 */           ||           context&& !res.ends('+') {a+b}
 }
+// Test 11.3 - One line with comments
+fn main() {
+    if 1234 == 0
+	/*x*/ & /*y*/ cc & dd {} }
 
 // Test 12.1 - Pre-comments break to few lines - only "&&"
 fn main() {

--- a/tests/source/issue-binop-comments/binop-comments-back.rs
+++ b/tests/source/issue-binop-comments/binop-comments-back.rs
@@ -1,0 +1,160 @@
+// rustfmt-binop_separator: Back
+
+// Test 1
+fn main() {
+    let x = 2      /* x */             *              4;
+}
+
+// Test 2
+fn main() {
+    let x = 2      /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */             *              4;
+}
+
+// Test 3
+fn main() {
+    let x = 2      *              /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */             4;
+}
+
+// Test 4
+fn main() {
+    let x = 2        /* x */      *       /* y */     4;
+}
+
+// Test 5
+fn main() {
+    let x = 2        /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */      *       
+					/* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */     4;
+}
+
+
+// Test 11.1 - One line
+fn main() {
+	if context()                     &&            bounds.len() == 1                        ||           context&& !res.ends('+') {a+b}
+}
+// Test 11.2 - One line with comments
+fn main() {
+	if context() /* cond 1 */        &&            bounds.len() == 1 /* cond 2 */           ||           context&& !res.ends('+') {a+b}
+}
+
+// Test 12.1 - Pre-comments break to few lines - only "&&"
+fn main() {
+	if context() /* condition 1 expression */ && bounds.len() == 1 /* condition 2 expression */ && context /* condition 3 expression */ && !res.ends('+') {a+b}
+}
+// Test 12.2 - Pre-comments break to few lines - "&&" and "||"
+fn main() {
+	if context() /* condition 1 expression */ && bounds.len() == 1 /* condition 2 expression */ || context /* condition 3 expression */ && !res.ends('+') {a+b}
+}
+
+// Test 13.1 - Post-comments break to few lines - only "&&"
+fn main() {
+	if context() && /* condition 1 expression */ bounds.len() == 1 && /* condition 2 expression */ context && /* condition 3 expression */  !res.ends('+') /* closing comment */ {a+b}
+}
+// Test 13.2 - Pre and Post-comments break to few lines - only "&&"
+fn main() {
+	if context() /* pre comment 1 */ && /* post comment 1 */ bounds.len() == 1 /* pre comment 2 */ && /* post comment 2 */ context /* pre comment 3 */ && /* post comment 3 */  !res.ends('+') /* closing comment */ {a+b}
+}
+
+// Test 14.1 - Each "&&" starts new line
+fn main() {
+	if context.inside_macro() && bounds.len() == 1&& context.snippet(self.span).ends_with('+') & !res.ends_with('+') { a+b }
+}
+// Test 14.2 - "||" starts new line
+fn main() {
+	if context.inside_macro() && bounds.len() == 1 || context.snippet(self.span).ends_with('+') & !res.ends_with('+') { a+b }
+}
+
+// Test 15.1 - Each "&&" starts new line - with comments
+fn main() {
+	if context.inside_macro()  /* cond 1 */ && bounds.len() == 1 /* cond 2 */ && context.snippet(self.span).ends_with('+') /* cond 3 */ && !res.ends_with('+') { a+b }
+}
+// Test 15.2 - "||" starts new line - with comments
+fn main() {
+	if context.inside_macro()  /* cond 1 */ && bounds.len() == 1 /* cond 2 */ || context.snippet(self.span).ends_with('+') /* cond 3 */ && !res.ends_with('+') { a+b }
+}
+
+// Test 16 - Each "." and some "&&"/"||" starts new line
+fn main() {
+	if a {
+		if b {
+			if c {
+				if d {
+					if e {
+				if item_kind.is_same_item_kind(&***ppi, self.file_mod_map).context.inside_macro()&& bounds.len() == 1 || context.snippet(self.span).ends_with('+')&& !res.ends_with('+') { a+b }
+					}
+				}
+			}
+		}
+	}
+}
+
+
+// Test 17.1
+fn main() {
+    let x = 2        /* v */
+	/* w */        *       /* x */
+	        4   ;
+}
+
+// Test 17.2 
+fn main() {
+    let x = 2        /* v */
+	/* w */        *       /* x */
+	/* y */        4   ;
+}
+
+
+// Test 18.1 - Multi separators - One line Pre-comments
+fn main() {
+/* comments before the if statement */
+    if context1()   /* condition 1 explanations */
+        && bounds.len() == 1    /* condition 2 explanations */
+        && context3 /* condition 3 explanations */
+        && !res.ends('+') /* condition 4 explanations */
+/* comments to the executed block */
+    {a + b}
+}
+
+// Test 18.2 - Multi separators - One line Post-comments
+fn main() {
+	     /* comments before the if statement */
+    if context1() &&   /* condition 1 explanations */
+        bounds.len() == 1 &&    /* condition 2 explanations */
+        context3 && /* condition 3 explanations */
+        !res.ends('+') /* condition 4 explanations */
+	    /* comments to the executed block */
+    {a + b}
+}
+
+// Test 19.1 - Multi separators - Multi line Pre-comments
+fn main() {
+	/* comments before the if statement
+	 * with some explanations about the if */
+    if context1()   /* condition 1 explanations
+		            * with some added details about condition 1 */
+        && bounds.len() == 1    /* condition 2 explanations
+		                   * with some added details about condition 2 */
+        && context3 /* condition 3 explanations
+		                * with some added details about condition 3 */
+        && !res.ends('+') /* condition 4 explanations
+		                   * with some added details about condition 4 */
+	/* comments to the executed block
+	 * with some explanations about the executed block */
+    {a + b}
+}
+
+// Test 19.2 - Multi separators - Multi line Post-comments
+fn main() {
+	/* comments before the if statement
+	 * with some explanations about the if */
+    if context1() /* pre condition1 */ &&  /* condition 1 explanations
+		              * with some added details about condition 1 */
+        bounds.len() == 1 &&   /* condition 2 explanations
+		                   * with some added details about condition 2 */
+        context3 && /* condition 3 explanations
+		                * with some added details about condition 3 */
+        !res.ends('+') /* condition 4 explanations
+		                   * with some added details about condition 4 */
+	/* comments to the executed block
+	 * with some explanations about the executed block */
+    {a + b}
+}

--- a/tests/source/issue-binop-comments/binop-comments-front.rs
+++ b/tests/source/issue-binop-comments/binop-comments-front.rs
@@ -88,14 +88,14 @@ fn main() {
 }
 
 
-// Test 17.1
+// Test 21.1
 fn main() {
     let x = 2        /* v */
 	/* w */        *       /* x */
 	        4   ;
 }
 
-// Test 17.2 
+// Test 21.2 
 fn main() {
     let x = 2        /* v */
 	/* w */        *       /* x */
@@ -103,7 +103,7 @@ fn main() {
 }
 
 
-// Test 18.1 - Multi separators - One line Pre-comments
+// Test 22.1 - Multi separators - One line Pre-comments
 fn main() {
 /* comments before the if statement */
     if context1()   /* condition 1 explanations */
@@ -114,7 +114,7 @@ fn main() {
     {a + b}
 }
 
-// Test 18.2 - Multi separators - One line Post-comments
+// Test 22.2 - Multi separators - One line Post-comments
 fn main() {
 	     /* comments before the if statement */
     if context1() &&   /* condition 1 explanations */
@@ -125,7 +125,7 @@ fn main() {
     {a + b}
 }
 
-// Test 19.1 - Multi separators - Multi line Pre-comments
+// Test 23.1 - Multi separators - Multi line Pre-comments
 fn main() {
 	/* comments before the if statement
 	 * with some explanations about the if */
@@ -142,7 +142,7 @@ fn main() {
     {a + b}
 }
 
-// Test 19.2 - Multi separators - Multi line Post-comments
+// Test 23.2 - Multi separators - Multi line Post-comments
 fn main() {
 	/* comments before the if statement
 	 * with some explanations about the if */
@@ -156,5 +156,29 @@ fn main() {
 		                   * with some added details about condition 4 */
 	/* comments to the executed block
 	 * with some explanations about the executed block */
+    {a + b}
+}
+
+// Test 24.1 - Multi separators - Multi line Pre-comments with long line
+fn main() {
+    if context1()   /* condition 1 explanations longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+		            * with some added details about condition 1 */
+        && bounds.len() == 1    /* condition 2 explanations
+		                   * with some added details about condition 2 longggggggggggggggggggggg */
+        && context3 /* condition 3 explanations longgggggggggggggggggggggggggggggggggggggggg
+		                * with some added details about condition 3 longgggggggggggggggggggggggggg */
+    {a + b}
+}
+
+// Test 24.2 - Multi separators - Multi line Post-comments with long line
+fn main() {
+    if context1() /* pre condition1 longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ &&  /* condition 1 explanations
+		              * with some added details about condition 1 */
+        bounds.len() == 1 &&   /* condition 2 explanations longgggggggggggggggggggggggggggggggggggggg
+		                   * with some added details about condition 2 */
+        context3 && /* condition 3 explanations
+		                * with some added details about condition 3 longggggggggggggggggggggggggggggggggggggg */
+        !res.ends('+') /* condition 4 explanations longgggggggggggggggggggggggggggggggggggggggggggggg
+		                   * with some added details about condition 4 longgggggggggggggggggggggggggggggggggggg*/
     {a + b}
 }

--- a/tests/source/issue-binop-comments/binop-comments-front.rs
+++ b/tests/source/issue-binop-comments/binop-comments-front.rs
@@ -1,0 +1,160 @@
+// rustfmt-binop_separator: Front
+
+// Test 1
+fn main() {
+    let x = 2      /* x */             *              4;
+}
+
+// Test 2
+fn main() {
+    let x = 2      /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */             *              4;
+}
+
+// Test 3
+fn main() {
+    let x = 2      *              /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */             4;
+}
+
+// Test 4
+fn main() {
+    let x = 2        /* x */      *       /* y */     4;
+}
+
+// Test 5
+fn main() {
+    let x = 2        /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */      *       
+					/* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */     4;
+}
+
+
+// Test 11.1 - One line
+fn main() {
+	if context()                     &&            bounds.len() == 1                        ||           context&& !res.ends('+') {a+b}
+}
+// Test 11.2 - One line with comments
+fn main() {
+	if context() /* cond 1 */        &&            bounds.len() == 1 /* cond 2 */           ||           context&& !res.ends('+') {a+b}
+}
+
+// Test 12.1 - Pre-comments break to few lines - only "&&"
+fn main() {
+	if context() /* condition 1 expression */ && bounds.len() == 1 /* condition 2 expression */ && context /* condition 3 expression */ && !res.ends('+') {a+b}
+}
+// Test 12.2 - Pre-comments break to few lines - "&&" and "||"
+fn main() {
+	if context() /* condition 1 expression */ && bounds.len() == 1 /* condition 2 expression */ || context /* condition 3 expression */ && !res.ends('+') {a+b}
+}
+
+// Test 13.1 - Post-comments break to few lines - only "&&"
+fn main() {
+	if context() && /* condition 1 expression */ bounds.len() == 1 && /* condition 2 expression */ context && /* condition 3 expression */  !res.ends('+') /* closing comment */ {a+b}
+}
+// Test 13.2 - Pre and Post-comments break to few lines - only "&&"
+fn main() {
+	if context() /* pre comment 1 */ && /* post comment 1 */ bounds.len() == 1 /* pre comment 2 */ && /* post comment 2 */ context /* pre comment 3 */ && /* post comment 3 */  !res.ends('+') /* closing comment */ {a+b}
+}
+
+// Test 14.1 - Each "&&" starts new line
+fn main() {
+	if context.inside_macro() && bounds.len() == 1&& context.snippet(self.span).ends_with('+') & !res.ends_with('+') { a+b }
+}
+// Test 14.2 - "||" starts new line
+fn main() {
+	if context.inside_macro() && bounds.len() == 1 || context.snippet(self.span).ends_with('+') & !res.ends_with('+') { a+b }
+}
+
+// Test 15.1 - Each "&&" starts new line - with comments
+fn main() {
+	if context.inside_macro()  /* cond 1 */ && bounds.len() == 1 /* cond 2 */ && context.snippet(self.span).ends_with('+') /* cond 3 */ && !res.ends_with('+') { a+b }
+}
+// Test 15.2 - "||" starts new line - with comments
+fn main() {
+	if context.inside_macro()  /* cond 1 */ && bounds.len() == 1 /* cond 2 */ || context.snippet(self.span).ends_with('+') /* cond 3 */ && !res.ends_with('+') { a+b }
+}
+
+// Test 16 - Each "." and some "&&"/"||" starts new line
+fn main() {
+	if a {
+		if b {
+			if c {
+				if d {
+					if e {
+				if item_kind.is_same_item_kind(&***ppi, self.file_mod_map).context.inside_macro()&& bounds.len() == 1 || context.snippet(self.span).ends_with('+')&& !res.ends_with('+') { a+b }
+					}
+				}
+			}
+		}
+	}
+}
+
+
+// Test 17.1
+fn main() {
+    let x = 2        /* v */
+	/* w */        *       /* x */
+	        4   ;
+}
+
+// Test 17.2 
+fn main() {
+    let x = 2        /* v */
+	/* w */        *       /* x */
+	/* y */        4   ;
+}
+
+
+// Test 18.1 - Multi separators - One line Pre-comments
+fn main() {
+/* comments before the if statement */
+    if context1()   /* condition 1 explanations */
+        && bounds.len() == 1    /* condition 2 explanations */
+        && context3 /* condition 3 explanations */
+        && !res.ends('+') /* condition 4 explanations */
+/* comments to the executed block */
+    {a + b}
+}
+
+// Test 18.2 - Multi separators - One line Post-comments
+fn main() {
+	     /* comments before the if statement */
+    if context1() &&   /* condition 1 explanations */
+        bounds.len() == 1 &&    /* condition 2 explanations */
+        context3 && /* condition 3 explanations */
+        !res.ends('+') /* condition 4 explanations */
+	    /* comments to the executed block */
+    {a + b}
+}
+
+// Test 19.1 - Multi separators - Multi line Pre-comments
+fn main() {
+	/* comments before the if statement
+	 * with some explanations about the if */
+    if context1()   /* condition 1 explanations
+		            * with some added details about condition 1 */
+        && bounds.len() == 1    /* condition 2 explanations
+		                   * with some added details about condition 2 */
+        && context3 /* condition 3 explanations
+		                * with some added details about condition 3 */
+        && !res.ends('+') /* condition 4 explanations
+		                   * with some added details about condition 4 */
+	/* comments to the executed block
+	 * with some explanations about the executed block */
+    {a + b}
+}
+
+// Test 19.2 - Multi separators - Multi line Post-comments
+fn main() {
+	/* comments before the if statement
+	 * with some explanations about the if */
+    if context1() /* pre condition1 */ &&  /* condition 1 explanations
+		              * with some added details about condition 1 */
+        bounds.len() == 1 &&   /* condition 2 explanations
+		                   * with some added details about condition 2 */
+        context3 && /* condition 3 explanations
+		                * with some added details about condition 3 */
+        !res.ends('+') /* condition 4 explanations
+		                   * with some added details about condition 4 */
+	/* comments to the executed block
+	 * with some explanations about the executed block */
+    {a + b}
+}

--- a/tests/source/issue-binop-comments/binop-comments-front.rs
+++ b/tests/source/issue-binop-comments/binop-comments-front.rs
@@ -35,6 +35,10 @@ fn main() {
 fn main() {
 	if context() /* cond 1 */        &&            bounds.len() == 1 /* cond 2 */           ||           context&& !res.ends('+') {a+b}
 }
+// Test 11.3 - One line with comments
+fn main() {
+    if 1234 == 0
+	/*x*/ & /*y*/ cc & dd {} }
 
 // Test 12.1 - Pre-comments break to few lines - only "&&"
 fn main() {

--- a/tests/source/issue-binop-comments/binop-comments-front.rs
+++ b/tests/source/issue-binop-comments/binop-comments-front.rs
@@ -186,3 +186,37 @@ fn main() {
 		                   * with some added details about condition 4 longgggggggggggggggggggggggggggggggggggg*/
     {a + b}
 }
+
+// Test 25.1 - binop with one line comment
+fn main() {
+if
+a // comment1
+| bbbbbb    |    cccccc
+{}
+}
+
+// Test 25.2 - binop with one line comment
+fn main() {
+if
+a // comment1
+	// comment2
+| b
+{}
+}
+
+// Test 25.3 - binop with one line comment
+fn main() {
+if a
+|  // comment3
+b
+{}
+}
+
+// Test 25.4 - binop with one line comment
+fn main() {
+if a     // comment1
+|           // comment3
+b   |   c
+{}
+}
+		

--- a/tests/target/comment-not-disappear.rs
+++ b/tests/target/comment-not-disappear.rs
@@ -32,7 +32,8 @@ fn foo() -> Vec<i32> {
 
 fn calc_page_len(prefix_len: usize, sofar: usize) -> usize {
     2 // page type and flags
-    + 1 // stored depth
-    + 2 // stored count
-    + prefix_len + sofar // sum of size of all the actual items
+        + 1 // stored depth
+        + 2 // stored count
+        + prefix_len
+        + sofar // sum of size of all the actual items
 }

--- a/tests/target/issue-binop-comments/binop-comments-back.rs
+++ b/tests/target/issue-binop-comments/binop-comments-back.rs
@@ -267,3 +267,35 @@ fn main() {
         a + b
     }
 }
+
+// Test 25.1 - binop with one line comment
+fn main() {
+    if a // comment1
+        | bbbbbb |
+        cccccc
+    {}
+}
+
+// Test 25.2 - binop with one line comment
+fn main() {
+    if a // comment1
+         // comment2
+        | b
+    {}
+}
+
+// Test 25.3 - binop with one line comment
+fn main() {
+    if a | // comment3
+        b
+    {}
+}
+
+// Test 25.4 - binop with one line comment
+fn main() {
+    if a // comment1
+        | // comment3
+        b |
+        c
+    {}
+}

--- a/tests/target/issue-binop-comments/binop-comments-back.rs
+++ b/tests/target/issue-binop-comments/binop-comments-back.rs
@@ -1,0 +1,231 @@
+// rustfmt-binop_separator: Back
+
+// Test 1
+fn main() {
+    let x = 2 /* x */ * 4;
+}
+
+// Test 2
+fn main() {
+    let x = 2
+        /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+        *
+        4;
+}
+
+// Test 3
+fn main() {
+    let x = 2 *
+        /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */
+        4;
+}
+
+// Test 4
+fn main() {
+    let x = 2 /* x */ * /* y */ 4;
+}
+
+// Test 5
+fn main() {
+    let x = 2 /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */ *
+        /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */
+        4;
+}
+
+// Test 11.1 - One line
+fn main() {
+    if context() && bounds.len() == 1 || context && !res.ends('+') {
+        a + b
+    }
+}
+// Test 11.2 - One line with comments
+fn main() {
+    if context() /* cond 1 */ && bounds.len() == 1 /* cond 2 */ || context && !res.ends('+') {
+        a + b
+    }
+}
+
+// Test 12.1 - Pre-comments break to few lines - only "&&"
+fn main() {
+    if context() /* condition 1 expression */ &&
+        bounds.len() == 1 /* condition 2 expression */ &&
+        context /* condition 3 expression */ &&
+        !res.ends('+')
+    {
+        a + b
+    }
+}
+// Test 12.2 - Pre-comments break to few lines - "&&" and "||"
+fn main() {
+    if context() /* condition 1 expression */ && bounds.len() == 1 /* condition 2 expression */ ||
+        context /* condition 3 expression */ && !res.ends('+')
+    {
+        a + b
+    }
+}
+
+// Test 13.1 - Post-comments break to few lines - only "&&"
+fn main() {
+    if context() && /* condition 1 expression */
+        bounds.len() == 1 && /* condition 2 expression */
+        context && /* condition 3 expression */
+        !res.ends('+')
+    /* closing comment */
+    {
+        a + b
+    }
+}
+// Test 13.2 - Pre and Post-comments break to few lines - only "&&"
+fn main() {
+    if context() /* pre comment 1 */ && /* post comment 1 */
+        bounds.len() == 1 /* pre comment 2 */ && /* post comment 2 */
+        context /* pre comment 3 */ && /* post comment 3 */
+        !res.ends('+')
+    /* closing comment */
+    {
+        a + b
+    }
+}
+
+// Test 14.1 - Each "&&" starts new line
+fn main() {
+    if context.inside_macro() &&
+        bounds.len() == 1 &&
+        context.snippet(self.span).ends_with('+') & !res.ends_with('+')
+    {
+        a + b
+    }
+}
+// Test 14.2 - "||" starts new line
+fn main() {
+    if context.inside_macro() && bounds.len() == 1 ||
+        context.snippet(self.span).ends_with('+') & !res.ends_with('+')
+    {
+        a + b
+    }
+}
+
+// Test 15.1 - Each "&&" starts new line - with comments
+fn main() {
+    if context.inside_macro() /* cond 1 */ &&
+        bounds.len() == 1 /* cond 2 */ &&
+        context.snippet(self.span).ends_with('+') /* cond 3 */ &&
+        !res.ends_with('+')
+    {
+        a + b
+    }
+}
+// Test 15.2 - "||" starts new line - with comments
+fn main() {
+    if context.inside_macro() /* cond 1 */ && bounds.len() == 1 /* cond 2 */ ||
+        context.snippet(self.span).ends_with('+') /* cond 3 */ && !res.ends_with('+')
+    {
+        a + b
+    }
+}
+
+// Test 16 - Each "." and some "&&"/"||" starts new line
+fn main() {
+    if a {
+        if b {
+            if c {
+                if d {
+                    if e {
+                        if item_kind
+                            .is_same_item_kind(&***ppi, self.file_mod_map)
+                            .context
+                            .inside_macro() &&
+                            bounds.len() == 1 ||
+                            context.snippet(self.span).ends_with('+') && !res.ends_with('+')
+                        {
+                            a + b
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Test 17.1
+fn main() {
+    let x = 2 /* v */
+              /* w */ * /* x */
+        4;
+}
+
+// Test 17.2
+fn main() {
+    let x = 2 /* v */
+              /* w */ * /* x */
+                            /* y */
+        4;
+}
+
+// Test 18.1 - Multi separators - One line Pre-comments
+fn main() {
+    /* comments before the if statement */
+    if context1() /* condition 1 explanations */ &&
+        bounds.len() == 1 /* condition 2 explanations */ &&
+        context3 /* condition 3 explanations */ &&
+        !res.ends('+')
+    /* condition 4 explanations */
+    /* comments to the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 18.2 - Multi separators - One line Post-comments
+fn main() {
+    /* comments before the if statement */
+    if context1() && /* condition 1 explanations */
+        bounds.len() == 1 && /* condition 2 explanations */
+        context3 && /* condition 3 explanations */
+        !res.ends('+')
+    /* condition 4 explanations */
+    /* comments to the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 19.1 - Multi separators - Multi line Pre-comments
+fn main() {
+    /* comments before the if statement
+     * with some explanations about the if */
+    if context1() /* condition 1 explanations
+                   * with some added details about condition 1 */ &&
+        bounds.len() == 1 /* condition 2 explanations
+                           * with some added details about condition 2 */ &&
+        context3 /* condition 3 explanations
+                  * with some added details about condition 3 */ &&
+        !res.ends('+')
+    /* condition 4 explanations
+     * with some added details about condition 4 */
+    /* comments to the executed block
+     * with some explanations about the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 19.2 - Multi separators - Multi line Post-comments
+fn main() {
+    /* comments before the if statement
+     * with some explanations about the if */
+    if context1() /* pre condition1 */ && /* condition 1 explanations
+                                           * with some added details about condition 1 */
+        bounds.len() == 1 && /* condition 2 explanations
+                              * with some added details about condition 2 */
+        context3 && /* condition 3 explanations
+                     * with some added details about condition 3 */
+        !res.ends('+')
+    /* condition 4 explanations
+     * with some added details about condition 4 */
+    /* comments to the executed block
+     * with some explanations about the executed block */
+    {
+        a + b
+    }
+}

--- a/tests/target/issue-binop-comments/binop-comments-back.rs
+++ b/tests/target/issue-binop-comments/binop-comments-back.rs
@@ -44,6 +44,10 @@ fn main() {
         a + b
     }
 }
+// Test 11.3 - One line with comments
+fn main() {
+    if 1234 == 0 /*x*/ & /*y*/ cc & dd {}
+}
 
 // Test 12.1 - Pre-comments break to few lines - only "&&"
 fn main() {

--- a/tests/target/issue-binop-comments/binop-comments-back.rs
+++ b/tests/target/issue-binop-comments/binop-comments-back.rs
@@ -147,14 +147,14 @@ fn main() {
     }
 }
 
-// Test 17.1
+// Test 21.1
 fn main() {
     let x = 2 /* v */
               /* w */ * /* x */
         4;
 }
 
-// Test 17.2
+// Test 21.2
 fn main() {
     let x = 2 /* v */
               /* w */ * /* x */
@@ -162,7 +162,7 @@ fn main() {
         4;
 }
 
-// Test 18.1 - Multi separators - One line Pre-comments
+// Test 22.1 - Multi separators - One line Pre-comments
 fn main() {
     /* comments before the if statement */
     if context1() /* condition 1 explanations */ &&
@@ -176,7 +176,7 @@ fn main() {
     }
 }
 
-// Test 18.2 - Multi separators - One line Post-comments
+// Test 22.2 - Multi separators - One line Post-comments
 fn main() {
     /* comments before the if statement */
     if context1() && /* condition 1 explanations */
@@ -190,7 +190,7 @@ fn main() {
     }
 }
 
-// Test 19.1 - Multi separators - Multi line Pre-comments
+// Test 23.1 - Multi separators - Multi line Pre-comments
 fn main() {
     /* comments before the if statement
      * with some explanations about the if */
@@ -210,7 +210,7 @@ fn main() {
     }
 }
 
-// Test 19.2 - Multi separators - Multi line Post-comments
+// Test 23.2 - Multi separators - Multi line Post-comments
 fn main() {
     /* comments before the if statement
      * with some explanations about the if */
@@ -225,6 +225,40 @@ fn main() {
      * with some added details about condition 4 */
     /* comments to the executed block
      * with some explanations about the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 24.1 - Multi separators - Multi line Pre-comments with long line
+fn main() {
+    if context1()
+        /* condition 1 explanations longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+         * with some added details about condition 1 */ &&
+        bounds.len() == 1
+        /* condition 2 explanations
+         * with some added details about condition 2 longggggggggggggggggggggg */ &&
+        context3
+    /* condition 3 explanations longgggggggggggggggggggggggggggggggggggggggg
+     * with some added details about condition 3 longgggggggggggggggggggggggggg */
+    {
+        a + b
+    }
+}
+
+// Test 24.2 - Multi separators - Multi line Post-comments with long line
+fn main() {
+    if context1() /* pre condition1 longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/
+        && /* condition 1 explanations
+                * with some added details about condition 1 */
+        bounds.len() == 1 && /* condition 2 explanations longgggggggggggggggggggggggggggggggggggggg
+                              * with some added details about condition 2 */
+        context3 &&
+        /* condition 3 explanations
+         * with some added details about condition 3 longggggggggggggggggggggggggggggggggggggg */
+        !res.ends('+')
+    /* condition 4 explanations longgggggggggggggggggggggggggggggggggggggggggggggg
+     * with some added details about condition 4 longgggggggggggggggggggggggggggggggggggg*/
     {
         a + b
     }

--- a/tests/target/issue-binop-comments/binop-comments-front.rs
+++ b/tests/target/issue-binop-comments/binop-comments-front.rs
@@ -145,14 +145,14 @@ fn main() {
     }
 }
 
-// Test 17.1
+// Test 21.1
 fn main() {
     let x = 2 /* v */
               /* w */
         * /* x */ 4;
 }
 
-// Test 17.2
+// Test 21.2
 fn main() {
     let x = 2 /* v */
               /* w */
@@ -160,7 +160,7 @@ fn main() {
           /* y */ 4;
 }
 
-// Test 18.1 - Multi separators - One line Pre-comments
+// Test 22.1 - Multi separators - One line Pre-comments
 fn main() {
     /* comments before the if statement */
     if context1() /* condition 1 explanations */
@@ -174,7 +174,7 @@ fn main() {
     }
 }
 
-// Test 18.2 - Multi separators - One line Post-comments
+// Test 22.2 - Multi separators - One line Post-comments
 fn main() {
     /* comments before the if statement */
     if context1()
@@ -188,7 +188,7 @@ fn main() {
     }
 }
 
-// Test 19.1 - Multi separators - Multi line Pre-comments
+// Test 23.1 - Multi separators - Multi line Pre-comments
 fn main() {
     /* comments before the if statement
      * with some explanations about the if */
@@ -208,7 +208,7 @@ fn main() {
     }
 }
 
-// Test 19.2 - Multi separators - Multi line Post-comments
+// Test 23.2 - Multi separators - Multi line Post-comments
 fn main() {
     /* comments before the if statement
      * with some explanations about the if */
@@ -223,6 +223,39 @@ fn main() {
      * with some added details about condition 4 */
     /* comments to the executed block
      * with some explanations about the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 24.1 - Multi separators - Multi line Pre-comments with long line
+fn main() {
+    if context1()
+        /* condition 1 explanations longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+         * with some added details about condition 1 */
+        && bounds.len() == 1
+        /* condition 2 explanations
+         * with some added details about condition 2 longggggggggggggggggggggg */
+        && context3
+    /* condition 3 explanations longgggggggggggggggggggggggggggggggggggggggg
+     * with some added details about condition 3 longgggggggggggggggggggggggggg */
+    {
+        a + b
+    }
+}
+
+// Test 24.2 - Multi separators - Multi line Post-comments with long line
+fn main() {
+    if context1() /* pre condition1 longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/
+        && /* condition 1 explanations
+            * with some added details about condition 1 */ bounds.len() == 1
+        && /* condition 2 explanations longgggggggggggggggggggggggggggggggggggggg
+            * with some added details about condition 2 */ context3
+        && /* condition 3 explanations
+            * with some added details about condition 3 longggggggggggggggggggggggggggggggggggggg */
+        !res.ends('+')
+    /* condition 4 explanations longgggggggggggggggggggggggggggggggggggggggggggggg
+     * with some added details about condition 4 longgggggggggggggggggggggggggggggggggggg*/
     {
         a + b
     }

--- a/tests/target/issue-binop-comments/binop-comments-front.rs
+++ b/tests/target/issue-binop-comments/binop-comments-front.rs
@@ -42,6 +42,10 @@ fn main() {
         a + b
     }
 }
+// Test 11.3 - One line with comments
+fn main() {
+    if 1234 == 0 /*x*/ & /*y*/ cc & dd {}
+}
 
 // Test 12.1 - Pre-comments break to few lines - only "&&"
 fn main() {

--- a/tests/target/issue-binop-comments/binop-comments-front.rs
+++ b/tests/target/issue-binop-comments/binop-comments-front.rs
@@ -264,3 +264,35 @@ fn main() {
         a + b
     }
 }
+
+// Test 25.1 - binop with one line comment
+fn main() {
+    if a // comment1
+        | bbbbbb
+        | cccccc
+    {}
+}
+
+// Test 25.2 - binop with one line comment
+fn main() {
+    if a // comment1
+         // comment2
+        | b
+    {}
+}
+
+// Test 25.3 - binop with one line comment
+fn main() {
+    if a | // comment3
+        b
+    {}
+}
+
+// Test 25.4 - binop with one line comment
+fn main() {
+    if a // comment1
+        | // comment3
+        b
+        | c
+    {}
+}

--- a/tests/target/issue-binop-comments/binop-comments-front.rs
+++ b/tests/target/issue-binop-comments/binop-comments-front.rs
@@ -1,0 +1,229 @@
+// rustfmt-binop_separator: Front
+
+// Test 1
+fn main() {
+    let x = 2 /* x */ * 4;
+}
+
+// Test 2
+fn main() {
+    let x = 2
+        /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+        * 4;
+}
+
+// Test 3
+fn main() {
+    let x = 2
+        * /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */
+        4;
+}
+
+// Test 4
+fn main() {
+    let x = 2 /* x */ * /* y */ 4;
+}
+
+// Test 5
+fn main() {
+    let x = 2 /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+        * /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */ 4;
+}
+
+// Test 11.1 - One line
+fn main() {
+    if context() && bounds.len() == 1 || context && !res.ends('+') {
+        a + b
+    }
+}
+// Test 11.2 - One line with comments
+fn main() {
+    if context() /* cond 1 */ && bounds.len() == 1 /* cond 2 */ || context && !res.ends('+') {
+        a + b
+    }
+}
+
+// Test 12.1 - Pre-comments break to few lines - only "&&"
+fn main() {
+    if context() /* condition 1 expression */
+        && bounds.len() == 1 /* condition 2 expression */
+        && context /* condition 3 expression */
+        && !res.ends('+')
+    {
+        a + b
+    }
+}
+// Test 12.2 - Pre-comments break to few lines - "&&" and "||"
+fn main() {
+    if context() /* condition 1 expression */ && bounds.len() == 1 /* condition 2 expression */
+        || context /* condition 3 expression */ && !res.ends('+')
+    {
+        a + b
+    }
+}
+
+// Test 13.1 - Post-comments break to few lines - only "&&"
+fn main() {
+    if context()
+        && /* condition 1 expression */ bounds.len() == 1
+        && /* condition 2 expression */ context
+        && /* condition 3 expression */ !res.ends('+')
+    /* closing comment */
+    {
+        a + b
+    }
+}
+// Test 13.2 - Pre and Post-comments break to few lines - only "&&"
+fn main() {
+    if context() /* pre comment 1 */
+        && /* post comment 1 */ bounds.len() == 1 /* pre comment 2 */
+        && /* post comment 2 */ context /* pre comment 3 */
+        && /* post comment 3 */ !res.ends('+')
+    /* closing comment */
+    {
+        a + b
+    }
+}
+
+// Test 14.1 - Each "&&" starts new line
+fn main() {
+    if context.inside_macro()
+        && bounds.len() == 1
+        && context.snippet(self.span).ends_with('+') & !res.ends_with('+')
+    {
+        a + b
+    }
+}
+// Test 14.2 - "||" starts new line
+fn main() {
+    if context.inside_macro() && bounds.len() == 1
+        || context.snippet(self.span).ends_with('+') & !res.ends_with('+')
+    {
+        a + b
+    }
+}
+
+// Test 15.1 - Each "&&" starts new line - with comments
+fn main() {
+    if context.inside_macro() /* cond 1 */
+        && bounds.len() == 1 /* cond 2 */
+        && context.snippet(self.span).ends_with('+') /* cond 3 */
+        && !res.ends_with('+')
+    {
+        a + b
+    }
+}
+// Test 15.2 - "||" starts new line - with comments
+fn main() {
+    if context.inside_macro() /* cond 1 */ && bounds.len() == 1 /* cond 2 */
+        || context.snippet(self.span).ends_with('+') /* cond 3 */ && !res.ends_with('+')
+    {
+        a + b
+    }
+}
+
+// Test 16 - Each "." and some "&&"/"||" starts new line
+fn main() {
+    if a {
+        if b {
+            if c {
+                if d {
+                    if e {
+                        if item_kind
+                            .is_same_item_kind(&***ppi, self.file_mod_map)
+                            .context
+                            .inside_macro()
+                            && bounds.len() == 1
+                            || context.snippet(self.span).ends_with('+') && !res.ends_with('+')
+                        {
+                            a + b
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Test 17.1
+fn main() {
+    let x = 2 /* v */
+              /* w */
+        * /* x */ 4;
+}
+
+// Test 17.2
+fn main() {
+    let x = 2 /* v */
+              /* w */
+        * /* x */
+          /* y */ 4;
+}
+
+// Test 18.1 - Multi separators - One line Pre-comments
+fn main() {
+    /* comments before the if statement */
+    if context1() /* condition 1 explanations */
+        && bounds.len() == 1 /* condition 2 explanations */
+        && context3 /* condition 3 explanations */
+        && !res.ends('+')
+    /* condition 4 explanations */
+    /* comments to the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 18.2 - Multi separators - One line Post-comments
+fn main() {
+    /* comments before the if statement */
+    if context1()
+        && /* condition 1 explanations */ bounds.len() == 1
+        && /* condition 2 explanations */ context3
+        && /* condition 3 explanations */ !res.ends('+')
+    /* condition 4 explanations */
+    /* comments to the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 19.1 - Multi separators - Multi line Pre-comments
+fn main() {
+    /* comments before the if statement
+     * with some explanations about the if */
+    if context1() /* condition 1 explanations
+                   * with some added details about condition 1 */
+        && bounds.len() == 1 /* condition 2 explanations
+                              * with some added details about condition 2 */
+        && context3 /* condition 3 explanations
+                     * with some added details about condition 3 */
+        && !res.ends('+')
+    /* condition 4 explanations
+     * with some added details about condition 4 */
+    /* comments to the executed block
+     * with some explanations about the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 19.2 - Multi separators - Multi line Post-comments
+fn main() {
+    /* comments before the if statement
+     * with some explanations about the if */
+    if context1() /* pre condition1 */
+        && /* condition 1 explanations
+            * with some added details about condition 1 */ bounds.len() == 1
+        && /* condition 2 explanations
+            * with some added details about condition 2 */ context3
+        && /* condition 3 explanations
+            * with some added details about condition 3 */ !res.ends('+')
+    /* condition 4 explanations
+     * with some added details about condition 4 */
+    /* comments to the executed block
+     * with some explanations about the executed block */
+    {
+        a + b
+    }
+}


### PR DESCRIPTION
This PR is for handling **pre/post comments to binop**, based on initial examples given in #2896 discussion.
Two test files are added (with the same cases): one for "_Front_" _binop_separator_ and one for "_Back_".

**Comments about approach taken:**
1. Comments are trimmed and are put in the same line of other code when possible.  Original prefix/suffix white spaces are trimmed.
   
2. **Multi-lines comments** are appended to a line or starts new line based on the width if **longest** line in the comment and not the first line width.  This is because all the lines in a multi-line comment are indented to the same place, so even if the first line may be appended to the previous line, a longer line in the comment may exceed the maximum allowed width.
   
3. When _binop_separator=="Front"_, **something will be added to the separator line**, so that the separator will not be left alone in the line.  This is **even if line will become too long**. Reasoning is that separators are usually short, so only in rare cases they will be the cause for making the line too long, and readability is better when the separator is not alone in a line.
For example, the code:
         `a + /* longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg comment*/ b`
     will be formatted as:
```
    a
    \+ /* longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg comment*/
    b
```
     and NOT as:

```
    a
    +
    /* longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg comment*/
    b 
```

**Possible Issues:**
1. The prefix/suffix items where added in `PairList struct` using `String `and not `&str`, as I could not find an easy way to use `&str`.  Also, maybe the prefix/suffix items should have been collected into one vector with the separator instead of having 3 separate vectors.
   
2. There is no distinction between comment that follows `if` condition about the  _if statement_ and a comment that precede the execution block after the _if statement_. This is not directly related to the _binop comments_, but is raised here since the last comment to the _if statement_ would become a _binop prefix comment_ if another condition will be added to the if statement. For example, in test 22.1 (Front):
```
		&& !res.ends('+')
	/* condition 4 explanations */
	/* comments to the executed block */
	{
		a + b
	}
```
	  Was expected to be:
```
		&& !res.ends('+') /* condition 4 explanations */
	/* comments to the executed block */
	{
			a + b
	}
```