### PR TITLE
Adjusting help message

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -178,10 +178,18 @@ fn make_opts() -> Options {
     opts.optflag("v", "verbose", "Print verbose output");
     opts.optflag("q", "quiet", "Print less output");
     opts.optflag("V", "version", "Show version information");
+    let help_topics = if is_nightly {
+        "`config` or `file-lines`"
+    } else {
+        "`config`"
+    };
+    let mut help_topic_msg = "Show this message or help about a specific topic: ".to_owned();
+    help_topic_msg.push_str(help_topics);
+
     opts.optflagopt(
         "h",
         "help",
-        "Show this message or help about a specific topic: `config` or `file-lines`",
+        &help_topic_msg,
         "=TOPIC",
     );
 
@@ -437,7 +445,7 @@ fn determine_operation(matches: &Matches) -> Result<Operation, OperationError> {
             return Ok(Operation::Help(HelpOp::None));
         } else if topic == Some("config".to_owned()) {
             return Ok(Operation::Help(HelpOp::Config));
-        } else if topic == Some("file-lines".to_owned()) {
+        } else if topic == Some("file-lines".to_owned()) && is_nightly() {
             return Ok(Operation::Help(HelpOp::FileLines));
         } else {
             return Err(OperationError::UnknownHelpTopic(topic.unwrap()));


### PR DESCRIPTION
On stable, running with `--help|-h` shows information about `file-lines` which is a nightly-only option (#4798). This commit removes all mention of `file-lines` from the help message on stable.

There is room for improvement here; perhaps a new struct called, e.g., `StableOptions` could be added to complement the existing `GetOptsOptions` struct. `StableOptions` could have a field for each field in `GetOptsOptions`, with each field's value being a `bool` that specifies whether or not the option exists on stable. Or is this adding too much complexity?