### PR TITLE
Stabilize blank_lines_upper_bound

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -181,7 +181,7 @@ lines are found, they are trimmed down to match this integer.
 
 - **Default value**: `1`
 - **Possible values**: any non-negative integer
-- **Stable**: No (tracking issue: [#3381](https://github.com/rust-lang/rustfmt/issues/3381))
+- **Stable**: Yes
 
 ### Example
 Original Code:

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,7 @@ create_config! {
         "How to handle trailing commas for lists";
     match_block_trailing_comma: bool, false, true,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
-    blank_lines_upper_bound: usize, 1, false,
+    blank_lines_upper_bound: usize, 1, true,
         "Maximum number of blank lines which can be put between items";
     blank_lines_lower_bound: usize, 0, false,
         "Minimum number of blank lines which must be put between items";


### PR DESCRIPTION
Closes #3381

Looks like any outstanding discussion has died out and that we won't change the default? Can we stabilize this feature please? If anything, the discussion around the default showed that **many** people want this set to two or higher. So let us do that on stable rather than needing to use the nightly formatter in our CI just to check formatting.

I have not contributed to rustfmt before. Maybe I'm not doing the correct thing here. I just mimicked other stabilization PRs. I want to get this ball rolling.

The formatting RFC discussion: https://github.com/rust-dev-tools/fmt-rfcs/issues/57