### PR TITLE
prepare v1.4.24 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## [Unreleased]
 
-## [1.4.22] 2020-10-30
+## [1.4.24] 2020-11-05
+
+### Changed
+
+- Block wrapped match arm bodies containing a single macro call expression are no longer flattened ([#4496](https://github.com/rust-lang/rustfmt/pull/4496)). This allows programmer discretion so that the block wrapping can be preserved in cases where needed to prevent issues in expansion, such as with trailing semicolons, and aligns with updated [Style Guide guidance](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/expressions.md#macro-call-expressions) for such scenarios.
+
+### Fixed
+- Remove useless `deprecated` attribute on a trait impl block in the rustfmt lib, as these now trigger errors ([rust-lang/rust/#78626](https://github.com/rust-lang/rust/pull/78626))
+
+## [1.4.23] 2020-10-30
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.23"
+version = "1.4.24"
 dependencies = [
  "annotate-snippets 0.6.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustfmt-nightly"
-version = "1.4.23"
+version = "1.4.24"
 authors = ["Nicholas Cameron <ncameron@mozilla.com>", "The Rustfmt developers"]
 description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang/rustfmt"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,9 @@ impl FormatReport {
     }
 }
 
-#[deprecated(note = "Use FormatReportFormatter instead")]
+/// Deprecated - Use FormatReportFormatter instead
+// https://github.com/rust-lang/rust/issues/78625
+// https://github.com/rust-lang/rust/issues/39935
 impl fmt::Display for FormatReport {
     // Prints all the formatting errors.
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -302,8 +302,6 @@ fn block_can_be_flattened<'a>(
             if !is_unsafe_block(block)
                 && !context.inside_macro()
                 && is_simple_block(context, block, Some(&expr.attrs))
-                // Don't flatten a block containing a macro invocation,
-                // since it may expand to a statement
                 && !stmt_is_expr_mac(&block.stmts[0]) =>
         {
             Some(&*block)

--- a/tests/target/configs/match_arm_blocks/false.rs
+++ b/tests/target/configs/match_arm_blocks/false.rs
@@ -5,6 +5,8 @@ fn main() {
     match lorem {
         true =>
             foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(x),
-        false => println!("{}", sit),
+        false => {
+            println!("{}", sit)
+        }
     }
 }

--- a/tests/target/configs/match_arm_blocks/true.rs
+++ b/tests/target/configs/match_arm_blocks/true.rs
@@ -6,6 +6,8 @@ fn main() {
         true => {
             foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(x)
         }
-        false => println!("{}", sit),
+        false => {
+            println!("{}", sit)
+        }
     }
 }

--- a/tests/target/issue-2936.rs
+++ b/tests/target/issue-2936.rs
@@ -11,7 +11,9 @@ impl Something for AStruct {
                 let err: &CStr = match err.kind {
                     ParseErrorKind::Custom(StyleParseErrorKind::MediaQueryExpectedFeatureName(
                         ..,
-                    )) => cstr!("PEMQExpectedFeatureName"),
+                    )) => {
+                        cstr!("PEMQExpectedFeatureName")
+                    }
                 };
             }
         };

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -166,9 +166,15 @@ fn issue355() {
         a => println!("a", b),
         b => vec![1, 2],
         c => vec![3; 4],
-        d => println!("a", b),
-        e => vec![1, 2],
-        f => vec![3; 4],
+        d => {
+            println!("a", b)
+        }
+        e => {
+            vec![1, 2]
+        }
+        f => {
+            vec![3; 4]
+        }
         h => println!("a", b), // h comment
         i => vec![1, 2],       // i comment
         j => vec![3; 4],       // j comment


### PR DESCRIPTION
Refs https://github.com/rust-lang/rust/issues/78341, needed due to subsequent breaking changes being merged upstream (more detail in https://github.com/rust-lang/rust/pull/78775)