### PR TITLE
BraceStyle AlwaysNewLine for extern blocks

### DIFF
--- a/tests/source/configs/brace_style/extern_always_next_line.rs
+++ b/tests/source/configs/brace_style/extern_always_next_line.rs
@@ -1,0 +1,37 @@
+// rustfmt-brace_style: AlwaysNextLine
+// AlwaysNextLine brace style for extern blocks
+
+fn main()
+{
+    extern "C"
+    {
+        fn i_am_good(x: i32);
+    }
+
+    extern "Rust"   {
+        fn foo(x: i32);
+    }
+
+    extern {
+        #[link_name = "actual_symbol_name"]
+        fn foobar();
+    }
+
+    extern "cdecl" {}
+
+    extern "stdcall" {  }
+
+    extern "win64" {
+        fn bar(x: i32);
+    }
+
+    extern "aapcs" {
+    }
+
+    extern "fastcall" 
+    {/* f*/}
+
+    unsafe extern "C++" { 
+        fn lorem();
+    }
+}

--- a/tests/target/configs/brace_style/extern_always_next_line.rs
+++ b/tests/target/configs/brace_style/extern_always_next_line.rs
@@ -1,0 +1,42 @@
+// rustfmt-brace_style: AlwaysNextLine
+// AlwaysNextLine brace style for extern blocks
+
+fn main()
+{
+    extern "C"
+    {
+        fn i_am_good(x: i32);
+    }
+
+    extern "Rust"
+    {
+        fn foo(x: i32);
+    }
+
+    extern "C"
+    {
+        #[link_name = "actual_symbol_name"]
+        fn foobar();
+    }
+
+    extern "cdecl" {}
+
+    extern "stdcall" {}
+
+    extern "win64"
+    {
+        fn bar(x: i32);
+    }
+
+    extern "aapcs" {}
+
+    extern "fastcall"
+    {
+        /* f*/
+    }
+
+    unsafe extern "C++"
+    {
+        fn lorem();
+    }
+}


### PR DESCRIPTION
* extern blocks can now get an opening brace on a new line

* add test case for extern blocks

I also made sure that there are no trailing spaces for the `extern "C"` line after formatted.

fixes issue #4428