### PR TITLE
1.x: Preserve polarity on negative non-trait impl

### DIFF
--- a/tests/source/negative-impl.rs
+++ b/tests/source/negative-impl.rs
@@ -1,0 +1,7 @@
+impl ! Display for JoinHandle { }
+
+impl ! Box < JoinHandle > { }
+
+impl ! std :: fmt :: Display for JoinHandle < T : std :: future :: Future + std :: marker :: Send + std :: marker :: Sync > { }
+
+impl ! JoinHandle < T : std :: future :: Future < Output > + std :: marker :: Send + std :: marker :: Sync + 'static > + 'static { }

--- a/tests/target/negative-impl.rs
+++ b/tests/target/negative-impl.rs
@@ -1,0 +1,14 @@
+impl !Display for JoinHandle {}
+
+impl !Box<JoinHandle> {}
+
+impl !std::fmt::Display
+    for JoinHandle<T: std::future::Future + std::marker::Send + std::marker::Sync>
+{
+}
+
+impl
+    !JoinHandle<T: std::future::Future<Output> + std::marker::Send + std::marker::Sync + 'static>
+        + 'static
+{
+}


### PR DESCRIPTION
Clean backport of #4567. I am considering using this syntax for something in https://github.com/dtolnay/cxx but would first need it to be not erased by at least the version of rustfmt shipping with the latest stable toolchain.

I saw 1.4.28 is released already but there wasn't a 1.4.29 branch yet -- you may need to [change the base branch](https://github.blog/2016-08-15-change-the-base-branch-of-a-pull-request/) after creating one.