### PR TITLE
Control-flow comments formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-#error_on_line_overflow = true
+error_on_line_overflow = true
 error_on_unformatted = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-error_on_line_overflow = true
+#error_on_line_overflow = true
 error_on_unformatted = true

--- a/src/formatting/expr.rs
+++ b/src/formatting/expr.rs
@@ -1042,8 +1042,7 @@ impl<'a> ControlFlow<'a> {
                 between_kwd_cond,
                 shape,
                 true,
-            )
-            .unwrap()
+            )?
         };
 
         /* Combine with post-condition comment */
@@ -1054,8 +1053,7 @@ impl<'a> ControlFlow<'a> {
             mk_sp(cond_span.hi(), self.block.span.lo()),
             shape,
             true,
-        )
-        .unwrap();
+        )?;
 
         /* Add separator before block */
         let last = cond_with_after_cond_comment.lines().last()?.trim_end();
@@ -1204,8 +1202,7 @@ impl<'a> Rewrite for ControlFlow<'a> {
                 after_else,
                 shape,
                 true,
-            )
-            .unwrap();
+            )?;
 
             /* Add separator befor block */
             let last = else_with_post_comment.lines().last()?.trim_end();

--- a/tests/source/comments-control-flow.rs
+++ b/tests/source/comments-control-flow.rs
@@ -1,0 +1,44 @@
+// Issue #4549
+
+fn main() {
+    if /*w*/ 5 /*x*/ == /*y*/ 6 /*z*/ {}
+}
+
+fn main() {
+    /*pre-if*/ if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ { x = y +7; }
+	/*pre-elseif*/ else if /*post-elseif*/ z == u /*pre-elseif-block*/ { y = 5;}
+	/*pre-else*/ else /*post-else*/ {z = x;}
+}
+
+fn main() {
+    /*pre-if*/ if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ { x = y +7; }
+	/*pre-elseif*/ else if /*post-elseif Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ z == u /*pre-elseif-block*/ { y = 5; }
+	/*pre-else*/ else /*post-else*/ { z = x; }
+}
+
+fn main() {
+    /*pre-if*/ if // post-if - make sure that x and y states are the same
+	5 /*x*/ == /*y*/ 6 //pre-if-block - when they are same change y to next state
+	{ x = y +7; }
+}
+
+fn main() {
+    /*pre-if*/ if // post-if - make sure that x and y states are the sameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+	5 /*x*/ == /*y*/ 6 //pre-if-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+	{ x = y +7; }
+}
+
+fn main() {
+    if 5 == 6 { x = y +7; }
+	else if z == u { y = 5; }
+	else { z = x; }
+}
+
+fn main() {
+if // if comment
+5 == 6 { x = y +7; }
+}fn main() {
+if
+// if comment
+5 == 6 { x = y +7; }
+}

--- a/tests/source/comments-control-flow.rs
+++ b/tests/source/comments-control-flow.rs
@@ -1,30 +1,35 @@
 // Issue #4549
 
+// Different `if`/`else` expressions
+// NOTE: comments before and after the condition sign are currently not handled,
+//       so the original code snippet is used.
+//       Therefore, althorugh  such cases are included in some of the tests,
+//       such as `if x /*x*/ == /*y*/ y`, they are not really part of the tests purpose.
 fn main() {
-    if /*w*/ 5 /*x*/ == /*y*/ 6 /*z*/ {}
+    if /*w*/ x /*x*/ == /*y*/ y /*z*/ {}
 }
 
 fn main() {
-    /*pre-if*/ if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ { x = y +7; }
+    /*pre-if*/ if /*post-if*/ x == y /*pre-if-block*/ { x = y +7; }
 	/*pre-elseif*/ else if /*post-elseif*/ z == u /*pre-elseif-block*/ { y = 5;}
 	/*pre-else*/ else /*post-else*/ {z = x;}
 }
 
 fn main() {
-    /*pre-if*/ if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ { x = y +7; }
+    /*pre-if*/ if /*post-if*/ x /*x*/ == /*y*/ y /*pre-if-block*/ { x = y +7; }
 	/*pre-elseif*/ else if /*post-elseif Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ z == u /*pre-elseif-block*/ { y = 5; }
 	/*pre-else*/ else /*post-else*/ { z = x; }
 }
 
 fn main() {
     /*pre-if*/ if // post-if - make sure that x and y states are the same
-	5 /*x*/ == /*y*/ 6 //pre-if-block - when they are same change y to next state
+	x == y //pre-if-block - when they are same change y to next state
 	{ x = y +7; }
 }
 
 fn main() {
     /*pre-if*/ if // post-if - make sure that x and y states are the sameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-	5 /*x*/ == /*y*/ 6 //pre-if-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+	x /*x*/ == /*y*/ y //pre-if-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 	{ x = y +7; }
 }
 
@@ -41,4 +46,72 @@ if // if comment
 if
 // if comment
 5 == 6 { x = y +7; }
+}
+
+// Tests for `loop`
+fn main() {
+				loop                {           x = y +7;              };
+
+	/*pre-statement*/ loop /*pre-block*/ { x = y +7; };
+
+	/*pre-statement*/ loop /*pre-block Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ { y = 5; };
+
+	/*pre-statement*/ loop /*pre-block Longerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/ { y = 5; };
+
+	loop /*pre-block Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ {exppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp};		
+}
+
+// Tests for `while`
+// NOTE: same coments limitations as for `if`.
+fn main() {
+	/*pre-statement*/ while /*post-cond*/ x /*x*/ == /*y*/ y /*pre-block*/ { x = y +7; };
+
+	/*pre-statement*/ while /*pre-cond Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ z == u /*pre-block*/ { y = 5; };
+
+	/*pre-statement*/ while /*pre-cond Longerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/ z == u /*pre-block*/ { y = 5; };
+
+	/*pre-statement*/ while // pre-cond - make sure that x and y states are the sameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+	x /*x*/ == /*y*/ y //pre-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+	{ x = y +7; }
+}
+
+// Tests for `if/while let`
+// NOTE: comments before an after the `pat` item that follows `let` (e.g. the `Some(x)`
+//       in `let Some(x) =`) are currently not handledand, so original code is used.
+//       E.g., in `while let /*C1*/ Some(x) /*C2*/ = /*C3*/ exp /*C4*/{}`, only the
+//       `C3` and `C4` comments are handled, and therefore comments such as `C1` AND `C2`
+//       are not included in the test.
+fn main() {
+	/*pre-statement*/ while let Some(x) = /*pre-epr*/ exp /*pre-block*/ { y = x +7; };
+
+	/*pre-statement*/ while let Some(x) = /*pre-expr Longggggggggggggggggggggggggggggggggggggggggggggggggggg*/ exp /*pre-block*/ { y = x; };
+
+	/*pre-statement*/ while let Some(x) = /*pre-expr Longerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/ exp /*pre-block*/ { y = x; };
+
+	/*pre-statement*/ while let Some(x) = // pre-exprrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
+	exp //pre-blockkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
+	{ y = x +7; }
+}
+fn main() {
+	/*pre-statement*/ if let Some(x) = /*pre-epr*/ exp /*pre-block*/ { y = x +7; };
+
+	/*pre-statement*/ if let Some(ref         /*def*/ mut       /*abc*/ state) =       /*pre-epr*/ exp           /*pre-block*/       { y = x +7; };
+
+	/*pre-statement*/ if let Some(ref         /*def*/ mut       /*abc*/ state) =       /*pre-eprrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/ exp           /*pre-blockkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk*/         { y = x +7; };
+}
+
+// Tests for `for`
+// NOTE: comments `in` aare currently not handledand, so original code is used.
+//       E.g., in `for x /*C1*/ in /*C2*/`, only the `C2` comment is handled,
+//       and therefore comments such as `C1` are not included in the test.
+fn main() {
+	/*pre-statement*/ for /*post-cond*/ x in /*post-in*/ exp /*pre-block*/ { y = x +7; };
+
+	/*pre-statement*/for /*pre-cond Longggggggggggggggggggggggggggggggggggggggggggggggggggg*/ x in exp /*pre-block*/ { y = x; };
+
+	/*pre-statement*/ for /*pre-cond Longerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/ x in exp /*pre-block*/ { y = x; };
+
+	/*pre-statement*/ for // pre-cond - make sure that x and y states are the sameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+	x in /*post-innnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn*/ exp //pre-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+	{ y = x +7; }
 }

--- a/tests/target/comments-control-flow.rs
+++ b/tests/target/comments-control-flow.rs
@@ -1,0 +1,79 @@
+// Issue #4549
+
+fn main() {
+    if /*w*/ 5 /*x*/ == /*y*/ 6 /*z*/ {}
+}
+
+fn main() {
+    /*pre-if*/
+    if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ {
+        x = y + 7;
+    }
+    /*pre-elseif*/
+    else if /*post-elseif*/ z == u /*pre-elseif-block*/ {
+        y = 5;
+    }
+    /*pre-else*/
+    else /*post-else*/ {
+        z = x;
+    }
+}
+
+fn main() {
+    /*pre-if*/
+    if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ {
+        x = y + 7;
+    }
+    /*pre-elseif*/
+    else if /*post-elseif Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ z == u
+    /*pre-elseif-block*/ {
+        y = 5;
+    }
+    /*pre-else*/
+    else /*post-else*/ {
+        z = x;
+    }
+}
+
+fn main() {
+    /*pre-if*/
+    if // post-if - make sure that x and y states are the same
+    5 /*x*/ == /*y*/ 6 //pre-if-block - when they are same change y to next state
+    {
+        x = y + 7;
+    }
+}
+
+fn main() {
+    /*pre-if*/
+    if // post-if - make sure that x and y states are the sameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    5 /*x*/ == /*y*/ 6
+    //pre-if-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    {
+        x = y + 7;
+    }
+}
+
+fn main() {
+    if 5 == 6 {
+        x = y + 7;
+    } else if z == u {
+        y = 5;
+    } else {
+        z = x;
+    }
+}
+
+fn main() {
+    if // if comment
+    5 == 6 {
+        x = y + 7;
+    }
+}
+fn main() {
+    if
+    // if comment
+    5 == 6 {
+        x = y + 7;
+    }
+}

--- a/tests/target/comments-control-flow.rs
+++ b/tests/target/comments-control-flow.rs
@@ -1,12 +1,17 @@
 // Issue #4549
 
+// Different `if`/`else` expressions
+// NOTE: comments before and after the condition sign are currently not handled,
+//       so the original code snippet is used.
+//       Therefore, althorugh  such cases are included in some of the tests,
+//       such as `if x /*x*/ == /*y*/ y`, they are not really part of the tests purpose.
 fn main() {
-    if /*w*/ 5 /*x*/ == /*y*/ 6 /*z*/ {}
+    if /*w*/ x /*x*/ == /*y*/ y /*z*/ {}
 }
 
 fn main() {
     /*pre-if*/
-    if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ {
+    if /*post-if*/ x == y /*pre-if-block*/ {
         x = y + 7;
     }
     /*pre-elseif*/
@@ -21,7 +26,7 @@ fn main() {
 
 fn main() {
     /*pre-if*/
-    if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ {
+    if /*post-if*/ x /*x*/ == /*y*/ y /*pre-if-block*/ {
         x = y + 7;
     }
     /*pre-elseif*/
@@ -38,7 +43,7 @@ fn main() {
 fn main() {
     /*pre-if*/
     if // post-if - make sure that x and y states are the same
-    5 /*x*/ == /*y*/ 6 //pre-if-block - when they are same change y to next state
+    x == y //pre-if-block - when they are same change y to next state
     {
         x = y + 7;
     }
@@ -47,7 +52,7 @@ fn main() {
 fn main() {
     /*pre-if*/
     if // post-if - make sure that x and y states are the sameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
-    5 /*x*/ == /*y*/ 6
+    x /*x*/ == /*y*/ y
     //pre-if-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
     {
         x = y + 7;
@@ -75,5 +80,151 @@ fn main() {
     // if comment
     5 == 6 {
         x = y + 7;
+    }
+}
+
+// Tests for `loop`
+fn main() {
+    loop {
+        x = y + 7;
+    }
+
+    /*pre-statement*/
+    loop /*pre-block*/ {
+        x = y + 7;
+    }
+
+    /*pre-statement*/
+    loop /*pre-block Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ {
+        y = 5;
+    }
+
+    /*pre-statement*/
+    loop /*pre-block Longerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/ {
+        y = 5;
+    }
+
+    loop
+    /*pre-block Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/
+    {
+        exppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp
+    }
+}
+
+// Tests for `while`
+// NOTE: same coments limitations as for `if`.
+fn main() {
+    /*pre-statement*/
+    while /*post-cond*/ x /*x*/ == /*y*/ y /*pre-block*/ {
+        x = y + 7;
+    }
+
+    /*pre-statement*/
+    while /*pre-cond Longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg*/ z == u
+    /*pre-block*/ {
+        y = 5;
+    }
+
+    /*pre-statement*/
+    while /*pre-cond Longerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/
+    z == u /*pre-block*/ {
+        y = 5;
+    }
+
+    /*pre-statement*/
+    while
+    // pre-cond - make sure that x and y states are the sameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    x /*x*/ == /*y*/ y
+    //pre-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    {
+        x = y + 7;
+    }
+}
+
+// Tests for `if/while let`
+// NOTE: comments before an after the `pat` item that follows `let` (e.g. the `Some(x)`
+//       in `let Some(x) =`) are currently not handledand, so original code is used.
+//       E.g., in `while let /*C1*/ Some(x) /*C2*/ = /*C3*/ exp /*C4*/{}`, only the
+//       `C3` and `C4` comments are handled, and therefore comments such as `C1` AND `C2`
+//       are not included in the test.
+fn main() {
+    /*pre-statement*/
+    while let Some(x) = /*pre-epr*/ exp /*pre-block*/ {
+        y = x + 7;
+    }
+
+    /*pre-statement*/
+    while let Some(x) = /*pre-expr Longggggggggggggggggggggggggggggggggggggggggggggggggggg*/ exp
+    /*pre-block*/ {
+        y = x;
+    }
+
+    /*pre-statement*/
+    while let Some(x) =
+        /*pre-expr Longerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/
+        exp /*pre-block*/
+    {
+        y = x;
+    }
+
+    /*pre-statement*/
+    while let Some(x) =
+        // pre-exprrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
+        exp
+    //pre-blockkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
+    {
+        y = x + 7;
+    }
+}
+fn main() {
+    /*pre-statement*/
+    if let Some(x) = /*pre-epr*/ exp /*pre-block*/ {
+        y = x + 7;
+    };
+
+    /*pre-statement*/
+    if let Some(ref /*def*/ mut /*abc*/ state) = /*pre-epr*/ exp /*pre-block*/ {
+        y = x + 7;
+    };
+
+    /*pre-statement*/
+    if let Some(ref /*def*/ mut /*abc*/ state) =
+        /*pre-eprrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/
+        exp /*pre-blockkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk*/
+    {
+        y = x + 7;
+    };
+}
+
+// Tests for `for`
+// NOTE: comments `in` aare currently not handledand, so original code is used.
+//       E.g., in `for x /*C1*/ in /*C2*/`, only the `C2` comment is handled,
+//       and therefore comments such as `C1` are not included in the test.
+fn main() {
+    /*pre-statement*/
+    for /*post-cond*/ x in /*post-in*/ exp /*pre-block*/ {
+        y = x + 7;
+    }
+
+    /*pre-statement*/
+    for /*pre-cond Longggggggggggggggggggggggggggggggggggggggggggggggggggg*/ x in exp /*pre-block*/ {
+        y = x;
+    }
+
+    /*pre-statement*/
+    for /*pre-cond Longerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr*/
+    x in exp /*pre-block*/ {
+        y = x;
+    }
+
+    /*pre-statement*/
+    for
+    // pre-cond - make sure that x and y states are the sameeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    x in
+        /*post-innnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn*/
+        exp
+    //pre-block - when they are same change y to next stateeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+    {
+        y = x + 7;
     }
 }

--- a/tests/target/control-brace-style-always-next-line.rs
+++ b/tests/target/control-brace-style-always-next-line.rs
@@ -8,8 +8,7 @@ fn main() {
     }
 
 
-    'label: loop
-    // loop comment
+    'label: loop // loop comment
     {
         let foo = ();
     }

--- a/tests/target/control-brace-style-always-same-line.rs
+++ b/tests/target/control-brace-style-always-same-line.rs
@@ -5,8 +5,7 @@ fn main() {
     }
 
 
-    'label: loop
-    // loop comment
+    'label: loop // loop comment
     {
         let foo = ();
     }

--- a/tests/target/else-if-brace-style-always-next-line.rs
+++ b/tests/target/else-if-brace-style-always-next-line.rs
@@ -7,8 +7,7 @@ fn main() {
         let bar = ();
     }
 
-    if false
-    // lone if comment
+    if false // lone if comment
     {
         let foo = ();
         let bar = ();
@@ -34,19 +33,16 @@ fn main() {
         let baz = ();
     }
 
-    if true
-    // else-if-chain if comment
+    if true // else-if-chain if comment
     {
         let foo = ();
     }
-    else if false
-    // else-if-chain else-if comment
+    else if false // else-if-chain else-if comment
     {
         let foo = ();
         let bar = ();
     }
-    else
-    // else-if-chain else comment
+    else // else-if-chain else comment
     {
         let foo = ();
         let bar = ();

--- a/tests/target/else-if-brace-style-always-same-line.rs
+++ b/tests/target/else-if-brace-style-always-same-line.rs
@@ -4,8 +4,7 @@ fn main() {
         let bar = ();
     }
 
-    if false
-    // lone if comment
+    if false // lone if comment
     {
         let foo = ();
         let bar = ();
@@ -26,17 +25,14 @@ fn main() {
         let baz = ();
     }
 
-    if true
-    // else-if-chain if comment
+    if true // else-if-chain if comment
     {
         let foo = ();
-    } else if false
-    // else-if-chain else-if comment
+    } else if false // else-if-chain else-if comment
     {
         let foo = ();
         let bar = ();
-    } else
-    // else-if-chain else comment
+    } else // else-if-chain else comment
     {
         let foo = ();
         let bar = ();

--- a/tests/target/else-if-brace-style-closing-next-line.rs
+++ b/tests/target/else-if-brace-style-closing-next-line.rs
@@ -6,8 +6,7 @@ fn main() {
         let bar = ();
     }
 
-    if false
-    // lone if comment
+    if false // lone if comment
     {
         let foo = ();
         let bar = ();
@@ -30,19 +29,16 @@ fn main() {
         let baz = ();
     }
 
-    if true
-    // else-if-chain if comment
+    if true // else-if-chain if comment
     {
         let foo = ();
     }
-    else if false
-    // else-if-chain else-if comment
+    else if false // else-if-chain else-if comment
     {
         let foo = ();
         let bar = ();
     }
-    else
-    // else-if-chain else comment
+    else // else-if-chain else comment
     {
         let foo = ();
         let bar = ();

--- a/tests/target/issue-447.rs
+++ b/tests/target/issue-447.rs
@@ -1,40 +1,32 @@
 // rustfmt-normalize_comments: true
 
 fn main() {
-    if
+    if // shouldn't be dropped
     // shouldn't be dropped
-    // shouldn't be dropped
-    cond
-    // shouldn't be dropped
+    cond // shouldn't be dropped
     // shouldn't be dropped
     {
     }
     // shouldn't be dropped
     // shouldn't be dropped
-    else
+    else // shouldn't be dropped
     // shouldn't be dropped
+    if // shouldn't be dropped
     // shouldn't be dropped
-    if
-    // shouldn't be dropped
-    // shouldn't be dropped
-    cond
-    // shouldn't be dropped
+    cond // shouldn't be dropped
     // shouldn't be dropped
     {
     }
     // shouldn't be dropped
     // shouldn't be dropped
-    else
-    // shouldn't be dropped
+    else // shouldn't be dropped
     // shouldn't be dropped
     {
     }
 
-    if
+    if // shouldn't be dropped
     // shouldn't be dropped
-    // shouldn't be dropped
-    let Some(x) = y
-    // shouldn't be dropped
+    let Some(x) = y // shouldn't be dropped
     // shouldn't be dropped
     {}
 }

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -12,8 +12,7 @@ fn main() {
     }
 
     'a: while loooooooooooooooooooooooooooooooooong_variable_name + another_value > some_other_value
-    {
-    }
+    {}
 
     while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
     }


### PR DESCRIPTION
A proposed fix for issue #4549 for control-flow comments formatting.  The approach taken is:
1. **"pre-else"** comments continue to be in a separate line, to be compatible with the formatting of the "pre-if" comments.
2. The **"post-if/else"** comments and **"post-condition / pre-block"** comments are formatted using `combine_strs_with_missing_comments()`, instead of just putting them in a separate line.

The general output with these changes is:
```rust
    /*pre-if*/
    if /*post-if*/ 5 /*x*/ == /*y*/ 6 /*pre-if-block*/ {
        x = y + 7;
    }
    /*pre-elseif*/
    else if /*post-elseif*/ z == u /*pre-elseif-block*/ {
        y = 5;
    }
    /*pre-else*/
    else /*post-else*/ {
        z = x;
    }
```

This change requires some changes to existing test cases, but it seems that at least in most of these cases this change is what is desired.  For example, currently rustfmt formats the following from [else-if-brace-style-closing-next-line.rs](https://github.com/rust-lang/rustfmt/blob/10b95e0716e099e669370d508bff3f1af5a762bc/tests/source/else-if-brace-style-closing-next-line.rs#L10):
```rust
    if false // lone if comment
```
as:
```rust
    if false
    // lone if comment
```
With the change the output format is:
```rust
    if false // lone if comment 
```
which seem to be better, as the comment remains in the same line of the `if` as in the source.