### PR TITLE
Circumvent rust build regression

### DIFF
--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -121,7 +121,7 @@ macro_rules! create_config {
                         | "array_width"
                         | "chain_width" => self.0.set_heuristics(),
                         "license_template_path" => self.0.set_license_template(),
-                        &_ => (),
+                        _ => (),
                     }
                 }
             }
@@ -272,7 +272,7 @@ macro_rules! create_config {
                     | "array_width"
                     | "chain_width" => self.set_heuristics(),
                     "license_template_path" => self.set_license_template(),
-                    &_ => (),
+                    _ => (),
                 }
             }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/78549 is currently blocking build with latest nightly. Even though that issue is getting fixed, this PR circumvents it and makes builds work again.

This fixes https://github.com/rust-lang/rust/issues/78341 and should allow https://github.com/rust-lang/rustfmt/pull/4503 and others to proceed.