### PR TITLE
v1.4.30 backport of bounds indentation issue

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -962,22 +962,21 @@ fn join_bounds_inner(
                 joiner
             };
 
-            let (trailing_str, extendable) = if i == 0 {
+            let (extendable, trailing_str) = if i == 0 {
                 let bound_str = item.rewrite(context, shape)?;
-                let bound_str_clone = bound_str.clone();
-                (bound_str, is_bound_extendable(&bound_str_clone, item))
+                (is_bound_extendable(&bound_str, item), bound_str)
             } else {
                 let bound_str = &item.rewrite(context, shape)?;
                 match leading_span {
                     Some(ls) if has_leading_comment => (
+                        is_bound_extendable(bound_str, item),
                         combine_strs_with_missing_comments(
                             context, joiner, bound_str, ls, shape, true,
                         )?,
-                        is_bound_extendable(bound_str, item),
                     ),
                     _ => (
-                        String::from(joiner) + bound_str,
                         is_bound_extendable(bound_str, item),
+                        String::from(joiner) + bound_str,
                     ),
                 }
             };

--- a/src/types.rs
+++ b/src/types.rs
@@ -931,7 +931,7 @@ fn join_bounds_inner(
                 _ => false,
             };
 
-            let shape = if i > 0 && need_indent && force_newline {
+            let shape = if need_indent && force_newline {
                 shape
                     .block_indent(context.config.tab_spaces())
                     .with_max_width(context.config)

--- a/tests/source/issue_4636.rs
+++ b/tests/source/issue_4636.rs
@@ -1,0 +1,13 @@
+pub trait PrettyPrinter<'tcx>:
+    Printer<
+        'tcx,
+        Error = fmt::Error,
+        Path = Self,
+        Region = Self,
+        Type = Self,
+        DynExistential = Self,
+        Const = Self,
+    > + fmt::Write
+    {
+         //
+    }

--- a/tests/target/issue_4636.rs
+++ b/tests/target/issue_4636.rs
@@ -1,0 +1,13 @@
+pub trait PrettyPrinter<'tcx>:
+    Printer<
+        'tcx,
+        Error = fmt::Error,
+        Path = Self,
+        Region = Self,
+        Type = Self,
+        DynExistential = Self,
+        Const = Self,
+    > + fmt::Write
+{
+    //
+}


### PR DESCRIPTION
A bug was reported (#4636) that currently exists in the rustfmt version on beta (1.4.30) which has been fixed in rustfmt v1.4.32. We need to get this fixed to avoid shipping a known bug on stable, but we cannot readily do the typical roll-forward approach due to conflicting needs in the rustc-ap crates that had to be bumped between those two rustfmt versions (refs https://github.com/rust-lang/rust/pull/81151#issuecomment-761949761)

Instead, cherry-picking these commits that fixed the bug back onto the rustfmt 1.4.30 branch so the bug fix can still be pulled in for the 1.50 release