### PR TITLE
Document RUSTFMT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ notes above on running rustfmt.
   | checkstyle |           emits in a checkstyle format            |     Yes      |
   |    json    |           emits diffs in a json format            |     Yes      |
 
+* You can specify the path to your own `rustfmt` by setting the `RUSTFMT`
+  environment variable.
+
 ## License
 
 Rustfmt is distributed under the terms of both the MIT license and the

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ The easiest way to run rustfmt against a project is with `cargo fmt`. `cargo fmt
 single-crate projects and [cargo workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html).
 Please see `cargo fmt --help` for usage information.
 
+You can specify the path to your own `rustfmt` binary for cargo to use by setting the`RUSTFMT` 
+environment variable.
+
 ### Running `rustfmt` directly
 
 To format individual files or arbitrary codes from stdin, the `rustfmt` binary should be used. Some
@@ -265,7 +268,6 @@ notes above on running rustfmt.
 
 * For things you do not want rustfmt to mangle, use `#[rustfmt::skip]`
 * To prevent rustfmt from formatting a macro or an attribute,
-  use `#[rustfmt::skip::macros(target_macro_name)]` or
   `#[rustfmt::skip::attributes(target_attribute_name)]`
 
   Example:
@@ -305,9 +307,6 @@ notes above on running rustfmt.
   |   stdout   |              writes output to stdout              |      No      |
   | checkstyle |           emits in a checkstyle format            |     Yes      |
   |    json    |           emits diffs in a json format            |     Yes      |
-
-* You can specify the path to your own `rustfmt` by setting the `RUSTFMT`
-  environment variable.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ notes above on running rustfmt.
 
 * For things you do not want rustfmt to mangle, use `#[rustfmt::skip]`
 * To prevent rustfmt from formatting a macro or an attribute,
+  use `#[rustfmt::skip::macros(target_macro_name)]` or
   `#[rustfmt::skip::attributes(target_attribute_name)]`
 
   Example:


### PR DESCRIPTION
This PR the `RUSTFMT` environment variable in the readme of this repo, added in #4419.

Closes #4426 once the PR to the [cargo book](https://github.com/rust-lang/cargo/pull/8767) gets accepted.