### PR TITLE
Use rustfmt given by RUSTFMT env var

### DIFF
--- a/config_proc_macro/src/utils.rs
+++ b/config_proc_macro/src/utils.rs
@@ -1,5 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use std::env;
+use std::ffi::OsStr;
 
 pub fn fold_quote<F, I, T>(input: impl Iterator<Item = I>, f: F) -> TokenStream
 where
@@ -21,7 +23,12 @@ pub(crate) fn debug_with_rustfmt(input: &TokenStream) {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
-    let mut child = Command::new("rustfmt")
+    let rustfmt_var = env::var_os("RUSTFMT");
+    let rustfmt = match &rustfmt_var {
+        Some(rustfmt) => rustfmt,
+        None => OsStr::new("rustfmt"),
+    };
+    let mut child = Command::new(rustfmt)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -5,6 +5,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
@@ -149,6 +150,15 @@ fn is_status_options(s: &str) -> bool {
         || s.starts_with("--print-config=")
 }
 
+fn rustfmt_command() -> Command {
+    let rustfmt_var = env::var_os("RUSTFMT");
+    let rustfmt = match &rustfmt_var {
+        Some(rustfmt) => rustfmt,
+        None => OsStr::new("rustfmt"),
+    };
+    Command::new(rustfmt)
+}
+
 fn build_rustfmt_args(opts: &Opts, rustfmt_args: &mut Vec<String>) -> Result<(), String> {
     let mut contains_check = false;
     let mut contains_emit_mode = false;
@@ -240,7 +250,7 @@ fn handle_command_status(status: Result<i32, io::Error>) -> i32 {
 }
 
 fn get_rustfmt_info(args: &[String]) -> Result<i32, io::Error> {
-    let mut command = Command::new("rustfmt")
+    let mut command = rustfmt_command()
         .stdout(std::process::Stdio::inherit())
         .args(args)
         .spawn()
@@ -625,7 +635,7 @@ fn run_rustfmt(
             println!();
         }
 
-        let mut command = Command::new("rustfmt")
+        let mut command = rustfmt_command()
             .stdout(stdout)
             .args(files)
             .args(&["--edition", edition])

--- a/src/format-diff/main.rs
+++ b/src/format-diff/main.rs
@@ -11,6 +11,8 @@ use serde_json as json;
 use thiserror::Error;
 
 use std::collections::HashSet;
+use std::env;
+use std::ffi::OsStr;
 use std::io::{self, BufRead};
 use std::process;
 
@@ -90,7 +92,12 @@ fn run_rustfmt(files: &HashSet<String>, ranges: &[Range]) -> Result<(), FormatDi
     debug!("Files: {:?}", files);
     debug!("Ranges: {:?}", ranges);
 
-    let exit_status = process::Command::new("rustfmt")
+    let rustfmt_var = env::var_os("RUSTFMT");
+    let rustfmt = match &rustfmt_var {
+        Some(rustfmt) => rustfmt,
+        None => OsStr::new("rustfmt"),
+    };
+    let exit_status = process::Command::new(rustfmt)
         .args(files)
         .arg("--file-lines")
         .arg(ranges_as_json)


### PR DESCRIPTION
This matches how Cargo uses the rustc and rustdoc specified by RUSTC and RUSTDOC environment variables (see https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads).

Without this I was not able to find a way to get a `cargo fmt` invoking the build of rustfmt that my work codebase is supposed to use, because cargo always prepends its own bin directory to PATH before calling any subcommand, and rustup places its own rustfmt executable there.

```console
$ PATH=/path/to:$PATH cargo fmt  # does not work
```