### PR TITLE
Bump rustc-ap-* crates to version 706

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,32 +107,32 @@ lazy_static = "1.0.0"
 
 [dependencies.rustc_ast]
 package = "rustc-ap-rustc_ast"
-version = "705.0.0"
+version = "706.0.0"
 
 [dependencies.rustc_ast_pretty]
 package = "rustc-ap-rustc_ast_pretty"
-version = "705.0.0"
+version = "706.0.0"
 
 [dependencies.rustc_data_structures]
 package = "rustc-ap-rustc_data_structures"
-version = "705.0.0"
+version = "706.0.0"
 
 [dependencies.rustc_errors]
 package = "rustc-ap-rustc_errors"
-version = "705.0.0"
+version = "706.0.0"
 
 [dependencies.rustc_expand]
 package = "rustc-ap-rustc_expand"
-version = "705.0.0"
+version = "706.0.0"
 
 [dependencies.rustc_parse]
 package = "rustc-ap-rustc_parse"
-version = "705.0.0"
+version = "706.0.0"
 
 [dependencies.rustc_session]
 package = "rustc-ap-rustc_session"
-version = "705.0.0"
+version = "706.0.0"
 
 [dependencies.rustc_span]
 package = "rustc-ap-rustc_span"
-version = "705.0.0"
+version = "706.0.0"


### PR DESCRIPTION
A local `cargo check --all-targets` did not emit any errors so let's see what CI thinks.