### PR TITLE
Filter out block comment in filter_normal_code

### DIFF
--- a/tests/source/comment2.rs
+++ b/tests/source/comment2.rs
@@ -2,3 +2,11 @@
 
 /// This is a long line that angers rustfmt. Rustfmt shall deal with it swiftly and justly.
 pub mod foo {}
+
+fn chains() {
+    test().map(|| {
+        let x = 11;
+        /* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue
+         * ligula ac quam */ x
+    });
+}

--- a/tests/target/comment2.rs
+++ b/tests/target/comment2.rs
@@ -3,3 +3,12 @@
 /// This is a long line that angers rustfmt. Rustfmt shall deal with it swiftly
 /// and justly.
 pub mod foo {}
+
+fn chains() {
+    test().map(|| {
+        let x = 11;
+        /* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam
+         * lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam */
+        x
+    });
+}


### PR DESCRIPTION
This PR aims at resolving #4668. The `filter_normal_code` and its unit test modifications are ready for review; I am working on the idempotence/system tests.