### PR TITLE
Fix some clippy warnings

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{format_err, Result};
-use env_logger;
+
 use io::Error as IoError;
 use thiserror::Error;
 
@@ -233,7 +233,7 @@ fn execute(opts: &Options) -> Result<i32> {
             let file = PathBuf::from(path);
             let file = file.canonicalize().unwrap_or(file);
 
-            let (config, _) = load_config(Some(file.parent().unwrap()), Some(options.clone()))?;
+            let (config, _) = load_config(Some(file.parent().unwrap()), Some(options))?;
             let toml = config.all_options().to_toml()?;
             io::stdout().write_all(toml.as_bytes())?;
 
@@ -565,7 +565,7 @@ impl GetOptsOptions {
         options.inline_config = matches
             .opt_strs("config")
             .iter()
-            .flat_map(|config| config.split(","))
+            .flat_map(|config| config.split(','))
             .map(
                 |key_val| match key_val.char_indices().find(|(_, ch)| *ch == '=') {
                     Some((middle, _)) => {
@@ -681,7 +681,7 @@ impl CliOptions for GetOptsOptions {
     }
 
     fn config_path(&self) -> Option<&Path> {
-        self.config_path.as_ref().map(|p| &**p)
+        self.config_path.as_deref()
     }
 }
 

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -2,8 +2,6 @@
 
 #![deny(warnings)]
 
-use cargo_metadata;
-
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;

--- a/src/format-diff/main.rs
+++ b/src/format-diff/main.rs
@@ -4,10 +4,9 @@
 
 #![deny(warnings)]
 
-use env_logger;
 #[macro_use]
 extern crate log;
-use regex;
+
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 use thiserror::Error;

--- a/src/git-rustfmt/main.rs
+++ b/src/git-rustfmt/main.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
-use env_logger;
 use getopts::{Matches, Options};
 use rustfmt_nightly as rustfmt;
 


### PR DESCRIPTION
This commit can be replicated with
`cargo clippy --fix -Z unstable-options && cargo +nightly-2021-02-10 fmt`.