### PR TITLE
Comments between assignment (without let) lhs and rhs handling

### DIFF
--- a/src/formatting/expr.rs
+++ b/src/formatting/expr.rs
@@ -194,11 +194,11 @@ pub(crate) fn format_expr(
         ast::ExprKind::Path(ref qself, ref path) => {
             rewrite_path(context, PathContext::Expr, qself.as_ref(), path, shape)
         }
-        ast::ExprKind::Assign(ref lhs, ref rhs, _) => {
-            rewrite_assignment(context, lhs, rhs, None, shape)
+        ast::ExprKind::Assign(ref lhs, ref rhs, op_span) => {
+            rewrite_assignment(context, lhs, rhs, op_span, shape)
         }
         ast::ExprKind::AssignOp(ref op, ref lhs, ref rhs) => {
-            rewrite_assignment(context, lhs, rhs, Some(op), shape)
+            rewrite_assignment(context, lhs, rhs, op.span, shape)
         }
         ast::ExprKind::Continue(ref opt_label) => {
             let id_str = match *opt_label {
@@ -1895,25 +1895,24 @@ fn rewrite_assignment(
     context: &RewriteContext<'_>,
     lhs: &ast::Expr,
     rhs: &ast::Expr,
-    op: Option<&ast::BinOp>,
+    op_span: Span,
     shape: Shape,
 ) -> Option<String> {
-    let span_hi = rhs.span.lo();
-    let (operator_str, span_lo) = match op {
-        Some(op) => (context.snippet(op.span), op.span.hi()),
-        None => {
-            let lo = lhs.span.hi();
-            let offset = context.snippet(mk_sp(lo, span_hi)).find_uncommented("=")? + 1;
-            ("=", lo + BytePos(offset as u32))
-        }
-    };
-
     // 1 = space between lhs and operator.
+    let operator_str = context.snippet(op_span);
     let lhs_shape = shape.sub_width(operator_str.len() + 1)?;
     let lhs_str = format!("{} {}", lhs.rewrite(context, lhs_shape)?, operator_str);
 
-    let between_span = mk_sp(span_lo, span_hi);
-    rewrite_assign_rhs_with_span(context, lhs_str, rhs, shape, between_span)
+    let comments_span = mk_sp(op_span.hi(), rhs.span.lo());
+    rewrite_assign_rhs_with_comments(
+        context,
+        lhs_str,
+        rhs,
+        shape,
+        RhsTactics::Default,
+        comments_span,
+        true,
+    )
 }
 
 /// Controls where to put the rhs.
@@ -1937,26 +1936,6 @@ pub(crate) fn rewrite_assign_rhs<S: Into<String>, R: Rewrite>(
     shape: Shape,
 ) -> Option<String> {
     rewrite_assign_rhs_with(context, lhs, ex, shape, RhsTactics::Default)
-}
-
-// The left hand side must contain everything up to, and including, the
-// assignment operator.
-pub(crate) fn rewrite_assign_rhs_with_span<S: Into<String>, R: Rewrite>(
-    context: &RewriteContext<'_>,
-    lhs: S,
-    ex: &R,
-    shape: Shape,
-    between_span: Span,
-) -> Option<String> {
-    rewrite_assign_rhs_with_comments(
-        context,
-        lhs,
-        ex,
-        shape,
-        RhsTactics::Default,
-        between_span,
-        true,
-    )
 }
 
 pub(crate) fn rewrite_assign_rhs_expr<R: Rewrite>(

--- a/tests/source/lhs-to-rhs-between-comments/assignment.rs
+++ b/tests/source/lhs-to-rhs-between-comments/assignment.rs
@@ -1,0 +1,48 @@
+// "=" Assignemnt
+fn main () {
+    let var = first;
+    var = second;
+    }
+    fn main () {
+    let var = /* Block comment */ first;
+    var = /* Block comment */ second;
+    }
+    fn main () {
+    let var = // Line comment
+    first;
+        var = // Line comment
+        second;
+    }
+    fn main () {
+    let var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ first;
+    var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ second;
+    }
+    fn main () {
+    let var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ first;
+    var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ second;
+    }
+    
+    // BinOp Assigment
+    fn main () {
+    let var = first;
+    var += second;
+    }
+    fn main () {
+    let var = /* Block comment */ first;
+    var -= /* Block comment */ second;
+    }
+    fn main () {
+    let var = // Line comment
+    first;
+    var *= // Line comment
+    second;
+    }
+    fn main () {
+    let var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ first;
+    var /= /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ second;
+    }
+    fn main () {
+    let var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ first;
+    var /= /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ second;
+    }
+    

--- a/tests/source/lhs-to-rhs-between-comments/assignment.rs
+++ b/tests/source/lhs-to-rhs-between-comments/assignment.rs
@@ -21,6 +21,20 @@ fn main () {
     let var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ first;
     var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ second;
     }
+    fn main () {
+    let var = /* Block comment line 1 
+    * Block comment line 2
+    * Block comment line 3 */ first;
+    var = /* Block comment line 1 
+    * Block comment line 2
+    * Block comment line 3 */ second;
+    var = /* Block comment line 1 longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+    * Block comment line 2
+    * Block comment line 3 */ third;
+    var = /* Block comment line 1 
+    * Block comment line 2 longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+    * Block comment line 3 */ forth;
+    }
     
     // BinOp Assigment
     fn main () {
@@ -45,4 +59,18 @@ fn main () {
     let var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ first;
     var /= /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */ second;
     }
-    
+    fn main () {
+    let var = /* Block comment line 1 
+    * Block comment line 2
+    * Block comment line 3 */ first;
+    var += /* Block comment line 1 
+    * Block comment line 2
+    * Block comment line 3 */ second;
+    var -= /* Block comment line 1 longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+    * Block comment line 2
+    * Block comment line 3 */ third;
+    var *= /* Block comment line 1 
+    * Block comment line 2 longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+    * Block comment line 3 */ forth;
+    }
+        

--- a/tests/target/lhs-to-rhs-between-comments/assignment.rs
+++ b/tests/target/lhs-to-rhs-between-comments/assignment.rs
@@ -1,0 +1,59 @@
+// "=" Assignemnt
+fn main() {
+    let var = first;
+    var = second;
+}
+fn main() {
+    let var = /* Block comment */ first;
+    var = /* Block comment */ second;
+}
+fn main() {
+    let var = // Line comment
+        first;
+    var = // Line comment
+        second;
+}
+fn main() {
+    let var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
+        first;
+    var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
+        second;
+}
+fn main() {
+    let var =
+        /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
+        first;
+    var =
+        /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
+        second;
+}
+
+// BinOp Assigment
+fn main() {
+    let var = first;
+    var += second;
+}
+fn main() {
+    let var = /* Block comment */ first;
+    var -= /* Block comment */ second;
+}
+fn main() {
+    let var = // Line comment
+        first;
+    var *= // Line comment
+        second;
+}
+fn main() {
+    let var = /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
+        first;
+    var /= /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
+        second;
+}
+fn main() {
+    let var =
+        /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
+        first;
+    var /=
+        /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
+        second;
+}

--- a/tests/target/lhs-to-rhs-between-comments/assignment.rs
+++ b/tests/target/lhs-to-rhs-between-comments/assignment.rs
@@ -27,6 +27,25 @@ fn main() {
         /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
         second;
 }
+fn main() {
+    let var = /* Block comment line 1
+         * Block comment line 2
+         * Block comment line 3 */
+        first;
+    var = /* Block comment line 1
+         * Block comment line 2
+         * Block comment line 3 */
+        second;
+    var =
+        /* Block comment line 1 longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+         * Block comment line 2
+         * Block comment line 3 */
+        third;
+    var = /* Block comment line 1
+         * Block comment line 2 longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+         * Block comment line 3 */
+        forth;
+}
 
 // BinOp Assigment
 fn main() {
@@ -56,4 +75,23 @@ fn main() {
     var /=
         /* Block comment longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg */
         second;
+}
+fn main() {
+    let var = /* Block comment line 1
+         * Block comment line 2
+         * Block comment line 3 */
+        first;
+    var += /* Block comment line 1
+         * Block comment line 2
+         * Block comment line 3 */
+        second;
+    var -=
+        /* Block comment line 1 longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+         * Block comment line 2
+         * Block comment line 3 */
+        third;
+    var *= /* Block comment line 1
+         * Block comment line 2 longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+         * Block comment line 3 */
+        forth;
 }


### PR DESCRIPTION
Add handling of comments between assignment (without let) lhs and rhs by using `rewrite_assign_rhs_with_comments()` (one of the cases identified in [#4626 discussion](https://github.com/rust-lang/rustfmt/pull/4626#issuecomment-761817663)).