### PR TITLE
Separator place for list post-comment

### DIFF
--- a/src/formatting/lists.rs
+++ b/src/formatting/lists.rs
@@ -415,9 +415,13 @@ where
 
             result.push(' ');
             result.push_str(&formatted_comment);
-        }
-
-        if separate && sep_place.is_back() {
+            // When `Horizontal`, post-comment always preceeds the separator,
+            // regardless of `sep_place`.  Otherwise pos-comment of a list item
+            // may be read as the pre-comment of the next ietm.
+            if separate {
+                result.push_str(formatting.separator);
+            }
+        } else if separate && sep_place.is_back() {
             result.push_str(formatting.separator);
         }
 

--- a/tests/source/issue-4552.rs
+++ b/tests/source/issue-4552.rs
@@ -1,0 +1,44 @@
+fn main() {
+    panic!("Foo {:?}", /*"*/
+                    1
+                );
+}
+fn main() {
+    panic!("Foo {:?}"            /*"*/,
+                    1
+                );
+}
+fn main() {
+    panic!("Foo {:?}",            /*"*/ 1
+                );
+}
+fn main() {
+    panic!("Foo {:?}"             /*"*/, 1
+                );
+}
+
+fn main() {
+	let v = ["A",              /* First Comment */
+	"C",             /* Second comment */
+	];
+}
+fn main() {
+	let v = ["A"                 /* First Comment */,
+	"C",                /* Second comment */
+	];
+}
+fn main() {
+	let v = ["A",            /* First Comment */         "C",           /* Second comment */      ];
+}
+fn main() {
+	let v = ["A"          /* First Comment */         , "C",           /* Second comment */           ];
+}
+
+fn main() {
+	let v = ["A" /* First longgggggggggggggggggggggggggggggggggg Comment */, "C", /* Second comment with some info*/
+	];
+}
+fn main() {
+	let v = ["A", /* First longgggggggggggggggggggggggggggggggggg Comment */ "C", /* Second comment with some info*/
+	];
+}

--- a/tests/target/issue-4552.rs
+++ b/tests/target/issue-4552.rs
@@ -1,0 +1,39 @@
+fn main() {
+    panic!("Foo {:?}" /*"*/, 1);
+}
+fn main() {
+    panic!("Foo {:?}" /*"*/, 1);
+}
+fn main() {
+    panic!("Foo {:?}", /*"*/ 1);
+}
+fn main() {
+    panic!("Foo {:?}" /*"*/, 1);
+}
+
+fn main() {
+    let v = ["A" /* First Comment */, "C" /* Second comment */];
+}
+fn main() {
+    let v = ["A" /* First Comment */, "C" /* Second comment */];
+}
+fn main() {
+    let v = ["A", /* First Comment */ "C" /* Second comment */];
+}
+fn main() {
+    let v = ["A" /* First Comment */, "C" /* Second comment */];
+}
+
+fn main() {
+    let v = [
+        "A", /* First longgggggggggggggggggggggggggggggggggg Comment */
+        "C", /* Second comment with some info*/
+    ];
+}
+fn main() {
+    let v = [
+        "A",
+        /* First longgggggggggggggggggggggggggggggggggg Comment */
+        "C", /* Second comment with some info*/
+    ];
+}


### PR DESCRIPTION
Proposed fix for issue #4552 - properly put the separator before or after list item post-comment, especially when list items that are in separate lines in the source code are formatted into one (`Horizontal`) line.

The change is based on the following assumptions according to the current code functionality (after several trial and errors ...):
1. A comment after the last list item in a source line is always considered as post-comment for that item and not a pre-comment for the next item that is in the next line.  E.g. in source line that ends with `"Item", /*comment*/`, the comment is a post-comment, although it is written after the `,` separator.
2. A comment between list items that are in the same line is regarded as pre or post comment, depending on whether it is before or after the separator.  E.g: `"Item1" /*Item1 post-comment*/, "Item2"`, and `"Item1", /*Item2 pre-comment*/ "Item2"`.
3. `write_list()` , where the change was done, should **place the separator before the post-comment if this is the last item in the line**, and **after after the post-comment if another item follows the comment of the same line**.  This is **regardless** of the separator place in the source code.