### PR TITLE
don't strip nonexistent trailing comma in derive with Visual indent_style

### DIFF
--- a/src/formatting/attr.rs
+++ b/src/formatting/attr.rs
@@ -187,9 +187,11 @@ fn format_derive(
     } else if let SeparatorTactic::Always = context.config.trailing_comma() {
         // Retain the trailing comma.
         result.push_str(&item_str);
-    } else {
+    } else if item_str.ends_with(",") {
         // Remove the trailing comma.
         result.push_str(&item_str[..item_str.len() - 1]);
+    } else {
+        result.push_str(&item_str);
     }
     result.push_str(")]");
 

--- a/tests/source/issue_4584.rs
+++ b/tests/source/issue_4584.rs
@@ -1,0 +1,19 @@
+// rustfmt-indent_style: Visual
+
+#[derive(Debug,)]
+pub enum Case {
+    Upper,
+    Lower
+}
+
+#[derive(Debug, Clone, PartialEq, Eq,)]
+pub enum Case {
+    Upper,
+    Lower
+}
+
+// NB - This formatting looks potentially off the desired state, but is
+// consistent with current behavior. Included here to provide a line wrapped
+// derive case with the changes applied to resolve issue #4584
+#[derive(Add, Sub, Mul, Div, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Serialize, Mul,)]
+struct Foo {}

--- a/tests/target/issue_4584.rs
+++ b/tests/target/issue_4584.rs
@@ -1,0 +1,32 @@
+// rustfmt-indent_style: Visual
+
+#[derive(Debug)]
+pub enum Case {
+    Upper,
+    Lower,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Case {
+    Upper,
+    Lower,
+}
+
+// NB - This formatting looks potentially off the desired state, but is
+// consistent with current behavior. Included here to provide a line wrapped
+// derive case with the changes applied to resolve issue #4584
+#[derive(Add,
+           Sub,
+           Mul,
+           Div,
+           Clone,
+           Copy,
+           Eq,
+           PartialEq,
+           Ord,
+           PartialOrd,
+           Debug,
+           Hash,
+           Serialize,
+           Mul)]
+struct Foo {}


### PR DESCRIPTION
Fixes #4584 