### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/formatting/attr.rs
+++ b/src/formatting/attr.rs
@@ -187,7 +187,7 @@ fn format_derive(
     } else if let SeparatorTactic::Always = context.config.trailing_comma() {
         // Retain the trailing comma.
         result.push_str(&item_str);
-    } else if item_str.ends_with(",") {
+    } else if item_str.ends_with(',') {
         // Remove the trailing comma.
         result.push_str(&item_str[..item_str.len() - 1]);
     } else {

--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -90,7 +90,7 @@ pub(crate) fn rewrite_closure(
         let between_span = Span::between(arg_span, first_span);
         if contains_comment(context.snippet(between_span)) {
             return rewrite_closure_with_block(body, &prefix, context, body_shape).and_then(|rw| {
-                let mut parts = rw.splitn(2, "\n");
+                let mut parts = rw.splitn(2, '\n');
                 let head = parts.next()?;
                 let rest = parts.next()?;
                 let block_shape = shape.block_indent(context.config.tab_spaces());

--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -1704,8 +1704,8 @@ impl<'a> Iterator for CommentReducer<'a> {
 fn remove_comment_header(comment: &str) -> &str {
     if comment.starts_with("///") || comment.starts_with("//!") {
         &comment[3..]
-    } else if comment.starts_with("//") {
-        &comment[2..]
+    } else if let Some(stripped) = comment.strip_prefix("//") {
+        &stripped
     } else if (comment.starts_with("/**") && !comment.starts_with("/**/"))
         || comment.starts_with("/*!")
     {

--- a/src/formatting/expr.rs
+++ b/src/formatting/expr.rs
@@ -444,7 +444,7 @@ pub(crate) fn format_expr(
     };
 
     expr_rw
-        .and_then(|expr_str| recover_comment_removed(expr_str, expr.span, context))
+        .map(|expr_str| recover_comment_removed(expr_str, expr.span, context))
         .and_then(|expr_str| {
             let attrs = outer_attributes(&expr.attrs);
             let attrs_str = attrs.rewrite(context, shape)?;

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -834,7 +834,7 @@ pub(crate) fn format_impl(
                 // there is only one where-clause predicate
                 // recover the suppressed comma in single line where_clause formatting
                 if generics.where_clause.predicates.len() == 1 {
-                    result.push_str(",");
+                    result.push(',');
                 }
                 result.push_str(&format!("{}{{{}}}", sep, sep));
             } else {
@@ -1737,10 +1737,10 @@ fn type_annotation_spacing(config: &Config) -> (&str, &str) {
 pub(crate) fn rewrite_struct_field_prefix(
     context: &RewriteContext<'_>,
     field: &ast::StructField,
-) -> Option<String> {
+) -> String {
     let vis = format_visibility(context, &field.vis);
     let type_annotation_spacing = type_annotation_spacing(context.config);
-    Some(match field.ident {
+    match field.ident {
         Some(name) => format!(
             "{}{}{}:",
             vis,
@@ -1748,7 +1748,7 @@ pub(crate) fn rewrite_struct_field_prefix(
             type_annotation_spacing.0
         ),
         None => vis.to_string(),
-    })
+    }
 }
 
 impl Rewrite for ast::StructField {
@@ -1768,7 +1768,7 @@ pub(crate) fn rewrite_struct_field(
     }
 
     let type_annotation_spacing = type_annotation_spacing(context.config);
-    let prefix = rewrite_struct_field_prefix(context, field)?;
+    let prefix = rewrite_struct_field_prefix(context, field);
 
     let attrs_str = field.attrs.rewrite(context, shape)?;
     let attrs_extendable = field.ident.is_none() && is_attributes_extendable(&attrs_str);
@@ -1945,7 +1945,7 @@ fn rewrite_static(
             comments_span,
             true,
         )
-        .and_then(|res| recover_comment_removed(res, static_parts.span, context))
+        .map(|res| recover_comment_removed(res, static_parts.span, context))
         .or_else(|| {
             let nested_indent = offset.block_indent(context.config);
             let ty_span_hi = static_parts.ty.span.hi();
@@ -2357,7 +2357,7 @@ fn rewrite_fn_base(
         ret_str_len,
         fn_brace_style,
         multi_line_ret_str,
-    )?;
+    );
 
     debug!(
         "rewrite_fn_base: one_line_budget: {}, multi_line_budget: {}, param_indent: {:?}",
@@ -2744,7 +2744,7 @@ fn compute_budgets_for_params(
     ret_str_len: usize,
     fn_brace_style: FnBraceStyle,
     force_vertical_layout: bool,
-) -> Option<(usize, usize, Indent)> {
+) -> (usize, usize, Indent) {
     debug!(
         "compute_budgets_for_params {} {:?}, {}, {:?}",
         result.len(),
@@ -2781,7 +2781,7 @@ fn compute_budgets_for_params(
                 }
             };
 
-            return Some((one_line_budget, multi_line_budget, indent));
+            return (one_line_budget, multi_line_budget, indent);
         }
     }
 
@@ -2793,7 +2793,7 @@ fn compute_budgets_for_params(
         // Account for `)` and possibly ` {`.
         IndentStyle::Visual => new_indent.width() + if ret_str_len == 0 { 1 } else { 3 },
     };
-    Some((0, context.budget(used_space), new_indent))
+    (0, context.budget(used_space), new_indent)
 }
 
 fn newline_for_brace(config: &Config, where_clause: &ast::WhereClause) -> FnBraceStyle {

--- a/src/formatting/lists.rs
+++ b/src/formatting/lists.rs
@@ -639,8 +639,8 @@ pub(crate) fn extract_post_comment(
     let post_snippet = post_snippet[..comment_end].trim();
     let post_snippet_trimmed = if post_snippet.starts_with(|c| c == ',' || c == ':') {
         post_snippet[1..].trim_matches(white_space)
-    } else if post_snippet.starts_with(separator) {
-        post_snippet[separator.len()..].trim_matches(white_space)
+    } else if let Some(post_snippet) = post_snippet.strip_prefix(separator) {
+        post_snippet.trim_matches(white_space)
     }
     // not comment or over two lines
     else if post_snippet.ends_with(',')

--- a/src/formatting/macros.rs
+++ b/src/formatting/macros.rs
@@ -1424,7 +1424,7 @@ impl MacroBranch {
         // Undo our replacement of macro variables.
         // FIXME: this could be *much* more efficient.
         for (old, new) in &substs {
-            if old_body.find(new).is_some() {
+            if old_body.contains(new) {
                 debug!("rewrite_macro_def: bailing matching variable: `{}`", new);
                 return None;
             }

--- a/src/formatting/overflow.rs
+++ b/src/formatting/overflow.rs
@@ -137,11 +137,10 @@ impl<'a> OverflowableItem<'a> {
     }
 
     pub(crate) fn is_expr(&self) -> bool {
-        match self {
-            OverflowableItem::Expr(..) => true,
-            OverflowableItem::MacroArg(MacroArg::Expr(..)) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            OverflowableItem::Expr(..) | OverflowableItem::MacroArg(MacroArg::Expr(..))
+        )
     }
 
     pub(crate) fn is_nested_call(&self) -> bool {

--- a/src/formatting/pairs.rs
+++ b/src/formatting/pairs.rs
@@ -280,8 +280,7 @@ where
     };
     let new_line_width = infix_with_sep.len() - 1 + rhs_result.len() + pp.suffix.len();
     let rhs_with_sep = if separator_place == SeparatorPlace::Front && new_line_width > shape.width {
-        let s: String = String::from(infix_with_sep);
-        infix_with_sep = s.trim_end().to_string();
+        infix_with_sep = infix_with_sep.trim_end().to_string();
         format!("{}{}", indent_str, rhs_result.trim_start())
     } else {
         rhs_result

--- a/src/formatting/patterns.rs
+++ b/src/formatting/patterns.rs
@@ -312,9 +312,9 @@ fn rewrite_struct_pat(
         if fields_str.contains('\n') || fields_str.len() > one_line_width {
             // Add a missing trailing comma.
             if context.config.trailing_comma() == SeparatorTactic::Never {
-                fields_str.push_str(",");
+                fields_str.push(',');
             }
-            fields_str.push_str("\n");
+            fields_str.push('\n');
             fields_str.push_str(&nested_shape.indent.to_string(context.config));
             fields_str.push_str("..");
         } else {
@@ -322,7 +322,7 @@ fn rewrite_struct_pat(
                 // there are preceding struct fields being matched on
                 if tactic == DefinitiveListTactic::Vertical {
                     // if the tactic is Vertical, write_list already added a trailing ,
-                    fields_str.push_str(" ");
+                    fields_str.push(' ');
                 } else {
                     fields_str.push_str(", ");
                 }

--- a/src/formatting/stmt.rs
+++ b/src/formatting/stmt.rs
@@ -113,5 +113,5 @@ fn format_stmt(
         }
         ast::StmtKind::MacCall(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => None,
     };
-    result.and_then(|res| recover_comment_removed(res, stmt.span(), context))
+    result.map(|res| recover_comment_removed(res, stmt.span(), context))
 }

--- a/src/formatting/string.rs
+++ b/src/formatting/string.rs
@@ -101,7 +101,7 @@ pub(crate) fn rewrite_string<'a>(
                 if is_new_line(grapheme) {
                     // take care of blank lines
                     result = trim_end_but_line_feed(fmt.trim_end, result);
-                    result.push_str("\n");
+                    result.push('\n');
                     if !is_bareline_ok && cur_start + i + 1 < graphemes.len() {
                         result.push_str(&indent_without_newline);
                         result.push_str(fmt.line_start);

--- a/src/formatting/syntux/parser.rs
+++ b/src/formatting/syntux/parser.rs
@@ -90,7 +90,7 @@ impl<'a> ParserBuilder<'a> {
                 rustc_span::FileName::Custom("stdin".to_owned()),
                 text,
             )
-            .map_err(|db| Some(db)),
+            .map_err(Some),
         }
     }
 }

--- a/src/formatting/types.rs
+++ b/src/formatting/types.rs
@@ -654,7 +654,7 @@ impl Rewrite for ast::Ty {
                 let mut_str = format_mutability(mt.mutbl);
                 let mut_len = mut_str.len();
                 let mut result = String::with_capacity(128);
-                result.push_str("&");
+                result.push('&');
                 let ref_hi = context.snippet_provider.span_after(self.span(), "&");
                 let mut cmnt_lo = ref_hi;
 
@@ -677,7 +677,7 @@ impl Rewrite for ast::Ty {
                     } else {
                         result.push_str(&lt_str);
                     }
-                    result.push_str(" ");
+                    result.push(' ');
                     cmnt_lo = lifetime.ident.span.hi();
                 }
 
@@ -988,11 +988,7 @@ fn join_bounds_inner(
                     true,
                 )
                 .map(|v| (v, trailing_span, extendable)),
-                _ => Some((
-                    String::from(strs) + &trailing_str,
-                    trailing_span,
-                    extendable,
-                )),
+                _ => Some((strs + &trailing_str, trailing_span, extendable)),
             }
         },
     )?;

--- a/src/formatting/vertical.rs
+++ b/src/formatting/vertical.rs
@@ -50,16 +50,15 @@ impl AlignedItem for ast::StructField {
             mk_sp(self.attrs.last().unwrap().span.hi(), self.span.lo())
         };
         let attrs_extendable = self.ident.is_none() && is_attributes_extendable(&attrs_str);
-        Some(rewrite_struct_field_prefix(context, self)).and_then(|field_str| {
-            combine_strs_with_missing_comments(
-                context,
-                &attrs_str,
-                &field_str,
-                missing_span,
-                shape,
-                attrs_extendable,
-            )
-        })
+        let prefix = rewrite_struct_field_prefix(context, self);
+        combine_strs_with_missing_comments(
+            context,
+            &attrs_str,
+            &prefix,
+            missing_span,
+            shape,
+            attrs_extendable,
+        )
     }
 
     fn rewrite_aligned_item(

--- a/src/formatting/vertical.rs
+++ b/src/formatting/vertical.rs
@@ -50,7 +50,7 @@ impl AlignedItem for ast::StructField {
             mk_sp(self.attrs.last().unwrap().span.hi(), self.span.lo())
         };
         let attrs_extendable = self.ident.is_none() && is_attributes_extendable(&attrs_str);
-        rewrite_struct_field_prefix(context, self).and_then(|field_str| {
+        Some(rewrite_struct_field_prefix(context, self)).and_then(|field_str| {
             combine_strs_with_missing_comments(
                 context,
                 &attrs_str,

--- a/src/rustfmt/main.rs
+++ b/src/rustfmt/main.rs
@@ -361,7 +361,7 @@ impl CliOptions for Opt {
             config.set().error_on_unformatted(true);
         }
         if let Some(ref edition) = self.edition {
-            config.set().edition((*edition).clone());
+            config.set().edition(*edition);
         }
         if let Some(ref inline_configs) = self.inline_config {
             for inline_config in inline_configs {
@@ -527,7 +527,7 @@ fn format(opt: Opt) -> Result<i32> {
             println!(
                 "Using rustfmt config file(s) {}",
                 paths
-                    .into_iter()
+                    .iter()
                     .map(|p| p.display().to_string())
                     .collect::<Vec<_>>()
                     .join(","),


### PR DESCRIPTION
Fixes

clippy::single_char_pattern
clippy::manual_strip
clippy::unneccessary_wraps
clippy::redundant_closure
clippy::single_char_add_str
clippy::search_is_some
clippy::clone_on_copy
clippy::into_iter_on_ref