### PR TITLE
Fix test config dir

### DIFF
--- a/src/formatting/syntux/session/ignore_path.rs
+++ b/src/formatting/syntux/session/ignore_path.rs
@@ -42,22 +42,48 @@ mod test {
 
     use super::IgnorePathSet;
     use crate::config::{Config, FileName};
+    use crate::is_nightly_channel;
 
     #[test]
     fn test_ignore_path_set() {
-        match option_env!("CFG_RELEASE_CHANNEL") {
-            // this test requires nightly
-            None | Some("nightly") => {
-                let config =
-                    Config::from_toml(r#"ignore = ["foo.rs", "bar_dir/*"]"#, Path::new(""))
-                        .unwrap();
-                let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
+        if !is_nightly_channel!() {
+            // This test requires nightly
+            return;
+        }
+        let config =
+            Config::from_toml(r#"ignore = ["foo.rs", "bar_dir/*"]"#, Path::new("")).unwrap();
+        let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
 
-                assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/foo.rs"))));
-                assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz.rs"))));
-                assert!(!ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/bar.rs"))));
-            }
-            _ => {}
-        };
+        assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/foo.rs"))));
+        assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz.rs"))));
+        assert!(!ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/bar.rs"))));
+    }
+    #[test]
+    fn test_ignore_path_set_with_dir() {
+        if !is_nightly_channel!() {
+            // This test requires nightly
+            return;
+        }
+        let config = Config::from_toml(
+            r#"ignore = ["tests/**/foo/bar.rs"]"#,
+            Path::new("tests/config/"),
+        )
+        .unwrap();
+        info!(
+            "rustfmt_toml_path: {:?}",
+            &config.ignore().rustfmt_toml_path()
+        );
+        let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
+
+        assert_eq!(
+            ignore_path_set.is_match(&FileName::Real(PathBuf::from("tests/source/foo/bar.rs"))),
+            false
+        );
+        assert_eq!(
+            ignore_path_set.is_match(&FileName::Real(PathBuf::from(
+                "tests/tests/source/foo/bar.rs"
+            ))),
+            true
+        );
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -703,7 +703,7 @@ fn get_config(config_file: Option<&Path>) -> Config {
         .read_to_string(&mut def_config)
         .expect("Couldn't read config");
 
-    Config::from_toml(&def_config, Path::new("tests/config/")).expect("invalid TOML")
+    Config::from_toml(&def_config, Path::new("tests/")).expect("invalid TOML")
 }
 
 // Reads significant comments of the form: `// rustfmt-key: value` into a hash map.

--- a/tests/source/issue-3779/lib.rs
+++ b/tests/source/issue-3779/lib.rs
@@ -1,3 +1,4 @@
+// rustfmt-recursive: true
 // rustfmt-unstable: true
 // rustfmt-config: issue-3779.toml
 

--- a/tests/target/issue-3779/lib.rs
+++ b/tests/target/issue-3779/lib.rs
@@ -1,3 +1,4 @@
+// rustfmt-recursive: true
 // rustfmt-unstable: true
 // rustfmt-config: issue-3779.toml
 


### PR DESCRIPTION
Fix #4592 
Part of #4113 

Test config with `tests/config/` make ignore dir root to `tests/` and it return false with files like `tests/source/foo/bar.rs`.
I remove `config/` and add test cases to ignore_path module.