### PR TITLE
Improve pasta copyability of `merge_imports` deprecation message

### DIFF
--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -409,7 +409,7 @@ macro_rules! create_config {
                 if self.was_set().merge_imports() {
                     eprintln!(
                         "Warning: the `merge_imports` option is deprecated. \
-                        Use `imports_granularity=Crate` instead"
+                        Use `imports_granularity=\"Crate\"` instead"
                     );
                     if !self.was_set().imports_granularity() {
                         self.imports_granularity.2 = if self.merge_imports() {


### PR DESCRIPTION
Add double quotes around `Crate` so that it can be copied directly into a `Cargo.toml` file