### PR TITLE
`imports_granularity = "Module"` with path contains `self`

### DIFF
--- a/tests/source/issue-4681-imports_granularity_default.rs
+++ b/tests/source/issue-4681-imports_granularity_default.rs
@@ -1,0 +1,6 @@
+use crate::lexer;
+use crate::lexer::tokens::TokenData;
+use crate::lexer::{tokens::TokenData};
+use crate::lexer::self;
+use crate::lexer::{self};
+use crate::lexer::{self, tokens::TokenData};

--- a/tests/source/issue-4681-imports_granularity_module.rs
+++ b/tests/source/issue-4681-imports_granularity_module.rs
@@ -1,8 +1,5 @@
-// rustfmt-imports_granularity: Item
+// rustfmt-imports_granularity: Module
 
 use crate::lexer;
-use crate::lexer::tokens::TokenData;
-use crate::lexer::{tokens::TokenData};
 use crate::lexer::self;
-use crate::lexer::{self};
 use crate::lexer::{self, tokens::TokenData};

--- a/tests/source/issue-4681-imports_granularity_module.rs
+++ b/tests/source/issue-4681-imports_granularity_module.rs
@@ -1,0 +1,8 @@
+// rustfmt-imports_granularity: Item
+
+use crate::lexer;
+use crate::lexer::tokens::TokenData;
+use crate::lexer::{tokens::TokenData};
+use crate::lexer::self;
+use crate::lexer::{self};
+use crate::lexer::{self, tokens::TokenData};

--- a/tests/target/issue-4681-imports_granularity_default.rs
+++ b/tests/target/issue-4681-imports_granularity_default.rs
@@ -1,0 +1,6 @@
+use crate::lexer;
+use crate::lexer;
+use crate::lexer::tokens::TokenData;
+use crate::lexer::tokens::TokenData;
+use crate::lexer::{self};
+use crate::lexer::{self, tokens::TokenData};

--- a/tests/target/issue-4681-imports_granularity_module.rs
+++ b/tests/target/issue-4681-imports_granularity_module.rs
@@ -1,9 +1,5 @@
-// rustfmt-imports_granularity: Item
+// rustfmt-imports_granularity: Module
 
 use crate::lexer;
-use crate::lexer;
 use crate::lexer::tokens::TokenData;
-use crate::lexer::tokens::TokenData;
-use crate::lexer::tokens::TokenData;
-use crate::lexer::{self};
 use crate::lexer::{self};

--- a/tests/target/issue-4681-imports_granularity_module.rs
+++ b/tests/target/issue-4681-imports_granularity_module.rs
@@ -1,0 +1,9 @@
+// rustfmt-imports_granularity: Item
+
+use crate::lexer;
+use crate::lexer;
+use crate::lexer::tokens::TokenData;
+use crate::lexer::tokens::TokenData;
+use crate::lexer::tokens::TokenData;
+use crate::lexer::{self};
+use crate::lexer::{self};


### PR DESCRIPTION
Suggested fix for  #4681: when `imports_granularity = "Module"`, the formatting output of `use crate::lexer::{self, tokens::TokenData}` includes now `crate::lexer::{self}` instead of `crate::lexer::self`.

The change in `merge_use_trees()` is based on the code in `flatten_use_trees()` that handles similar issue.