### PR TITLE
Use a custom env var for log settings intead of default RUST_LOG

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -115,7 +115,7 @@ example, the `issue-1111.rs` test file is configured by the file
 ## Debugging
 
 Some `rewrite_*` methods use the `debug!` macro for printing useful information.
-These messages can be printed by using the environment variable `RUST_LOG=rustfmt=DEBUG`.
+These messages can be printed by using the environment variable `RUSTFMT_LOG=rustfmt=DEBUG`.
 These traces can be helpful in understanding which part of the code was used
 and get a better grasp on the execution flow.
 

--- a/src/format-diff/main.rs
+++ b/src/format-diff/main.rs
@@ -61,7 +61,7 @@ pub struct Opts {
 }
 
 fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env("RUSTFMT_LOG").init();
     let opts = Opts::from_args();
     if let Err(e) = run(opts) {
         println!("{}", e);

--- a/src/git-rustfmt/main.rs
+++ b/src/git-rustfmt/main.rs
@@ -133,7 +133,7 @@ struct Opt {
 }
 
 fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env("RUSTFMT_LOG").init();
 
     let opt: Opt = Opt::from_args();
 

--- a/src/rustfmt/main.rs
+++ b/src/rustfmt/main.rs
@@ -20,7 +20,7 @@ use rustfmt_nightly::{
 };
 
 fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env("RUSTFMT_LOG").init();
 
     let opt: Opt = Opt::from_args();
 


### PR DESCRIPTION
`cargo fmt` is very noisy when the env var `RUST_LOG` is set to `debug`. Developers set this variable for debugging their own code and almost never want to see debug output from rustfmt. Note that rustc and clippy do not output any debug logging, regardless of the `RUST_LOG` variable.

This change is to use a different variable, `RUSTFMT_LOG` instead, so that the rustfmt developers can still control  logging as before, but without user log settings affecting rustfmt.