### PR TITLE
Use linker provided by Rust for Windows GNU in CI build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -63,6 +63,8 @@ jobs:
 
     - name: cargo-make
       run: cargo install --force cargo-make
+      env:
+        RUSTFLAGS: -C link-self-contained=yes
 
     - name: build
       run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,7 @@ install:
 build: false
 
 test_script:
+  - set RUSTFLAGS=-C link-self-contained=yes
   - cargo install cargo-make
   - cargo make build-bins
   - cargo make test-all


### PR DESCRIPTION
The linker in the PATH in the Gitlab runner environment causes build failures. Fixes #4765.