### PR TITLE
Fix rewrite of closures with a return type

### DIFF
--- a/src/formatting/closures.rs
+++ b/src/formatting/closures.rs
@@ -409,18 +409,21 @@ pub(crate) fn rewrite_last_closure(
         if is_block_closure_forced(context, body, capture) {
             return rewrite_closure_with_block(body, &prefix, context, body_shape).map(
                 |body_str| {
-                    // If the expression can fit in a single line, we need not force block closure.
-                    if body_str.lines().count() <= 7 {
-                        match rewrite_closure_expr(body, &prefix, context, shape) {
-                            Some(ref single_line_body_str)
-                                if !single_line_body_str.contains('\n') =>
-                            {
-                                single_line_body_str.clone()
+                    match fn_decl.output {
+                        ast::FnRetTy::Default(..) if body_str.lines().count() <= 7 => {
+                            // If the expression can fit in a single line, we need not force block
+                            // closure.  However, if the closure has a return type, then we must
+                            // keep the blocks.
+                            match rewrite_closure_expr(body, &prefix, context, shape) {
+                                Some(ref single_line_body_str)
+                                    if !single_line_body_str.contains('\n') =>
+                                {
+                                    single_line_body_str.clone()
+                                }
+                                _ => body_str,
                             }
-                            _ => body_str,
                         }
-                    } else {
-                        body_str
+                        _ => body_str,
                     }
                 },
             );

--- a/tests/source/issue-4577.rs
+++ b/tests/source/issue-4577.rs
@@ -1,0 +1,20 @@
+fn main() {
+    let s: String = "ABAABBAA".chars()
+        .filter(|c| {
+            if *c == 'A' {
+                true
+            }
+            else {
+                false
+            }
+        })
+        .map(|c| -> char {
+        if c == 'A' {
+            '0'
+        } else {
+            '1'
+        }
+    }).collect();
+    
+    println!("{}", s);
+}

--- a/tests/target/issue-4577.rs
+++ b/tests/target/issue-4577.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let s: String = "ABAABBAA"
+        .chars()
+        .filter(|c| if *c == 'A' { true } else { false })
+        .map(|c| -> char {
+            if c == 'A' { '0' } else { '1' }
+        })
+        .collect();
+
+    println!("{}", s);
+}


### PR DESCRIPTION
If the closure's body fits in a line, the block is removed but it is
necessary if the closure has a return type.

Close #4577