### PR TITLE
Bump rustc-ap to v679

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,10 +441,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -463,15 +490,24 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -561,19 +597,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
 dependencies = [
- "lock_api",
- "parking_lot_core 0.7.2",
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -583,7 +620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "rustc_version",
@@ -593,12 +630,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec 1.4.0",
@@ -769,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa951ccfe33e3d46ad7b2922ddb935583e9e98029f428681b98afd74cc042b7"
+checksum = "e8e941a8fc3878a111d2bbfe78e39522d884136f0b412b12592195f26f653476"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.4.0",
@@ -779,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa7b3cf87d6249653c00f2fd338adf4e72c8bc617870dda9dfd421aba197a66"
+checksum = "3b58b6b035710df7f339a2bf86f6dafa876efd95439540970e24609e33598ca6"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -796,11 +834,11 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be435169657440d6287b07a929c9fcc6db04c8c4fc835e0ab5b0fa945a8c028"
+checksum = "3d379a900d6a1f098490d92ab83e87487dcee2e4ec3f04c3ac4512b5117b64e2"
 dependencies = [
- "itertools",
+ "itertools 0.9.0",
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_attr",
@@ -815,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38779f1e954d46303e72be59bb32033d920698ef55c3039266fef349d870fb9d"
+checksum = "658d925c0da9e3c5cddc5e54f4fa8c03b41aff1fc6dc5e41837c1118ad010ac0"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
@@ -827,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b419c0ae11c46e86b27e3ae0f5ee9ff2418870c6307f6fed30b02fe727526a"
+checksum = "3f387037534f34c148aed753622677500e42d190a095670e7ac3fffc09811a59"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -846,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1cf84a72b8aa2e6fe4172c2246d707969217d4da1e7a689e12db80d8d5b63d9"
+checksum = "14ffd17a37e00d77926a0713f191c59ff3aeb2b551a024c7cfffce14bab79be8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -858,7 +896,7 @@ dependencies = [
  "jobserver",
  "libc",
  "measureme",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "rustc-ap-rustc_graphviz",
  "rustc-ap-rustc_index",
  "rustc-ap-rustc_macros",
@@ -876,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd08b5d165336da31dfbf5fb1b829eec0bb8516c6e4b755ee659d297d22c5dba"
+checksum = "2b3263ddcfa9eb911e54a4e8088878dd9fd10e00d8b99b01033ba4a2733fe91d"
 dependencies = [
  "annotate-snippets",
  "atty",
@@ -895,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bb89221349eb78ae87d4f5680a62e4b98f30ce0effbef3b694b91643eeff9"
+checksum = "e1ab7e68cede8a2273fd8b8623002ce9dc832e061dfc3330e9bcc1fc2a722d73"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_passes",
@@ -918,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4056fa564cd0ec3a0456f69d863682863bcdc5f303bf4bf24886d82456c0ceca"
+checksum = "eea2dc95421bc19bbd4d939399833a882c46b684283b4267ad1fcf982fc043d9"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_span",
@@ -928,21 +966,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626f3dc6ad181fa202994261d86e45db844fc5f30915d42df49d8ce270ed2543"
+checksum = "1e44c1804f09635f83f6cf1e04c2e92f8aeb7b4e850ac6c53d373dab02c13053"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0615d11907c251a58e48e695653fb50a9c8efafddaeedfeb3291806bf9ae6127"
+checksum = "dc491f2b9be6e928f6df6b287549b8d50c48e8eff8638345155f40fa2cfb785d"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c365a380a861aabebde64b519fd3766c978009baae7e4244d1f55c5b4cb509ae"
+checksum = "fa73f3fed413cdb6290738a10267da17b9ae8e02087334778b9a8c9491c5efc0"
 dependencies = [
  "arrayvec",
  "rustc-ap-rustc_macros",
@@ -951,18 +989,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4ceff9b806d9d7176a31a1d5e2bcb3d98b26b51f6abd136d76ce1d2825233a"
+checksum = "e993881244a92f3b44cf43c8f22ae2ca5cefe4f55a34e2b65b72ee66fe5ad077"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f520638ea4f2c80aa56347a3019d79b09bb4de80efb4dfbdc029cdd89a1ad4"
+checksum = "4effe366556e1d75344764adf4d54cba7c2fad33dbd07588e96d0853831ddc7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -972,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169d79f505ffd2c892c0def471eeb5f40c4ae25fff99f1ec3c46868ba47be3a8"
+checksum = "0342675835251571471d3dca9ea1576a853a8dfa1f4b0084db283c861223cb60"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_ast",
@@ -992,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8c16fb186e7130223b1528ee6ea5b11acdcc185f86774f1c44b5b40c0964f2"
+checksum = "438255ed968d73bf6573aa18d3b8d33c0a85ecdfd14160ef09ff813938e0606c"
 dependencies = [
  "indexmap",
  "smallvec 1.4.0",
@@ -1002,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bf5f3b6619c58f8ac45ca1f2fcc740494e958975565662e984d665a8fc462b"
+checksum = "7d61ff76dede8eb827f6805754900d1097a7046f938f950231b62b448f55bf78"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1023,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca3c82f0bb52a333385d21b6725e9e426625a754d104102e80eed42dca1b114"
+checksum = "1c267f15c3cfc82a8a441d2bf86bcccf299d1eb625822468e3d8ee6f7c5a1c89"
 dependencies = [
  "cfg-if",
  "md-5",
@@ -1042,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c36eadab721da7d7e949cfe3043decde13fa9b91a57a309fdb6f1857646cc1"
+checksum = "8b1b4b266c4d44aac0f7f83b6741d8f0545b03d1ce32f3b5254f2014225cb96c"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -1122,7 +1160,7 @@ dependencies = [
  "dunce",
  "env_logger",
  "ignore",
- "itertools",
+ "itertools 0.8.2",
  "lazy_static",
  "log",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,32 +107,32 @@ lazy_static = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "678.0.0"
+version = "679.0.0"

--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -188,6 +188,7 @@ fn rewrite_closure_with_block(
             id: ast::NodeId::root(),
             kind: ast::StmtKind::Expr(ptr::P(body.clone())),
             span: body.span,
+            tokens: None,
         }],
         id: ast::NodeId::root(),
         rules: ast::BlockCheckMode::Default,
@@ -196,6 +197,7 @@ fn rewrite_closure_with_block(
             .first()
             .map(|attr| attr.span.to(body.span))
             .unwrap_or(body.span),
+        tokens: None,
     };
     let block =
         rewrite_block_with_visitor(context, "", &block, Some(&body.attrs), None, shape, false)?;

--- a/src/formatting/imports.rs
+++ b/src/formatting/imports.rs
@@ -4,7 +4,6 @@ use std::fmt;
 
 use rustc_ast::ast::{self, UseTreeKind};
 use rustc_span::{
-    source_map,
     symbol::{self, sym},
     BytePos, Span, DUMMY_SP,
 };
@@ -508,16 +507,16 @@ impl UseTree {
     fn same_visibility(&self, other: &UseTree) -> bool {
         match (&self.visibility, &other.visibility) {
             (
-                Some(source_map::Spanned {
-                    node: ast::VisibilityKind::Inherited,
+                Some(ast::Visibility {
+                    kind: ast::VisibilityKind::Inherited,
                     ..
                 }),
                 None,
             )
             | (
                 None,
-                Some(source_map::Spanned {
-                    node: ast::VisibilityKind::Inherited,
+                Some(ast::Visibility {
+                    kind: ast::VisibilityKind::Inherited,
                     ..
                 }),
             )

--- a/src/formatting/macros.rs
+++ b/src/formatting/macros.rs
@@ -1286,8 +1286,8 @@ impl MacroParser {
             }
         };
         if let Some(TokenTree::Token(Token { kind, span })) = self.toks.look_ahead(0) {
-            if (is_macro_rules && *kind == TokenKind::Semi)
-                || (!is_macro_rules && *kind == TokenKind::Comma)
+            if (is_macro_rules && kind == TokenKind::Semi)
+                || (!is_macro_rules && kind == TokenKind::Comma)
             {
                 hi = span.hi();
                 self.toks.next();

--- a/src/formatting/syntux/parser.rs
+++ b/src/formatting/syntux/parser.rs
@@ -118,7 +118,7 @@ impl<'a> Parser<'a> {
     ) -> Result<(ast::Mod, Vec<ast::Attribute>), ParserError> {
         let result = catch_unwind(AssertUnwindSafe(|| {
             let mut parser = new_parser_from_file(sess.inner(), &path, Some(span));
-            match parser.parse_mod(&TokenKind::Eof) {
+            match parser.parse_mod(&TokenKind::Eof, ast::Unsafe::No) {
                 Ok(result) => Some(result),
                 Err(mut e) => {
                     e.cancel();

--- a/src/formatting/utils.rs
+++ b/src/formatting/utils.rs
@@ -43,11 +43,11 @@ pub(crate) fn extra_offset(text: &str, shape: Shape) -> usize {
 }
 
 pub(crate) fn is_same_visibility(a: &Visibility, b: &Visibility) -> bool {
-    match (&a.node, &b.node) {
+    match (&a.kind, &b.kind) {
         (
             VisibilityKind::Restricted { path: p, .. },
             VisibilityKind::Restricted { path: q, .. },
-        ) => pprust::path_to_string(p) == pprust::path_to_string(q),
+        ) => pprust::path_to_string(&p) == pprust::path_to_string(&q),
         (VisibilityKind::Public, VisibilityKind::Public)
         | (VisibilityKind::Inherited, VisibilityKind::Inherited)
         | (
@@ -67,7 +67,7 @@ pub(crate) fn format_visibility(
     context: &RewriteContext<'_>,
     vis: &Visibility,
 ) -> Cow<'static, str> {
-    match vis.node {
+    match vis.kind {
         VisibilityKind::Public => Cow::from("pub "),
         VisibilityKind::Inherited => Cow::from(""),
         VisibilityKind::Crate(CrateSugar::PubCrate) => Cow::from("pub(crate) "),

--- a/src/formatting/visitor.rs
+++ b/src/formatting/visitor.rs
@@ -2,7 +2,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use rustc_ast::{ast, attr::HasAttrs, token::DelimToken, visit};
-use rustc_span::{symbol, BytePos, Pos, Span};
+use rustc_span::{symbol, BytePos, Pos, Span, DUMMY_SP};
 
 use crate::config::{BraceStyle, Config};
 use crate::formatting::{
@@ -24,9 +24,9 @@ use crate::formatting::{
     stmt::Stmt,
     syntux::session::ParseSess,
     utils::{
-        self, contains_skip, count_newlines, depr_skip_annotation, inner_attributes,
-        last_line_contains_single_line_comment, last_line_width, mk_sp, ptr_vec_to_ref_vec,
-        rewrite_ident, starts_with_newline, stmt_expr,
+        self, contains_skip, count_newlines, depr_skip_annotation, format_unsafety,
+        inner_attributes, last_line_contains_single_line_comment, last_line_width, mk_sp,
+        ptr_vec_to_ref_vec, rewrite_ident, starts_with_newline, stmt_expr,
     },
 };
 use crate::result::{ErrorKind, FormatError};
@@ -661,7 +661,11 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             }
             ast::AssocItemKind::Fn(defaultness, ref sig, ref generics, Some(ref body)) => {
                 let inner_attrs = inner_attributes(&ti.attrs);
-                let vis = rustc_span::source_map::dummy_spanned(ast::VisibilityKind::Inherited);
+                let vis = ast::Visibility {
+                    kind: ast::VisibilityKind::Inherited,
+                    span: DUMMY_SP,
+                    tokens: None,
+                };
                 let fn_ctxt = visit::FnCtxt::Assoc(visit::AssocCtxt::Trait);
                 self.visit_fn(
                     visit::FnKind::Fn(fn_ctxt, ti.ident, sig, &vis, Some(body)),
@@ -968,6 +972,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     ) {
         let vis_str = utils::format_visibility(&self.get_context(), vis);
         self.push_str(&*vis_str);
+        self.push_str(format_unsafety(m.unsafety));
         self.push_str("mod ");
         // Calling `to_owned()` to work around borrow checker.
         let ident_str = rewrite_ident(&self.get_context(), ident).to_owned();

--- a/tests/source/unsafe-mod.rs
+++ b/tests/source/unsafe-mod.rs
@@ -1,0 +1,7 @@
+// These are supported by rustc syntactically but not semantically.
+
+#[cfg(any())]
+unsafe mod m { }
+
+#[cfg(any())]
+unsafe extern "C++" { }

--- a/tests/target/unsafe-mod.rs
+++ b/tests/target/unsafe-mod.rs
@@ -1,0 +1,7 @@
+// These are supported by rustc syntactically but not semantically.
+
+#[cfg(any())]
+unsafe mod m {}
+
+#[cfg(any())]
+unsafe extern "C++" {}


### PR DESCRIPTION
I need this for being able to use https://github.com/rust-lang/rust/pull/75857.