### PR TITLE
Document code block annotated with several attributes

### DIFF
--- a/src/formatting/comment.rs
+++ b/src/formatting/comment.rs
@@ -428,10 +428,9 @@ enum CodeBlockAttribute {
 
 impl CodeBlockAttribute {
     fn new(attributes: &str) -> Vec<CodeBlockAttribute> {
-        let mut result: Vec<CodeBlockAttribute> = vec![];
-        let attrs_iter = attributes.split(',');
-        for cba in attrs_iter {
-            result.push(match cba.trim() {
+        attributes
+            .split(',')
+            .map(|cba| match cba.trim() {
                 "rust" | "" => CodeBlockAttribute::Rust,
                 "ignore" => CodeBlockAttribute::Ignore,
                 "text" => CodeBlockAttribute::Text,
@@ -440,8 +439,7 @@ impl CodeBlockAttribute {
                 "compile_fail" => CodeBlockAttribute::CompileFail,
                 _ => CodeBlockAttribute::Text,
             })
-        }
-        return result;
+            .collect()
     }
 }
 
@@ -692,7 +690,7 @@ impl<'a> CommentRewrite<'a> {
                     _ => false,
                 }) {
                     trim_custom_comment_prefix(&self.code_block_buffer)
-                } else if code_block_attr_inner.is_empty() {
+                } else if self.code_block_buffer.is_empty() {
                     String::new()
                 } else {
                     let mut config = self.fmt.config.clone();

--- a/tests/source/issue-3158.rs
+++ b/tests/source/issue-3158.rs
@@ -1,0 +1,80 @@
+// rustfmt-format_code_in_doc_comments: true
+
+// Rust and ignore or compile_fail attributes:
+
+/// ```rust
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```rust,ignore
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```rust,no_run
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```rust,   ignore  , no_run
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```complie_fail
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```rust, no_run,compile_fail
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```,
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```,,,,,,,,,,,
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```,, ,    ,     rust    , , ,, , , ,
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }
+
+/// ```,, ,    ,     rust    , , ,, ignore, , ,
+///fn main() {
+///x = y;
+///}
+/// ```
+foo! { x, y }

--- a/tests/source/issue-3158.rs
+++ b/tests/source/issue-3158.rs
@@ -30,7 +30,7 @@ foo! { x, y }
 /// ```
 foo! { x, y }
 
-/// ```complie_fail
+/// ```compile_fail
 ///fn main() {
 ///x = y;
 ///}
@@ -76,5 +76,17 @@ foo! { x, y }
 ///fn main() {
 ///x = y;
 ///}
+/// ```
+foo! { x, y }
+
+/// ```
+/// ```
+foo! { x, y }
+
+/// ```rust
+/// ```
+foo! { x, y }
+
+/// ```ignore
 /// ```
 foo! { x, y }

--- a/tests/target/issue-3158.rs
+++ b/tests/target/issue-3158.rs
@@ -1,0 +1,80 @@
+// rustfmt-format_code_in_doc_comments: true
+
+// Rust and ignore or compile_fail attributes:
+
+/// ```rust
+/// fn main() {
+///     x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```rust,ignore
+/// fn main() {
+/// x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```rust,no_run
+/// fn main() {
+///     x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```rust,   ignore  , no_run
+/// fn main() {
+/// x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```complie_fail
+/// fn main() {
+/// x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```rust, no_run,compile_fail
+/// fn main() {
+/// x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```
+/// fn main() {
+///     x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```,
+/// fn main() {
+///     x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```,,,,,,,,,,,
+/// fn main() {
+///     x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```,, ,    ,     rust    , , ,, , , ,
+/// fn main() {
+///     x = y;
+/// }
+/// ```
+foo! { x, y }
+
+/// ```,, ,    ,     rust    , , ,, ignore, , ,
+/// fn main() {
+/// x = y;
+/// }
+/// ```
+foo! { x, y }

--- a/tests/target/issue-3158.rs
+++ b/tests/target/issue-3158.rs
@@ -30,7 +30,7 @@ foo! { x, y }
 /// ```
 foo! { x, y }
 
-/// ```complie_fail
+/// ```compile_fail
 /// fn main() {
 /// x = y;
 /// }
@@ -76,5 +76,17 @@ foo! { x, y }
 /// fn main() {
 /// x = y;
 /// }
+/// ```
+foo! { x, y }
+
+/// ```
+/// ```
+foo! { x, y }
+
+/// ```rust
+/// ```
+foo! { x, y }
+
+/// ```ignore
 /// ```
 foo! { x, y }


### PR DESCRIPTION
Suggested fix for #3158 per the requested functionality described in the issue (applicable when `format_code_in_doc_comments` is set):
1. Support list of comma separated `CodeBlockAttribute` attributes.
2. Handle `compile_fail` the same as `text` and `ignore`, assuming that when compilation fails, the original code is used.