### PR TITLE
Sync with `rustc_span` changes

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-05-04"
+channel = "nightly-2021-05-13"
 components = ["rustc-dev"]

--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -28,7 +28,7 @@ pub enum FileName {
 impl From<rustc_span::FileName> for FileName {
     fn from(name: rustc_span::FileName) -> FileName {
         match name {
-            rustc_span::FileName::Real(p) => FileName::Real(p.into_local_path()),
+            rustc_span::FileName::Real(rustc_span::RealFileName::LocalPath(p)) => FileName::Real(p),
             rustc_span::FileName::Custom(ref f) if f == "stdin" => FileName::Stdin,
             _ => unreachable!(),
         }

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -70,7 +70,7 @@ where
         fn from(filename: &FileName) -> rustc_span::FileName {
             match filename {
                 FileName::Real(path) => {
-                    rustc_span::FileName::Real(rustc_span::RealFileName::Named(path.to_owned()))
+                    rustc_span::FileName::Real(rustc_span::RealFileName::LocalPath(path.to_owned()))
                 }
                 FileName::Stdin => rustc_span::FileName::Custom("stdin".to_owned()),
             }

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -65,7 +65,8 @@ impl Emitter for SilentOnIgnoredFilesEmitter {
         }
         if let Some(primary_span) = &db.span.primary_span() {
             let file_name = self.source_map.span_to_filename(*primary_span);
-            if let rustc_span::FileName::Real(rustc_span::RealFileName::Named(ref path)) = file_name
+            if let rustc_span::FileName::Real(rustc_span::RealFileName::LocalPath(ref path)) =
+                file_name
             {
                 if self
                     .ignore_path_set
@@ -157,7 +158,7 @@ impl ParseSess {
         self.parse_sess
             .source_map()
             .get_source_file(&rustc_span::FileName::Real(
-                rustc_span::RealFileName::Named(path.to_path_buf()),
+                rustc_span::RealFileName::LocalPath(path.to_path_buf()),
             ))
             .is_some()
     }
@@ -347,7 +348,7 @@ mod tests {
             let source =
                 String::from(r#"extern "system" fn jni_symbol!( funcName ) ( ... ) -> {} "#);
             source_map.new_source_file(
-                SourceMapFileName::Real(RealFileName::Named(PathBuf::from("foo.rs"))),
+                SourceMapFileName::Real(RealFileName::LocalPath(PathBuf::from("foo.rs"))),
                 source,
             );
             let mut emitter = build_emitter(
@@ -374,7 +375,7 @@ mod tests {
             let source_map = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let source = String::from(r#"pub fn bar() { 1x; }"#);
             source_map.new_source_file(
-                SourceMapFileName::Real(RealFileName::Named(PathBuf::from("foo.rs"))),
+                SourceMapFileName::Real(RealFileName::LocalPath(PathBuf::from("foo.rs"))),
                 source,
             );
             let mut emitter = build_emitter(
@@ -400,7 +401,7 @@ mod tests {
             let source_map = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let source = String::from(r#"pub fn bar() { 1x; }"#);
             source_map.new_source_file(
-                SourceMapFileName::Real(RealFileName::Named(PathBuf::from("foo.rs"))),
+                SourceMapFileName::Real(RealFileName::LocalPath(PathBuf::from("foo.rs"))),
                 source,
             );
             let mut emitter = build_emitter(
@@ -430,15 +431,15 @@ mod tests {
             let fatal_source =
                 String::from(r#"extern "system" fn jni_symbol!( funcName ) ( ... ) -> {} "#);
             source_map.new_source_file(
-                SourceMapFileName::Real(RealFileName::Named(PathBuf::from("bar.rs"))),
+                SourceMapFileName::Real(RealFileName::LocalPath(PathBuf::from("bar.rs"))),
                 bar_source,
             );
             source_map.new_source_file(
-                SourceMapFileName::Real(RealFileName::Named(PathBuf::from("foo.rs"))),
+                SourceMapFileName::Real(RealFileName::LocalPath(PathBuf::from("foo.rs"))),
                 foo_source,
             );
             source_map.new_source_file(
-                SourceMapFileName::Real(RealFileName::Named(PathBuf::from("fatal.rs"))),
+                SourceMapFileName::Real(RealFileName::LocalPath(PathBuf::from("fatal.rs"))),
                 fatal_source,
             );
             let mut emitter = build_emitter(

--- a/src/syntux/session.rs
+++ b/src/syntux/session.rs
@@ -191,7 +191,7 @@ impl ParseSess {
     }
 
     pub(crate) fn span_to_debug_info(&self, span: Span) -> String {
-        self.parse_sess.source_map().span_to_string(span)
+        self.parse_sess.source_map().span_to_diagnostic_string(span)
     }
 
     pub(crate) fn inner(&self) -> &RawParseSess {


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/83813 made some changes to `SourceMap` and `RealFileName` which need to be reflected here once they land in nightly

Closes - after updating rustfmt submodule - https://github.com/rust-lang/rust/issues/85226