### PR TITLE
[1.x] backport some const generic fixes for v1.4.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [1.4.33] 2021-??-??
+
+### Fixed
+- Fix erroneous removal of `const` keyword on const trait impl ([#4084](https://github.com/rust-lang/rustfmt/issues/4084))
+- Fix incorrect span usage wit const generics in supertraits ([#4204](https://github.com/rust-lang/rustfmt/issues/4204))
+- Use correct span for const generic params ([#4263](https://github.com/rust-lang/rustfmt/issues/4263))
+- Correct span on const generics to include type bounds ([#4310](https://github.com/rust-lang/rustfmt/issues/4310))
+
+### Install/Download Options
+- **crates.io package** - *pending*
+- **rustup (nightly)** - *pending*
+- **GitHub Release Binaries** - [Release v1.4.33](https://github.com/rust-lang/rustfmt/releases/tag/v1.4.33)
+- **Build from source** - [Tag v1.4.33](https://github.com/rust-lang/rustfmt/tree/v1.4.33), see instructions for how to [install rustfmt from source][install-from-source]
+
 ## [1.4.32] 2021-01-16
 
 ### Fixed
@@ -9,7 +23,7 @@
 
 ### Install/Download Options
 - **crates.io package** - *pending*
-- **rustup (nightly)** - *pending*
+- **rustup (nightly)** - Starting in `2021-01-18`
 - **GitHub Release Binaries** - [Release v1.4.32](https://github.com/rust-lang/rustfmt/releases/tag/v1.4.32)
 - **Build from source** - [Tag v1.4.32](https://github.com/rust-lang/rustfmt/tree/v1.4.32), see instructions for how to [install rustfmt from source][install-from-source]
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -1141,14 +1141,15 @@ pub(crate) fn format_trait(
         }
         result.push('{');
 
-        let snippet = context.snippet(item.span);
+        let block_span = mk_sp(generics.where_clause.span.hi(), item.span.hi());
+        let snippet = context.snippet(block_span);
         let open_pos = snippet.find_uncommented("{")? + 1;
         let outer_indent_str = offset.block_only().to_string_with_newline(context.config);
 
         if !trait_items.is_empty() || contains_comment(&snippet[open_pos..]) {
             let mut visitor = FmtVisitor::from_context(context);
             visitor.block_indent = offset.block_only().block_indent(context.config);
-            visitor.last_pos = item.span.lo() + BytePos(open_pos as u32);
+            visitor.last_pos = block_span.lo() + BytePos(open_pos as u32);
 
             for item in trait_items {
                 visitor.visit_trait_item(item);

--- a/src/items.rs
+++ b/src/items.rs
@@ -828,6 +828,7 @@ fn format_impl_ref_and_type(
         unsafety,
         polarity,
         defaultness,
+        constness,
         ref generics,
         of_trait: ref trait_ref,
         ref self_ty,
@@ -851,6 +852,7 @@ fn format_impl_ref_and_type(
         };
         let generics_str = rewrite_generics(context, "impl", generics, shape)?;
         result.push_str(&generics_str);
+        result.push_str(format_constness_right(constness));
 
         let polarity_str = match polarity {
             ast::ImplPolarity::Negative(_) => "!",

--- a/src/items.rs
+++ b/src/items.rs
@@ -2217,11 +2217,10 @@ fn rewrite_fn_base(
 
     // Skip `pub(crate)`.
     let lo_after_visibility = get_bytepos_after_visibility(&fn_sig.visibility, span);
-    // A conservative estimation, to goal is to be over all parens in generics
+    // A conservative estimation, the goal is to be over all parens in generics
     let params_start = fn_sig
         .generics
         .params
-        .iter()
         .last()
         .map_or(lo_after_visibility, |param| param.span().hi());
     let params_end = if fd.inputs.is_empty() {

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -132,7 +132,8 @@ impl Spanned for ast::GenericParam {
         };
         let ty_hi = if let ast::GenericParamKind::Type {
             default: Some(ref ty),
-        } = self.kind
+        }
+        | ast::GenericParamKind::Const { ref ty, .. } = self.kind
         {
             ty.span().hi()
         } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -101,6 +101,14 @@ pub(crate) fn format_constness(constness: ast::Const) -> &'static str {
 }
 
 #[inline]
+pub(crate) fn format_constness_right(constness: ast::Const) -> &'static str {
+    match constness {
+        ast::Const::Yes(..) => " const",
+        ast::Const::No => "",
+    }
+}
+
+#[inline]
 pub(crate) fn format_defaultness(defaultness: ast::Defaultness) -> &'static str {
     match defaultness {
         ast::Defaultness::Default(..) => "default ",

--- a/tests/source/const_generics.rs
+++ b/tests/source/const_generics.rs
@@ -34,3 +34,11 @@ type Foo<const N: usize> = [i32; N + 1];
 pub trait Foo: Bar<{Baz::COUNT}> {
 	const ASD: usize;
 }
+
+// #4263
+fn const_generics_on_params<
+    // AAAA
+        const BBBB: usize,
+    /* CCCC */
+    const DDDD: usize,
+    >() {}

--- a/tests/source/const_generics.rs
+++ b/tests/source/const_generics.rs
@@ -30,3 +30,7 @@ fn foo<const X: usize>() {
 }
 
 type Foo<const N: usize> = [i32; N + 1];
+
+pub trait Foo: Bar<{Baz::COUNT}> {
+	const ASD: usize;
+}

--- a/tests/source/impls.rs
+++ b/tests/source/impls.rs
@@ -160,3 +160,11 @@ impl<'a, 'b, 'c> SomeThing<Something> for (&'a mut SomethingLong, &'b mut Someth
 
 // #2746
 impl<'seq1, 'seq2, 'body, 'scope, Channel> Adc12< Dual, MasterRunningDma<'seq1, 'body, 'scope, Channel>, SlaveRunningDma<'seq2, 'body, 'scope>, > where Channel: DmaChannel, {}
+
+// #4084
+impl     const       std::default::Default for Struct {
+    #[inline]
+    fn default() -> Self {
+        Self { f: 12.5 }
+    }
+}

--- a/tests/target/const_generics.rs
+++ b/tests/target/const_generics.rs
@@ -26,3 +26,12 @@ type Foo<const N: usize> = [i32; N + 1];
 pub trait Foo: Bar<{ Baz::COUNT }> {
     const ASD: usize;
 }
+
+// #4263
+fn const_generics_on_params<
+    // AAAA
+    const BBBB: usize,
+    /* CCCC */
+    const DDDD: usize,
+>() {
+}

--- a/tests/target/const_generics.rs
+++ b/tests/target/const_generics.rs
@@ -22,3 +22,7 @@ fn foo<const X: usize>() {
 }
 
 type Foo<const N: usize> = [i32; N + 1];
+
+pub trait Foo: Bar<{ Baz::COUNT }> {
+    const ASD: usize;
+}

--- a/tests/target/impls.rs
+++ b/tests/target/impls.rs
@@ -234,3 +234,11 @@ where
     Channel: DmaChannel,
 {
 }
+
+// #4084
+impl const std::default::Default for Struct {
+    #[inline]
+    fn default() -> Self {
+        Self { f: 12.5 }
+    }
+}

--- a/tests/target/issue-4310.rs
+++ b/tests/target/issue-4310.rs
@@ -1,0 +1,9 @@
+#![feature(const_generics)]
+
+fn foo<
+    const N: [u8; {
+        struct Inner<'a>(&'a ());
+        3
+    }],
+>() {
+}


### PR DESCRIPTION
Backports some of the const generic related fixes in preparation for the upcoming v1.4.33 release

Includes backported fixes for:
* #4084
* #4204
* #4263
* #4310