### PR TITLE
prepare for v1.4.23 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e941a8fc3878a111d2bbfe78e39522d884136f0b412b12592195f26f653476"
+checksum = "d1c93a754d8026d90ac78a6cbbe9ea96bc914c3b7279e2c28b6e3a7f972f370a"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "smallvec 1.4.2",
@@ -945,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b58b6b035710df7f339a2bf86f6dafa876efd95439540970e24609e33598ca6"
+checksum = "680fc977e0138606169d9df563d80bf891dbaad5ea31f2dbc027b88d4379526d"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d379a900d6a1f098490d92ab83e87487dcee2e4ec3f04c3ac4512b5117b64e2"
+checksum = "568484d3a1f27629d248859083148794cf510a56703033d6bfc8a99dc25061d8"
 dependencies = [
  "itertools 0.9.0",
  "rustc-ap-rustc_ast",
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658d925c0da9e3c5cddc5e54f4fa8c03b41aff1fc6dc5e41837c1118ad010ac0"
+checksum = "2e9bca9174b96ca0d43da37e99554cc92a23891c67d61aea28941f271802d952"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f387037534f34c148aed753622677500e42d190a095670e7ac3fffc09811a59"
+checksum = "7a55e4a48ddb8681350bacfc2a0528aab92cb949d1319a37516f3a4a0887065f"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -1012,10 +1012,11 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ffd17a37e00d77926a0713f191c59ff3aeb2b551a024c7cfffce14bab79be8"
+checksum = "3d9ab43857012b05d21469faacbf264a260cb195234685217235ac9fc0aef4b9"
 dependencies = [
+ "arrayvec 0.5.1",
  "bitflags",
  "cfg-if",
  "crossbeam-utils 0.7.0",
@@ -1042,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3263ddcfa9eb911e54a4e8088878dd9fd10e00d8b99b01033ba4a2733fe91d"
+checksum = "fae07ec2982336cbb24ffa9372bcb99e53bc11349ea4c18e277e26c6e335b004"
 dependencies = [
  "annotate-snippets 0.8.0",
  "atty",
@@ -1061,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ab7e68cede8a2273fd8b8623002ce9dc832e061dfc3330e9bcc1fc2a722d73"
+checksum = "467da6ff9ae25cc5d42c550d05139b66a9d233ded99ba075d603d2d81b6833e9"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_passes",
@@ -1084,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea2dc95421bc19bbd4d939399833a882c46b684283b4267ad1fcf982fc043d9"
+checksum = "1c8d97da0b8c738e5d81fd87ec09c24fd7629a7d09c2fbaaa5cc65ee88cc02df"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_span",
@@ -1094,21 +1095,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e44c1804f09635f83f6cf1e04c2e92f8aeb7b4e850ac6c53d373dab02c13053"
+checksum = "f48e05e2d6f70ca7b3060cae874d7bff3bfb746459b30167a72851eb3315acb0"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc491f2b9be6e928f6df6b287549b8d50c48e8eff8638345155f40fa2cfb785d"
+checksum = "aba5fc553fb1aa193946f1d549535dd3260a2a27d2a3e1bb87927f8a5721e3d4"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa73f3fed413cdb6290738a10267da17b9ae8e02087334778b9a8c9491c5efc0"
+checksum = "d1f0eae2b583705f5e8fac5cefb5b44eb6c60804371d351652584d945752f69b"
 dependencies = [
  "arrayvec 0.5.1",
  "rustc-ap-rustc_macros",
@@ -1117,18 +1118,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e993881244a92f3b44cf43c8f22ae2ca5cefe4f55a34e2b65b72ee66fe5ad077"
+checksum = "c0c9a47e24d4b7d74ec583d8813803b36985ee082fe7debe55f257df92d5fe50"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4effe366556e1d75344764adf4d54cba7c2fad33dbd07588e96d0853831ddc7c"
+checksum = "33c94c1dbab188f380c4b1291616231d39ebb89d0d51d29c93be72825aeff0ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1138,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0342675835251571471d3dca9ea1576a853a8dfa1f4b0084db283c861223cb60"
+checksum = "e923400798f2213b6be951ba0c9905eb66ad58fe665fc843513496cd567142d9"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_ast",
@@ -1158,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438255ed968d73bf6573aa18d3b8d33c0a85ecdfd14160ef09ff813938e0606c"
+checksum = "fc0c8a49f60cc2805f07213c7442a8be42225c2a7cfaf40bda751433fa51c52f"
 dependencies = [
  "indexmap",
  "smallvec 1.4.2",
@@ -1168,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d61ff76dede8eb827f6805754900d1097a7046f938f950231b62b448f55bf78"
+checksum = "b87138ef05f3069fdce0e759809cc8e9c9db6c183f15523b9ec0b843b48cdaed"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1189,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c267f15c3cfc82a8a441d2bf86bcccf299d1eb625822468e3d8ee6f7c5a1c89"
+checksum = "3b8eb89541600fb44f79db273167a59eade2e4faebe828bbba7e1906784a943e"
 dependencies = [
  "cfg-if",
  "md-5",
@@ -1208,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "679.0.0"
+version = "683.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1b4b266c4d44aac0f7f83b6741d8f0545b03d1ce32f3b5254f2014225cb96c"
+checksum = "a1ef97b8a6a40d5324975ce48de1fe86e60d67b42950b33cd4e33624ccaee7e8"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -1427,9 +1428,9 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "stacker"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92bc346006ae78c539d6ab2cf1a1532bc657b8339c464877a990ec82073c66f"
+checksum = "21ccb4c06ec57bc82d0f610f1a2963d7648700e43a6f513e564b9c89f7991786"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,19 +935,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_arena"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c93a754d8026d90ac78a6cbbe9ea96bc914c3b7279e2c28b6e3a7f972f370a"
+checksum = "d77be159a7d411e02ddf51a97cc2f98e88b93bf2856ac203dea737b8041ed23c"
 dependencies = [
- "rustc-ap-rustc_data_structures",
  "smallvec 1.4.2",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_ast"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680fc977e0138606169d9df563d80bf891dbaad5ea31f2dbc027b88d4379526d"
+checksum = "584ac06879fc46441feb444b6b6f55bf71489e3dc10a6a94222513f118468526"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",
@@ -962,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_passes"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568484d3a1f27629d248859083148794cf510a56703033d6bfc8a99dc25061d8"
+checksum = "155c1e648133f0df2848d899564aade8bd58ce2c82b03727e8437ec2523f420b"
 dependencies = [
  "itertools 0.9.0",
  "rustc-ap-rustc_ast",
@@ -981,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_ast_pretty"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9bca9174b96ca0d43da37e99554cc92a23891c67d61aea28941f271802d952"
+checksum = "f3786235c5f1466ffd0f00cb1851e7cd8637f07d12efdeb206de3aa8cc285cf7"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_span",
@@ -993,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_attr"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a55e4a48ddb8681350bacfc2a0528aab92cb949d1319a37516f3a4a0887065f"
+checksum = "6e02580ccbaf8d417c59d97a946b446b2a5332d68a0cf1eab74bb5dd33100e99"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_pretty",
@@ -1012,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9ab43857012b05d21469faacbf264a260cb195234685217235ac9fc0aef4b9"
+checksum = "be2a1c1a22021daef8354fb7504da4ed6df6e0aaf345af32c51e4ccf8afc07c0"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -1043,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae07ec2982336cbb24ffa9372bcb99e53bc11349ea4c18e277e26c6e335b004"
+checksum = "f81730d3ab322d96265163f9ab2ced6815d336a0441a85641d134c30d69d6660"
 dependencies = [
  "annotate-snippets 0.8.0",
  "atty",
@@ -1062,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_expand"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467da6ff9ae25cc5d42c550d05139b66a9d233ded99ba075d603d2d81b6833e9"
+checksum = "325f40a43586a4fbd1d3837c3bb024db3729193146201d13f59b637d28e73ffe"
 dependencies = [
  "rustc-ap-rustc_ast",
  "rustc-ap-rustc_ast_passes",
@@ -1085,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_feature"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8d97da0b8c738e5d81fd87ec09c24fd7629a7d09c2fbaaa5cc65ee88cc02df"
+checksum = "e53e214c56bd3db863bf87e23a68cc9c7b2ccf1796dc63b5c795f75e1457654b"
 dependencies = [
  "rustc-ap-rustc_data_structures",
  "rustc-ap-rustc_span",
@@ -1095,21 +1094,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_fs_util"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48e05e2d6f70ca7b3060cae874d7bff3bfb746459b30167a72851eb3315acb0"
+checksum = "9783efc336cdb51ca8ed281040bf72bcb178a2a29867aade35893e4335f7ac01"
 
 [[package]]
 name = "rustc-ap-rustc_graphviz"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba5fc553fb1aa193946f1d549535dd3260a2a27d2a3e1bb87927f8a5721e3d4"
+checksum = "bb71e52620bcba8695271b90cb1d294ed16f1dcc81e85327e6dc67e6b5c3ef1d"
 
 [[package]]
 name = "rustc-ap-rustc_index"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f0eae2b583705f5e8fac5cefb5b44eb6c60804371d351652584d945752f69b"
+checksum = "c1e73d13c4839873924d0c04fb885a4e3980b5c8416f8a96f925a8e5a4eb9c8e"
 dependencies = [
  "arrayvec 0.5.1",
  "rustc-ap-rustc_macros",
@@ -1118,18 +1117,18 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_lexer"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c9a47e24d4b7d74ec583d8813803b36985ee082fe7debe55f257df92d5fe50"
+checksum = "de5fb086575a381760a993126795222a49f3bab9faeb91dc67268dd19eab5c13"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_macros"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c94c1dbab188f380c4b1291616231d39ebb89d0d51d29c93be72825aeff0ff"
+checksum = "1cb3c133f618b5296c2ba57f05ee7b4c3fbec09d2779922083c2d16c5674f57c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1139,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_parse"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e923400798f2213b6be951ba0c9905eb66ad58fe665fc843513496cd567142d9"
+checksum = "9cc8e42993c1ff89f56e2e00240a186c6eaaad6839a271ee3d534240a624ea5a"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_ast",
@@ -1159,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_serialize"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0c8a49f60cc2805f07213c7442a8be42225c2a7cfaf40bda751433fa51c52f"
+checksum = "1bb88c78d4551e0243518d05ea3ab16388af97ec839e60de71c39147154a0303"
 dependencies = [
  "indexmap",
  "smallvec 1.4.2",
@@ -1169,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_session"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87138ef05f3069fdce0e759809cc8e9c9db6c183f15523b9ec0b843b48cdaed"
+checksum = "f1362a5e57049bc7d722b06f5a8886fbf169e3a892ac793aedd8529ef60a8750"
 dependencies = [
  "bitflags",
  "getopts",
@@ -1190,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_span"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8eb89541600fb44f79db273167a59eade2e4faebe828bbba7e1906784a943e"
+checksum = "b67a086e3f81d54cb9d83974b11961ca8c4111a0955173124314e1ae99a1c2ad"
 dependencies = [
  "cfg-if",
  "md-5",
@@ -1209,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_target"
-version = "683.0.0"
+version = "684.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ef97b8a6a40d5324975ce48de1fe86e60d67b42950b33cd4e33624ccaee7e8"
+checksum = "574c6a3e4495dfc522918103bd2cc77148a4716a58583ebed1a764963769151f"
 dependencies = [
  "bitflags",
  "rustc-ap-rustc_data_structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,36 +66,36 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "679.0.0"
+version = "683.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "679.0.0"
+version = "683.0.0"
 
 [dependencies.rustc_attr]
 package = "rustc-ap-rustc_attr"
-version = "679.0.0"
+version = "683.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "679.0.0"
+version = "683.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "679.0.0"
+version = "683.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "679.0.0"
+version = "683.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "679.0.0"
+version = "683.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "679.0.0"
+version = "683.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "679.0.0"
+version = "683.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,36 +66,36 @@ rustc-workspace-hack = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "683.0.0"
+version = "684.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "683.0.0"
+version = "684.0.0"
 
 [dependencies.rustc_attr]
 package = "rustc-ap-rustc_attr"
-version = "683.0.0"
+version = "684.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "683.0.0"
+version = "684.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "683.0.0"
+version = "684.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "683.0.0"
+version = "684.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "683.0.0"
+version = "684.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "683.0.0"
+version = "684.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "683.0.0"
+version = "684.0.0"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -124,6 +124,9 @@ pub(crate) fn format_expr(
         | ast::ExprKind::Loop(..)
         | ast::ExprKind::While(..) => to_control_flow(expr, expr_type)
             .and_then(|control_flow| control_flow.rewrite(context, shape)),
+        ast::ExprKind::ConstBlock(ref anon_const) => {
+            Some(format!("const {}", anon_const.rewrite(context, shape)?))
+        }
         ast::ExprKind::Block(ref block, opt_label) => {
             match expr_type {
                 ExprType::Statement => {

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -353,6 +353,7 @@ impl<'a> FmtVisitor<'a> {
 
         let remaining = snippet[status.line_start..subslice.len() + offset].trim();
         if !remaining.is_empty() {
+            self.push_str(&self.block_indent.to_string(self.config));
             self.push_str(remaining);
             status.line_start = subslice.len() + offset;
         }

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -52,6 +52,10 @@ impl<'a> Stmt<'a> {
         result
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(self.inner.kind, ast::StmtKind::Empty)
+    }
+
     fn is_last_expr(&self) -> bool {
         if !self.is_last {
             return false;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -461,6 +461,7 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::While(..)
         | ast::ExprKind::If(..)
         | ast::ExprKind::Block(..)
+        | ast::ExprKind::ConstBlock(..)
         | ast::ExprKind::Async(..)
         | ast::ExprKind::Loop(..)
         | ast::ExprKind::ForLoop(..)

--- a/tests/source/issue-4018.rs
+++ b/tests/source/issue-4018.rs
@@ -1,0 +1,13 @@
+fn main() {
+    ;
+           /* extra comment */            ;
+}
+
+fn main() {
+    println!("");
+    // comment 1
+    // comment 2
+    // comment 3
+    // comment 4
+    ;
+}

--- a/tests/source/issue-4398.rs
+++ b/tests/source/issue-4398.rs
@@ -1,0 +1,19 @@
+impl Struct {
+    /// Documentation for `foo`
+    #[rustfmt::skip] // comment on why use a skip here
+    pub fn foo(&self) {}
+}
+
+impl Struct {
+    /// Documentation for `foo`
+       #[rustfmt::skip] // comment on why use a skip here
+    pub fn foo(&self) {}
+}
+
+/// Documentation for `Struct`
+#[rustfmt::skip] // comment
+impl Struct {
+    /// Documentation for `foo`
+       #[rustfmt::skip] // comment on why use a skip here
+    pub fn foo(&self) {}
+}

--- a/tests/target/issue-4018.rs
+++ b/tests/target/issue-4018.rs
@@ -1,0 +1,11 @@
+fn main() {
+    /* extra comment */
+}
+
+fn main() {
+    println!("");
+    // comment 1
+    // comment 2
+    // comment 3
+    // comment 4
+}

--- a/tests/target/issue-4398.rs
+++ b/tests/target/issue-4398.rs
@@ -1,0 +1,19 @@
+impl Struct {
+    /// Documentation for `foo`
+    #[rustfmt::skip] // comment on why use a skip here
+    pub fn foo(&self) {}
+}
+
+impl Struct {
+    /// Documentation for `foo`
+    #[rustfmt::skip] // comment on why use a skip here
+    pub fn foo(&self) {}
+}
+
+/// Documentation for `Struct`
+#[rustfmt::skip] // comment
+impl Struct {
+    /// Documentation for `foo`
+       #[rustfmt::skip] // comment on why use a skip here
+    pub fn foo(&self) {}
+}


### PR DESCRIPTION
Mostly just pulls in the commits to bump the rustc-ap crates to v684 (which contains some crucial upstream parser/span fixes) and also backporting a few bug fixes