### PR TITLE
ci: GHA Workflow Updates

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,9 @@
 name: integration
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   integration-tests:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,9 @@
 name: linux
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,5 +1,9 @@
 name: mac
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,9 @@
 name: windows
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,6 @@ jobs:
         include:
           - channel: nightly
             target: i686-pc-windows-gnu
-            mingw-7z-path: mingw
 
     env:
       CFG_RELEASE_CHANNEL: nightly
@@ -36,42 +35,6 @@ jobs:
       run: git config --global core.autocrlf false
     - name: checkout
       uses: actions/checkout@v2
-
-    # The Windows runners do not (yet) have a proper msys/mingw environment
-    # pre-configured like AppVeyor does, though they will likely be added in the future.
-    # https://github.com/actions/virtual-environments/issues/30
-    #
-    # In the interim, this ensures mingw32 is installed and available on the PATH
-    # for the i686-pc-windows-gnu target. This approach is used because it's common in
-    # other rust projects and there are issues/limitations with the msys2 chocolatey nuget
-    # package and numworks/setup-msys2 action.
-    # https://github.com/rust-lang/rust/blob/master/src/ci/scripts/install-mingw.sh#L59
-    # https://github.com/rust-lang/rustup/blob/master/appveyor.yml
-    #
-    # Use GitHub Actions cache support to avoid downloading the .7z file every time
-    # to be cognizant of the AWS egress cost impacts
-    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
-    - name: cache mingw.7z
-      id: cache-mingw
-      with:
-        path: ${{ matrix.mingw-7z-path }}
-        key: ${{ matrix.channel }}-${{ matrix.target }}-mingw
-      uses: actions/cache@v1
-      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly'
-    - name: download mingw.7z
-      run: |
-        # Disable the download progress bar which can cause perf issues
-        $ProgressPreference = "SilentlyContinue"
-        md -Force ${{ matrix.mingw-7z-path }}
-        Invoke-WebRequest https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z -OutFile ${{ matrix.mingw-7z-path }}/mingw.7z
-      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly' && steps.cache-mingw.outputs.cache-hit != 'true'
-      shell: powershell
-    - name: install mingw32
-      run: |
-        7z x -y ${{ matrix.mingw-7z-path }}/mingw.7z -oC:\msys64 | Out-Null
-        echo "C:\msys64\mingw32\bin" >> $GITHUB_PATH
-      if: matrix.target == 'i686-pc-windows-gnu' && matrix.channel == 'nightly'
-      shell: powershell
 
       # Run build
     - name: setup


### PR DESCRIPTION
Only run workflows on pushes to `master`, and do some mingw cleanup on Windows 