### PR TITLE
Fix issue with extra semicolon when import comment precedes semicolon

### DIFF
--- a/src/formatting/lists.rs
+++ b/src/formatting/lists.rs
@@ -745,11 +745,11 @@ pub(crate) fn extract_post_comment(
         post_snippet.trim_matches(white_space)
     }
     // not comment or over two lines
-    else if post_snippet.ends_with(',')
+    else if post_snippet.ends_with(separator)
         && (!post_snippet.trim().starts_with("//") || post_snippet.trim().contains('\n'))
     {
         post_snippet[..(post_snippet.len() - 1)].trim_matches(white_space)
-    } else if let Some(sep_pos) = post_snippet.find_uncommented(",") {
+    } else if let Some(sep_pos) = post_snippet.find_uncommented(separator) {
         _post_snippet_without_sep = [
             post_snippet[..sep_pos]
                 .trim_matches(white_space)

--- a/tests/source/imports/imports_granularity_crate-with-comments.rs
+++ b/tests/source/imports/imports_granularity_crate-with-comments.rs
@@ -1,0 +1,32 @@
+// rustfmt-imports_granularity: Crate
+
+// With one comment per item - after the the `;`
+use foo1 ; /* 2nd foo1 - comment after ; */ 
+use crate::foo2::bar ; /* 1st foo1::bar - comment after ; */ 
+use crate::foo2::bar  ;
+
+// With one comment per item - before the the `;`
+use foo3  /* 2nd foo3 - comment before ; */ ; 
+use crate::foo4::bar  /* 1st foo4::bar - comment before ; */ ;
+use crate::foo4::bar  ;             
+
+// With multiline comments or multi comments - after the `;`
+use crate::foo5; /* foo5 - Multiline comment before ; line 1
+            * foo5 - Multiline comment before ; line 2 */  
+use crate::foo5; 
+use crate::foo6; // foo6- mixed comments before ; - 1st line comment ;   
+            /* foo6- mixed comments before ; - 2nd block comment */    
+use crate::foo6;      
+
+// With multiline comments or multi comments - before the `;`
+use crate::foo7 /* foo7 - Multiline comment before ; line 1
+            * foo7 - Multiline comment before ; line 2 */  ;  
+use crate::foo7; 
+use crate::foo8 // foo8- mixed comments before ; - 1st line comment ;   
+            /* foo8- mixed comments before ; - 2nd block comment */ ;  
+use crate::foo8;  
+
+// With one comment for a module
+use crate::foo21::{self}  ; /* external comment for foo21 {self} */
+use crate::foo21::{foo} ;
+use crate::foo21::{bar} ;         

--- a/tests/source/imports/imports_granularity_default-with-comments.rs
+++ b/tests/source/imports/imports_granularity_default-with-comments.rs
@@ -1,0 +1,38 @@
+// With one comment per item - after the the `;`
+use crate::foo1  ;
+use crate::foo1 ; /* 2nd foo1 - comment after ; */ 
+use crate::foo2::bar ; /* 1st foo1::bar - comment after ; */ 
+use crate::foo2::bar  ;
+
+// With one comment per item - before the the `;`
+use crate::foo3  ;
+use crate::foo3  /* 2nd foo3 - comment before ; */ ; 
+use crate::foo4::bar  /* 1st foo4::bar - comment before ; */ ;
+use crate::foo4::bar  ;
+
+// With multiline comments or multi comments - after the `;`
+use crate::foo5; /* foo5 - Multiline comment before ; line 1
+            * foo5 - Multiline comment before ; line 2 */  
+use crate::foo5; 
+use crate::foo6; // foo6- mixed comments before ; - 1st line comment ;   
+            /* foo6- mixed comments before ; - 2nd block comment */    
+use crate::foo6;      
+
+// With multiline comments or multi comments - before the `;`
+use crate::foo8 // foo8- mixed comments before ; - 1st line comment ;   
+            /* foo8- mixed comments before ; - 2nd block comment */ ;  
+use crate::foo8;   
+
+// With two comments per item
+use crate::foo11  ; /* 1st foo11 - comment */ 
+use crate::foo11 ;  /* 2nd foo11 - comment */          
+
+// With one comment for a module
+use crate::foo21::{self}  ; /* external comment for foo21 {self} */
+use crate::foo21::{foo} ;  /* external comment for foo21 {foo} */
+use crate::foo21::{bar} ;
+
+// With internal and external comment for a module
+use crate::foo22::{self}  ; /* external comment for foo22 {self} */
+use crate::foo22::{foo /* internal comment for foo22 {foo} */} ; 
+use crate::foo22::{bar /* internal comment for foo22 {bar} */} ;          

--- a/tests/source/imports/imports_granularity_item-with-comments.rs
+++ b/tests/source/imports/imports_granularity_item-with-comments.rs
@@ -1,0 +1,24 @@
+// rustfmt-imports_granularity: Item
+
+// With one comment per item - after the the `;`
+use crate::foo2::bar ; /* 1st foo1::bar - comment after ; */ 
+use crate::foo2::bar  ;
+
+// With one comment per item - before the the `;`
+use crate::foo4::bar  /* 1st foo4::bar - comment before ; */ ;
+use crate::foo4::bar  ;
+
+// With multiline comments or multi comments - after the `;`
+use crate::foo5; /* foo5 - Multiline comment before ; line 1
+            * foo5 - Multiline comment before ; line 2 */   
+use crate::foo6; // foo6- mixed comments before ; - 1st line comment ;   
+            /* foo6- mixed comments before ; - 2nd block comment */         
+
+// With multiline comments or multi comments - before the `;` 
+use crate::foo8 // foo8- mixed comments before ; - 1st line comment ;   
+            /* foo8- mixed comments before ; - 2nd block comment */ ;  
+
+// With one comment for a module
+use crate::foo21::{self}  ; /* external comment for foo21 {self} */
+use crate::foo21::{foo} ;  /* external comment for foo21 {foo} */
+use crate::foo21::{bar} ;

--- a/tests/source/imports/imports_granularity_module-with-comments.rs
+++ b/tests/source/imports/imports_granularity_module-with-comments.rs
@@ -1,0 +1,34 @@
+// rustfmt-imports_granularity: Module
+
+// With one comment per item - after the the `;`
+use crate::foo1  ;
+use crate::foo1 ; /* 2nd foo1 - comment after ; */ 
+use crate::foo2::bar ; /* 1st foo1::bar - comment after ; */ 
+use crate::foo2::bar  ;
+
+// With one comment per item - before the the `;`
+use crate::foo3  ;
+use crate::foo3  /* 2nd foo3 - comment before ; */ ; 
+use crate::foo4::bar  /* 1st foo4::bar - comment before ; */ ;
+use crate::foo4::bar  ;
+
+// With multiline comments or multi comments - after the `;`
+use crate::foo5; /* foo5 - Multiline comment before ; line 1
+            * foo5 - Multiline comment before ; line 2 */  
+use crate::foo5; 
+use crate::foo6; // foo6- mixed comments before ; - 1st line comment ;   
+            /* foo6- mixed comments before ; - 2nd block comment */    
+use crate::foo6;      
+
+// With multiline comments or multi comments - before the `;`
+use crate::foo7 /* foo7 - Multiline comment before ; line 1
+            * foo7 - Multiline comment before ; line 2 */  ;  
+use crate::foo7; 
+use crate::foo8 // foo8- mixed comments before ; - 1st line comment ;   
+            /* foo8- mixed comments before ; - 2nd block comment */ ;  
+use crate::foo8;      
+
+// With one comment for a module
+use crate::foo21::{self}  ; /* external comment for foo21 {self} */
+use crate::foo21::{foo} ;
+use crate::foo21::{bar} ;

--- a/tests/target/imports/imports_granularity_crate-with-comments.rs
+++ b/tests/target/imports/imports_granularity_crate-with-comments.rs
@@ -1,0 +1,25 @@
+// rustfmt-imports_granularity: Crate
+
+// With one comment per item - after the the `;`
+use crate::foo2::bar; /* 1st foo1::bar - comment after ; */
+use foo1; /* 2nd foo1 - comment after ; */
+
+// With one comment per item - before the the `;`
+use crate::foo4::bar; /* 1st foo4::bar - comment before ; */
+use foo3; /* 2nd foo3 - comment before ; */
+
+// With multiline comments or multi comments - after the `;`
+use crate::foo5; /* foo5 - Multiline comment before ; line 1
+                  * foo5 - Multiline comment before ; line 2 */
+use crate::{foo5, foo6}; // foo6- mixed comments before ; - 1st line comment ;
+/* foo6- mixed comments before ; - 2nd block comment */
+use crate::foo6;
+
+// With multiline comments or multi comments - before the `;`
+use crate::foo8; // foo8- mixed comments before ; - 1st line comment ;
+/* foo8- mixed comments before ; - 2nd block comment */
+use crate::{foo7, foo8}; /* foo7 - Multiline comment before ; line 1
+                          * foo7 - Multiline comment before ; line 2 */
+
+// With one comment for a module
+use crate::foo21::{self, bar, foo}; /* external comment for foo21 {self} */

--- a/tests/target/imports/imports_granularity_default-with-comments.rs
+++ b/tests/target/imports/imports_granularity_default-with-comments.rs
@@ -1,0 +1,38 @@
+// With one comment per item - after the the `;`
+use crate::foo1;
+use crate::foo1; /* 2nd foo1 - comment after ; */
+use crate::foo2::bar; /* 1st foo1::bar - comment after ; */
+use crate::foo2::bar;
+
+// With one comment per item - before the the `;`
+use crate::foo3;
+use crate::foo3; /* 2nd foo3 - comment before ; */
+use crate::foo4::bar; /* 1st foo4::bar - comment before ; */
+use crate::foo4::bar;
+
+// With multiline comments or multi comments - after the `;`
+use crate::foo5; /* foo5 - Multiline comment before ; line 1
+                  * foo5 - Multiline comment before ; line 2 */
+use crate::foo5;
+use crate::foo6; // foo6- mixed comments before ; - 1st line comment ;
+/* foo6- mixed comments before ; - 2nd block comment */
+use crate::foo6;
+
+// With multiline comments or multi comments - before the `;`
+use crate::foo8; // foo8- mixed comments before ; - 1st line comment ;
+/* foo8- mixed comments before ; - 2nd block comment */
+use crate::foo8;
+
+// With two comments per item
+use crate::foo11; /* 1st foo11 - comment */
+use crate::foo11; /* 2nd foo11 - comment */
+
+// With one comment for a module
+use crate::foo21::bar;
+use crate::foo21::foo; /* external comment for foo21 {foo} */
+use crate::foo21::{self}; /* external comment for foo21 {self} */
+
+// With internal and external comment for a module
+use crate::foo22::{self}; /* external comment for foo22 {self} */
+use crate::foo22::{bar /* internal comment for foo22 {bar} */};
+use crate::foo22::{foo /* internal comment for foo22 {foo} */};

--- a/tests/target/imports/imports_granularity_item-with-comments.rs
+++ b/tests/target/imports/imports_granularity_item-with-comments.rs
@@ -1,0 +1,21 @@
+// rustfmt-imports_granularity: Item
+
+// With one comment per item - after the the `;`
+use crate::foo2::bar; /* 1st foo1::bar - comment after ; */
+
+// With one comment per item - before the the `;`
+use crate::foo4::bar; /* 1st foo4::bar - comment before ; */
+
+// With multiline comments or multi comments - after the `;`
+use crate::foo5; /* foo5 - Multiline comment before ; line 1
+                  * foo5 - Multiline comment before ; line 2 */
+use crate::foo6; // foo6- mixed comments before ; - 1st line comment ;
+/* foo6- mixed comments before ; - 2nd block comment */
+
+// With multiline comments or multi comments - before the `;`
+use crate::foo8;
+
+// With one comment for a module
+use crate::foo21::bar;
+use crate::foo21::foo; /* external comment for foo21 {foo} */
+use crate::foo21::{self}; /* external comment for foo21 {self} */

--- a/tests/target/imports/imports_granularity_module-with-comments.rs
+++ b/tests/target/imports/imports_granularity_module-with-comments.rs
@@ -1,0 +1,27 @@
+// rustfmt-imports_granularity: Module
+
+// With one comment per item - after the the `;`
+use crate::foo1;
+use crate::foo1; /* 2nd foo1 - comment after ; */
+use crate::foo2::bar; /* 1st foo1::bar - comment after ; */
+
+// With one comment per item - before the the `;`
+use crate::foo3;
+use crate::foo3; /* 2nd foo3 - comment before ; */
+use crate::foo4::bar; /* 1st foo4::bar - comment before ; */
+
+// With multiline comments or multi comments - after the `;`
+use crate::foo5; /* foo5 - Multiline comment before ; line 1
+                  * foo5 - Multiline comment before ; line 2 */
+use crate::{foo5, foo6}; // foo6- mixed comments before ; - 1st line comment ;
+/* foo6- mixed comments before ; - 2nd block comment */
+use crate::foo6;
+
+// With multiline comments or multi comments - before the `;`
+use crate::foo8; // foo8- mixed comments before ; - 1st line comment ;
+/* foo8- mixed comments before ; - 2nd block comment */
+use crate::{foo7, foo8}; /* foo7 - Multiline comment before ; line 1
+                          * foo7 - Multiline comment before ; line 2 */
+
+// With one comment for a module
+use crate::foo21::{self, bar, foo}; /* external comment for foo21 {self} */


### PR DESCRIPTION
Fix an issue identified in [#4737 evaluation](https://github.com/rust-lang/rustfmt/pull/4737#discussion_r594374489), where an extra semicolon was added for import with comment preceding the `;`.  For example, with imports granularity `Crate/Module/Item` the following code:
```rust
use crate::bar::self /* bar 1 */;
use crate::bar::self;
```
was formatted as:
```rust
use crate::bar; /* bar 1 */;
```

The fix is extending handling that was done by `extract_post_comment()` to `,` after the comment, to be for the `separator` parameter instead of the constant `,`.

The test files added include some additional tests for imports with comments, as a basis for tests for other imports comments issues.  This is because 4 files are needed to test imports by granularity (`Crate/Module/Item` and default), so it seems that it is better to have all the imports comments related PRs tests per granularity in one file.