### PR TITLE
Add arch name to archive files created in the upload workflow

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -9,7 +9,7 @@ jobs:
     name: build-release
     strategy:
       matrix:
-        build: [linux, macos, windows-gnu, windows-msvc]
+        build: [linux-x86_64, macos-x86_64, windows-x86_64-gnu, windows-x86_64-msvc]
         include:
           - build: linux-x86_64
             os: ubuntu-latest

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -11,16 +11,16 @@ jobs:
       matrix:
         build: [linux, macos, windows-gnu, windows-msvc]
         include:
-          - build: linux
+          - build: linux-x86_64
             os: ubuntu-latest
             rust: nightly
-          - build: macos
+          - build: macos-x86_64
             os: macos-latest
             rust: nightly
-          - build: windows-gnu
+          - build: windows-x86_64-gnu
             os: windows-latest
             rust: nightly-x86_64-gnu
-          - build: windows-msvc
+          - build: windows-x86_64-msvc
             os: windows-latest
             rust: nightly-x86_64-msvc
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This is helpful for my [ubi tool](https://github.com/houseabsolute/ubi). It also prepares for doing ARM builds for macOS, which will probably be a thing in the near future.