### PR TITLE
Fix to some `rustfmt::skip` issues

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -164,6 +164,15 @@ fn format_project(
         )
     });
 
+    // Debug messages with skipped ranges for all input files
+    for (filename, format_result) in format_report.format_result_as_rc().borrow().iter() {
+        let skipped_ranges = &format_result.formatted_snippet().non_formatted_ranges;
+        debug!(
+            "format_project: filename \"{:?}\" skipped_ranges \"{:?}\"",
+            filename, skipped_ranges
+        );
+    }
+
     Ok(format_report)
 }
 

--- a/src/formatting/items.rs
+++ b/src/formatting/items.rs
@@ -889,6 +889,11 @@ pub(crate) fn format_impl(
 
             visitor.format_missing(item.span.hi() - BytePos(1));
 
+            context
+                .skipped_range
+                .borrow_mut()
+                .append(&mut visitor.skipped_range.borrow_mut());
+
             let inner_indent_str = visitor.block_indent.to_string_with_newline(context.config);
             let outer_indent_str = offset.block_only().to_string_with_newline(context.config);
 
@@ -1260,6 +1265,11 @@ pub(crate) fn format_trait(
             }
 
             visitor.format_missing(item.span.hi() - BytePos(1));
+
+            context
+                .skipped_range
+                .borrow_mut()
+                .append(&mut visitor.skipped_range.borrow_mut());
 
             let inner_indent_str = visitor.block_indent.to_string_with_newline(context.config);
 

--- a/src/formatting/macros.rs
+++ b/src/formatting/macros.rs
@@ -1568,6 +1568,11 @@ fn rewrite_macro_with_items(
         visitor.visit_item(&item, false);
     }
 
+    context
+        .skipped_range
+        .borrow_mut()
+        .append(&mut visitor.skipped_range.borrow_mut());
+
     let mut result = String::with_capacity(256);
     result.push_str(&macro_name);
     result.push_str(opener);

--- a/tests/source/skip/skip-and-whitespaces-at-line-end.rs
+++ b/tests/source/skip/skip-and-whitespaces-at-line-end.rs
@@ -1,0 +1,106 @@
+// *** "rustfmt::skip" and Whitespaces at nd of line
+// *** All source lines starts with indent by 3 tabls.
+
+// Impl - original code from issue #4706
+            impl      Foo          {
+            #[rustfmt::skip]
+            fn foo() {
+            Bar     
+            //     ^ there is whitespace here
+            }
+
+            fn bar() {
+            Qux // asdf
+            }
+            }
+
+// Impl - all skipped lines end with white spaces
+            #[rustfmt::skip]
+            /// DOC1   
+            /// DOC2   
+            impl      Foo1          {     
+            fn foo1() {
+            Bar1     
+            }   
+            }     
+
+            impl      Foo2          {
+            #[rustfmt::skip]
+            /// DOC1   
+            /// DOC2   
+            fn foo2() {    
+            Bar2     
+            }       
+            }
+
+            impl      Foo3          {
+            fn foo3() {
+            #[rustfmt::skip]
+            /// DOC1   
+            /// DOC2        
+            Bar2     
+            }  
+            }
+
+// fn - all skipped lines end with white spaces            
+            #[rustfmt::skip]
+            /// DOC1   
+            /// DOC2   
+            fn foo2() {    
+            Bar2     
+            }       
+
+            fn foo3() {
+            #[rustfmt::skip]
+            /// DOC1   
+            /// DOC2        
+            Bar2     
+            }
+
+// Trait - all skipped lines end with white spaces
+
+            // All skipped lines end with white spaces
+            #[rustfmt::skip]
+            #[allow(non_snake_case)]    
+            trait Animal1 {    
+            fn new(name: &'static str) -> Self;    
+
+            fn talk(&self) {}     
+            }    
+
+            // All skipped lines end with white spaces
+            #[allow(non_snake_case)]
+            trait Animal1 {
+            #[rustfmt::skip]
+            fn new(name: &'static str) -> Self;    
+   
+            fn talk(&self) {}    
+            }
+
+            // Internal skipped line
+            #[allow(non_snake_case)]
+            trait Animal3 {
+            fn new(name: &'static str) -> Self;
+
+            fn talk(&self) {
+            #[rustfmt::skip]
+            let x = 1;    
+            //          ^ there is whitespace here
+            }
+            }
+
+// Macro - all skipped lines end with white spaces.
+            #[rustfmt::skip]
+            macro_rules! my_macro1 {    
+            () => {};    
+            }    
+
+            // Skipped range in macro definitin body does **NOT** enter into final `skipped_range`
+            // list since macro definition is formatted as a stand alone `snippet`.
+            macro_rules! my_macro2 {
+            ($param) => {
+            #[rustfmt::skip]
+            $param
+            //     ^ there are **NO** trailing whitespaces here 
+            };
+            }    

--- a/tests/target/issue-4398.rs
+++ b/tests/target/issue-4398.rs
@@ -6,7 +6,7 @@ impl Struct {
 
 impl Struct {
     /// Documentation for `foo`
-    #[rustfmt::skip] // comment on why use a skip here
+       #[rustfmt::skip] // comment on why use a skip here
     pub fn foo(&self) {}
 }
 

--- a/tests/target/skip/skip-and-whitespaces-at-line-end.rs
+++ b/tests/target/skip/skip-and-whitespaces-at-line-end.rs
@@ -1,0 +1,106 @@
+// *** "rustfmt::skip" and Whitespaces at nd of line
+// *** All source lines starts with indent by 3 tabls.
+
+// Impl - original code from issue #4706
+impl Foo {
+    #[rustfmt::skip]
+            fn foo() {
+            Bar     
+            //     ^ there is whitespace here
+            }
+
+    fn bar() {
+        Qux // asdf
+    }
+}
+
+// Impl - all skipped lines end with white spaces
+#[rustfmt::skip]
+            /// DOC1   
+            /// DOC2   
+            impl      Foo1          {     
+            fn foo1() {
+            Bar1     
+            }   
+            }
+
+impl Foo2 {
+    #[rustfmt::skip]
+            /// DOC1   
+            /// DOC2   
+            fn foo2() {    
+            Bar2     
+            }
+}
+
+impl Foo3 {
+    fn foo3() {
+        #[rustfmt::skip]
+            /// DOC1   
+            /// DOC2        
+            Bar2
+    }
+}
+
+// fn - all skipped lines end with white spaces
+#[rustfmt::skip]
+            /// DOC1   
+            /// DOC2   
+            fn foo2() {    
+            Bar2     
+            }
+
+fn foo3() {
+    #[rustfmt::skip]
+            /// DOC1   
+            /// DOC2        
+            Bar2
+}
+
+// Trait - all skipped lines end with white spaces
+
+// All skipped lines end with white spaces
+#[rustfmt::skip]
+            #[allow(non_snake_case)]    
+            trait Animal1 {    
+            fn new(name: &'static str) -> Self;    
+
+            fn talk(&self) {}     
+            }
+
+// All skipped lines end with white spaces
+#[allow(non_snake_case)]
+trait Animal1 {
+    #[rustfmt::skip]
+            fn new(name: &'static str) -> Self;
+
+    fn talk(&self) {}
+}
+
+// Internal skipped line
+#[allow(non_snake_case)]
+trait Animal3 {
+    fn new(name: &'static str) -> Self;
+
+    fn talk(&self) {
+        #[rustfmt::skip]
+            let x = 1;
+        //          ^ there is whitespace here
+    }
+}
+
+// Macro - all skipped lines end with white spaces.
+#[rustfmt::skip]
+            macro_rules! my_macro1 {    
+            () => {};    
+            }
+
+// Skipped range in macro definitin body does **NOT** enter into final `skipped_range`
+// list since macro definition is formatted as a stand alone `snippet`.
+macro_rules! my_macro2 {
+    ($param) => {
+        #[rustfmt::skip]
+            $param
+        //     ^ there are **NO** trailing whitespaces here
+    };
+}


### PR DESCRIPTION
Suggested fix for issue #4706, including enhancements to the handling of `#[rustfmt::skip]`.

#4706 issue was caused because `format_impl()` did not copy the skipped range from the local `context` into the `visitor.context`.  The same issue was corrected also in `format_trait()` and `rewrite_macro_with_items()`.

While testing I found that there are cases where `self.line_number` in `push_skipped_with_span()` is incorrect (usually 0 or 1).  That caused an incorrect skipped range to be created.  Therefore, I had to make changes to this function.  The main change is that the beginning of the skipped range mainly depends on the beginning of the attributes block, instead of `self.line_number`.

Another major change to `push_skipped_with_span()` is related to the following comment: https://github.com/rust-lang/rustfmt/blob/94035f9148d31d3f714d9c649cf2de0f0edb4f46/src/formatting/visitor.rs#L856
This comment is not correct in general, as in several cases only the first attribute in an attributes block is not skipped (this was also partly discussed in [PR #4707](https://github.com/rust-lang/rustfmt/pull/4707#issuecomment-807716739)).  Therefore, my change to `push_skipped_with_span()` assumes that only the first attribute line should not be skipped.  If this is the correct approach, then the above comment should be removed.  Otherwise, `push_skipped_with_span()` should be changed so the beginning of the skipped range will depend on the end of the attributes block, instead of its beginning.

I am aware that the above changes are more general than the specific #4706 issue, but there doesn't seem to be a good way to fix only this issue, because of the required change for `push_skipped_with_span()` to handle wrong `self.line_number` that impacts other skip cases.

Because of the general changes, the test cases file include tests for skipping fn/impl/trait/macro.  In addition, a test was added in `report.rs` to make sure that the generated `skip_ranges` is correct.
