### PR TITLE
Use relative-path for logical path traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 
 [[package]]
+name = "relative-path"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a479d53d7eed831f3c92ca79c61002d5987e21417d528296832f802bca532380"
+
+[[package]]
 name = "rust-argon2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +609,7 @@ dependencies = [
  "lazy_static",
  "log",
  "regex",
+ "relative-path",
  "rustc-workspace-hack",
  "rustfmt-config_proc_macro",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ rustfmt-config_proc_macro = { version = "0.2", path = "config_proc_macro" }
 lazy_static = "1.0.0"
 anyhow = "1.0"
 thiserror = "1.0"
+relative-path = "1.4.0"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-05-04"
+channel = "nightly-2021-05-01"
 components = ["rustc-dev"]


### PR DESCRIPTION
Fixes #4477

This fixes the longstanding issue where you get the following error in case a relative path is specified on Windows which contains `.` or `..` components:

```text
error: couldn't read \\?\D:\Repo\tokio\tokio\tests\..\src\fs\file.rs: The filename, directory name, or volume label syntax is incorrect. (os error 123)
  --> \\?\D:\Repo\tokio\tokio\tests\fs_file_mocked.rs:28:1
   |
28 | mod file;
   | ^^^^^^^^^

Error writing files: failed to resolve mod `file`: \\?\D:\Repo\tokio\tokio\tests\..\src\fs\file.rs does not exist
```

If you doubt if this issue is still present, you can checkout the Tokio project and give it a spin.

The long version is that paths beginning with `\\?\` on Windows are "raw paths" which [turns of automatic expansion of `.` and `..`](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#win32-file-namespaces) causing them to be treated as files and not current and parent directory. Joining them using the regular method as provided by `Path` causes `.` and `..` to be incorrectly included in the absolute path.

These kinds of paths are returned by e.g. the [`fs::canonicalize`](https://doc.rust-lang.org/std/fs/fn.canonicalize.html) implementation on Windows.

For more, see: https://github.com/udoprog/patterns/blob/main/examples/relative-path.rs

Note that an alternative is to avoid path canonicalization in how rustfmt processes things, allowing it to work like `rustc` [since that basically uses the same implementation in how the `path` attribute is expanded](https://github.com/rust-lang/rust/blob/master/compiler/rustc_expand/src/module.rs#L166).