### PR TITLE
fix: don't force a newline after an empty where clause

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2418,7 +2418,8 @@ fn rewrite_fn_base(
     result.push_str(&where_clause_str);
 
     force_new_line_for_brace |= last_line_contains_single_line_comment(&result);
-    force_new_line_for_brace |= is_params_multi_lined && context.config.where_single_line();
+    force_new_line_for_brace |=
+        is_params_multi_lined && context.config.where_single_line() && !where_clause_str.is_empty();
     Some((result, force_new_line_for_brace))
 }
 

--- a/tests/target/configs/where_single_line/true-with-brace-style.rs
+++ b/tests/target/configs/where_single_line/true-with-brace-style.rs
@@ -1,0 +1,22 @@
+// rustfmt-brace_style: SameLineWhere
+// rustfmt-where_single_line: true
+
+fn lorem_multi_line_clauseless<Ipsum, Dolor, Sit, Amet>(
+    a: Aaaaaaaaaaaaaaa,
+    b: Bbbbbbbbbbbbbbbb,
+    c: Ccccccccccccccccc,
+    d: Ddddddddddddddddddddddddd,
+    e: Eeeeeeeeeeeeeeeeeee,
+) -> T {
+    // body
+}
+
+fn lorem_multi_line_clauseless<Ipsum, Dolor, Sit, Amet>(
+    a: Aaaaaaaaaaaaaaa,
+    b: Bbbbbbbbbbbbbbbb,
+    c: Ccccccccccccccccc,
+    d: Ddddddddddddddddddddddddd,
+    e: Eeeeeeeeeeeeeeeeeee,
+) {
+    // body
+}


### PR DESCRIPTION
Fixes #4547.

This PR is based off of the `rustfmt-1.4.28` branch, although it should be trivially portable to `master`, if you'd prefer. A new test file is included.