### PR TITLE
1.x: Preserve and format type aliases in extern blocks

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -3059,7 +3059,7 @@ impl Rewrite for ast::ForeignItem {
         // FIXME: this may be a faulty span from libsyntax.
         let span = mk_sp(self.span.lo(), self.span.hi() - BytePos(1));
 
-        let item_str: String = match self.kind {
+        let item_str = match self.kind {
             ast::ForeignItemKind::Fn(_, ref fn_sig, ref generics, _) => rewrite_fn_base(
                 context,
                 shape.indent,

--- a/src/items.rs
+++ b/src/items.rs
@@ -1862,6 +1862,9 @@ pub(crate) fn rewrite_type_alias(
         let lhs = format!("{}=", prefix);
         rewrite_assign_rhs(context, lhs, &**ty, shape).map(|s| s + ";")
     } else {
+        if !generics.where_clause.predicates.is_empty() {
+            prefix.push_str(&indent.to_string_with_newline(context.config));
+        }
         Some(format!("{};", prefix))
     }
 }

--- a/tests/target/issue-4159.rs
+++ b/tests/target/issue-4159.rs
@@ -1,0 +1,18 @@
+extern "C" {
+    type A: Ord;
+
+    type A<'a>
+    where
+        'a: 'static,;
+
+    type A<T: Ord>
+    where
+        T: 'static,;
+
+    type A = u8;
+
+    type A<'a: 'static, T: Ord + 'static>: Eq + PartialEq
+    where
+        T: 'static + Copy,
+    = Vec<u8>;
+}

--- a/tests/target/issue-4159.rs
+++ b/tests/target/issue-4159.rs
@@ -3,13 +3,11 @@ extern "C" {
 
     type A<'a>
     where
-        'a: 'static,
-    ;
+        'a: 'static;
 
     type A<T: Ord>
     where
-        T: 'static,
-    ;
+        T: 'static;
 
     type A = u8;
 

--- a/tests/target/issue-4159.rs
+++ b/tests/target/issue-4159.rs
@@ -3,11 +3,13 @@ extern "C" {
 
     type A<'a>
     where
-        'a: 'static,;
+        'a: 'static,
+    ;
 
     type A<T: Ord>
     where
-        T: 'static,;
+        T: 'static,
+    ;
 
     type A = u8;
 


### PR DESCRIPTION
This is a straightforward backport of #4164 to resolve rustfmt deleting important code when using the `cxx` crate; see https://github.com/dtolnay/cxx/issues/330#issuecomment-702233661.