### PR TITLE
1.x fix for missing comments extra macro body indentation

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -331,6 +331,9 @@ pub(crate) struct ReportedErrors {
 
     /// Formatted code differs from existing code (--check only).
     pub(crate) has_diff: bool,
+
+    /// Formatted code missed something, like lost comments or extra trailing space
+    pub(crate) has_unformatted_code_errors: bool,
 }
 
 impl ReportedErrors {
@@ -342,6 +345,7 @@ impl ReportedErrors {
         self.has_macro_format_failure |= other.has_macro_format_failure;
         self.has_check_errors |= other.has_check_errors;
         self.has_diff |= other.has_diff;
+        self.has_unformatted_code_errors |= other.has_unformatted_code_errors;
     }
 }
 

--- a/tests/source/issue-4603.rs
+++ b/tests/source/issue-4603.rs
@@ -1,0 +1,47 @@
+// Formatting when original macro snippet is used
+
+// Original issue #4603 code
+#![feature(or_patterns)]
+macro_rules! t_or_f {
+    () => {
+        (true // some comment
+        | false)
+    };
+}
+
+// Other test cases variations
+macro_rules! RULES {
+    () => {
+        (
+		xxxxxxx // COMMENT
+        | yyyyyyy
+        )
+    };
+}
+macro_rules! RULES {
+    () => {
+        (xxxxxxx // COMMENT
+            | yyyyyyy)
+    };
+}
+
+fn main() {
+	macro_rules! RULES {
+		() => {
+			(xxxxxxx // COMMENT
+			| yyyyyyy)
+		};
+	}
+}
+
+macro_rules! RULES {
+    () => {
+        (xxxxxxx /* COMMENT */ | yyyyyyy)
+    };
+}
+macro_rules! RULES {
+    () => {
+        (xxxxxxx /* COMMENT */
+        | yyyyyyy)
+    };
+}

--- a/tests/target/issue-4603.rs
+++ b/tests/target/issue-4603.rs
@@ -1,0 +1,47 @@
+// Formatting when original macro snippet is used
+
+// Original issue #4603 code
+#![feature(or_patterns)]
+macro_rules! t_or_f {
+    () => {
+        (true // some comment
+        | false)
+    };
+}
+
+// Other test cases variations
+macro_rules! RULES {
+    () => {
+        (
+		xxxxxxx // COMMENT
+        | yyyyyyy
+        )
+    };
+}
+macro_rules! RULES {
+    () => {
+        (xxxxxxx // COMMENT
+            | yyyyyyy)
+    };
+}
+
+fn main() {
+    macro_rules! RULES {
+		() => {
+			(xxxxxxx // COMMENT
+			| yyyyyyy)
+		};
+	}
+}
+
+macro_rules! RULES {
+    () => {
+        (xxxxxxx /* COMMENT */ | yyyyyyy)
+    };
+}
+macro_rules! RULES {
+    () => {
+        (xxxxxxx /* COMMENT */
+        | yyyyyyy)
+    };
+}


### PR DESCRIPTION
1.x fix for issue #4603 - infinite macro body indentation because of "missing comment".  The fix is per the [approach](https://github.com/rust-lang/rustfmt/pull/4629#issuecomment-774201165) discussed in #4629.

As discussed, the fix includes handling both `LostComment` and `TrailingWhitespace` errors, although I am not sure if `TrailingWhitespace` is needed.

UPDATE: the **tests fail** because an issue that i cannot understand.  When running `cargo make test` in my local machine it fails on the same errors.  However, when running manually the created `./target/debug/rustfmt` the **output is o.k**.  I hoped that this is a problem in my local machine, but unfortunately it seems it isn't.  I will be glad to get help with this issue.