### PR TITLE
BraceStyle AlwaysNewLine for unsafe blocks

### DIFF
--- a/tests/source/configs/brace_style/unsafe_always_next_line.rs
+++ b/tests/source/configs/brace_style/unsafe_always_next_line.rs
@@ -1,0 +1,25 @@
+// rustfmt-brace_style: AlwaysNextLine
+// AlwaysNextLine brace style for unsafe blocks
+
+fn main()
+{
+    unsafe
+    {
+        let good = ();
+    }
+
+    unsafe {}
+
+    unsafe {
+        let ugly = ();
+    }
+
+    unsafe   /* f   */ {}
+
+    unsafe /* f*/ {
+        let x = 1;
+    }
+
+    unsafe { /*lol*/
+    }
+}

--- a/tests/target/configs/brace_style/unsafe_always_next_line.rs
+++ b/tests/target/configs/brace_style/unsafe_always_next_line.rs
@@ -1,0 +1,30 @@
+// rustfmt-brace_style: AlwaysNextLine
+// AlwaysNextLine brace style for unsafe blocks
+
+fn main()
+{
+    unsafe
+    {
+        let good = ();
+    }
+
+    unsafe {}
+
+    unsafe
+    {
+        let ugly = ();
+    }
+
+    unsafe /* f   */
+    {
+    }
+
+    unsafe /* f*/
+    {
+        let x = 1;
+    }
+
+    unsafe
+    { /*lol*/
+    }
+}


### PR DESCRIPTION
* Unsafe blocks can now get an opening brace on a new line

* Add test case for unsafe blocks

Hello relating to this issue : https://github.com/rust-lang/rustfmt/issues/3376 and this issue : https://github.com/rust-lang/rustfmt/issues/3377

All comments or suggestions are very welcome, I'm far from being a rust pro :)

Cheers