### PR TITLE
Don't insert semicolons inside of a `macro_rules!` arm body

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -62,13 +62,14 @@ pub(crate) fn format_input_inner(
     input: Input,
     config: &Config,
     operation_setting: OperationSetting,
+    is_macro_def: bool,
 ) -> Result<FormatReport, OperationError> {
     if !config.version_meets_requirement() {
         return Err(OperationError::VersionMismatch);
     }
 
     rustc_span::with_session_globals(config.edition().into(), || {
-        format_project(input, config, operation_setting)
+        format_project(input, config, operation_setting, is_macro_def)
     })
 }
 
@@ -76,6 +77,7 @@ fn format_project(
     input: Input,
     config: &Config,
     operation_setting: OperationSetting,
+    is_macro_def: bool,
 ) -> Result<FormatReport, OperationError> {
     let mut timer = Timer::start();
 
@@ -149,7 +151,7 @@ fn format_project(
             &format_report,
             &files,
             original_snippet.clone(),
-            operation_setting.is_macro_def,
+            is_macro_def,
         )?;
     }
     timer = timer.done_formatting();

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -149,6 +149,7 @@ fn format_project(
             &format_report,
             &files,
             original_snippet.clone(),
+            operation_setting.is_macro_def,
         )?;
     }
     timer = timer.done_formatting();
@@ -173,6 +174,7 @@ fn format_file(
     report: &FormatReport,
     file_mod_map: &FileModMap<'_>,
     original_snippet: Option<String>,
+    is_macro_def: bool,
 ) -> Result<(), OperationError> {
     let snippet_provider = parse_session.snippet_provider(module.as_ref().inner);
     let mut visitor = FmtVisitor::from_parse_sess(
@@ -182,6 +184,7 @@ fn format_file(
         file_mod_map,
         report.clone(),
     );
+    visitor.is_macro_def = is_macro_def;
     visitor.skip_context.update_with_attrs(&krate.attrs);
     visitor.last_pos = snippet_provider.start_pos();
     visitor.skip_empty_lines(snippet_provider.end_pos());

--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -684,7 +684,9 @@ impl<'a> CommentRewrite<'a> {
                         let mut config = self.fmt.config.clone();
                         config.set().wrap_comments(false);
                         if config.format_code_in_doc_comments() {
-                            if let Some(s) = format_code_block(&self.code_block_buffer, &config) {
+                            if let Some(s) =
+                                format_code_block(&self.code_block_buffer, &config, false)
+                            {
                                 trim_custom_comment_prefix(s.as_ref())
                             } else {
                                 trim_custom_comment_prefix(&self.code_block_buffer)

--- a/src/formatting/macros.rs
+++ b/src/formatting/macros.rs
@@ -1379,12 +1379,12 @@ impl MacroBranch {
         config.set().max_width(new_width);
 
         // First try to format as items, then as statements.
-        let new_body_snippet = match format_snippet(&body_str, &config) {
+        let new_body_snippet = match format_snippet(&body_str, &config, true) {
             Some(new_body) => new_body,
             None => {
                 let new_width = new_width + config.tab_spaces();
                 config.set().max_width(new_width);
-                match format_code_block(&body_str, &config) {
+                match format_code_block(&body_str, &config, true) {
                     Some(new_body) => new_body,
                     None => return None,
                 }

--- a/src/formatting/rewrite.rs
+++ b/src/formatting/rewrite.rs
@@ -33,6 +33,7 @@ pub(crate) struct RewriteContext<'a> {
     pub(crate) file_mod_map: &'a FileModMap<'a>,
     pub(crate) config: &'a Config,
     pub(crate) inside_macro: Rc<Cell<bool>>,
+    pub(crate) is_macro_def: bool,
     // Force block indent style even if we are using visual indent style.
     pub(crate) use_block: Cell<bool>,
     // When `is_if_else_block` is true, unindent the comment on top

--- a/src/formatting/utils.rs
+++ b/src/formatting/utils.rs
@@ -717,14 +717,14 @@ pub(crate) fn format_snippet(
 
         let result = {
             let input = Input::Text(snippet.into());
-            crate::format(
+            crate::format_input_inner(
                 input,
                 &config,
                 OperationSetting {
                     verbosity: Verbosity::Quiet,
-                    is_macro_def,
                     ..OperationSetting::default()
                 },
+                is_macro_def,
             )
         };
         match result {

--- a/src/formatting/visitor.rs
+++ b/src/formatting/visitor.rs
@@ -90,6 +90,8 @@ pub(crate) struct FmtVisitor<'a> {
     pub(crate) skip_context: SkipContext,
     /// If set to `true`, normalize number of vertical spaces on formatting missing snippets.
     pub(crate) normalize_vertical_spaces: bool,
+    /// If set to `true`, we are formatting a macro definition
+    pub(crate) is_macro_def: bool,
 }
 
 impl<'a> Drop for FmtVisitor<'a> {
@@ -888,6 +890,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             report,
             skip_context: Default::default(),
             normalize_vertical_spaces: false,
+            is_macro_def: false,
         }
     }
 
@@ -1091,6 +1094,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             report: self.report.clone(),
             skip_context: self.skip_context.clone(),
             skipped_range: self.skipped_range.clone(),
+            is_macro_def: self.is_macro_def,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ mod test;
 pub struct OperationSetting {
     /// If set to `true`, format sub-modules which are defined in the given input.
     pub recursive: bool,
+    /// If set to `true`, we are formatting a macro definition
+    pub is_macro_def: bool,
     pub verbosity: Verbosity,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use crate::emitter::rustfmt_diff::{ModifiedChunk, ModifiedLines};
 pub use crate::format_report_formatter::{FormatReportFormatter, FormatReportFormatterBuilder};
 pub use crate::formatting::report::{FormatReport, FormatResult};
 
-use crate::formatting::format_input_inner;
+pub(crate) use crate::formatting::format_input_inner;
 use crate::{emitter::Verbosity, result::OperationError};
 
 #[cfg(feature = "config")]
@@ -39,8 +39,6 @@ mod test;
 pub struct OperationSetting {
     /// If set to `true`, format sub-modules which are defined in the given input.
     pub recursive: bool,
-    /// If set to `true`, we are formatting a macro definition
-    pub is_macro_def: bool,
     pub verbosity: Verbosity,
 }
 
@@ -51,7 +49,12 @@ pub fn format(
     config: &Config,
     operation_setting: OperationSetting,
 ) -> Result<FormatReport, OperationError> {
-    format_input_inner(input, config, operation_setting)
+    format_input_inner(
+        input,
+        config,
+        operation_setting,
+        /* is_macro_def */ false,
+    )
 }
 
 pub fn format_inputs<'a>(

--- a/src/rustfmt/main.rs
+++ b/src/rustfmt/main.rs
@@ -438,7 +438,6 @@ fn format_string(input: String, opt: Opt) -> Result<i32> {
     let setting = OperationSetting {
         recursive: opt.recursive,
         verbosity: Verbosity::Quiet,
-        is_macro_def: false,
     };
     let report = rustfmt_nightly::format(Input::Text(input), &config, setting)?;
 
@@ -539,7 +538,6 @@ fn format(opt: Opt) -> Result<i32> {
     let setting = OperationSetting {
         recursive: opt.recursive,
         verbosity: opt.verbosity(),
-        is_macro_def: false,
     };
 
     let inputs = FileConfigPairIter::new(&opt, config_paths.is_some()).collect::<Vec<_>>();

--- a/src/rustfmt/main.rs
+++ b/src/rustfmt/main.rs
@@ -438,6 +438,7 @@ fn format_string(input: String, opt: Opt) -> Result<i32> {
     let setting = OperationSetting {
         recursive: opt.recursive,
         verbosity: Verbosity::Quiet,
+        is_macro_def: false,
     };
     let report = rustfmt_nightly::format(Input::Text(input), &config, setting)?;
 
@@ -538,6 +539,7 @@ fn format(opt: Opt) -> Result<i32> {
     let setting = OperationSetting {
         recursive: opt.recursive,
         verbosity: opt.verbosity(),
+        is_macro_def: false,
     };
 
     let inputs = FileConfigPairIter::new(&opt, config_paths.is_some()).collect::<Vec<_>>();

--- a/tests/target/macro_rules_semi.rs
+++ b/tests/target/macro_rules_semi.rs
@@ -1,0 +1,22 @@
+macro_rules! expr {
+    (no_semi) => {
+        return true
+    };
+    (semi) => {
+        return true;
+    };
+}
+
+fn foo() -> bool {
+    match true {
+        true => expr!(no_semi),
+        false if false => {
+            expr!(semi)
+        }
+        false => {
+            expr!(semi);
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Currently, rustfmt inserts semicolons for certain trailing expressions
(`return`, `continue`, and `break`). However, this should not be done in
the body of a `macro_rules!` arm, since the macro might be used in
expression position (where a trailing semicolon will be invalid).

Currently, this rewriting has no effect due to https://github.com/rust-lang/rust/issues/33953
If this issue is fixed, then this rewriting will prevent some macros
from being used in expression position.

This commit prevents rustfmt from inserting semicolons for trailing
expressions in `macro_rules!` arms. The user is free to either include
or omit the semicolon - rustfmt will not modify either case.