### PR TITLE
Add imports_granularity="Item".

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1710,7 +1710,7 @@ pub enum Foo {}
 Merge together related imports based on their paths.
 
 - **Default value**: `Preserve`
-- **Possible values**: `Preserve`, `Crate`, `Module`
+- **Possible values**: `Preserve`, `Crate`, `Module`, `Item`
 - **Stable**: No
 
 #### `Preserve` (default):
@@ -1747,6 +1747,21 @@ use foo::b::{f, g};
 use foo::d::e;
 use foo::{a, b, c};
 use qux::{h, i};
+```
+
+#### `Item`:
+
+Flatten imports so that each has its own `use` statement.
+
+```rust
+use foo::a;
+use foo::b;
+use foo::b::f;
+use foo::b::g;
+use foo::c;
+use foo::d::e;
+use qux::h;
+use qux::i;
 ```
 
 ## `merge_imports`

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -128,6 +128,8 @@ pub enum ImportGranularity {
     Crate,
     /// Use one `use` statement per module.
     Module,
+    /// Use one `use` statement per imported item.
+    Item,
 }
 
 #[config_type]

--- a/src/formatting/imports.rs
+++ b/src/formatting/imports.rs
@@ -182,6 +182,24 @@ pub(crate) fn merge_use_trees(use_trees: Vec<UseTree>, merge_by: SharedPrefix) -
     result
 }
 
+pub(crate) fn flatten_use_trees(use_trees: Vec<UseTree>) -> Vec<UseTree> {
+    use_trees
+        .into_iter()
+        .flat_map(UseTree::flatten)
+        .map(|mut tree| {
+            // If a path ends in `::self`, rewrite it to `::{self}`.
+            if let Some(UseSegment::Slf(..)) = tree.path.last() {
+                let self_segment = tree.path.pop().unwrap();
+                tree.path.push(UseSegment::List(vec![UseTree::from_path(
+                    vec![self_segment],
+                    DUMMY_SP,
+                )]));
+            }
+            tree
+        })
+        .collect()
+}
+
 impl fmt::Debug for UseTree {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
@@ -1065,6 +1083,25 @@ mod test {
             Module,
             ["foo::{a::b, a::c, d::e, d::f}"],
             ["foo::a::{b, c}", "foo::d::{e, f}"]
+        );
+    }
+
+    #[test]
+    fn test_flatten_use_trees() {
+        assert_eq!(
+            flatten_use_trees(parse_use_trees!["foo::{a::{b, c}, d::e}"]),
+            parse_use_trees!["foo::a::b", "foo::a::c", "foo::d::e"]
+        );
+
+        assert_eq!(
+            flatten_use_trees(parse_use_trees!["foo::{self, a, b::{c, d}, e::*}"]),
+            parse_use_trees![
+                "foo::{self}",
+                "foo::a",
+                "foo::b::c",
+                "foo::b::d",
+                "foo::e::*"
+            ]
         );
     }
 

--- a/tests/source/imports_granularity_item.rs
+++ b/tests/source/imports_granularity_item.rs
@@ -1,0 +1,6 @@
+// rustfmt-imports_granularity: Item
+
+use a::{b, c, d};
+use a::{f::g, h::{i, j}};
+use a::{l::{self, m, n::o, p::*}};
+use a::q::{self};

--- a/tests/target/imports_granularity_item.rs
+++ b/tests/target/imports_granularity_item.rs
@@ -1,0 +1,13 @@
+// rustfmt-imports_granularity: Item
+
+use a::b;
+use a::c;
+use a::d;
+use a::f::g;
+use a::h::i;
+use a::h::j;
+use a::l::m;
+use a::l::n::o;
+use a::l::p::*;
+use a::l::{self};
+use a::q::{self};


### PR DESCRIPTION
This option splits all imports into their own `use` statement.
