### PR TITLE
Don't flatten a block containing a single macro call

### DIFF
--- a/src/formatting/matches.rs
+++ b/src/formatting/matches.rs
@@ -295,6 +295,15 @@ fn rewrite_match_arm(
     )
 }
 
+fn stmt_is_expr_mac(stmt: &ast::Stmt) -> bool {
+    if let ast::StmtKind::Expr(expr) = &stmt.kind {
+        if let ast::ExprKind::MacCall(_) = &expr.kind {
+            return true;
+        }
+    }
+    false
+}
+
 fn block_can_be_flattened<'a>(
     context: &RewriteContext<'_>,
     expr: &'a ast::Expr,
@@ -303,7 +312,10 @@ fn block_can_be_flattened<'a>(
         ast::ExprKind::Block(ref block, _)
             if !is_unsafe_block(block)
                 && !context.inside_macro()
-                && is_simple_block(context, block, Some(&expr.attrs)) =>
+                && is_simple_block(context, block, Some(&expr.attrs))
+                // Don't flatten a block containing a macro invocation,
+                // since it may expand to a statement
+                && !stmt_is_expr_mac(&block.stmts[0]) =>
         {
             Some(&*block)
         }

--- a/tests/target/configs/match_arm_blocks/false.rs
+++ b/tests/target/configs/match_arm_blocks/false.rs
@@ -5,6 +5,8 @@ fn main() {
     match lorem {
         true =>
             foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(x),
-        false => println!("{}", sit),
+        false => {
+            println!("{}", sit)
+        }
     }
 }

--- a/tests/target/configs/match_arm_blocks/true.rs
+++ b/tests/target/configs/match_arm_blocks/true.rs
@@ -6,6 +6,8 @@ fn main() {
         true => {
             foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(x)
         }
-        false => println!("{}", sit),
+        false => {
+            println!("{}", sit)
+        }
     }
 }

--- a/tests/target/issue-2936.rs
+++ b/tests/target/issue-2936.rs
@@ -11,7 +11,9 @@ impl Something for AStruct {
                 let err: &CStr = match err.kind {
                     ParseErrorKind::Custom(StyleParseErrorKind::MediaQueryExpectedFeatureName(
                         ..,
-                    )) => cstr!("PEMQExpectedFeatureName"),
+                    )) => {
+                        cstr!("PEMQExpectedFeatureName")
+                    }
                 };
             }
         };

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -166,9 +166,15 @@ fn issue355() {
         a => println!("a", b),
         b => vec![1, 2],
         c => vec![3; 4],
-        d => println!("a", b),
-        e => vec![1, 2],
-        f => vec![3; 4],
+        d => {
+            println!("a", b)
+        }
+        e => {
+            vec![1, 2]
+        }
+        f => {
+            vec![3; 4]
+        }
         h => println!("a", b), // h comment
         i => vec![1, 2],       // i comment
         j => vec![3; 4],       // j comment


### PR DESCRIPTION
We no longer flatten a block that looks like this:

```rust
match val {
    pat => { macro_call!() }
}
```

Currently, rust ignores trailing semicolons in macro expansion in
expression position (see https://github.com/rust-lang/rust/issues/33953)

If this is changed, flattening a block with a macro call may break the
user's code - the trailing semicolon will no longer parse if the macro
call occurs immediately on the right-hand side of the match arm
(e.g. `pat => macro_call!()`)