### PR TITLE
Don't insert trailing comma on struct lit rest (no base) in a macro definition

### DIFF
--- a/src/formatting/expr.rs
+++ b/src/formatting/expr.rs
@@ -1654,7 +1654,10 @@ fn rewrite_struct_lit<'a>(
             nested_shape,
             tactic,
             context,
-            force_no_trailing_comma || has_base || !context.use_block_indent(),
+            force_no_trailing_comma
+                || has_base
+                || !context.use_block_indent()
+                || matches!(struct_rest, ast::StructRest::Rest(_)),
         );
 
         write_list(&item_vec, &fmt)?

--- a/tests/source/issue_4675.rs
+++ b/tests/source/issue_4675.rs
@@ -1,0 +1,8 @@
+macro_rules! foo {
+    ($s:ident ( $p:pat )) => {
+        Foo {
+            name: Name::$s($p),
+            ..
+    }
+    };
+}

--- a/tests/target/issue_4675.rs
+++ b/tests/target/issue_4675.rs
@@ -1,0 +1,8 @@
+macro_rules! foo {
+    ($s:ident ( $p:pat )) => {
+        Foo {
+            name: Name::$s($p),
+            ..
+        }
+    };
+}


### PR DESCRIPTION
Fixes #4675 