### PR TITLE
prepare v1.4.34 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.4.34] 2021-01-28
+
+### Fixed
+- Don't insert trailing comma on (base-less) rest in struct literals within macros ([#4675](https://github.com/rust-lang/rustfmt/issues/4675))
+
+### Install/Download Options
+- **crates.io package** - *pending*
+- **rustup (nightly)** - *pending*
+- **GitHub Release Binaries** - [Release v1.4.34](https://github.com/rust-lang/rustfmt/releases/tag/v1.4.34)
+- **Build from source** - [Tag v1.4.34](https://github.com/rust-lang/rustfmt/tree/v1.4.34), see instructions for how to [install rustfmt from source][install-from-source]
+
 ## [1.4.33] 2021-01-27
 
 ### Changed
@@ -24,7 +35,7 @@ https://rust-lang.github.io/rustfmt/?version=v1.4.33&search=#imports_granularity
 
 ### Install/Download Options
 - **crates.io package** - *pending*
-- **rustup (nightly)** - *pending*
+- **rustup (nightly)** - n/a (superseded by [v1.4.34](#1434-2021-01-28))
 - **GitHub Release Binaries** - [Release v1.4.33](https://github.com/rust-lang/rustfmt/releases/tag/v1.4.33)
 - **Build from source** - [Tag v1.4.33](https://github.com/rust-lang/rustfmt/tree/v1.4.33), see instructions for how to [install rustfmt from source][install-from-source]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.33"
+version = "1.4.34"
 dependencies = [
  "annotate-snippets 0.6.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustfmt-nightly"
-version = "1.4.33"
+version = "1.4.34"
 authors = ["Nicholas Cameron <ncameron@mozilla.com>", "The Rustfmt developers"]
 description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang/rustfmt"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1629,7 +1629,10 @@ fn rewrite_struct_lit<'a>(
             nested_shape,
             tactic,
             context,
-            force_no_trailing_comma || has_base || !context.use_block_indent(),
+            force_no_trailing_comma
+                || has_base
+                || !context.use_block_indent()
+                || matches!(struct_rest, ast::StructRest::Rest(_)),
         );
 
         write_list(&item_vec, &fmt)?

--- a/tests/source/issue_4675.rs
+++ b/tests/source/issue_4675.rs
@@ -1,0 +1,8 @@
+macro_rules! foo {
+    ($s:ident ( $p:pat )) => {
+        Foo {
+            name: Name::$s($p),
+            ..
+    }
+    };
+}

--- a/tests/target/issue_4675.rs
+++ b/tests/target/issue_4675.rs
@@ -1,0 +1,8 @@
+macro_rules! foo {
+    ($s:ident ( $p:pat )) => {
+        Foo {
+            name: Name::$s($p),
+            ..
+        }
+    };
+}


### PR DESCRIPTION
One more bug fix atop the v1.4.33 release, bumping the version since the GH release+tag was already created for 1.4.33