### PR TITLE
Infinite macro body indentation

### DIFF
--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -687,9 +687,13 @@ impl<'a> CommentRewrite<'a> {
                         let mut config = self.fmt.config.clone();
                         config.set().wrap_comments(false);
                         if config.format_code_in_doc_comments() {
-                            if let Some(s) =
-                                format_code_block(&self.code_block_buffer, &config, false)
-                            {
+                            let mut macro_original_code_was_used = false;
+                            if let Some(s) = format_code_block(
+                                &self.code_block_buffer,
+                                &config,
+                                false,
+                                &mut macro_original_code_was_used,
+                            ) {
                                 trim_custom_comment_prefix(s.as_ref())
                             } else {
                                 trim_custom_comment_prefix(&self.code_block_buffer)
@@ -1604,6 +1608,7 @@ pub(crate) fn recover_comment_removed(
     let snippet = context.snippet(span);
     let includes_comment = contains_comment(snippet);
     if snippet != new && includes_comment && changed_comment_content(snippet, &new) {
+        context.macro_original_code_was_used.replace(true);
         snippet.to_owned()
     } else {
         new

--- a/src/formatting/expr.rs
+++ b/src/formatting/expr.rs
@@ -606,6 +606,11 @@ pub(crate) fn rewrite_block_with_visitor(
         .skipped_range
         .borrow_mut()
         .append(&mut visitor_context.skipped_range.borrow_mut());
+
+    if visitor.macro_original_code_was_used.get() {
+        context.macro_original_code_was_used.replace(true);
+    }
+
     Some(format!("{}{}{}", prefix, label_str, visitor.buffer))
 }
 

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -890,6 +890,10 @@ pub(crate) fn format_impl(
             result.push_str(&inner_indent_str);
             result.push_str(visitor.buffer.trim());
             result.push_str(&outer_indent_str);
+
+            if visitor.macro_original_code_was_used.get() {
+                context.macro_original_code_was_used.replace(true);
+            }
         } else if need_newline || !context.config.empty_item_single_line() {
             result.push_str(&sep);
         }
@@ -1266,6 +1270,10 @@ pub(crate) fn format_trait(
             result.push_str(&inner_indent_str);
             result.push_str(visitor.buffer.trim());
             result.push_str(&outer_indent_str);
+
+            if visitor.macro_original_code_was_used.get() {
+                context.macro_original_code_was_used.replace(true);
+            }
         } else if result.contains('\n') {
             result.push_str(&outer_indent_str);
         }
@@ -3264,6 +3272,11 @@ impl Rewrite for ast::ForeignItem {
                     defaultness,
                     Some(&inner_attrs),
                 );
+
+                if visitor.macro_original_code_was_used.get() {
+                    context.macro_original_code_was_used.replace(true);
+                }
+
                 Some(visitor.buffer.to_owned())
             }
             ast::ForeignItemKind::Fn(_, ref fn_sig, ref generics, None) => rewrite_fn_base(

--- a/src/formatting/rewrite.rs
+++ b/src/formatting/rewrite.rs
@@ -44,6 +44,7 @@ pub(crate) struct RewriteContext<'a> {
     pub(crate) snippet_provider: &'a SnippetProvider,
     // Used for `format_snippet`
     pub(crate) macro_rewrite_failure: Cell<bool>,
+    pub(crate) macro_original_code_was_used: Cell<bool>,
     pub(crate) report: FormatReport,
     pub(crate) skip_context: SkipContext,
     pub(crate) skipped_range: Rc<RefCell<Vec<NonFormattedRange>>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,13 @@ pub fn format(
     config: &Config,
     operation_setting: OperationSetting,
 ) -> Result<FormatReport, OperationError> {
+    let mut macro_original_code_was_used = false;
     format_input_inner(
         input,
         config,
         operation_setting,
         /* is_macro_def */ false,
+        &mut macro_original_code_was_used,
     )
 }
 

--- a/tests/source/issue-4603.rs
+++ b/tests/source/issue-4603.rs
@@ -1,0 +1,47 @@
+// Formatting when original macro snippet is used
+
+// Original issue #4603 code
+#![feature(or_patterns)]
+macro_rules! t_or_f {
+    () => {
+        (true // some comment
+        | false)
+    };
+}
+
+// Other test cases variations
+macro_rules! RULES {
+    () => {
+        (
+		xxxxxxx // COMMENT
+        | yyyyyyy
+        )
+    };
+}
+macro_rules! RULES {
+    () => {
+        (xxxxxxx // COMMENT
+            | yyyyyyy)
+    };
+}
+
+fn main() {
+	macro_rules! RULES {
+		() => {
+			(xxxxxxx // COMMENT
+			| yyyyyyy)
+		};
+	}
+}
+
+macro_rules! RULES {
+    () => {
+        (xxxxxxx /* COMMENT */ | yyyyyyy)
+    };
+}
+macro_rules! RULES {
+    () => {
+        (xxxxxxx /* COMMENT */
+        | yyyyyyy)
+    };
+}

--- a/tests/source/issue-4609.rs
+++ b/tests/source/issue-4609.rs
@@ -1,0 +1,72 @@
+// Original issue
+macro_rules! outer {
+    ($d:tt) => {
+		macro_rules! inner {
+			($d s:expr) => {
+				println!("{}", $d s);
+			}
+		}
+	};
+}
+
+// Other tests with illegal code
+fn main() {
+	let s = 7;
+	
+	macro_rules! outer {
+		($d:tt) => {
+			macro_rules! inner {
+				($d s:something) => {
+					println!("{}", $d s);
+				}
+			}
+		};
+	}
+	
+	outer!(5);
+	inner!(5 s:something);
+}
+macro_rules! outer {
+    () => {
+		macro_rules! inner {
+			() => {
+				println!("", $dddddd sssssss);
+			}
+		}
+	};
+}
+
+// Tests with legal code
+macro_rules! outer {
+    () => {
+		macro_rules! inner {
+			() => {
+				println!("", zddddd, ssssss, vvvvvvv);
+			}
+		}
+	};
+}
+macro_rules! outer {
+		($d:tt) => {
+							macro_rules! inner {
+			($d s:expr) => {
+					}
+		}
+    };
+}
+fn main() {
+	let s = 7;
+	
+	macro_rules! outer {
+		($d:tt) => {
+			macro_rules! inner {
+				($d s:something) => {
+					println!("{}{}", $d, s);
+				}
+			}
+		};
+	}
+	
+	outer!(5);
+	inner!(5 s:something);
+}

--- a/tests/target/issue-4603.rs
+++ b/tests/target/issue-4603.rs
@@ -1,0 +1,47 @@
+// Formatting when original macro snippet is used
+
+// Original issue #4603 code
+#![feature(or_patterns)]
+macro_rules! t_or_f {
+    () => {
+        (true // some comment
+        | false)
+    };
+}
+
+// Other test cases variations
+macro_rules! RULES {
+    () => {
+        (
+		xxxxxxx // COMMENT
+        | yyyyyyy
+        )
+    };
+}
+macro_rules! RULES {
+    () => {
+        (xxxxxxx // COMMENT
+            | yyyyyyy)
+    };
+}
+
+fn main() {
+    macro_rules! RULES {
+        () => {
+			(xxxxxxx // COMMENT
+			| yyyyyyy)
+		};
+    }
+}
+
+macro_rules! RULES {
+    () => {
+        (xxxxxxx /* COMMENT */ | yyyyyyy)
+    };
+}
+macro_rules! RULES {
+    () => {
+        (xxxxxxx /* COMMENT */
+        | yyyyyyy)
+    };
+}

--- a/tests/target/issue-4609.rs
+++ b/tests/target/issue-4609.rs
@@ -1,0 +1,71 @@
+// Original issue
+macro_rules! outer {
+    ($d:tt) => {
+		macro_rules! inner {
+			($d s:expr) => {
+				println!("{}", $d s);
+			}
+		}
+	};
+}
+
+// Other tests with illegal code
+fn main() {
+    let s = 7;
+
+    macro_rules! outer {
+        ($d:tt) => {
+			macro_rules! inner {
+				($d s:something) => {
+					println!("{}", $d s);
+				}
+			}
+		};
+    }
+
+    outer!(5);
+    inner!(5 s:something);
+}
+macro_rules! outer {
+    () => {
+		macro_rules! inner {
+			() => {
+				println!("", $dddddd sssssss);
+			}
+		}
+	};
+}
+
+// Tests with legal code
+macro_rules! outer {
+    () => {
+        macro_rules! inner {
+            () => {
+                println!("", zddddd, ssssss, vvvvvvv);
+            };
+        }
+    };
+}
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {};
+        }
+    };
+}
+fn main() {
+    let s = 7;
+
+    macro_rules! outer {
+        ($d:tt) => {
+            macro_rules! inner {
+                ($d s:something) => {
+                    println!("{}{}", $d, s);
+                };
+            }
+        };
+    }
+
+    outer!(5);
+    inner!(5 s:something);
+}


### PR DESCRIPTION
Proposed fix for issues #4603 and #4609.  Both issues are caused because **original code snippet** is used during macro definition formatting - caused by a missing comment in #4603 and macro code that rustfmt doesn't understand in #4609.  The extra indentation is caused since [MacroBranch() indents the body of the formatted macro](https://github.com/rust-lang/rustfmt/blob/94f17f8dde15b883002e9d935be3a60919240a48/src/formatting/macros.rs#L1406-L1422).  The problem is that the indentation assumes that the macro body is properly formatted, when the first line starts at column 1. However, this is not the case original code snippet, so each time the code is formatted another extra indentation is added to these lines.

The fix here is by adding a writable `bool` parameter through all the function calls, either as additional function parameter or by added parameter to `FmtVisitor` and `RewriteContext`. When original code snippet is used the event is escalated up by setting this parameter to to `true`. 

This approach seem to be similar to the approach taken with `is_macro_def` and `is_nested_macro`, except that escalation is up instead of down.  Although the approach is not very elegant, I didn't find a better way to do it, except for using a kind of a global variable, which I am not sure is desired.