### PR TITLE
Add some basic tests for `try{}` expressions

### DIFF
--- a/tests/source/try_block.rs
+++ b/tests/source/try_block.rs
@@ -1,0 +1,30 @@
+// rustfmt-edition: 2018
+
+fn main() -> Result<(), !> {
+    let _x: Option<_> = try {
+        4
+    };
+
+    try {}
+}
+
+fn baz() -> Option<i32> {
+    if (1 == 1) {
+        return try {
+            5
+        };
+    }
+
+    // test
+    let x: Option<()> = try {
+        // try blocks are great
+    };
+
+    let y: Option<i32> = try {
+        6
+    }; // comment
+
+    let x: Option<i32> = try { baz()?; baz()?; baz()?; 7 };
+
+    return None;
+}

--- a/tests/target/try_block.rs
+++ b/tests/target/try_block.rs
@@ -1,0 +1,29 @@
+// rustfmt-edition: 2018
+
+fn main() -> Result<(), !> {
+    let _x: Option<_> = try { 4 };
+
+    try {}
+}
+
+fn baz() -> Option<i32> {
+    if (1 == 1) {
+        return try { 5 };
+    }
+
+    // test
+    let x: Option<()> = try {
+        // try blocks are great
+    };
+
+    let y: Option<i32> = try { 6 }; // comment
+
+    let x: Option<i32> = try {
+        baz()?;
+        baz()?;
+        baz()?;
+        7
+    };
+
+    return None;
+}


### PR DESCRIPTION
They failed to parse in rustfmt on me in https://github.com/rust-lang/rust/pull/77877, which looks like it's since been fixed, but I figured I'd send in some basic tests (mostly copied from `async{}`'s) anyway.