### PR TITLE
update parsing to better handle unclosed delimeters in input file

### DIFF
--- a/src/formatting/syntux/parser.rs
+++ b/src/formatting/syntux/parser.rs
@@ -23,7 +23,6 @@ pub(crate) struct Directory {
 /// A parser for Rust source code.
 pub(crate) struct Parser<'a> {
     parser: RawParser<'a>,
-    sess: &'a ParseSess,
 }
 
 /// A builder for the `Parser`.
@@ -74,7 +73,7 @@ impl<'a> ParserBuilder<'a> {
             }
         };
 
-        Ok(Parser { parser, sess })
+        Ok(Parser { parser })
     }
 
     fn parser(
@@ -160,6 +159,25 @@ impl<'a> Parser<'a> {
         directory_ownership: Option<DirectoryOwnership>,
         sess: &'a ParseSess,
     ) -> Result<ast::Crate, ParserError> {
+        let krate = Parser::parse_crate_inner(config, input, directory_ownership, sess)?;
+        if !sess.has_errors() {
+            return Ok(krate);
+        }
+
+        if sess.can_reset_errors() {
+            sess.reset_errors();
+            return Ok(krate);
+        }
+
+        Err(ParserError::ParseError)
+    }
+
+    fn parse_crate_inner(
+        config: &'a Config,
+        input: Input,
+        directory_ownership: Option<DirectoryOwnership>,
+        sess: &'a ParseSess,
+    ) -> Result<ast::Crate, ParserError> {
         let mut parser = ParserBuilder::default()
             .config(config)
             .input(input)
@@ -167,25 +185,14 @@ impl<'a> Parser<'a> {
             .sess(sess)
             .build()?;
 
-        parser.parse_crate_inner()
+        parser.parse_crate_mod()
     }
 
-    fn parse_crate_inner(&mut self) -> Result<ast::Crate, ParserError> {
+    fn parse_crate_mod(&mut self) -> Result<ast::Crate, ParserError> {
         let mut parser = AssertUnwindSafe(&mut self.parser);
 
         match catch_unwind(move || parser.parse_crate_mod()) {
-            Ok(Ok(krate)) => {
-                if !self.sess.has_errors() {
-                    return Ok(krate);
-                }
-
-                if self.sess.can_reset_errors() {
-                    self.sess.reset_errors();
-                    return Ok(krate);
-                }
-
-                Err(ParserError::ParseError)
-            }
+            Ok(Ok(k)) => Ok(k),
             Ok(Err(mut db)) => {
                 db.emit();
                 Err(ParserError::ParseError)

--- a/src/test/parser.rs
+++ b/src/test/parser.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+
+use super::{format_file, read_config};
+use crate::{
+    formatting::modules::{ModuleResolutionError, ModuleResolutionErrorKind},
+    OperationError,
+};
+
+#[test]
+fn parser_errors_in_submods_are_surfaced() {
+    // See also https://github.com/rust-lang/rustfmt/issues/4126
+    let filename = "tests/parser/issue-4126/lib.rs";
+    let file = PathBuf::from(filename);
+    let exp_mod_name = "invalid";
+    let (config, operation, _) = read_config(&file);
+    if let Err(OperationError::ModuleResolutionError { 0: inner }) =
+        format_file(&file, operation, config)
+    {
+        let ModuleResolutionError { module, kind } = inner;
+        assert_eq!(&module, exp_mod_name);
+        if let ModuleResolutionErrorKind::ParseError { file } = kind {
+            assert_eq!(file, PathBuf::from("tests/parser/issue-4126/invalid.rs"));
+        } else {
+            panic!("Expected parser error");
+        }
+    } else {
+        panic!("Expected ModuleResolution operation error");
+    }
+}
+
+fn assert_parser_error(filename: &str, exp_panic: bool) {
+    let file = PathBuf::from(filename);
+    let (config, operation, _) = read_config(&file);
+    if let Err(OperationError::ParseError { input, is_panic }) =
+        format_file(&file, operation, config)
+    {
+        assert_eq!(input.as_path().unwrap(), file);
+        assert_eq!(is_panic, exp_panic);
+    } else {
+        panic!("Expected ParseError operation error");
+    }
+}
+
+#[test]
+fn parser_creation_errors_on_entry_new_parser_from_file_panic() {
+    // See also https://github.com/rust-lang/rustfmt/issues/4418
+    let filename = "tests/parser/issue_4418.rs";
+    let should_panic = true;
+    assert_parser_error(filename, should_panic);
+}
+
+#[test]
+fn crate_parsing_errors_on_unclosed_delims() {
+    // See also https://github.com/rust-lang/rustfmt/issues/4466
+    let filename = "tests/parser/unclosed-delims/issue_4466.rs";
+    let should_panic = false;
+    assert_parser_error(filename, should_panic);
+}

--- a/tests/parser/unclosed-delims/issue_4466.rs
+++ b/tests/parser/unclosed-delims/issue_4466.rs
@@ -1,0 +1,11 @@
+fn main() {
+    if true {
+        println!("answer: {}", a_func();
+    } else {
+        println!("don't think so.");
+    }
+}
+
+fn a_func() -> i32 {
+    42
+}


### PR DESCRIPTION
Fixes #4466 

We have historically assumed that the initial crate parsing (rustc_parse's `parse_crate_mod`) was successful and that we have a formattable root AST node when all of the following conditions are true:

* the call did not panic
* the call returns successfully with a `Crate`
* the session does not contain any parsing errors

However, this is apparently not a completely safe assumption. This is because unclosed delim errors are buffered and not guaranteed to have been emitted until _after_ the parser has been dropped. In cases where the input file has unclosed delims, and no other parser errors (such as #4466 which could easily occur in editor-format-on-save scenarios) then the parse session was still empty of errors when we do our initial check on the result of `parse_crate_mod`. As such rustfmt was assuming the crate had been parsed without errors and the AST could be used for formatting, which was incorrect.

AFAICT there's nothing available outside of rustc_parse that grants us insight into the unclosed delims, so this PR refactors our parsing just a bit to ensure that the parser has indeed been dropped (and thus unclosed delim errors emitted) before we check for session errors.

I think it _may_ be worth pursuing some tweaks upstream in `rustc_parse`, for example ensuring (or at least conditionally supporting) the emission of delim errors as part `parse_crate_mod`, or adding a helper function on the parser `has_unclosed_delims()`, but I do think we should go ahead with a rustfmt fix anyway