### PR TITLE
Fix warnings

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1674,7 +1674,8 @@ fn remove_comment_header(comment: &str) -> &str {
     } else {
         assert!(
             comment.starts_with("/*"),
-            format!("string '{}' is not a comment", comment)
+            "string '{}' is not a comment",
+            comment
         );
         &comment[2..comment.len() - 2]
     }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -76,7 +76,7 @@ fn format_project<T: FormatHandler>(
     // Parse the crate.
     let mut report = FormatReport::new();
     let directory_ownership = input.to_directory_ownership();
-    let krate = match Parser::parse_crate(config, input, directory_ownership, &parse_session) {
+    let krate = match Parser::parse_crate(input, &parse_session) {
         Ok(krate) => krate,
         // Surface parse error via Session (errors are merged there from report)
         Err(e) => {

--- a/src/git-rustfmt/main.rs
+++ b/src/git-rustfmt/main.rs
@@ -127,7 +127,6 @@ fn make_opts() -> Options {
 struct Config {
     commits: String,
     uncommitted: bool,
-    check: bool,
 }
 
 impl Config {
@@ -146,11 +145,9 @@ impl Config {
         let mut config = Config {
             commits: "1".to_owned(),
             uncommitted: false,
-            check: false,
         };
 
         if matches.opt_present("c") {
-            config.check = true;
             unimplemented!();
         }
 

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -12,7 +12,7 @@ use rustc_span::{sym, symbol::kw, Span};
 
 use crate::attr::first_attr_value_str_by_name;
 use crate::syntux::session::ParseSess;
-use crate::{Config, Input};
+use crate::Input;
 
 pub(crate) type DirectoryOwnership = rustc_expand::module::DirectoryOwnership;
 pub(crate) type ModulePathSuccess = rustc_expand::module::ModulePathSuccess;
@@ -31,10 +31,8 @@ pub(crate) struct Parser<'a> {
 /// A builder for the `Parser`.
 #[derive(Default)]
 pub(crate) struct ParserBuilder<'a> {
-    config: Option<&'a Config>,
     sess: Option<&'a ParseSess>,
     input: Option<Input>,
-    directory_ownership: Option<DirectoryOwnership>,
 }
 
 impl<'a> ParserBuilder<'a> {
@@ -45,19 +43,6 @@ impl<'a> ParserBuilder<'a> {
 
     pub(crate) fn sess(mut self, sess: &'a ParseSess) -> ParserBuilder<'a> {
         self.sess = Some(sess);
-        self
-    }
-
-    pub(crate) fn config(mut self, config: &'a Config) -> ParserBuilder<'a> {
-        self.config = Some(config);
-        self
-    }
-
-    pub(crate) fn directory_ownership(
-        mut self,
-        directory_ownership: Option<DirectoryOwnership>,
-    ) -> ParserBuilder<'a> {
-        self.directory_ownership = directory_ownership;
         self
     }
 
@@ -157,12 +142,10 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn parse_crate(
-        config: &'a Config,
         input: Input,
-        directory_ownership: Option<DirectoryOwnership>,
         sess: &'a ParseSess,
     ) -> Result<ast::Crate, ParserError> {
-        let krate = Parser::parse_crate_inner(config, input, directory_ownership, sess)?;
+        let krate = Parser::parse_crate_inner(input, sess)?;
         if !sess.has_errors() {
             return Ok(krate);
         }
@@ -175,19 +158,12 @@ impl<'a> Parser<'a> {
         Err(ParserError::ParseError)
     }
 
-    fn parse_crate_inner(
-        config: &'a Config,
-        input: Input,
-        directory_ownership: Option<DirectoryOwnership>,
-        sess: &'a ParseSess,
-    ) -> Result<ast::Crate, ParserError> {
-        let mut parser = ParserBuilder::default()
-            .config(config)
+    fn parse_crate_inner(input: Input, sess: &'a ParseSess) -> Result<ast::Crate, ParserError> {
+        ParserBuilder::default()
             .input(input)
-            .directory_ownership(directory_ownership)
             .sess(sess)
-            .build()?;
-        parser.parse_crate_mod()
+            .build()?
+            .parse_crate_mod()
     }
 
     fn parse_crate_mod(&mut self) -> Result<ast::Crate, ParserError> {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -133,10 +133,8 @@ fn verify_config_used(path: &Path, config_name: &str) {
                     .map(Result::unwrap)
                     .take_while(|l| l.starts_with("//"))
                     .any(|l| l.starts_with(&format!("// rustfmt-{}", config_name))),
-                format!(
-                    "config option file {} does not contain expected config name",
-                    path.display()
-                )
+                "config option file {} does not contain expected config name",
+                path.display()
             );
         }
     }
@@ -884,6 +882,7 @@ fn rustfmt() -> PathBuf {
     me.push("rustfmt");
     assert!(
         me.is_file() || me.with_extension("exe").is_file(),
+        "{}",
         if cfg!(release) {
             "no rustfmt bin, try running `cargo build --release` before testing"
         } else {


### PR DESCRIPTION
- Fix nightly warning about `format!`
- Remove unused functions and fields

This will be needed for https://github.com/rust-lang/rust/pull/82208 since rust-lang/rust denies warnings, but is also helpful without that change.