### PR TITLE
Recognize when a block comment has been ended inside a string literal…

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1311,6 +1311,9 @@ where
                 char_kind = FullCodeCharKind::InStringCommented;
                 if chr == '"' {
                     CharClassesStatus::BlockComment(deepness)
+                } else if chr == '*' && self.base.peek().map(RichChar::get_char) == Some('/') {
+                    char_kind = FullCodeCharKind::InComment;
+                    CharClassesStatus::BlockCommentClosing(deepness - 1)
                 } else {
                     CharClassesStatus::StringInBlockComment(deepness)
                 }

--- a/tests/source/issue-4312.rs
+++ b/tests/source/issue-4312.rs
@@ -1,0 +1,8 @@
+fn main() {
+    /* " */
+    println!("Hello, world!");
+    /* abc " */
+    println!("Hello, world!");
+    /* " abc */
+    println!("Hello, world!");
+}

--- a/tests/source/issue-4312.rs
+++ b/tests/source/issue-4312.rs
@@ -1,3 +1,4 @@
+// issue 4312
 fn main() {
     /* " */
     println!("Hello, world!");
@@ -5,4 +6,17 @@ fn main() {
     println!("Hello, world!");
     /* " abc */
     println!("Hello, world!");
+    let y = 4;
+    let x = match 1 + y == 3 {
+        True => 3,
+        False => 4,
+        /* " unreachable */
+    };
+}
+
+// issue 4806
+enum X {
+    A,
+    B,
+    /*"*/
 }

--- a/tests/target/issue-4312.rs
+++ b/tests/target/issue-4312.rs
@@ -1,0 +1,8 @@
+fn main() {
+    /* " */
+    println!("Hello, world!");
+    /* abc " */
+    println!("Hello, world!");
+    /* " abc */
+    println!("Hello, world!");
+}

--- a/tests/target/issue-4312.rs
+++ b/tests/target/issue-4312.rs
@@ -1,3 +1,4 @@
+// issue 4312
 fn main() {
     /* " */
     println!("Hello, world!");
@@ -5,4 +6,17 @@ fn main() {
     println!("Hello, world!");
     /* " abc */
     println!("Hello, world!");
+    let y = 4;
+    let x = match 1 + y == 3 {
+        True => 3,
+        False => 4,
+        /* " unreachable */
+    };
+}
+
+// issue 4806
+enum X {
+    A,
+    B,
+    /*"*/
 }


### PR DESCRIPTION
Back-porting the change in #4320 to branch `rustfmt-1.4.37`.
This would fix #4312 and its duplicate, #4744 .
Any suggestion is appreciated!