### PR TITLE
Comments handling for BinOp and Lists and for Multiline

### DIFF
--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -51,7 +51,7 @@ fn type_annotation_separator(config: &Config) -> &str {
 impl Rewrite for ast::Local {
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
         debug!(
-            "Local::rewrite {:?} {} {:?}",
+            "Rewrite for ast::Local::rewrite {:?} {} {:?}",
             self, shape.width, shape.indent
         );
 
@@ -77,10 +77,6 @@ impl Rewrite for ast::Local {
                 false,
             )?
         };
-        debug!(
-            "** [DBO] Rewrite for ast::Local: attrs_str={:?}, result={:?};",
-            attrs_str, result
-        );
 
         // 4 = "let ".len()
         let pat_shape = shape.offset_left(4)?;
@@ -116,21 +112,12 @@ impl Rewrite for ast::Local {
 
             infix
         };
-        debug!(
-            "** [DBO] Rewrite for ast::Local: infix={:?}, result={:?};",
-            infix, result
-        );
 
         let mut need_newline_after_comment_after_assign = false;
         if self.init.is_none() {
-            debug!("** [DBO] Rewrite for ast::Local: self.init.is_none();");
             result.push_str(&infix);
         } else {
             let ex = self.init.as_ref().unwrap();
-            debug!(
-                "** [DBO] Rewrite for ast::Local: result={:?}, ex={:?};",
-                result, ex
-            );
             let base_span = if let Some(ref ty) = self.ty {
                 mk_sp(ty.span.hi(), self.span.hi())
             } else {
@@ -177,11 +164,6 @@ impl Rewrite for ast::Local {
                         shape,
                         true,
                     )?;
-                    debug!(
-                        "** [DBO] Rewrite for ast::Local: comment_before_assign result={:?}, comment snippet={:?};",
-                        result,
-                        context.snippet(mk_sp(comment_start_pos, assign_lo))
-                    );
                 }
 
                 if !comment_after_assign.is_empty() {
@@ -212,11 +194,6 @@ impl Rewrite for ast::Local {
                             .to_string_with_newline(context.config);
                         result = result + &new_indent_str
                     }
-                    debug!(
-                        "** [DBO] Rewrite for ast::Local: comment_after_assign result={:?}, comment snippet={:?};",
-                        result,
-                        context.snippet(mk_sp(assign_hi, comment_end_pos))
-                    );
                 }
             }
 
@@ -225,10 +202,6 @@ impl Rewrite for ast::Local {
             if need_newline_after_comment_after_assign {
                 nested_shape = nested_shape.block_indent(context.config.tab_spaces())
             };
-            debug!(
-                "** [DBO] Rewrite for ast::Local: result={:?}, nested_shape={:?};",
-                result, shape,
-            );
             let rhs = rewrite_assign_rhs_expr(
                 context,
                 &result,
@@ -237,10 +210,6 @@ impl Rewrite for ast::Local {
                 RhsTactics::Default,
                 true,
             )?;
-            debug!(
-                "** [DBO] Rewrite for ast::Local: rhs={:?}, nested_shape={:?}, result={:?};",
-                rhs, nested_shape, result,
-            );
             let missing_width = 0;
             if missing_width == 0 {
                 if !(rhs.chars().next()?.is_whitespace() || result.chars().last()?.is_whitespace())
@@ -249,10 +218,6 @@ impl Rewrite for ast::Local {
                 }
                 result = result + &rhs;
             } else {
-                debug!(
-                    "** [DBO] Rewrite for ast::Local: extend line indent by w={:?};",
-                    missing_width
-                );
                 for _ in 0..=missing_width - 1 {
                     result.push(' ');
                 }
@@ -260,7 +225,6 @@ impl Rewrite for ast::Local {
             }
         }
 
-        debug!("** [DBO] Rewrite for ast::Local: resultE={:?};", result);
         Some(result)
     }
 }

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -150,8 +150,10 @@ impl Rewrite for ast::Local {
                         attr_span_lo
                     }
                 };
-                let comment_after_assign =
-                    context.snippet(mk_sp(assign_hi, comment_end_pos)).trim();
+                let comment_after_assign_with_end = context
+                    .snippet(mk_sp(assign_hi, comment_end_pos))
+                    .trim_start();
+                let comment_after_assign = comment_after_assign_with_end.trim_end();
 
                 if comment_before_assign.is_empty() {
                     result.push_str(&infix);
@@ -187,7 +189,7 @@ impl Rewrite for ast::Local {
 
                     need_newline_after_comment_after_assign =
                         comment_after_assign.trim_start().starts_with("//")
-                            || comment_after_assign.contains('\n');
+                            || comment_after_assign_with_end.contains('\n');
                     if need_newline_after_comment_after_assign {
                         let new_indent_str = &shape
                             .block_indent(context.config.tab_spaces())

--- a/src/formatting/lists.rs
+++ b/src/formatting/lists.rs
@@ -270,6 +270,7 @@ where
 {
     let tactic = formatting.tactic;
     let sep_len = formatting.separator.len();
+    debug!("write_list: {:?} {:?}", tactic, sep_len);
 
     // Now that we know how we will layout, we can decide for sure if there
     // will be a trailing separator.
@@ -415,10 +416,6 @@ where
             if item_max_width? < inner_item_width {
                 item_max_width = None;
             }
-            debug!(
-                "** [DBO] write_list: item_max_width={:?}, inner_item_width={}, inner_item={:?};",
-                item_max_width, inner_item_width, inner_item
-            );
         }
         if tactic == DefinitiveListTactic::Horizontal && item.post_comment.is_some() {
             let comment = item.post_comment.as_ref().unwrap();

--- a/src/formatting/pairs.rs
+++ b/src/formatting/pairs.rs
@@ -178,10 +178,24 @@ fn rewrite_pairs_multiline<T: Rewrite>(
         /* First multiline comment prefix and suffix in SeparatorPlace::Back
          * and that are added to existing line requires less alignment, compared to
          * the other comments that are added to already block aligned lines */
-        let prefix_with_start = prefix_iter.next()?.trim_end();
+        let prefix_with_start_and_end = prefix_iter.next()?;
+        let prefix_with_start = prefix_with_start_and_end.trim_end();
         let prefix = prefix_with_start.trim_start();
-        let suffix_with_start = suffix_iter.next()?.trim_end();
+        let suffix_with_start_and_end = suffix_iter.next()?;
+        let suffix_with_start = suffix_with_start_and_end.trim_end();
         let suffix = suffix_with_start.trim_start();
+
+        let prefix_ends_line = if let Some(pos) = prefix_with_start_and_end.rfind('/') {
+            prefix_with_start_and_end[pos..].contains('\n')
+        } else {
+            prefix_with_start_and_end.contains('\n')
+        };
+        let suffix_ends_line = if let Some(pos) = suffix_with_start_and_end.rfind('/') {
+            suffix_with_start_and_end[pos..].contains('\n')
+        } else {
+            suffix_with_start_and_end.contains('\n')
+        };
+
         let prelen = if prefix.is_empty() {
             0
         } else {
@@ -258,7 +272,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
                     0,
                     true,
                     !prefix_with_start.starts_with("\n"),
-                    true,
+                    !prefix_ends_line,
                     true,
                 )?;
                 // Combine separator - using nested_shape in case it is in new line
@@ -294,7 +308,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
                     0,
                     true,
                     !suffix_with_start.starts_with("\n"),
-                    true,
+                    !suffix_ends_line,
                     false,
                 )?;
                 result.push_str(&indent_str);
@@ -356,7 +370,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
                     indentation_offset,
                     true,
                     !prefix_with_start.starts_with("\n"),
-                    true,
+                    !prefix_ends_line,
                     false,
                 )?;
 
@@ -381,7 +395,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
                     indentation_offset,
                     true,
                     !suffix_with_start.starts_with("\n"),
-                    true,
+                    !suffix_ends_line,
                     false,
                 )?;
             }

--- a/src/formatting/shape.rs
+++ b/src/formatting/shape.rs
@@ -96,6 +96,11 @@ impl Indent {
             Cow::from(indent)
         }
     }
+
+    pub(crate) fn align(mut self, offset: usize) -> Indent {
+        self.alignment += offset;
+        self
+    }
 }
 
 impl Add for Indent {
@@ -208,7 +213,7 @@ impl Shape {
             Shape {
                 width: self.width,
                 indent: self.indent + extra_width,
-                offset: self.indent.alignment + extra_width,
+                offset: 0,
             }
         }
     }
@@ -284,6 +289,15 @@ impl Shape {
             width: INFINITE_SHAPE_WIDTH,
             ..*self
         }
+    }
+
+    // Create `Indent` from `Shape` for a acomment indentation.
+    // `Indent` width is the total `shape.indent` witdh and `alignment` is:
+    //     `shape.offset` when in the same line of preceding code,
+    //     or 0 when in new line.
+    pub(crate) fn to_comment_indent(self, in_new_line: bool) -> Indent {
+        let offset = if in_new_line { 0 } else { self.offset };
+        self.indent.block_only().align(offset)
     }
 }
 
@@ -368,6 +382,6 @@ mod test {
         assert_eq!(config.max_width(), shape.width);
         assert_eq!(4, shape.indent.block_indent);
         assert_eq!(28, shape.indent.alignment);
-        assert_eq!(28, shape.offset);
+        assert_eq!(0, shape.offset);
     }
 }

--- a/src/formatting/stmt.rs
+++ b/src/formatting/stmt.rs
@@ -97,38 +97,27 @@ fn format_stmt(
     stmt: &ast::Stmt,
     expr_type: ExprType,
 ) -> Option<String> {
+    debug!("format_stmt: {:?} {:?}", stmt.kind, shape);
     skip_out_of_file_lines_range!(context, stmt.span());
 
     let result = match stmt.kind {
         ast::StmtKind::Local(ref local) => {
             let result = local.rewrite(context, shape);
-            debug!("** [DBO] format_stmt: result1={:?};", result);
             /* Add comment between expression and ";" */
             if result.is_some() {
-                debug!(
-                    "** [DBO] format_stmt: local.span.hi()={:?}, stmt.span.hi()={:?}, local={:?};",
-                    local.span.hi(),
-                    stmt.span.hi(),
-                    local
-                );
                 if local.init.as_ref().is_some()
                     && local.init.as_ref()?.span.hi() < local.span.hi() - BytePos(1)
                 {
                     let comment_span =
                         mk_sp(local.init.as_ref()?.span.hi(), local.span.hi() - BytePos(1));
-                    let r = combine_strs_with_missing_comments(
+                    combine_strs_with_missing_comments(
                         context,
                         &result?,
                         ";",
                         comment_span,
                         shape,
                         true,
-                    );
-                    debug!(
-                        "** [DBO] format_stmt: combine_strs_with_missing_comments={:?};",
-                        r
-                    );
-                    r
+                    )
                 } else {
                     Some(result? + ";")
                 }

--- a/src/formatting/utils.rs
+++ b/src/formatting/utils.rs
@@ -251,7 +251,6 @@ pub(crate) fn longest_line_width(s: &str) -> usize {
         .map(|l| unicode_str_width(l))
         .max()
         .unwrap_or(0);
-    debug!("**** [DBO] longest_line_width: w={}, s={:?};", w, s);
     w
 }
 
@@ -263,7 +262,6 @@ pub(crate) fn longest_trimmed_line_width(s: &str) -> usize {
         .map(|l| unicode_str_width(l.trim()))
         .max()
         .unwrap_or(0);
-    debug!("**** [DBO] longest_trimmed_line_width: w={}, s={:?};", w, s);
     w
 }
 

--- a/tests/source/binop-comments/binop-comments-before-semicolon.rs
+++ b/tests/source/binop-comments/binop-comments-before-semicolon.rs
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Comment after BinOp rhs but before the ";".
+ * 
+ * Notes:
+ * 1. Formatting assumes no change in comment place, and requies adding the ';'
+ *    by `format_stmt()` instead of `Rewrite for ast::Local()`.
+ * 2. A simpler implementation may be to move the comment after the ";"
+ *    (and then the above change is not required).
+ * 3. It is assumed that the ";" can be appended to the end of the line even if this will cause
+ *    exceeding maximum line width.  This si to make sure the ';'  will not be in a line by itself.
+ ***********************************************************************/
+
+/***********************************************
+ *  No comments before the ';'
+ **********************************************/
+// Test 1 - no comments
+fn main() {
+let x = 2     *      4;
+}
+// Test 2 - no comments
+fn main() {
+let x = 2     *      4           ;
+}
+// Test 3 - close-comment after the ';'
+fn main() {
+    let x = 2     *      4   ;        /* u */
+    }
+// Test 4 - line-comment after the ';'
+fn main() {
+    let x = 2     *      4   ;        // u
+    }
+// Test 5 - comment after the ';' with following expression
+fn main() {
+    let x = 2     *      4   ;        /* u */   let    y    =     3     +     5    ;
+    }
+
+/***********************************************
+ *  One comment before the ';'
+ **********************************************/
+ // Test 11 - closed comment before the ';'
+fn main() {
+let x = 2     *      4           /* z */   ;
+}
+// Test 12 - closed comment before the ';'
+fn main() {
+let x = 2     *      4           /* z */   ;   let    y    =     3     +     5    ;
+}
+// Test 13 - line-comment comment before the ';'
+fn main() {
+let x = 2     *      4           // z
+;
+}
+// Test 14 - line-comment comment before the ';' with following expression
+fn main() {
+let x = 2     *      4           // z
+;   let    y    =     3     +     5    ;
+}
+// Test 15 - long closed-comment before the ';'
+fn main() {
+let x = 2    *   4     /* zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz */ ;
+}
+
+/***********************************************
+ *  Multiple comments in expression
+ **********************************************/
+ // Test 21 - several closed comments in expression
+fn main() {
+let x = 2    *      /* x */
+/* y */        4     /* z */ ;
+}
+// Test 22 - several closed comments in expression
+fn main() {
+let x = 2        /* v */    /* w */        *       /* x */    /* y */        4     /* z */ ;   /*u*/
+}
+// Test 23 - several closed comments in expression
+fn main() {
+let x = 2        /* v */
+/* w */        *       /* x */
+/* y */        4     /* z */ ;
+}
+// Test 24 - several closed comments in expression with following expression
+fn main() {
+let x = 2        /* v */
+/* w */        *       /* x */
+/* y */        4     /* z */ ;    /* u */    let    y    =     3     +     5    ;
+}

--- a/tests/source/comment-indentation.rs
+++ b/tests/source/comment-indentation.rs
@@ -1,0 +1,273 @@
+/***************************************
+ * Misc comments indentation tests
+ ***************************************/
+
+/*********************************
+ * Several comments on one Compare line
+************************************/
+// Test 1 - several comments on one Compare line
+fn main() {
+    if    /*w*/    5    /*x*/    ==    /*y*/    6   /*z*/ {}
+    }
+// Test 2 - several comments on one Compare line    
+fn main() {
+        if              /* y */ a == b               /* x */ {}
+        }
+// Test 3 - several comments on one Cast line
+fn main() {
+        let x          /* yyy */  =                    /* x as */ 0f64            as i32;
+        }
+
+/*********************************
+ * Comment remain in new line or code line - as in original code
+************************************/
+// Test 11 - Comment remain in new line as in original code
+fn main() {
+    if
+    // comment1
+    a        ==         b
+    {}
+    }
+// Test 12 - Comment remain in new line as in original code    
+fn main() {
+    if           true
+               // else-if-chain if comment
+    {
+        let             foo       =              ();
+    }
+}
+// Test 13 - Comment remain in line of code as in original code
+fn main() {
+    if             // comment1
+    a         ==           b
+    {}
+    }
+// Test 14 - Comment remain in line of code as in original code
+fn main() {
+    if a == b               // x
+    {}
+    }
+// Test 15 - Comment after assignment remain in new line and indented as the rhs code
+fn main() {
+    let xxxxx =
+    // after_comment
+    yyyyyy;
+}
+// Test 16 - Comment after assignment remain in code line
+fn main() {
+    let xxxxx = // after_comment
+    yyyyyy;
+}
+
+/*********************************
+ * Comment remain in new line or code line - as in original BinOp expression code
+************************************/
+// Test 21 - Comment remain in new line   
+fn main () {
+    let xxxxxxxx = yyyyyyyyyyy
+        && zzzzzzzzzzzzzzzz
+        // cccccccccccccccc
+        && uuuuuuuuuuuu;
+}
+// Test 22 - Comment remain in new line
+fn main () {
+    let xxxxxxxx = yyyyyyyyyyy
+        // cccccccccccccccc
+        && uuuuuuuuuuuu;
+}
+// Test 23 - Comment remain in new line
+fn main () {
+    let xxxxxxxx =
+        // cccccccccccccccc
+        uuuuuuuuuuuu;
+}
+// Test 24 - Comment remain in new line
+fn main () {
+    let xxxxxxxx =
+    // cccccccccccccccc
+        uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
+        && tttttttttttttttttttttttttttttttttttttttttttt;
+}
+// Test 25 - Comment remain in code line
+fn main () {
+    let xxxxxxxx = // cccccccccccccccc
+        uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
+        && tttttttttttttttttttttttttttttttttttttttttttt;
+}
+// Test 25- Comment remain in code line
+fn main () {
+    let xxxxxxxx =
+        uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu // cccccccccccccccc
+        && tttttttttttttttttttttttttttttttttttttttttttt;
+}
+// Test 26- Comment moved to new line because will exceed line width ??????????????????????????????
+fn main () {
+    let xxxxxxxxxxxxxxxxxxxxxxxxxxx =
+        uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu // cccccccccccccccc
+        && tttttttttttttttttttttttttttttttttttttttttttt;
+}
+
+/*********************************
+ * Comment moved to new line after block starting '{' ?????????????????????????????????????
+************************************/
+// Test 31 - comment moved to new line after '{'
+fn main() {
+    if a == b {              /* x */
+    c = 7;
+    }
+    }
+
+// Test 32 - comment moved to new line after '{'
+fn main () {
+        if xxxxxxxx { // cccccccccccccccc
+            yyyyyyyyy = uuuuuuuuuuuu;
+        }
+    }    
+
+/*********************************
+ * Comments in a list are alligned per the longest list item,
+ * up to first multi comments per item or multi-line comment.
+************************************/
+// Test 41 - one-line comments - only one per list item
+fn main() {
+    let v = ["A", /* item comment */
+        "B", /* item comment */
+        "Ccccccccc", /* item comment */
+        "Ddd", /* item comment */
+        ];
+}
+// Test 42 - one-line and multi-line comments - only one per list item
+fn main() {
+    let v = ["A", /* item comment */
+        "B", /* item comment */
+        "Ccccccccc", /* item comment line 1
+                  * line 2 */
+        "Ddd", /* item comment */
+        ];
+}
+// Test 43 - one-line and multi-line comments per same item
+fn main() {
+    let v = ["A",
+        "B",
+        "Ccccccccc", /* Multiline comment line 1 *
+                  * Multiline comment line 2 */
+                  /* Additional comment 2 */
+        "Ddd",
+        ];
+}
+// Test 44 - one-line and multi-line comments - several comments per item
+fn main() {
+        let v = ["A",
+            "BB", /* Comment for prev multiline comment param */
+            "Ccccccccc", /* Multiline comment line 1 *
+                      * Multiline comment line 2 */
+                      /* Additional comment 2 */
+            "Ddd",	/* Yet another multiline comment line 1 *
+                       * Yet another multiline comment line 2 */
+            "EEEE",	/* And another multiline comment line 1 *
+                       * And another multiline comment line 2 */
+            ];
+    }
+// Test 45 - one-line and multi-line comments - several comments per item
+fn main(
+        p1: Binary, /* comment for prev multiline comment param */
+        param2: Binary, /* Multiline comment line 1 *
+                      * Multiline comment line 2 */
+                /* Additional comment */
+    ) {
+       x = 7;
+    }
+
+/*********************************
+ * Comments in Arithmetic expression
+************************************/
+// Test 51
+fn main () {
+	let y = 2 /* 1 This is the first bin op argument *
+		  * 2 which will be multiplied by the second argument */
+		* /* 3 This is the multiplying operation *
+		  * 4 which multiplies both arguments */
+		4 /* 5 This is the second argument *
+		  * 6 which is multiplied by the first argument */;
+	/* 7 And this is a comment for the next operation *
+	 * 8 and some more info */
+	let i = 7;
+}
+// Test 52
+fn main () {
+	let y = 2 /* 1 This is the first bin op argument */
+		  /* 2 which will be multiplied by the second argument */
+		* /* 3 This is the multiplying operation */
+		  /* 4 which multiplies both arguments */
+		4 /* 5 This is the second argument */
+		  /* 6 which is multiplied by the first argument */;
+	/* 7 And this is a comment for the next operation */
+	/* 8 and some more info */
+	let i = 7;
+}
+// Test 53
+fn main () {
+let y = 2
+*
+4 /* C5 */
+/* C6 */;
+}
+// Test 54
+fn main () {
+let y = 2
+*
+4 /* C5 *
+* C6 */;
+}
+// Test 55
+fn main () {
+let y = 2
+*
+4 /* 5 This is the second argument */
+/* 6 which is multiplied by the first argument */;
+}
+// Test 56
+fn main () {
+let y = /* 0 Multiplication of two numebers */
+2
+*
+4 /* 5 This is the second argument */
+/* 6 which is multiplied by the first argument */;
+/* 7 And this is a comment for the next operation */
+let i = 7;
+}
+// Test 57
+fn main () {
+let y = /* 0 Multiplication of two numebers */
+2
+*
+4; /* 5 This is the second argument */
+/* 6 which is multiplied by the first argument */
+/* 7 And this is a comment for the next operation */
+let i = 7;
+}
+
+/*********************************
+ * Comments before and after end of expression ';'
+************************************/
+// Test 61 - comments before and after ';' - first comment same line of code
+fn main() {
+    let y = 2
+                    /* 5 This is the second argument */
+        /* 6 which is multiplied by the first argument */;
+                      /* 7 And this is a comment for the next operation */
+}
+// Test 62 - comments before and after ';' - first comment in new line
+fn main() {
+    let y = 2         /* 5 This is the second argument */
+        /* 6 which is multiplied by the first argument */;
+                      /* 7 And this is a comment for the next operation */
+}
+// Test 63 - comments after ';' with following expression
+fn main() {
+    let y = 2 * 4;
+                   /* 5 This is the second argument */
+        /* 6 which is multiplied by the first argument */
+                                 /* 7 And this is a comment for the next operation */
+    let i = 7;
+}

--- a/tests/source/comment-indentation.rs
+++ b/tests/source/comment-indentation.rs
@@ -100,7 +100,7 @@ fn main () {
         uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu // cccccccccccccccc
         && tttttttttttttttttttttttttttttttttttttttttttt;
 }
-// Test 26- Comment moved to new line because will exceed line width ??????????????????????????????
+// Test 26- Comment moved to new line because will exceed line width
 fn main () {
     let xxxxxxxxxxxxxxxxxxxxxxxxxxx =
         uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu // cccccccccccccccc
@@ -108,7 +108,7 @@ fn main () {
 }
 
 /*********************************
- * Comment moved to new line after block starting '{' ?????????????????????????????????????
+ * Comment moved to new line after block starting '{'
 ************************************/
 // Test 31 - comment moved to new line after '{'
 fn main() {

--- a/tests/source/issue-4243.rs
+++ b/tests/source/issue-4243.rs
@@ -1,8 +1,10 @@
 fn main() {
-    type A: AA /*AA*/ + /*AB*/ AB 
-+ AC = AA 
-/*AA*/ + 
- /*AB*/ AB+AC;
+    type A: AA      /*AA*/       +         /*AB*/ AB 
++        AC          =           AA 
+/*AA*/        + 
+ /*AB*/             AB+AC;
+
+ type A1:  AA    /*AA*/     +      /*AB*/     AB +      AC    =   AA   /*AA*/    +   /*AB*/   AB+    AC;
 
     type B: BA /*BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA*/+/*BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB*/ BB
    + BC = BA /*BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA*/ + /*BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB*/ BB+ BC;

--- a/tests/source/issue-4406-cast-comments.rs
+++ b/tests/source/issue-4406-cast-comments.rs
@@ -1,50 +1,51 @@
 /*****
- *  Tests for proper formatting of pre and post cast ("as") comments
+ *  Tests for proper formatting of pre and post cast ("as") comments.
+ *  Current test don't include multi-line comments as they are not properly handled yet.
  ******/
 
-// Test 1
+// Test 1 - pre-cast comment
 fn main() {
     let x = 0f64            /* x as */ as i32;
 }
 
-// Test 2
+// Test 2 - pre-cast comment
 fn main() {
 let x = 1       /* foo as */   as      i32;
 }
 
-// Test 3
+// Test 3 - post-cast comment
 fn main() {
 let x = 1                  as        /* bar as */  i32;
 }
 
-// Test 4
+// Test 4 - pre&post-cast comment
 fn main() {
 let x = 1       /* as foo */   as        /* as bar */  i32;
 }
 
-// Test 5
+// Test 5 - pre&post-cast comment
 fn main() {
 let x = 1       /* as foo */as/* as bar */  i32;
 }
 
-// Test 6
+// Test 6 - pre&post-cast comment, cast in new line
 fn main() {
 let x = 1       /* as foo */
 as/* as bar */
 i32;
 }
 
-// Test 7
+// Test 7 - pre&post-cast long comment
 fn main() {
 let x = 1       /* as foo yyyyyyyyyyy */as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/  i32;
 }
 
-// Test 8
+// Test 8 - pre&post-cast long comment
 fn main() {
 let x = 1       /* as foo yyyyyyyyyyy */as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/  i32;
 }
 
-// Test 9
+// Test 9 - pre&post-cast long comment, cast in new line
 fn main() {
 let x = 1       /* as foo yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */
 as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/
@@ -72,8 +73,9 @@ fn main() {
 
 
 /*****
- *  Tests for not moving "as" to new line unnecessarily - from #3528
+ *  Test for not moving "as" to new line unnecessarily - from #3528
  ******/
+ // Test 15
 fn get_old_backends(old_toml_config: &toml::Value) -> Option<Vec<Box<dyn Backend>>> {
     old_toml_config.as_table().and_then(|table| {
         table
@@ -96,3 +98,86 @@ fn get_old_backends(old_toml_config: &toml::Value) -> Option<Vec<Box<dyn Backend
             })
     })
 }
+
+
+/*****
+ *  Tests for for onle-line open comments ("//")
+ ******/
+ // Test 20
+fn main() {
+    if 1234 == 0
+    /*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/ & /*yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy*/ cc & dd {} }
+	
+// Test 21
+fn main() {
+    if 'a' == b // x
+    as char {}
+}
+
+// Test 22
+fn main() {
+    if 'a' == b as  // x
+	char {}
+}
+
+/*********************************
+ *  Tests for multi-line comments.
+ *  For FUTURE_USE when will be supported by rusfmt.
+ ******
+// Test 32 - Multiline pre-cast comment
+fn main() {
+let x = 1       /* foo as
+                    * second comment line */
+   as      i32;
+}
+
+// Test 33 - Multiline post-cast comment
+fn main() {
+let x = 1                  as        /* bar as
+                * second comment line */  i32;
+}
+
+// Test 34 - Multiline pre&post-cast comment
+fn main() {
+let x = 1       /* foo as
+* second comment line */   as        /* bar as
+                * second comment line */  i32;
+}
+
+// Test 35 - Multiline pre&post-cast comment
+fn main() {
+let x = 1       /* as foo 
+* second comment line */as/* bar as
+* second comment line */  i32;
+}
+
+// Test 36 - Multiline pre&post-cast comment, cast in new line
+fn main() {
+let x = 1       /* as foo 
+* second comment line */
+as/* as bar 
+* second comment line */
+i32;
+}
+
+// Test 37 - Multiline pre&post-cast long comment
+fn main() {
+let x = 1       /* as foo yyyyyyyyyyy */as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 
+* second comment line */  i32;
+}
+
+// Test 38 - Multiline pre&post-cast long comment
+fn main() {
+let x = 1       /* as foo yyyyyyyyyyy */as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 
+* second comment line */  i32;
+}
+
+// Test 39 - Multiline pre&post-cast long comment, cast in new line
+fn main() {
+let x = 1       /* as foo yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy 
+* second comment line */
+as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 
+* second comment line */
+i32;
+}
+*************** FUTURE-USE ******************************/

--- a/tests/source/match-guard-comments.rs
+++ b/tests/source/match-guard-comments.rs
@@ -67,8 +67,7 @@ name if //BAD COMMENT
 // Test 10
 fn main() {
 match name{
-name if /*BAD COMMENT*/
-5 => 6
+name if /*BAD COMMENT*/      5 => 6
 } }
 // Test 11
 fn main() {

--- a/tests/source/match-guard-comments.rs
+++ b/tests/source/match-guard-comments.rs
@@ -1,0 +1,105 @@
+
+/**************************************************************
+ * Match pre/post Guard comments - between Condition ("if") and arrow ("=>")
+ **************************************************************/
+
+
+// Test 1
+fn main() {
+match var.name{
+name if
+//BAD COMMENT
+name.contains("smth")
+// other comment
+| name.contains("smth else") => {true}
+_ => false,
+} }
+// Test 2
+fn main() {
+match var.name{
+name if
+name.contains("smth")
+// other comment
+| name.contains("smth else") => {true}
+_ => false,
+} }
+// Test 3
+fn main() {
+match name {
+Some(A) if A == '/' && B == '*' => 88
+}
+}
+// Test 4
+fn main() {
+match name {
+/*v*/ name if    /*w*/    5       =>    /*y*/    6   /*z*/
+}}
+// Test 5
+fn main() {
+match name {
+/*v*/ name if    // w
+5       =>    /*y*/    6   /*z*/
+}}
+// Test 6
+fn main() {
+match name {
+/*v*/ name if    /*w*/    5    /*x*/    =>    /*y*/    6   /*z*/
+}}
+// Test 7
+fn main() {
+match name {
+/*v*/ name if    // w
+5    /*x*/    =>    /*y*/    6   /*z*/
+}}
+// Test 8
+fn main() {
+match name{
+name if
+//BAD COMMENT
+5 => 6
+} }
+// Test 9
+fn main() {
+match name{
+name if //BAD COMMENT
+5 => 6
+} }
+// Test 10
+fn main() {
+match name{
+name if /*BAD COMMENT*/
+5 => 6
+} }
+// Test 11
+fn main() {
+match name{
+name if
+
+/*BAD COMMENT*/
+
+5 => 6
+} }
+// Test 12
+fn main() {
+match name{
+name if //XXXXX
+5 /*BAD COMMENT*/ => 6 //YYY YYY
+} }
+// Test 13
+fn main() {
+match name{
+name if
+5 //BAD COMMENT
+=> 6
+} }
+// Test 14
+fn main() {
+if /*BAD COMMENT*/ 1 == 2 { 7 }
+}
+// Test 15
+fn main() {
+match name{
+name if
+5 => 6
+}
+let i=7; /* x */ }

--- a/tests/target/binop-comments/binop-comments-back.rs
+++ b/tests/target/binop-comments/binop-comments-back.rs
@@ -1,0 +1,334 @@
+// rustfmt-binop_separator: Back
+
+// Test 1
+fn main() {
+    let x = 2 /* x */ * 4;
+}
+
+// Test 2
+fn main() {
+    let x = 2
+    /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+    *
+        4;
+}
+
+// Test 3
+fn main() {
+    let x = 2 *
+    /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */
+        4;
+}
+
+// Test 4
+fn main() {
+    let x = 2 /* x */ * /* y */ 4;
+}
+
+// Test 5
+fn main() {
+    let x = 2 /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */ *
+    /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */
+        4;
+}
+
+// Test 11.1 - One line
+fn main() {
+    if context() && bounds.len() == 1 || context && !res.ends('+') {
+        a + b
+    }
+}
+// Test 11.2 - One line with comments
+fn main() {
+    if context() /* cond 1 */ && bounds.len() == 1 /* cond 2 */ || context && !res.ends('+') {
+        a + b
+    }
+}
+// Test 11.3 - One line with comments
+fn main() {
+    if 1234 == 0 /*x*/ & /*y*/ cc & dd {}
+}
+
+// Test 12.1 - Pre-comments break to few lines - only "&&"
+fn main() {
+    if context() /* condition 1 expression */ &&
+        bounds.len() == 1 /* condition 2 expression */ &&
+        context /* condition 3 expression */ &&
+        !res.ends('+')
+    {
+        a + b
+    }
+}
+// Test 12.2 - Pre-comments break to few lines - "&&" and "||"
+fn main() {
+    if context() /* condition 1 expression */ && bounds.len() == 1 /* condition 2 expression */ ||
+        context /* condition 3 expression */ && !res.ends('+')
+    {
+        a + b
+    }
+}
+
+// Test 13.1 - Post-comments break to few lines - only "&&"
+fn main() {
+    if context() && /* condition 1 expression */
+        bounds.len() == 1 && /* condition 2 expression */
+        context && /* condition 3 expression */
+        !res.ends('+') /* closing comment */
+    {
+        a + b
+    }
+}
+// Test 13.2 - Pre and Post-comments break to few lines - only "&&"
+fn main() {
+    if context() /* pre comment 1 */ && /* post comment 1 */
+        bounds.len() == 1 /* pre comment 2 */ && /* post comment 2 */
+        context /* pre comment 3 */ && /* post comment 3 */
+        !res.ends('+') /* closing comment */
+    {
+        a + b
+    }
+}
+
+// Test 14.1 - Each "&&" starts new line
+fn main() {
+    if context.inside_macro() &&
+        bounds.len() == 1 &&
+        context.snippet(self.span).ends_with('+') & !res.ends_with('+')
+    {
+        a + b
+    }
+}
+// Test 14.2 - "||" starts new line
+fn main() {
+    if context.inside_macro() && bounds.len() == 1 ||
+        context.snippet(self.span).ends_with('+') & !res.ends_with('+')
+    {
+        a + b
+    }
+}
+
+// Test 15.1 - Each "&&" starts new line - with comments
+fn main() {
+    if context.inside_macro() /* cond 1 */ &&
+        bounds.len() == 1 /* cond 2 */ &&
+        context.snippet(self.span).ends_with('+') /* cond 3 */ &&
+        !res.ends_with('+')
+    {
+        a + b
+    }
+}
+// Test 15.2 - "||" starts new line - with comments
+fn main() {
+    if context.inside_macro() /* cond 1 */ && bounds.len() == 1 /* cond 2 */ ||
+        context.snippet(self.span).ends_with('+') /* cond 3 */ && !res.ends_with('+')
+    {
+        a + b
+    }
+}
+
+// Test 16 - Each "." and some "&&"/"||" starts new line
+fn main() {
+    if a {
+        if b {
+            if c {
+                if d {
+                    if e {
+                        if item_kind
+                            .is_same_item_kind(&***ppi, self.file_mod_map)
+                            .context
+                            .inside_macro() &&
+                            bounds.len() == 1 ||
+                            context.snippet(self.span).ends_with('+') && !res.ends_with('+')
+                        {
+                            a + b
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Test 21.1
+fn main() {
+    let x = 2 /* v */
+    /* w */
+    * /* x */
+        4;
+}
+
+// Test 21.2
+fn main() {
+    let x = 2 /* v */
+    /* w */
+    * /* x */
+        /* y */
+        4;
+}
+
+// Test 22.1 - Multi separators - One line Pre-comments
+fn main() {
+    /* comments before the if statement */
+    if context1() /* condition 1 explanations */ &&
+        bounds.len() == 1 /* condition 2 explanations */ &&
+        context3 /* condition 3 explanations */ &&
+        !res.ends('+') /* condition 4 explanations */
+    /* comments to the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 22.2 - Multi separators - One line Post-comments
+fn main() {
+    /* comments before the if statement */
+    if context1() && /* condition 1 explanations */
+        bounds.len() == 1 && /* condition 2 explanations */
+        context3 && /* condition 3 explanations */
+        !res.ends('+') /* condition 4 explanations */
+    /* comments to the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 23.1 - Multi separators - Multi line Pre-comments
+fn main() {
+    /* comments before the if statement
+     * with some explanations about the if */
+    if context1() /* condition 1 explanations
+                   * with some added details about condition 1 */
+    &&
+        bounds.len() == 1 /* condition 2 explanations
+                           * with some added details about condition 2 */
+        &&
+        context3 /* condition 3 explanations
+                  * with some added details about condition 3 */
+        &&
+        !res.ends('+') /* condition 4 explanations
+                        * with some added details about condition 4 */
+    /* comments to the executed block
+     * with some explanations about the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 23.2 - Multi separators - Multi line Post-comments
+fn main() {
+    /* comments before the if statement
+     * with some explanations about the if */
+    if context1() /* pre condition1 */ && /* condition 1 explanations
+                                           * with some added details about condition 1 */
+        bounds.len() == 1 && /* condition 2 explanations
+                              * with some added details about condition 2 */
+        context3 && /* condition 3 explanations
+                     * with some added details about condition 3 */
+        !res.ends('+') /* condition 4 explanations
+                        * with some added details about condition 4 */
+    /* comments to the executed block
+     * with some explanations about the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 24.1 - Multi separators - Multi line Pre-comments with long line
+fn main() {
+    if context1()
+    /* condition 1 explanations longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+     * with some added details about condition 1 */
+    &&
+        bounds.len() == 1 /* condition 2 explanations
+                           * with some added details about condition 2 longggggggggggggggggggggg */
+        &&
+        context3 /* condition 3 explanations longgggggggggggggggggggggggggggggggggggggggg
+                  * with some added details about condition 3 longgggggggggggggggggggggggggg */
+    {
+        a + b
+    }
+}
+
+// Test 24.2 - Multi separators - Multi line Post-comments with long line
+fn main() {
+    if context1() /* pre condition1 longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/
+        && /* condition 1 explanations
+            * with some added details about condition 1 */
+        bounds.len() == 1 && /* condition 2 explanations longgggggggggggggggggggggggggggggggggggggg
+                              * with some added details about condition 2 */
+        context3 &&
+        /* condition 3 explanations
+         * with some added details about condition 3 longggggggggggggggggggggggggggggggggggggg */
+        !res.ends('+')
+    /* condition 4 explanations longgggggggggggggggggggggggggggggggggggggggggggggg
+     * with some added details about condition 4 longgggggggggggggggggggggggggggggggggggg*/
+    {
+        a + b
+    }
+}
+
+// Test 25.1 - binop with one line comment
+fn main() {
+    if a // comment1
+    |
+        bbbbbb |
+        cccccc
+    {}
+}
+
+// Test 25.2 - binop with one line comment
+fn main() {
+    if a // comment1
+    // comment2
+    |
+        b
+    {}
+}
+
+// Test 25.3 - binop with one line comment
+fn main() {
+    if a | // comment3
+        b
+    {}
+}
+
+// Test 25.4 - binop with one line comment
+fn main() {
+    if a // comment1
+    | // comment3
+        b |
+        c
+    {}
+}
+
+// Test 26.1 - Const binop line comments
+fn main() {
+    const xxxxxxxxxxxxxxxxxx: u32 =
+        // cccccccccccccccccccccccccccc
+        yyyyyyyyyyyyy
+        // ddddddddddddddddddddddddddddddddddddd
+        |
+            zzzzzzzzzzzz
+            // eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+            |
+            uuuuuuuuuuu;
+}
+
+// Test 26.2 - Const binop line comments (based on `comment-inside-const.rs` test)
+fn main() {
+    const xxxxxxxxxxxxxxxxxx: u32 =
+        // cccccccccccccccccccccccccccc
+        yyyyyyyyyyyyy |
+        // ddddddddddddddddddddddddddddddddddddd
+            zzzzzzzzzzzz |
+            // eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+            uuuuuuuuuuu;
+}
+
+// Test 26.3 - Const binop - no comments
+fn main() {
+    const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: u32 =
+        yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy |
+            zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz |
+            uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu;
+}

--- a/tests/target/binop-comments/binop-comments-before-semicolon.rs
+++ b/tests/target/binop-comments/binop-comments-before-semicolon.rs
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Comment after BinOp rhs but before the ";".
+ *
+ * Notes:
+ * 1. Formatting assumes no change in comment place, and requies adding the ';'
+ *    by `format_stmt()` instead of `Rewrite for ast::Local()`.
+ * 2. A simpler implementation may be to move the comment after the ";"
+ *    (and then the above change is not required).
+ * 3. It is assumed that the ";" can be appended to the end of the line even if this will cause
+ *    exceeding maximum line width.  This si to make sure the ';'  will not be in a line by itself.
+ ***********************************************************************/
+
+/***********************************************
+ *  No comments before the ';'
+ **********************************************/
+// Test 1 - no comments
+fn main() {
+    let x = 2 * 4;
+}
+// Test 2 - no comments
+fn main() {
+    let x = 2 * 4;
+}
+// Test 3 - close-comment after the ';'
+fn main() {
+    let x = 2 * 4; /* u */
+}
+// Test 4 - line-comment after the ';'
+fn main() {
+    let x = 2 * 4; // u
+}
+// Test 5 - comment after the ';' with following expression
+fn main() {
+    let x = 2 * 4; /* u */
+    let y = 3 + 5;
+}
+
+/***********************************************
+ *  One comment before the ';'
+ **********************************************/
+// Test 11 - closed comment before the ';'
+fn main() {
+    let x = 2 * 4 /* z */;
+}
+// Test 12 - closed comment before the ';'
+fn main() {
+    let x = 2 * 4 /* z */;
+    let y = 3 + 5;
+}
+// Test 13 - line-comment comment before the ';'
+fn main() {
+    let x = 2 * 4 // z
+    ;
+}
+// Test 14 - line-comment comment before the ';' with following expression
+fn main() {
+    let x = 2 * 4 // z
+    ;
+    let y = 3 + 5;
+}
+// Test 15 - long closed-comment before the ';'
+fn main() {
+    let x = 2 * 4
+    /* zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz */;
+}
+
+/***********************************************
+ *  Multiple comments in expression
+ **********************************************/
+// Test 21 - several closed comments in expression
+fn main() {
+    let x = 2
+        * /* x */
+    /* y */
+        4 /* z */;
+}
+// Test 22 - several closed comments in expression
+fn main() {
+    let x = 2 /* v */    /* w */ * /* x */    /* y */ 4 /* z */; /*u*/
+}
+// Test 23 - several closed comments in expression
+fn main() {
+    let x = 2 /* v */
+    /* w */
+        * /* x */
+    /* y */
+        4 /* z */;
+}
+// Test 24 - several closed comments in expression with following expression
+fn main() {
+    let x = 2 /* v */
+    /* w */
+        * /* x */
+    /* y */
+        4 /* z */; /* u */
+    let y = 3 + 5;
+}

--- a/tests/target/binop-comments/binop-comments-front.rs
+++ b/tests/target/binop-comments/binop-comments-front.rs
@@ -1,0 +1,330 @@
+// rustfmt-binop_separator: Front
+
+// Test 1
+fn main() {
+    let x = 2 /* x */ * 4;
+}
+
+// Test 2
+fn main() {
+    let x = 2
+        /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+        * 4;
+}
+
+// Test 3
+fn main() {
+    let x = 2
+        * /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */
+        4;
+}
+
+// Test 4
+fn main() {
+    let x = 2 /* x */ * /* y */ 4;
+}
+
+// Test 5
+fn main() {
+    let x = 2 /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */
+        * /* yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */ 4;
+}
+
+// Test 11.1 - One line
+fn main() {
+    if context() && bounds.len() == 1 || context && !res.ends('+') {
+        a + b
+    }
+}
+// Test 11.2 - One line with comments
+fn main() {
+    if context() /* cond 1 */ && bounds.len() == 1 /* cond 2 */ || context && !res.ends('+') {
+        a + b
+    }
+}
+// Test 11.3 - One line with comments
+fn main() {
+    if 1234 == 0 /*x*/ & /*y*/ cc & dd {}
+}
+
+// Test 12.1 - Pre-comments break to few lines - only "&&"
+fn main() {
+    if context() /* condition 1 expression */
+        && bounds.len() == 1 /* condition 2 expression */
+        && context /* condition 3 expression */
+        && !res.ends('+')
+    {
+        a + b
+    }
+}
+// Test 12.2 - Pre-comments break to few lines - "&&" and "||"
+fn main() {
+    if context() /* condition 1 expression */ && bounds.len() == 1 /* condition 2 expression */
+        || context /* condition 3 expression */ && !res.ends('+')
+    {
+        a + b
+    }
+}
+
+// Test 13.1 - Post-comments break to few lines - only "&&"
+fn main() {
+    if context()
+        && /* condition 1 expression */ bounds.len() == 1
+        && /* condition 2 expression */ context
+        && /* condition 3 expression */ !res.ends('+') /* closing comment */
+    {
+        a + b
+    }
+}
+// Test 13.2 - Pre and Post-comments break to few lines - only "&&"
+fn main() {
+    if context() /* pre comment 1 */
+        && /* post comment 1 */ bounds.len() == 1 /* pre comment 2 */
+        && /* post comment 2 */ context /* pre comment 3 */
+        && /* post comment 3 */ !res.ends('+') /* closing comment */
+    {
+        a + b
+    }
+}
+
+// Test 14.1 - Each "&&" starts new line
+fn main() {
+    if context.inside_macro()
+        && bounds.len() == 1
+        && context.snippet(self.span).ends_with('+') & !res.ends_with('+')
+    {
+        a + b
+    }
+}
+// Test 14.2 - "||" starts new line
+fn main() {
+    if context.inside_macro() && bounds.len() == 1
+        || context.snippet(self.span).ends_with('+') & !res.ends_with('+')
+    {
+        a + b
+    }
+}
+
+// Test 15.1 - Each "&&" starts new line - with comments
+fn main() {
+    if context.inside_macro() /* cond 1 */
+        && bounds.len() == 1 /* cond 2 */
+        && context.snippet(self.span).ends_with('+') /* cond 3 */
+        && !res.ends_with('+')
+    {
+        a + b
+    }
+}
+// Test 15.2 - "||" starts new line - with comments
+fn main() {
+    if context.inside_macro() /* cond 1 */ && bounds.len() == 1 /* cond 2 */
+        || context.snippet(self.span).ends_with('+') /* cond 3 */ && !res.ends_with('+')
+    {
+        a + b
+    }
+}
+
+// Test 16 - Each "." and some "&&"/"||" starts new line
+fn main() {
+    if a {
+        if b {
+            if c {
+                if d {
+                    if e {
+                        if item_kind
+                            .is_same_item_kind(&***ppi, self.file_mod_map)
+                            .context
+                            .inside_macro()
+                            && bounds.len() == 1
+                            || context.snippet(self.span).ends_with('+') && !res.ends_with('+')
+                        {
+                            a + b
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Test 21.1
+fn main() {
+    let x = 2 /* v */
+    /* w */
+        * /* x */ 4;
+}
+
+// Test 21.2
+fn main() {
+    let x = 2 /* v */
+    /* w */
+        * /* x */
+    /* y */
+        4;
+}
+
+// Test 22.1 - Multi separators - One line Pre-comments
+fn main() {
+    /* comments before the if statement */
+    if context1() /* condition 1 explanations */
+        && bounds.len() == 1 /* condition 2 explanations */
+        && context3 /* condition 3 explanations */
+        && !res.ends('+') /* condition 4 explanations */
+    /* comments to the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 22.2 - Multi separators - One line Post-comments
+fn main() {
+    /* comments before the if statement */
+    if context1()
+        && /* condition 1 explanations */ bounds.len() == 1
+        && /* condition 2 explanations */ context3
+        && /* condition 3 explanations */ !res.ends('+') /* condition 4 explanations */
+    /* comments to the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 23.1 - Multi separators - Multi line Pre-comments
+fn main() {
+    /* comments before the if statement
+     * with some explanations about the if */
+    if context1() /* condition 1 explanations
+                   * with some added details about condition 1 */
+        && bounds.len() == 1 /* condition 2 explanations
+                              * with some added details about condition 2 */
+        && context3 /* condition 3 explanations
+                     * with some added details about condition 3 */
+        && !res.ends('+') /* condition 4 explanations
+                           * with some added details about condition 4 */
+    /* comments to the executed block
+     * with some explanations about the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 23.2 - Multi separators - Multi line Post-comments
+fn main() {
+    /* comments before the if statement
+     * with some explanations about the if */
+    if context1() /* pre condition1 */
+        && /* condition 1 explanations
+            * with some added details about condition 1 */
+        bounds.len() == 1
+        && /* condition 2 explanations
+            * with some added details about condition 2 */
+        context3
+        && /* condition 3 explanations
+            * with some added details about condition 3 */
+        !res.ends('+') /* condition 4 explanations
+                        * with some added details about condition 4 */
+    /* comments to the executed block
+     * with some explanations about the executed block */
+    {
+        a + b
+    }
+}
+
+// Test 24.1 - Multi separators - Multi line Pre-comments with long line
+fn main() {
+    if context1()
+        /* condition 1 explanations longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+         * with some added details about condition 1 */
+        && bounds.len() == 1
+        /* condition 2 explanations
+         * with some added details about condition 2 longggggggggggggggggggggg */
+        && context3 /* condition 3 explanations longgggggggggggggggggggggggggggggggggggggggg
+                     * with some added details about condition 3 longgggggggggggggggggggggggggg */
+    {
+        a + b
+    }
+}
+
+// Test 24.2 - Multi separators - Multi line Post-comments with long line
+fn main() {
+    if context1() /* pre condition1 longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/
+        && /* condition 1 explanations
+            * with some added details about condition 1 */
+        bounds.len() == 1
+        && /* condition 2 explanations longgggggggggggggggggggggggggggggggggggggg
+            * with some added details about condition 2 */
+        context3
+        && /* condition 3 explanations
+            * with some added details about condition 3 longggggggggggggggggggggggggggggggggggggg */
+        !res.ends('+')
+    /* condition 4 explanations longgggggggggggggggggggggggggggggggggggggggggggggg
+     * with some added details about condition 4 longgggggggggggggggggggggggggggggggggggg*/
+    {
+        a + b
+    }
+}
+
+// Test 25.1 - binop with one line comment
+fn main() {
+    if a // comment1
+        | bbbbbb
+        | cccccc
+    {}
+}
+
+// Test 25.2 - binop with one line comment
+fn main() {
+    if a // comment1
+    // comment2
+        | b
+    {}
+}
+
+// Test 25.3 - binop with one line comment
+fn main() {
+    if a
+        | // comment3
+        b
+    {}
+}
+
+// Test 25.4 - binop with one line comment
+fn main() {
+    if a // comment1
+        | // comment3
+        b
+        | c
+    {}
+}
+
+// Test 26.1 - Const binop line comments
+fn main() {
+    const xxxxxxxxxxxxxxxxxx: u32 =
+        // cccccccccccccccccccccccccccc
+        yyyyyyyyyyyyy
+            // ddddddddddddddddddddddddddddddddddddd
+            | zzzzzzzzzzzz
+            // eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+            | uuuuuuuuuuu;
+}
+
+// Test 26.2 - Const binop line comments (based on `comment-inside-const.rs` test)
+fn main() {
+    const xxxxxxxxxxxxxxxxxx: u32 =
+        // cccccccccccccccccccccccccccc
+        yyyyyyyyyyyyy
+            |
+            // ddddddddddddddddddddddddddddddddddddd
+            zzzzzzzzzzzz
+            |
+            // eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+            uuuuuuuuuuu;
+}
+
+// Test 26.3 - Const binop - no comments
+fn main() {
+    const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: u32 =
+        yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+            | zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+            | uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu;
+}

--- a/tests/target/comment-indentation.rs
+++ b/tests/target/comment-indentation.rs
@@ -225,15 +225,16 @@ fn main() {
 }
 // Test 56
 fn main() {
-    let y = /* 0 Multiplication of two numebers */ 2 * 4
-    /* 5 This is the second argument */
+    let y = /* 0 Multiplication of two numebers */
+        2 * 4 /* 5 This is the second argument */
     /* 6 which is multiplied by the first argument */;
     /* 7 And this is a comment for the next operation */
     let i = 7;
 }
 // Test 57
 fn main() {
-    let y = /* 0 Multiplication of two numebers */ 2 * 4; /* 5 This is the second argument */
+    let y = /* 0 Multiplication of two numebers */
+        2 * 4; /* 5 This is the second argument */
     /* 6 which is multiplied by the first argument */
     /* 7 And this is a comment for the next operation */
     let i = 7;

--- a/tests/target/comment-indentation.rs
+++ b/tests/target/comment-indentation.rs
@@ -1,0 +1,265 @@
+/***************************************
+ * Misc comments indentation tests
+ ***************************************/
+
+/*********************************
+ * Several comments on one Compare line
+************************************/
+// Test 1 - several comments on one Compare line
+fn main() {
+    if /*w*/ 5 /*x*/ == /*y*/ 6 /*z*/ {}
+}
+// Test 2 - several comments on one Compare line
+fn main() {
+    if /* y */ a == b /* x */ {}
+}
+// Test 3 - several comments on one Cast line
+fn main() {
+    let x /* yyy */ = /* x as */ 0f64 as i32;
+}
+
+/*********************************
+ * Comment remain in new line or code line - as in original code
+************************************/
+// Test 11 - Comment remain in new line as in original code
+fn main() {
+    if
+       // comment1
+       a == b {}
+}
+// Test 12 - Comment remain in new line as in original code
+fn main() {
+    if true
+    // else-if-chain if comment
+    {
+        let foo = ();
+    }
+}
+// Test 13 - Comment remain in line of code as in original code
+fn main() {
+    if // comment1
+       a == b {}
+}
+// Test 14 - Comment remain in line of code as in original code
+fn main() {
+    if a == b // x
+    {}
+}
+// Test 15 - Comment after assignment remain in new line and indented as the rhs code
+fn main() {
+    let xxxxx =
+        // after_comment
+        yyyyyy;
+}
+// Test 16 - Comment after assignment remain in code line
+fn main() {
+    let xxxxx = // after_comment
+        yyyyyy;
+}
+
+/*********************************
+ * Comment remain in new line or code line - as in original BinOp expression code
+************************************/
+// Test 21 - Comment remain in new line
+fn main() {
+    let xxxxxxxx = yyyyyyyyyyy
+        && zzzzzzzzzzzzzzzz
+        // cccccccccccccccc
+        && uuuuuuuuuuuu;
+}
+// Test 22 - Comment remain in new line
+fn main() {
+    let xxxxxxxx = yyyyyyyyyyy
+        // cccccccccccccccc
+        && uuuuuuuuuuuu;
+}
+// Test 23 - Comment remain in new line
+fn main() {
+    let xxxxxxxx =
+        // cccccccccccccccc
+        uuuuuuuuuuuu;
+}
+// Test 24 - Comment remain in new line
+fn main() {
+    let xxxxxxxx =
+        // cccccccccccccccc
+        uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
+            && tttttttttttttttttttttttttttttttttttttttttttt;
+}
+// Test 25 - Comment remain in code line
+fn main() {
+    let xxxxxxxx = // cccccccccccccccc
+        uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
+            && tttttttttttttttttttttttttttttttttttttttttttt;
+}
+// Test 25- Comment remain in code line
+fn main() {
+    let xxxxxxxx = uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu // cccccccccccccccc
+        && tttttttttttttttttttttttttttttttttttttttttttt;
+}
+// Test 26- Comment moved to new line because will exceed line width ??????????????????????????????
+fn main() {
+    let xxxxxxxxxxxxxxxxxxxxxxxxxxx = uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
+        // cccccccccccccccc
+        && tttttttttttttttttttttttttttttttttttttttttttt;
+}
+
+/*********************************
+ * Comment moved to new line after block starting '{' ?????????????????????????????????????
+************************************/
+// Test 31 - comment moved to new line after '{'
+fn main() {
+    if a == b {
+        /* x */
+        c = 7;
+    }
+}
+
+// Test 32 - comment moved to new line after '{'
+fn main() {
+    if xxxxxxxx {
+        // cccccccccccccccc
+        yyyyyyyyy = uuuuuuuuuuuu;
+    }
+}
+
+/*********************************
+ * Comments in a list are alligned per the longest list item,
+ * up to first multi comments per item or multi-line comment.
+************************************/
+// Test 41 - one-line comments - only one per list item
+fn main() {
+    let v = [
+        "A",         /* item comment */
+        "B",         /* item comment */
+        "Ccccccccc", /* item comment */
+        "Ddd",       /* item comment */
+    ];
+}
+// Test 42 - one-line and multi-line comments - only one per list item
+fn main() {
+    let v = [
+        "A",         /* item comment */
+        "B",         /* item comment */
+        "Ccccccccc", /* item comment line 1
+                      * line 2 */
+        "Ddd", /* item comment */
+    ];
+}
+// Test 43 - one-line and multi-line comments per same item
+fn main() {
+    let v = [
+        "A",
+        "B",
+        "Ccccccccc", /* Multiline comment line 1 *
+                      * Multiline comment line 2 */
+        /* Additional comment 2 */
+        "Ddd",
+    ];
+}
+// Test 44 - one-line and multi-line comments - several comments per item
+fn main() {
+    let v = [
+        "A",
+        "BB",        /* Comment for prev multiline comment param */
+        "Ccccccccc", /* Multiline comment line 1 *
+                      * Multiline comment line 2 */
+        /* Additional comment 2 */
+        "Ddd",  /* Yet another multiline comment line 1 *
+                 * Yet another multiline comment line 2 */
+        "EEEE", /* And another multiline comment line 1 *
+                 * And another multiline comment line 2 */
+    ];
+}
+// Test 45 - one-line and multi-line comments - several comments per item
+fn main(
+    p1: Binary,     /* comment for prev multiline comment param */
+    param2: Binary, /* Multiline comment line 1 *
+                     * Multiline comment line 2 */
+    /* Additional comment */
+) {
+    x = 7;
+}
+
+/*********************************
+ * Comments in Arithmetic expression
+************************************/
+// Test 51
+fn main() {
+    let y = 2 /* 1 This is the first bin op argument *
+               * 2 which will be multiplied by the second argument */
+        * /* 3 This is the multiplying operation *
+           * 4 which multiplies both arguments */
+        4 /* 5 This is the second argument *
+           * 6 which is multiplied by the first argument */;
+    /* 7 And this is a comment for the next operation *
+     * 8 and some more info */
+    let i = 7;
+}
+// Test 52
+fn main() {
+    let y = 2 /* 1 This is the first bin op argument */
+    /* 2 which will be multiplied by the second argument */
+        * /* 3 This is the multiplying operation */
+    /* 4 which multiplies both arguments */
+        4 /* 5 This is the second argument */
+    /* 6 which is multiplied by the first argument */;
+    /* 7 And this is a comment for the next operation */
+    /* 8 and some more info */
+    let i = 7;
+}
+// Test 53
+fn main() {
+    let y = 2 * 4 /* C5 */
+    /* C6 */;
+}
+// Test 54
+fn main() {
+    let y = 2 * 4 /* C5 *
+                   * C6 */;
+}
+// Test 55
+fn main() {
+    let y = 2 * 4 /* 5 This is the second argument */
+    /* 6 which is multiplied by the first argument */;
+}
+// Test 56
+fn main() {
+    let y = /* 0 Multiplication of two numebers */ 2 * 4
+    /* 5 This is the second argument */
+    /* 6 which is multiplied by the first argument */;
+    /* 7 And this is a comment for the next operation */
+    let i = 7;
+}
+// Test 57
+fn main() {
+    let y = /* 0 Multiplication of two numebers */ 2 * 4; /* 5 This is the second argument */
+    /* 6 which is multiplied by the first argument */
+    /* 7 And this is a comment for the next operation */
+    let i = 7;
+}
+
+/*********************************
+ * Comments before and after end of expression ';'
+************************************/
+// Test 61 - comments before and after ';' - first comment same line of code
+fn main() {
+    let y = 2
+    /* 5 This is the second argument */
+    /* 6 which is multiplied by the first argument */;
+    /* 7 And this is a comment for the next operation */
+}
+// Test 62 - comments before and after ';' - first comment in new line
+fn main() {
+    let y = 2 /* 5 This is the second argument */
+    /* 6 which is multiplied by the first argument */;
+    /* 7 And this is a comment for the next operation */
+}
+// Test 63 - comments after ';' with following expression
+fn main() {
+    let y = 2 * 4;
+    /* 5 This is the second argument */
+    /* 6 which is multiplied by the first argument */
+    /* 7 And this is a comment for the next operation */
+    let i = 7;
+}

--- a/tests/target/comment-indentation.rs
+++ b/tests/target/comment-indentation.rs
@@ -97,7 +97,7 @@ fn main() {
     let xxxxxxxx = uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu // cccccccccccccccc
         && tttttttttttttttttttttttttttttttttttttttttttt;
 }
-// Test 26- Comment moved to new line because will exceed line width ??????????????????????????????
+// Test 26- Comment moved to new line because will exceed line width
 fn main() {
     let xxxxxxxxxxxxxxxxxxxxxxxxxxx = uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
         // cccccccccccccccc
@@ -105,7 +105,7 @@ fn main() {
 }
 
 /*********************************
- * Comment moved to new line after block starting '{' ?????????????????????????????????????
+ * Comment moved to new line after block starting '{'
 ************************************/
 // Test 31 - comment moved to new line after '{'
 fn main() {

--- a/tests/target/comment-inside-const.rs
+++ b/tests/target/comment-inside-const.rs
@@ -1,9 +1,11 @@
 fn issue982() {
     const SOME_CONSTANT: u32 =
         // Explanation why SOME_CONSTANT needs FLAG_A to be set.
-        FLAG_A |
-        // Explanation why SOME_CONSTANT needs FLAG_B to be set.
-        FLAG_B |
-        // Explanation why SOME_CONSTANT needs FLAG_C to be set.
-        FLAG_C;
+        FLAG_A
+            |
+            // Explanation why SOME_CONSTANT needs FLAG_B to be set.
+            FLAG_B
+            |
+            // Explanation why SOME_CONSTANT needs FLAG_C to be set.
+            FLAG_C;
 }

--- a/tests/target/comment-not-disappear.rs
+++ b/tests/target/comment-not-disappear.rs
@@ -25,14 +25,23 @@ fn c() {
 fn foo() -> Vec<i32> {
     (0..11)
         .map(|x|
-        // This comment disappears.
-        if x % 2 == 0 { x } else { x * 2 })
+            // This comment disappears.
+            if x % 2 == 0 { x } else { x * 2 })
+        .collect()
+}
+
+fn foo() -> Vec<i32> {
+    (0..11)
+        .map(|x|
+            /* This comment disappears */
+            if x % 2 == 0 { x } else { x * 2 })
         .collect()
 }
 
 fn calc_page_len(prefix_len: usize, sofar: usize) -> usize {
     2 // page type and flags
-    + 1 // stored depth
-    + 2 // stored count
-    + prefix_len + sofar // sum of size of all the actual items
+        + 1 // stored depth
+        + 2 // stored count
+        + prefix_len
+        + sofar // sum of size of all the actual items
 }

--- a/tests/target/control-brace-style-always-next-line.rs
+++ b/tests/target/control-brace-style-always-next-line.rs
@@ -8,8 +8,7 @@ fn main() {
     }
 
 
-    'label: loop
-    // loop comment
+    'label: loop // loop comment
     {
         let foo = ();
     }

--- a/tests/target/control-brace-style-always-same-line.rs
+++ b/tests/target/control-brace-style-always-same-line.rs
@@ -5,8 +5,7 @@ fn main() {
     }
 
 
-    'label: loop
-    // loop comment
+    'label: loop // loop comment
     {
         let foo = ();
     }

--- a/tests/target/else-if-brace-style-always-next-line.rs
+++ b/tests/target/else-if-brace-style-always-next-line.rs
@@ -7,8 +7,7 @@ fn main() {
         let bar = ();
     }
 
-    if false
-    // lone if comment
+    if false // lone if comment
     {
         let foo = ();
         let bar = ();
@@ -34,19 +33,16 @@ fn main() {
         let baz = ();
     }
 
-    if true
-    // else-if-chain if comment
+    if true // else-if-chain if comment
     {
         let foo = ();
     }
-    else if false
-    // else-if-chain else-if comment
+    else if false // else-if-chain else-if comment
     {
         let foo = ();
         let bar = ();
     }
-    else
-    // else-if-chain else comment
+    else // else-if-chain else comment
     {
         let foo = ();
         let bar = ();

--- a/tests/target/else-if-brace-style-always-same-line.rs
+++ b/tests/target/else-if-brace-style-always-same-line.rs
@@ -4,8 +4,7 @@ fn main() {
         let bar = ();
     }
 
-    if false
-    // lone if comment
+    if false // lone if comment
     {
         let foo = ();
         let bar = ();
@@ -26,17 +25,14 @@ fn main() {
         let baz = ();
     }
 
-    if true
-    // else-if-chain if comment
+    if true // else-if-chain if comment
     {
         let foo = ();
-    } else if false
-    // else-if-chain else-if comment
+    } else if false // else-if-chain else-if comment
     {
         let foo = ();
         let bar = ();
-    } else
-    // else-if-chain else comment
+    } else // else-if-chain else comment
     {
         let foo = ();
         let bar = ();

--- a/tests/target/else-if-brace-style-closing-next-line.rs
+++ b/tests/target/else-if-brace-style-closing-next-line.rs
@@ -6,8 +6,7 @@ fn main() {
         let bar = ();
     }
 
-    if false
-    // lone if comment
+    if false // lone if comment
     {
         let foo = ();
         let bar = ();
@@ -30,19 +29,16 @@ fn main() {
         let baz = ();
     }
 
-    if true
-    // else-if-chain if comment
+    if true // else-if-chain if comment
     {
         let foo = ();
     }
-    else if false
-    // else-if-chain else-if comment
+    else if false // else-if-chain else-if comment
     {
         let foo = ();
         let bar = ();
     }
-    else
-    // else-if-chain else comment
+    else // else-if-chain else comment
     {
         let foo = ();
         let bar = ();

--- a/tests/target/issue-3851.rs
+++ b/tests/target/issue-3851.rs
@@ -1,19 +1,21 @@
 fn main() {
+    let before
     // before_comment
-    let before = if true {
+    = if true {
         1.0
     };
 
     let after =
-    // after_comment
-    if true {
-        1.0
-    };
+        // after_comment
+        if true {
+            1.0
+        };
 
+    let both
     // before_comment
-    let both =
-    // after_comment
-    if true {
-        1.0
-    };
+    =
+        // after_comment
+        if true {
+            1.0
+        };
 }

--- a/tests/target/issue-4243.rs
+++ b/tests/target/issue-4243.rs
@@ -1,10 +1,10 @@
 fn main() {
     type A: AA /*AA*/ + /*AB*/ AB + AC = AA
-        /*AA*/
-        +
-        /*AB*/
-        AB
+        /*AA*/ +
+        /*AB*/ AB
         + AC;
+
+    type A1: AA /*AA*/ + /*AB*/ AB + AC = AA /*AA*/ + /*AB*/ AB + AC;
 
     type B: BA /*BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA*/
         + /*BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB*/ BB

--- a/tests/target/issue-4244.rs
+++ b/tests/target/issue-4244.rs
@@ -7,8 +7,7 @@ pub type B // Comment
     = SS;
 
 pub type C
-    /* Comment C */
-    = SS;
+    /* Comment C */ = SS;
 
 pub trait D<T> {
     type E /* Comment E */ = SS;
@@ -16,5 +15,4 @@ pub trait D<T> {
 
 type F<'a: 'static, T: Ord + 'static>: Eq + PartialEq
 where
-    T: 'static + Copy, /* x */
-= Vec<u8>;
+    T: 'static + Copy, /* x */ = Vec<u8>;

--- a/tests/target/issue-4406-cast-comments.rs
+++ b/tests/target/issue-4406-cast-comments.rs
@@ -1,51 +1,52 @@
 /*****
- *  Tests for proper formatting of pre and post cast ("as") comments
+ *  Tests for proper formatting of pre and post cast ("as") comments.
+ *  Current test don't include multi-line comments as they are not properly handled yet.
  ******/
 
-// Test 1
+// Test 1 - pre-cast comment
 fn main() {
     let x = 0f64 /* x as */ as i32;
 }
 
-// Test 2
+// Test 2 - pre-cast comment
 fn main() {
     let x = 1 /* foo as */ as i32;
 }
 
-// Test 3
+// Test 3 - post-cast comment
 fn main() {
     let x = 1 as /* bar as */ i32;
 }
 
-// Test 4
+// Test 4 - pre&post-cast comment
 fn main() {
     let x = 1 /* as foo */ as /* as bar */ i32;
 }
 
-// Test 5
+// Test 5 - pre&post-cast comment
 fn main() {
     let x = 1 /* as foo */ as /* as bar */ i32;
 }
 
-// Test 6
+// Test 6 - pre&post-cast comment, cast in new line
 fn main() {
     let x = 1 /* as foo */ as /* as bar */ i32;
 }
 
-// Test 7
+// Test 7 - pre&post-cast long comment
 fn main() {
     let x = 1 /* as foo yyyyyyyyyyy */
         as /* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/ i32;
 }
 
-// Test 8
+// Test 8 - pre&post-cast long comment
 fn main() {
     let x = 1 /* as foo yyyyyyyyyyy */
         as /* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/
         i32;
 }
 
-// Test 9
+// Test 9 - pre&post-cast long comment, cast in new line
 fn main() {
     let x = 1 /* as foo yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy */
         as /* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/
@@ -71,8 +72,9 @@ fn main() {
 }
 
 /*****
- *  Tests for not moving "as" to new line unnecessarily - from #3528
+ *  Test for not moving "as" to new line unnecessarily - from #3528
  ******/
+// Test 15
 fn get_old_backends(old_toml_config: &toml::Value) -> Option<Vec<Box<dyn Backend>>> {
     old_toml_config.as_table().and_then(|table| {
         table
@@ -82,18 +84,102 @@ fn get_old_backends(old_toml_config: &toml::Value) -> Option<Vec<Box<dyn Backend
                 backends
                     .into_iter()
                     .filter_map(|(key, value)| match AvailableBackend::from(key.as_str()) {
-                        AvailableBackend::Git => {
-                            Some(Box::new(Git {
-                                config: value.clone().try_into::<GitConfig>().unwrap(),
-                            }) as Box<dyn Backend>)
-                        }
-                        AvailableBackend::Github => {
-                            Some(Box::new(Github {
-                                config: value.clone().try_into::<GithubConfig>().unwrap(),
-                            }) as Box<dyn Backend>)
-                        }
+                        AvailableBackend::Git => Some(Box::new(Git {
+                            config: value.clone().try_into::<GitConfig>().unwrap(),
+                        }) as Box<dyn Backend>),
+                        AvailableBackend::Github => Some(Box::new(Github {
+                            config: value.clone().try_into::<GithubConfig>().unwrap(),
+                        }) as Box<dyn Backend>),
                     })
                     .collect()
             })
     })
 }
+
+/*****
+ *  Tests for for onle-line open comments ("//")
+ ******/
+// Test 20
+fn main() {
+    if 1234 == 0
+        /*xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx*/
+        & /*yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy*/ cc
+        & dd
+    {}
+}
+
+// Test 21
+fn main() {
+    if 'a' == b // x
+     as char
+    {}
+}
+
+// Test 22
+fn main() {
+    if 'a' == b as // x
+    char
+    {}
+}
+
+/*********************************
+ *  Tests for multi-line comments.
+ *  For FUTURE_USE when will be supported by rusfmt.
+ ******
+// Test 32 - Multiline pre-cast comment
+fn main() {
+let x = 1       /* foo as
+                    * second comment line */
+   as      i32;
+}
+
+// Test 33 - Multiline post-cast comment
+fn main() {
+let x = 1                  as        /* bar as
+                * second comment line */  i32;
+}
+
+// Test 34 - Multiline pre&post-cast comment
+fn main() {
+let x = 1       /* foo as
+* second comment line */   as        /* bar as
+                * second comment line */  i32;
+}
+
+// Test 35 - Multiline pre&post-cast comment
+fn main() {
+let x = 1       /* as foo
+* second comment line */as/* bar as
+* second comment line */  i32;
+}
+
+// Test 36 - Multiline pre&post-cast comment, cast in new line
+fn main() {
+let x = 1       /* as foo
+* second comment line */
+as/* as bar
+* second comment line */
+i32;
+}
+
+// Test 37 - Multiline pre&post-cast long comment
+fn main() {
+let x = 1       /* as foo yyyyyyyyyyy */as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+* second comment line */  i32;
+}
+
+// Test 38 - Multiline pre&post-cast long comment
+fn main() {
+let x = 1       /* as foo yyyyyyyyyyy */as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+* second comment line */  i32;
+}
+
+// Test 39 - Multiline pre&post-cast long comment, cast in new line
+fn main() {
+let x = 1       /* as foo yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+* second comment line */
+as/* as bar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+* second comment line */
+i32;
+}
+*************** FUTURE-USE ******************************/

--- a/tests/target/issue-4427.rs
+++ b/tests/target/issue-4427.rs
@@ -18,10 +18,8 @@ const D: usize = // baz
 const E: usize = /* foo */ 5;
 const F: usize = { 7 };
 const G: usize =
-    /* foooooooooooooooooooooooooooooooooooooooooooooooooooooooo0000000000000000xx00 */
-    5;
-const H: usize = /* asdfasdf */
-    match G > 1 {
+    /* foooooooooooooooooooooooooooooooooooooooooooooooooooooooo0000000000000000xx00 */ 5;
+const H: usize = /* asdfasdf */ match G > 1 {
         true => 1,
         false => 3,
     };

--- a/tests/target/issue-447.rs
+++ b/tests/target/issue-447.rs
@@ -1,40 +1,30 @@
 // rustfmt-normalize_comments: true
 
 fn main() {
-    if
+    if // shouldn't be dropped
     // shouldn't be dropped
-    // shouldn't be dropped
-    cond
-    // shouldn't be dropped
+       cond // shouldn't be dropped
     // shouldn't be dropped
     {
-    }
+    } // shouldn't be dropped
     // shouldn't be dropped
+    else // shouldn't be dropped
     // shouldn't be dropped
-    else
+    if // shouldn't be dropped
     // shouldn't be dropped
-    // shouldn't be dropped
-    if
-    // shouldn't be dropped
-    // shouldn't be dropped
-    cond
-    // shouldn't be dropped
+       cond // shouldn't be dropped
     // shouldn't be dropped
     {
-    }
+    } // shouldn't be dropped
     // shouldn't be dropped
-    // shouldn't be dropped
-    else
-    // shouldn't be dropped
+    else // shouldn't be dropped
     // shouldn't be dropped
     {
     }
 
-    if
+    if // shouldn't be dropped
     // shouldn't be dropped
-    // shouldn't be dropped
-    let Some(x) = y
-    // shouldn't be dropped
+       let Some(x) = y // shouldn't be dropped
     // shouldn't be dropped
     {}
 }

--- a/tests/target/issue_3853.rs
+++ b/tests/target/issue_3853.rs
@@ -11,13 +11,18 @@ fn mut_block_before_ident() {
 }
 
 fn ref_and_mut_blocks_before_ident() {
-    if let Some(ref /*abc*/ mut /*def*/ state) = foo {
+    if let Some(
+        ref /*abc*/
+        mut /*def*/ state,
+    ) = foo
+    {
         println!("deefefefefefwea");
     }
 }
 
 fn sub_pattern() {
-    let foo @ /*foo*/ bar(f) = 42;
+    let foo @ /*foo*/
+    bar(f) = 42;
 }
 
 fn no_prefix_block_before_ident() {

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -12,8 +12,7 @@ fn main() {
     }
 
     'a: while loooooooooooooooooooooooooooooooooong_variable_name + another_value > some_other_value
-    {
-    }
+    {}
 
     while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
     }

--- a/tests/target/match-guard-comments.rs
+++ b/tests/target/match-guard-comments.rs
@@ -1,0 +1,146 @@
+/**************************************************************
+ * Match pre/post Guard comments - between Condition ("if") and arrow ("=>")
+ **************************************************************/
+
+// Test 1
+fn main() {
+    match var.name {
+        name if
+        //BAD COMMENT
+        name.contains("smth")
+            // other comment
+            | name.contains("smth else") =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+// Test 2
+fn main() {
+    match var.name {
+        name if name.contains("smth")
+            // other comment
+            | name.contains("smth else") =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+// Test 3
+fn main() {
+    match name {
+        Some(A) if A == '/' && B == '*' => 88,
+    }
+}
+// Test 4
+fn main() {
+    match name {
+        /*v*/ name if /*w*/ 5 => {
+            /*y*/
+            6
+        } /*z*/
+    }
+}
+// Test 5
+fn main() {
+    match name {
+        /*v*/
+        name if // w
+        5 =>
+        {
+            /*y*/
+            6
+        } /*z*/
+    }
+}
+// Test 6
+fn main() {
+    match name {
+        /*v*/ name if /*w*/ 5 /*x*/ => {
+            /*y*/
+            6
+        } /*z*/
+    }
+}
+// Test 7
+fn main() {
+    match name {
+        /*v*/
+        name if // w
+        5 /*x*/ =>
+        {
+            /*y*/
+            6
+        } /*z*/
+    }
+}
+// Test 8
+fn main() {
+    match name {
+        name if
+        //BAD COMMENT
+        5 =>
+        {
+            6
+        }
+    }
+}
+// Test 9
+fn main() {
+    match name {
+        name if //BAD COMMENT
+        5 =>
+        {
+            6
+        }
+    }
+}
+// Test 10
+fn main() {
+    match name {
+        name if /*BAD COMMENT*/ 5 => 6,
+    }
+}
+// Test 11
+fn main() {
+    match name {
+        name if
+        /*BAD COMMENT*/
+        5 =>
+        {
+            6
+        }
+    }
+}
+// Test 12
+fn main() {
+    match name {
+        name if //XXXXX
+        5 /*BAD COMMENT*/ =>
+        {
+            6
+        } //YYY YYY
+    }
+}
+// Test 13
+fn main() {
+    match name {
+        name if 5 //BAD COMMENT
+         => 6,
+    }
+}
+// Test 14
+fn main() {
+    if /*BAD COMMENT*/ 1 == 2 {
+        7
+    }
+}
+// Test 15
+fn main() {
+    match name {
+        name if 5 => 6,
+    }
+    let i = 7; /* x */
+}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -157,7 +157,7 @@ fn issue339() {
         u => 2,
         v => {} /* funky block
                  * comment */
-                /* final comment */
+        /* final comment */
     }
 }
 


### PR DESCRIPTION
This PR was indented to be for **BinOp comments** handling (a replacement to the previous try - #4417).  However, because the changes touch general used functions, other features are affected, mainly general handling of **Multiline comments** and handling of **Lists comments**.

Some **test cases files** are added to test the changes.  In addition, some changes were done to existing test cases so that the expected formatting output will be according to the changes done.

A main change is adding `combine_strs_with_comments()` which was split from `combine_strs_with_missing_comments()`, and allow general handling of string-comments combining, not just span-comments.  In addition some parameters were added to allow more flexibility with the comments indentation.  The **multiline comments** handling changes were mainly done in `light_rewrite_comment()`.

As many changes are include in this PR, I understand that it may be difficult to test them to allow merging with the mainline.  However, at least this PR can be used for to decide about the desired formatting of different cases.  Once the output is agreed, it may be possible to merge subsets of these changes.

The main guidelines used for the comments indentations are:
1. **Comments that start a new** line in the original code will also start new line in the formatted code.  E.g. the following code format should not change:
```rust
let x =
    /* Comment starts a new line */ 5;
```

2. **Comment that ends a line** in the original code will also end a line in the formatted code.  Following code will always be in a new line.  E.g. the following code format should not change:
```rust
let x = /* Comment ends a line */
    5;
```
3. **Comments are trimmed** and original prefix/suffix white spaces are ignore (except for line start and end for the above formatting).

4. **Multiline comments** are appended to a line or starts new line based on the width of the **longest** line in the comment (and not the first line width).

5. **Comments at the end of a List items** (Array, function parameters, match items, etc.), are aligned to the "Block" of items they belong to - consecutive items that include post-line one-line comments (not multiline). E.g. formatting output example:
```rust
	struct s {
		a: Bool,     // comment 1
		bbb: Binary, // comment 2
		ccccccc: bool,
		dddddddd: Binary, /* comment 3 */
		e: bool,          // comment 4
	}
```

6. For **comments that follow each other**, the first line of the first comment is formatted and indented as the code.  The internal (non-first) comment lines indentation is:
	* If **all** the comments trimmed-left lines start with "`//`" or "`/*`", or '`*`' that follow at least one whitespace (i.e. "` *`"), the trimmed lines are indented as the first line, except that a ' ' is added before the '`*`' to the "` *`" lines. 
	* Otherwise, the multiline internal lies are not formatted and are written as is (assuming the comment is a commented code).	

	Formatting output example:
```rust
	fn main() {
        x = 6; /* Assignment comment 1st line
                * Assignment comment 2nd line */
        /* Code commented out:
		let y = 8;
             let z = 9;
                  let u = 20; */
	}
```