### PR TITLE
Backport some things for rustfmt 1.4.22

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.rs]
+indent_size = 4
+
+[tests/**/*.rs]
+charset = utf-8
+end_of_line = unset
+indent_size = unset
+indent_style = unset
+trim_trailing_whitespace = unset
+insert_final_newline = unset
+
+[appveyor.yml]
+end_of_line = unset

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,84 @@
+name: integration
+on: [push, pull_request]
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.integration }}
+    strategy:
+      # https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits
+      # There's a limit of 60 concurrent jobs across all repos in the rust-lang organization.
+      # In order to prevent overusing too much of that 60 limit, we throttle the
+      # number of rustfmt jobs that will run concurrently.
+      max-parallel: 4
+      fail-fast: false
+      matrix:
+        integration: [
+          bitflags,
+          error-chain,
+          log,
+          mdbook,
+          packed_simd,
+          rust-semverver,
+          tempdir,
+          futures-rs,
+          rust-clippy,
+          failure,
+        ]
+        include:
+          # Allowed Failures
+          # Actions doesn't yet support explicitly marking matrix legs as allowed failures
+          # https://github.community/t5/GitHub-Actions/continue-on-error-allow-failure-UI-indication/td-p/37033
+          # https://github.community/t5/GitHub-Actions/Why-a-matrix-step-will-be-canceled-if-another-one-failed/td-p/30920
+          # Instead, leverage `continue-on-error`
+          # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error
+          #
+          # Failing due to breaking changes in rustfmt 2.0 where empty
+          # match blocks have trailing commas removed
+          # https://github.com/rust-lang/rustfmt/pull/4226
+          - integration: chalk
+            allow-failure: true
+          - integration: crater
+            allow-failure: true
+          - integration: glob
+            allow-failure: true
+          - integration: stdsimd
+            allow-failure: true
+          # Using old rustfmt configuration option
+          - integration: rand
+            allow-failure: true
+          # Keep this as an allowed failure as it's fragile to breaking changes of rustc.
+          - integration: rust-clippy
+            allow-failure: true
+          # Using old rustfmt configuration option
+          - integration: packed_simd
+            allow-failure: true
+          # calebcartwright (2019-12-24)
+          # Keeping this as an allowed failure since it was flagged as such in the TravisCI config, even though
+          # it appears to have been passing for quite some time.
+          # Original comment was: temporal build failure due to breaking changes in the nightly compiler
+          - integration: rust-semverver
+            allow-failure: true
+          # Can be moved back to include section after https://github.com/rust-lang-nursery/failure/pull/298 is merged
+          - integration: failure
+            allow-failure: true
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+      # Run build
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly-x86_64-unknown-linux-gnu
+        target: x86_64-unknown-linux-gnu
+        override: true
+        profile: minimal
+        default: true
+    - name: run integration tests
+      env:
+        INTEGRATION: ${{ matrix.integration }}
+        TARGET: x86_64-unknown-linux-gnu
+      run: ./ci/integration.sh
+      continue-on-error: ${{ matrix.allow-failure == true }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,50 @@
+name: linux
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: (${{ matrix.target }}, ${{ matrix.channel }}, ${{ matrix.cfg-release-channel }})
+    strategy:
+      # https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits
+      # There's a limit of 60 concurrent jobs across all repos in the rust-lang organization.
+      # In order to prevent overusing too much of that 60 limit, we throttle the
+      # number of rustfmt jobs that will run concurrently.
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        target: [
+          x86_64-unknown-linux-gnu,
+        ]
+        channel: [ nightly ]
+        cfg-release-channel: [
+          beta,
+          nightly,
+        ]
+
+    env:
+      CFG_RELEASE_CHANNEL: ${{ matrix.cfg-release-channel }}
+      CFG_RELEASE: ${{ matrix.cfg-release-channel }}
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+      # Run build
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.channel }}-${{ matrix.target }}
+        target: ${{ matrix.target }}
+        override: true
+        profile: minimal
+        default: true
+
+    - name: build
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build
+
+    - name: test
+      run: cargo test

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,43 @@
+name: mac
+on: [push, pull_request]
+
+jobs:
+  test:
+    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
+    # macOS Catalina 10.15
+    runs-on: macos-latest
+    name: (${{ matrix.target }}, ${{ matrix.channel }})
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          x86_64-apple-darwin,
+        ]
+        channel: [ nightly ]
+
+    env:
+      CFG_RELEASE_CHANNEL: nightly
+      CFG_RELEASE: nightly
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+      # Run build
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.channel }}-${{ matrix.target }}
+        target: ${{ matrix.target }}
+        override: true
+        profile: minimal
+        default: true
+
+    - name: build
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build
+
+    - name: test
+      run: cargo test

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -1,0 +1,75 @@
+name: upload
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-release:
+    name: build-release
+    strategy:
+      matrix:
+        build: [linux, macos, windows-gnu, windows-msvc]
+        include:
+          - build: linux
+            os: ubuntu-latest
+            rust: nightly
+          - build: macos
+            os: macos-latest
+            rust: nightly
+          - build: windows-gnu
+            os: windows-latest
+            rust: nightly-x86_64-gnu
+          - build: windows-msvc
+            os: windows-latest
+            rust: nightly-x86_64-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Build release binaries
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: release
+
+      - name: Build archive
+        shell: bash
+        run: |
+          staging="rustfmt_${{ matrix.build }}_${{ github.event.release.tag_name }}"
+          mkdir -p "$staging"
+
+          cp {README.md,Configurations.md,CHANGELOG.md,LICENSE-MIT,LICENSE-APACHE} "$staging/"
+
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            cp "target/release/{rustfmt.exe,cargo-fmt.exe,rustfmt-format-diff.exe,git-rustfmt.exe}" "$staging/"
+            7z a "$staging.zip" "$staging"
+            echo "::set-env name=ASSET::$staging.zip"
+          else
+            cp "target/release/{rustfmt,cargo-fmt,rustfmt-format-diff,git-rustfmt} "$staging/"
+            tar czf "$staging.tar.gz" "$staging"
+            echo "::set-env name=ASSET::$staging.tar.gz"
+          fi
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.ASSET }}
+          asset_name: ${{ env.ASSET }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,98 @@
+name: windows
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    name: (${{ matrix.target }}, ${{ matrix.channel }})
+    strategy:
+      # https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits
+      # There's a limit of 60 concurrent jobs across all repos in the rust-lang organization.
+      # In order to prevent overusing too much of that 60 limit, we throttle the
+      # number of rustfmt jobs that will run concurrently.
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        target: [
+          i686-pc-windows-gnu,
+          i686-pc-windows-msvc,
+          x86_64-pc-windows-gnu,
+          x86_64-pc-windows-msvc,
+        ]
+        channel: [ nightly ]
+        include:
+          - channel: nightly
+            target: i686-pc-windows-gnu
+            mingw-7z-path: mingw
+
+    env:
+      CFG_RELEASE_CHANNEL: nightly
+      CFG_RELEASE: nightly
+
+    steps:
+    # The Windows runners have autocrlf enabled by default
+    # which causes failures for some of rustfmt's line-ending sensitive tests
+    - name: disable git eol translation
+      run: git config --global core.autocrlf false
+    - name: checkout
+      uses: actions/checkout@v2
+
+    # The Windows runners do not (yet) have a proper msys/mingw environment
+    # pre-configured like AppVeyor does, though they will likely be added in the future.
+    # https://github.com/actions/virtual-environments/issues/30
+    #
+    # In the interim, this ensures mingw32 is installed and available on the PATH
+    # for the i686-pc-windows-gnu target. This approach is used because it's common in
+    # other rust projects and there are issues/limitations with the msys2 chocolatey nuget
+    # package and numworks/setup-msys2 action.
+    # https://github.com/rust-lang/rust/blob/master/src/ci/scripts/install-mingw.sh#L59
+    # https://github.com/rust-lang/rustup/blob/master/appveyor.yml
+    #
+    # Use GitHub Actions cache support to avoid downloading the .7z file every time
+    # to be cognizant of the AWS egress cost impacts
+    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+    - name: cache mingw.7z
+      id: cache-mingw
+      with:
+        path: ${{ matrix.mingw-7z-path }}
+        key: ${{ matrix.channel }}-${{ matrix.target }}-mingw
+      uses: actions/cache@v1
+      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly'
+    - name: download mingw.7z
+      run: |
+        # Disable the download progress bar which can cause perf issues
+        $ProgressPreference = "SilentlyContinue"
+        md -Force ${{ matrix.mingw-7z-path }}
+        Invoke-WebRequest https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z -OutFile ${{ matrix.mingw-7z-path }}/mingw.7z
+      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly' && steps.cache-mingw.outputs.cache-hit != 'true'
+      shell: powershell
+    - name: install mingw32
+      run: |
+        7z x -y ${{ matrix.mingw-7z-path }}/mingw.7z -oC:\msys64 | Out-Null
+        echo ::add-path::C:\msys64\mingw32\bin
+      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly'
+      shell: powershell
+
+      # Run build
+    - name: setup
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.channel }}-${{ matrix.target }}
+        target: ${{ matrix.target }}
+        override: true
+        profile: minimal
+        default: true
+
+    - name: cargo-make
+      run: cargo install --force cargo-make
+
+    - name: build
+      run: |
+        rustc -Vv
+        cargo -V
+        cargo build
+      shell: cmd
+
+    - name: test
+      run: cargo test
+      shell: cmd

--- a/Configurations.md
+++ b/Configurations.md
@@ -1463,6 +1463,88 @@ fn main() {
 
 See also: [`match_block_trailing_comma`](#match_block_trailing_comma).
 
+## `match_arm_leading_pipes`
+
+Controls whether to include a leading pipe on match arms
+
+- **Default value**: `Never`
+- **Possible values**: `Always`, `Never`, `Preserve`
+- **Stable**: Yes
+
+#### `Never` (default):
+```rust
+// Leading pipes are removed from this:
+// fn foo() {
+//     match foo {
+//         | "foo" | "bar" => {}
+//         | "baz"
+//         | "something relatively long"
+//         | "something really really really realllllllllllllly long" => println!("x"),
+//         | "qux" => println!("y"),
+//         _ => {}
+//     }
+// }
+
+// Becomes
+fn foo() {
+    match foo {
+        "foo" | "bar" => {}
+        "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        "qux" => println!("y"),
+        _ => {}
+    }
+}
+```
+
+#### `Always`:
+```rust
+// Leading pipes are emitted on all arms of this:
+// fn foo() {
+//     match foo {
+//         "foo" | "bar" => {}
+//         "baz"
+//         | "something relatively long"
+//         | "something really really really realllllllllllllly long" => println!("x"),
+//         "qux" => println!("y"),
+//         _ => {}
+//     }
+// }
+
+// Becomes:
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        | _ => {}
+    }
+}
+```
+
+#### `Preserve`:
+```rust
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        _ => {}
+    }
+
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}
+```
+
 ## `match_block_trailing_comma`
 
 Put a trailing comma after a block based match arm (non-block arms are not affected)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -91,6 +91,8 @@ create_config! {
         "Align enum variants discrims, if their diffs fit within threshold";
     match_arm_blocks: bool, true, false, "Wrap the body of arms in blocks when it does not fit on \
         the same line with the pattern of arms";
+    match_arm_leading_pipes: MatchArmLeadingPipe, MatchArmLeadingPipe::Never, true,
+        "Determines whether leading pipes are emitted on match arms";
     force_multiline_blocks: bool, false, false,
         "Force multiline closure bodies and match arms to be wrapped in a block";
     fn_args_layout: Density, Density::Tall, true,
@@ -528,6 +530,7 @@ overflow_delimited_expr = false
 struct_field_align_threshold = 0
 enum_discrim_align_threshold = 0
 match_arm_blocks = true
+match_arm_leading_pipes = "Never"
 force_multiline_blocks = false
 fn_args_layout = "Tall"
 brace_style = "SameLineWhere"

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -392,3 +392,14 @@ impl Edition {
         }
     }
 }
+
+/// Controls how rustfmt should handle leading pipes on match arms.
+#[config_type]
+pub enum MatchArmLeadingPipe {
+    /// Place leading pipes on all match arms
+    Always,
+    /// Never emit leading pipes on match arms
+    Never,
+    /// Preserve any existing leading pipes
+    Preserve,
+}

--- a/tests/source/configs/match_arm_leading_pipes/always.rs
+++ b/tests/source/configs/match_arm_leading_pipes/always.rs
@@ -1,0 +1,27 @@
+// rustfmt-match_arm_leading_pipes: Always
+
+fn foo() {
+    match foo {
+        "foo"  |    "bar" => {}
+        "baz"
+        |  "something relatively long"
+        |     "something really really really realllllllllllllly long" => println!("x"),
+        "qux" => println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}

--- a/tests/source/configs/match_arm_leading_pipes/never.rs
+++ b/tests/source/configs/match_arm_leading_pipes/never.rs
@@ -1,0 +1,28 @@
+// rustfmt-match_arm_leading_pipes: Never
+
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        | "foo"
+        | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}

--- a/tests/source/configs/match_arm_leading_pipes/preserve.rs
+++ b/tests/source/configs/match_arm_leading_pipes/preserve.rs
@@ -1,0 +1,28 @@
+// rustfmt-match_arm_leading_pipes: Preserve
+
+fn foo() {
+    match foo {
+        | "foo"      | "bar" => {}
+        | "baz"
+        |                   "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" =>           println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        | "foo"
+        | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux"     => {    }
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}

--- a/tests/target/configs/match_arm_leading_pipes/always.rs
+++ b/tests/target/configs/match_arm_leading_pipes/always.rs
@@ -1,0 +1,27 @@
+// rustfmt-match_arm_leading_pipes: Always
+
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        | _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        | "foo" | "bar" => {}
+        | _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        | "qux" => {}
+        | "foo" | "bar" => {}
+        | _ => {}
+    }
+}

--- a/tests/target/configs/match_arm_leading_pipes/never.rs
+++ b/tests/target/configs/match_arm_leading_pipes/never.rs
@@ -1,0 +1,27 @@
+// rustfmt-match_arm_leading_pipes: Never
+
+fn foo() {
+    match foo {
+        "foo" | "bar" => {}
+        "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        "qux" => println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}

--- a/tests/target/configs/match_arm_leading_pipes/preserve.rs
+++ b/tests/target/configs/match_arm_leading_pipes/preserve.rs
@@ -1,0 +1,27 @@
+// rustfmt-match_arm_leading_pipes: Preserve
+
+fn foo() {
+    match foo {
+        | "foo" | "bar" => {}
+        | "baz"
+        | "something relatively long"
+        | "something really really really realllllllllllllly long" => println!("x"),
+        | "qux" => println!("y"),
+        _ => {}
+    }
+}
+
+fn issue_3973() {
+    match foo {
+        | "foo" | "bar" => {}
+        _ => {}
+    }
+}
+
+fn bar() {
+    match baz {
+        "qux" => {}
+        "foo" | "bar" => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
Backports the GitHub Actions Workflows as well as the `match_arm_leading_pipes` config option as requested