### PR TITLE
[#4429] Fix Error Retrieving Old Config Options

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,10 +181,12 @@
                   this.handleReqFailure(e);
                   return;
                 }
-                const reMajorVersion = /v(\d+)/;
+
+                const excludedTagVersions = new Set(['v0.7', 'v0.8.1']);
+
                 const tagOptions = tags
                   .map(tag => tag.name)
-                  .filter(tag => tag.startsWith('v'));
+                  .filter(tag => tag.startsWith('v') && !excludedTagVersions.has(tag));
                 this.versionOptions = this.versionOptions.concat(tagOptions);
               },
               updated() {


### PR DESCRIPTION
Add code to the doc/index.html file to handle the specific cases for version 0.8.1 and 0.7
of rustfmt where they don't have a explicit configuration.md file. Updated to pull the data
that is within the "Configuring Rustfmt" section of the original README