### PR TITLE
fix: don't force a newline after an empty where clause (master)

### DIFF
--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -2613,7 +2613,8 @@ fn rewrite_fn_base(
     result.push_str(&where_clause_str);
 
     force_new_line_for_brace |= last_line_contains_single_line_comment(&result);
-    force_new_line_for_brace |= is_params_multi_lined && context.config.where_single_line();
+    force_new_line_for_brace |=
+        is_params_multi_lined && context.config.where_single_line() && !where_clause_str.is_empty();
     Some((result, force_new_line_for_brace))
 }
 

--- a/tests/target/configs/where_single_line/true-with-brace-style.rs
+++ b/tests/target/configs/where_single_line/true-with-brace-style.rs
@@ -1,0 +1,22 @@
+// rustfmt-brace_style: SameLineWhere
+// rustfmt-where_single_line: true
+
+fn lorem_multi_line_clauseless<Ipsum, Dolor, Sit, Amet>(
+    a: Aaaaaaaaaaaaaaa,
+    b: Bbbbbbbbbbbbbbbb,
+    c: Ccccccccccccccccc,
+    d: Ddddddddddddddddddddddddd,
+    e: Eeeeeeeeeeeeeeeeeee,
+) -> T {
+    // body
+}
+
+fn lorem_multi_line_clauseless<Ipsum, Dolor, Sit, Amet>(
+    a: Aaaaaaaaaaaaaaa,
+    b: Bbbbbbbbbbbbbbbb,
+    c: Ccccccccccccccccc,
+    d: Ddddddddddddddddddddddddd,
+    e: Eeeeeeeeeeeeeeeeeee,
+) {
+    // body
+}


### PR DESCRIPTION
Rebase of #4548 onto `master`. Clean.