### PR TITLE
1.x: Bump rustc-ap to v679

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2958af0d6e0458434a25cd3a96f6e19f24f71bf50b900add520dec52e212866b"
+checksum = "baa951ccfe33e3d46ad7b2922ddb935583e9e98029f428681b98afd74cc042b7"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.2.0",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c82c2510460f2133548e62399e5acd30c25ae6ece30245baab3d1e00c2fefac"
+checksum = "ffa7b3cf87d6249653c00f2fd338adf4e72c8bc617870dda9dfd421aba197a66"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -924,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83977da57f81c6edd89bad47e49136680eaa33288de4abb702e95358c2a0fc6c"
+checksum = "3be435169657440d6287b07a929c9fcc6db04c8c4fc835e0ab5b0fa945a8c028"
 dependencies = [
  "itertools",
  "rustc-ap-rustc_ast",
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becf4ca1638b214694c71a8752192683048ab8bd47947cc481f57bd48157eeb9"
+checksum = "38779f1e954d46303e72be59bb32033d920698ef55c3039266fef349d870fb9d"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
@@ -955,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f21ca5dadce8a40d75a2756b77eab75b4c2d827f645c622dd93ee2285599640"
+checksum = "24b419c0ae11c46e86b27e3ae0f5ee9ff2418870c6307f6fed30b02fe727526a"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cd204764727fde9abf75333eb661f058bfc7242062d91019440fe1b240688b"
+checksum = "a1cf84a72b8aa2e6fe4172c2246d707969217d4da1e7a689e12db80d8d5b63d9"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -984,7 +984,6 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "lazy_static",
  "libc",
  "measureme",
  "parking_lot 0.10.2",
@@ -1005,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58116f119e37f14c029f99077b347069621118e048a69df74695b98204e7c136"
+checksum = "bd08b5d165336da31dfbf5fb1b829eec0bb8516c6e4b755ee659d297d22c5dba"
 dependencies = [
  "annotate-snippets 0.8.0",
  "atty",
@@ -1024,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e3c4bda9b64b92805bebe7431fdb8e24fd112b35a8c6d2174827441f10a6b2"
+checksum = "603bb89221349eb78ae87d4f5680a62e4b98f30ce0effbef3b694b91643eeff9"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_passes",
@@ -1047,32 +1046,31 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b612bb67d3fc49f395b03fc4ea4384a0145b05afbadab725803074ec827632b"
+checksum = "4056fa564cd0ec3a0456f69d863682863bcdc5f303bf4bf24886d82456c0ceca"
 dependencies = [
- "lazy_static",
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_span",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7630ad1a73a8434ee920676148cb5440ac57509bd20e94ec41087fb0b1d11c28"
+checksum = "626f3dc6ad181fa202994261d86e45db844fc5f30915d42df49d8ce270ed2543"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a603fca4817062eb4fb23ff129d475bd66a69fb32f34ed4362ae950cf814b49d"
+checksum = "0615d11907c251a58e48e695653fb50a9c8efafddaeedfeb3291806bf9ae6127"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9850c4a5d7c341513e10802bca9588bf8f452ceea2d5cfa87b934246a52622bc"
+checksum = "c365a380a861aabebde64b519fd3766c978009baae7e4244d1f55c5b4cb509ae"
 dependencies = [
  "arrayvec 0.5.1",
  "rustc-ap-rustc_macros",
@@ -1081,18 +1079,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d86722e5a1a615b198327d0d794cd9cbc8b9db4542276fc51fe078924de68ea"
+checksum = "3a4ceff9b806d9d7176a31a1d5e2bcb3d98b26b51f6abd136d76ce1d2825233a"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3fc8482e44cabdda7ac9a8e224aef62ebdf95274d629dac8db3b42321025fea"
+checksum = "b0f520638ea4f2c80aa56347a3019d79b09bb4de80efb4dfbdc029cdd89a1ad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1102,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3716cdcd978a91dbd4a2788400e90e809527f841426fbeb92f882f9b8582f3ab"
+checksum = "169d79f505ffd2c892c0def471eeb5f40c4ae25fff99f1ec3c46868ba47be3a8"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_ast",
@@ -1122,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68046d07988b349b2e1c8bc1c9664a1d06519354aa677b9df358c5c5c058da0"
+checksum = "5b8c16fb186e7130223b1528ee6ea5b11acdcc185f86774f1c44b5b40c0964f2"
 dependencies = [
  "indexmap",
  "smallvec 1.2.0",
@@ -1132,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85735553501a4de0c8904e37b7ccef79cc1c585a7d7f2cfa02cc38e0d149f982"
+checksum = "67bf5f3b6619c58f8ac45ca1f2fcc740494e958975565662e984d665a8fc462b"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1153,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c49ae8a0d3b9e27c6ffe8febeaa30f899294fff012de70625f9ee81c54fda85"
+checksum = "8ca3c82f0bb52a333385d21b6725e9e426625a754d104102e80eed42dca1b114"
 dependencies = [
  "cfg-if",
  "md-5",
@@ -1172,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "677.0.0"
+version = "678.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1765f447594740c501c7b666b87639aa7c1dae2bf8c3166d5d2dca16646fd034"
+checksum = "12c36eadab721da7d7e949cfe3043decde13fa9b91a57a309fdb6f1857646cc1"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,10 +521,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -545,15 +572,24 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
 
 [[package]]
 name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -651,19 +687,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
 dependencies = [
- "lock_api",
- "parking_lot_core 0.7.2",
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -673,7 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "rustc_version",
@@ -683,15 +720,16 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
  "winapi",
 ]
 
@@ -822,7 +860,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -897,19 +935,19 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa951ccfe33e3d46ad7b2922ddb935583e9e98029f428681b98afd74cc042b7"
+checksum = "e8e941a8fc3878a111d2bbfe78e39522d884136f0b412b12592195f26f653476"
 dependencies = [
  "rustc-ap-rustc_data_structures",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa7b3cf87d6249653c00f2fd338adf4e72c8bc617870dda9dfd421aba197a66"
+checksum = "3b58b6b035710df7f339a2bf86f6dafa876efd95439540970e24609e33598ca6"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -918,17 +956,17 @@ dependencies = [
  "rustc-ap-rustc_macros",
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_span",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be435169657440d6287b07a929c9fcc6db04c8c4fc835e0ab5b0fa945a8c028"
+checksum = "3d379a900d6a1f098490d92ab83e87487dcee2e4ec3f04c3ac4512b5117b64e2"
 dependencies = [
- "itertools",
+ "itertools 0.9.0",
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
  "rustc-ap-rustc_attr",
@@ -943,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38779f1e954d46303e72be59bb32033d920698ef55c3039266fef349d870fb9d"
+checksum = "658d925c0da9e3c5cddc5e54f4fa8c03b41aff1fc6dc5e41837c1118ad010ac0"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
@@ -955,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b419c0ae11c46e86b27e3ae0f5ee9ff2418870c6307f6fed30b02fe727526a"
+checksum = "3f387037534f34c148aed753622677500e42d190a095670e7ac3fffc09811a59"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -974,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1cf84a72b8aa2e6fe4172c2246d707969217d4da1e7a689e12db80d8d5b63d9"
+checksum = "14ffd17a37e00d77926a0713f191c59ff3aeb2b551a024c7cfffce14bab79be8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -986,7 +1024,7 @@ dependencies = [
  "jobserver",
  "libc",
  "measureme",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "rustc-ap-rustc_graphviz",
  "rustc-ap-rustc_index",
  "rustc-ap-rustc_macros",
@@ -994,7 +1032,7 @@ dependencies = [
  "rustc-hash",
  "rustc-rayon",
  "rustc-rayon-core",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
  "stable_deref_trait",
  "stacker",
  "tempfile",
@@ -1004,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd08b5d165336da31dfbf5fb1b829eec0bb8516c6e4b755ee659d297d22c5dba"
+checksum = "2b3263ddcfa9eb911e54a4e8088878dd9fd10e00d8b99b01033ba4a2733fe91d"
 dependencies = [
  "annotate-snippets 0.8.0",
  "atty",
@@ -1023,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bb89221349eb78ae87d4f5680a62e4b98f30ce0effbef3b694b91643eeff9"
+checksum = "e1ab7e68cede8a2273fd8b8623002ce9dc832e061dfc3330e9bcc1fc2a722d73"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_passes",
@@ -1040,15 +1078,15 @@ dependencies = [
  "rustc-ap-rustc_serialize",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
  "tracing",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4056fa564cd0ec3a0456f69d863682863bcdc5f303bf4bf24886d82456c0ceca"
+checksum = "eea2dc95421bc19bbd4d939399833a882c46b684283b4267ad1fcf982fc043d9"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_span",
@@ -1056,21 +1094,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626f3dc6ad181fa202994261d86e45db844fc5f30915d42df49d8ce270ed2543"
+checksum = "1e44c1804f09635f83f6cf1e04c2e92f8aeb7b4e850ac6c53d373dab02c13053"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0615d11907c251a58e48e695653fb50a9c8efafddaeedfeb3291806bf9ae6127"
+checksum = "dc491f2b9be6e928f6df6b287549b8d50c48e8eff8638345155f40fa2cfb785d"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c365a380a861aabebde64b519fd3766c978009baae7e4244d1f55c5b4cb509ae"
+checksum = "fa73f3fed413cdb6290738a10267da17b9ae8e02087334778b9a8c9491c5efc0"
 dependencies = [
  "arrayvec 0.5.1",
  "rustc-ap-rustc_macros",
@@ -1079,18 +1117,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4ceff9b806d9d7176a31a1d5e2bcb3d98b26b51f6abd136d76ce1d2825233a"
+checksum = "e993881244a92f3b44cf43c8f22ae2ca5cefe4f55a34e2b65b72ee66fe5ad077"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f520638ea4f2c80aa56347a3019d79b09bb4de80efb4dfbdc029cdd89a1ad4"
+checksum = "4effe366556e1d75344764adf4d54cba7c2fad33dbd07588e96d0853831ddc7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1100,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169d79f505ffd2c892c0def471eeb5f40c4ae25fff99f1ec3c46868ba47be3a8"
+checksum = "0342675835251571471d3dca9ea1576a853a8dfa1f4b0084db283c861223cb60"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_ast",
@@ -1113,26 +1151,26 @@ dependencies = [
  "rustc-ap-rustc_lexer",
  "rustc-ap-rustc_session",
  "rustc-ap-rustc_span",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
  "tracing",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8c16fb186e7130223b1528ee6ea5b11acdcc185f86774f1c44b5b40c0964f2"
+checksum = "438255ed968d73bf6573aa18d3b8d33c0a85ecdfd14160ef09ff813938e0606c"
 dependencies = [
  "indexmap",
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bf5f3b6619c58f8ac45ca1f2fcc740494e958975565662e984d665a8fc462b"
+checksum = "7d61ff76dede8eb827f6805754900d1097a7046f938f950231b62b448f55bf78"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1151,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca3c82f0bb52a333385d21b6725e9e426625a754d104102e80eed42dca1b114"
+checksum = "1c267f15c3cfc82a8a441d2bf86bcccf299d1eb625822468e3d8ee6f7c5a1c89"
 dependencies = [
  "cfg-if",
  "md-5",
@@ -1170,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "678.0.0"
+version = "679.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c36eadab721da7d7e949cfe3043decde13fa9b91a57a309fdb6f1857646cc1"
+checksum = "8b1b4b266c4d44aac0f7f83b6741d8f0545b03d1ce32f3b5254f2014225cb96c"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -1257,7 +1295,7 @@ dependencies = [
  "env_logger",
  "getopts",
  "ignore",
- "itertools",
+ "itertools 0.8.0",
  "lazy_static",
  "log",
  "regex",
@@ -1306,9 +1344,9 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -1377,9 +1415,9 @@ checksum = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 
 [[package]]
 name = "smallvec"
-version = "1.2.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1606,7 +1644,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.2.0",
+ "smallvec 1.4.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,36 +66,36 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "677.0.0"
+version = "678.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "677.0.0"
+version = "678.0.0"
 
 [dependencies.rustc_attr]
 package = "rustc-ap-rustc_attr"
-version = "677.0.0"
+version = "678.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "677.0.0"
+version = "678.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "677.0.0"
+version = "678.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "677.0.0"
+version = "678.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "677.0.0"
+version = "678.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "677.0.0"
+version = "678.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "677.0.0"
+version = "678.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,36 +66,36 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_attr]
 package = "rustc-ap-rustc_attr"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "678.0.0"
+version = "679.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "678.0.0"
+version = "679.0.0"

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -42,10 +42,7 @@ pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
         ast::StmtKind::Local(ref local) => local.span,
         ast::StmtKind::Item(ref item) => item.span,
         ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => expr.span,
-        ast::StmtKind::MacCall(ref mac) => {
-            let (ref mac, _, _) = **mac;
-            mac.span()
-        }
+        ast::StmtKind::MacCall(ref mac_stmt) => mac_stmt.mac.span(),
         ast::StmtKind::Empty => stmt.span,
     }
 }

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -150,10 +150,12 @@ fn rewrite_closure_with_block(
             id: ast::NodeId::root(),
             kind: ast::StmtKind::Expr(ptr::P(body.clone())),
             span: body.span,
+            tokens: None,
         }],
         id: ast::NodeId::root(),
         rules: ast::BlockCheckMode::Default,
         span: body.span,
+        tokens: None,
     };
     let block = crate::expr::rewrite_block_with_visitor(
         context,

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -4,7 +4,6 @@ use std::fmt;
 
 use rustc_ast::ast::{self, UseTreeKind};
 use rustc_span::{
-    source_map,
     symbol::{self, sym},
     BytePos, Span, DUMMY_SP,
 };
@@ -509,16 +508,16 @@ impl UseTree {
     fn same_visibility(&self, other: &UseTree) -> bool {
         match (&self.visibility, &other.visibility) {
             (
-                Some(source_map::Spanned {
-                    node: ast::VisibilityKind::Inherited,
+                Some(ast::Visibility {
+                    kind: ast::VisibilityKind::Inherited,
                     ..
                 }),
                 None,
             )
             | (
                 None,
-                Some(source_map::Spanned {
-                    node: ast::VisibilityKind::Inherited,
+                Some(ast::Visibility {
+                    kind: ast::VisibilityKind::Inherited,
                     ..
                 }),
             )

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1178,8 +1178,7 @@ fn next_space(tok: &TokenKind) -> SpaceState {
         | TokenKind::Pound
         | TokenKind::Dollar
         | TokenKind::OpenDelim(_)
-        | TokenKind::CloseDelim(_)
-        | TokenKind::Whitespace => SpaceState::Never,
+        | TokenKind::CloseDelim(_) => SpaceState::Never,
 
         TokenKind::Literal(..) | TokenKind::Ident(..) | TokenKind::Lifetime(_) => SpaceState::Ident,
 
@@ -1275,8 +1274,8 @@ impl MacroParser {
             span,
         })) = self.toks.look_ahead(0)
         {
-            self.toks.next();
             hi = span.hi();
+            self.toks.next();
         }
         Some(MacroBranch {
             span: mk_sp(lo, hi),

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -66,12 +66,11 @@ impl Spanned for ast::Stmt {
             ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => {
                 mk_sp(expr.span().lo(), self.span.hi())
             }
-            ast::StmtKind::MacCall(ref mac) => {
-                let (_, _, ref attrs) = **mac;
-                if attrs.is_empty() {
+            ast::StmtKind::MacCall(ref mac_stmt) => {
+                if mac_stmt.attrs.is_empty() {
                     self.span
                 } else {
-                    mk_sp(attrs[0].span.lo(), self.span.hi())
+                    mk_sp(mac_stmt.attrs[0].span.lo(), self.span.hi())
                 }
             }
             ast::StmtKind::Empty => self.span,

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -118,7 +118,7 @@ impl<'a> Parser<'a> {
     ) -> Result<(ast::Mod, Vec<ast::Attribute>), ParserError> {
         let result = catch_unwind(AssertUnwindSafe(|| {
             let mut parser = new_parser_from_file(sess.inner(), &path, Some(span));
-            match parser.parse_mod(&TokenKind::Eof) {
+            match parser.parse_mod(&TokenKind::Eof, ast::Unsafe::No) {
                 Ok(result) => Some(result),
                 Err(mut e) => {
                     e.cancel();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,11 +38,11 @@ pub(crate) fn extra_offset(text: &str, shape: Shape) -> usize {
 }
 
 pub(crate) fn is_same_visibility(a: &Visibility, b: &Visibility) -> bool {
-    match (&a.node, &b.node) {
+    match (&a.kind, &b.kind) {
         (
             VisibilityKind::Restricted { path: p, .. },
             VisibilityKind::Restricted { path: q, .. },
-        ) => pprust::path_to_string(p) == pprust::path_to_string(q),
+        ) => pprust::path_to_string(&p) == pprust::path_to_string(&q),
         (VisibilityKind::Public, VisibilityKind::Public)
         | (VisibilityKind::Inherited, VisibilityKind::Inherited)
         | (
@@ -62,7 +62,7 @@ pub(crate) fn format_visibility(
     context: &RewriteContext<'_>,
     vis: &Visibility,
 ) -> Cow<'static, str> {
-    match vis.node {
+    match vis.kind {
         VisibilityKind::Public => Cow::from("pub "),
         VisibilityKind::Inherited => Cow::from(""),
         VisibilityKind::Crate(CrateSugar::PubCrate) => Cow::from("pub(crate) "),

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -146,16 +146,15 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     self.push_rewrite(stmt.span(), rewrite)
                 }
             }
-            ast::StmtKind::MacCall(ref mac) => {
-                let (ref mac, _macro_style, ref attrs) = **mac;
-                if self.visit_attrs(attrs, ast::AttrStyle::Outer) {
+            ast::StmtKind::MacCall(ref mac_stmt) => {
+                if self.visit_attrs(&mac_stmt.attrs, ast::AttrStyle::Outer) {
                     self.push_skipped_with_span(
-                        attrs,
+                        &mac_stmt.attrs,
                         stmt.span(),
                         get_span_without_attrs(stmt.as_ast_node()),
                     );
                 } else {
-                    self.visit_mac(mac, None, MacroPosition::Statement);
+                    self.visit_mac(&mac_stmt.mac, None, MacroPosition::Statement);
                 }
                 self.format_missing(stmt.span().hi());
             }

--- a/tests/source/unsafe-mod.rs
+++ b/tests/source/unsafe-mod.rs
@@ -1,0 +1,7 @@
+// These are supported by rustc syntactically but not semantically.
+
+#[cfg(any())]
+unsafe mod m { }
+
+#[cfg(any())]
+unsafe extern "C++" { }

--- a/tests/target/unsafe-mod.rs
+++ b/tests/target/unsafe-mod.rs
@@ -1,0 +1,7 @@
+// These are supported by rustc syntactically but not semantically.
+
+#[cfg(any())]
+unsafe mod m {}
+
+#[cfg(any())]
+unsafe extern "C++" {}


### PR DESCRIPTION
This is a backport of https://github.com/rust-lang/rustfmt/pull/4423 and https://github.com/rust-lang/rustfmt/pull/4433.