### PR TITLE
1.x: Backport fixes around deleting pieces of extern functions

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -370,7 +370,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
 
     // Note that this only gets called for function definitions. Required methods
     // on traits do not get handled here.
-    fn visit_fn(
+    pub(crate) fn visit_fn(
         &mut self,
         fk: visit::FnKind<'_>,
         generics: &ast::Generics,

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -58,6 +58,25 @@ libc::c_long;
                                , mode3: *const c_char,
                                file: *mut FILE)
                               -> *mut FILE;
+
+
+       async fn foo(
+
+       ) -> *mut
+       Bar;
+       const fn foo(
+
+       ) ->
+                            *mut Bar;
+       unsafe fn foo(
+
+       ) -> *
+       mut
+       Bar;
+
+       pub async fn foo() -> *mut Bar;
+       pub(super) const fn foo() -> *mut Bar;
+       pub(crate) unsafe fn foo() -> *mut Bar;
    }
 
 extern {

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -60,10 +60,6 @@ libc::c_long;
                               -> *mut FILE;
 
 
-       async fn foo(
-
-       ) -> *mut
-       Bar;
        const fn foo(
 
        ) ->
@@ -74,7 +70,6 @@ libc::c_long;
        mut
        Bar;
 
-       pub async fn foo() -> *mut Bar;
        pub(super) const fn foo() -> *mut Bar;
        pub(crate) unsafe fn foo() -> *mut Bar;
    }

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -73,6 +73,14 @@ extern "C" {
         mode3: *const c_char,
         file: *mut FILE,
     ) -> *mut FILE;
+
+    async fn foo() -> *mut Bar;
+    const fn foo() -> *mut Bar;
+    unsafe fn foo() -> *mut Bar;
+
+    pub async fn foo() -> *mut Bar;
+    pub(super) const fn foo() -> *mut Bar;
+    pub(crate) unsafe fn foo() -> *mut Bar;
 }
 
 extern "C" {}

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -74,11 +74,9 @@ extern "C" {
         file: *mut FILE,
     ) -> *mut FILE;
 
-    async fn foo() -> *mut Bar;
     const fn foo() -> *mut Bar;
     unsafe fn foo() -> *mut Bar;
 
-    pub async fn foo() -> *mut Bar;
     pub(super) const fn foo() -> *mut Bar;
     pub(crate) unsafe fn foo() -> *mut Bar;
 }

--- a/tests/target/issue-4313.rs
+++ b/tests/target/issue-4313.rs
@@ -1,0 +1,5 @@
+extern "C" {
+    fn f() {
+        fn g() {}
+    }
+}


### PR DESCRIPTION
This PR is a clean backport of the 2 commits from https://github.com/rust-lang/rustfmt/pull/4291 and 1 commit from https://github.com/rust-lang/rustfmt/pull/4314, followed by 1 new commit to delete some test cases from #4291 involving `async fn` which fail on 1.x due to difference in default edition. #4291 is adequately tested by almost identical signatures using `const fn` and `unsafe fn` (the latter being what I actually care about) instead of async.

Backport motivated by the broken behavior being quite problematic for https://github.com/dtolnay/cxx.