### PR TITLE
fix a bunch of clippy warnings

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -183,7 +183,7 @@ fn format_derive(
     } else if let SeparatorTactic::Always = context.config.trailing_comma() {
         // Retain the trailing comma.
         result.push_str(&item_str);
-    } else if item_str.ends_with(",") {
+    } else if item_str.ends_with(',') {
         // Remove the trailing comma.
         result.push_str(&item_str[..item_str.len() - 1]);
     } else {

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -405,8 +405,8 @@ fn get_targets_recursive(
                 .packages
                 .iter()
                 .find(|p| p.name == dependency.name && p.source.is_none());
-            let manifest_path = if dependency_package.is_some() {
-                PathBuf::from(&dependency_package.unwrap().manifest_path)
+            let manifest_path = if let Some(dep_pkg) = dependency_package {
+                PathBuf::from(&dep_pkg.manifest_path)
             } else {
                 let mut package_manifest_path = PathBuf::from(&package.manifest_path);
                 package_manifest_path.pop();

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -231,10 +231,7 @@ impl ChainItem {
     }
 
     fn is_comment(&self) -> bool {
-        match self.kind {
-            ChainItemKind::Comment(..) => true,
-            _ => false,
-        }
+        matches!(self.kind, ChainItemKind::Comment(..))
     }
 
     fn rewrite_method_call(

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -336,7 +336,7 @@ pub(crate) fn rewrite_last_closure(
 
         // We force to use block for the body of the closure for certain kinds of expressions.
         if is_block_closure_forced(context, body) {
-            return rewrite_closure_with_block(body, &prefix, context, body_shape).and_then(
+            return rewrite_closure_with_block(body, &prefix, context, body_shape).map(
                 |body_str| {
                     match fn_decl.output {
                         ast::FnRetTy::Default(..) if body_str.lines().count() <= 7 => {
@@ -344,15 +344,15 @@ pub(crate) fn rewrite_last_closure(
                             // closure.  However, if the closure has a return type, then we must
                             // keep the blocks.
                             match rewrite_closure_expr(body, &prefix, context, shape) {
-                                Some(ref single_line_body_str)
+                                Some(single_line_body_str)
                                     if !single_line_body_str.contains('\n') =>
                                 {
-                                    Some(single_line_body_str.clone())
+                                    single_line_body_str
                                 }
-                                _ => Some(body_str),
+                                _ => body_str,
                             }
                         }
-                        _ => Some(body_str),
+                        _ => body_str,
                     }
                 },
             );
@@ -377,10 +377,7 @@ pub(crate) fn rewrite_last_closure(
 pub(crate) fn args_have_many_closure(args: &[OverflowableItem<'_>]) -> bool {
     args.iter()
         .filter_map(OverflowableItem::to_expr)
-        .filter(|expr| match expr.kind {
-            ast::ExprKind::Closure(..) => true,
-            _ => false,
-        })
+        .filter(|expr| matches!(expr.kind, ast::ExprKind::Closure(..)))
         .count()
         > 1
 }

--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -305,7 +305,7 @@ impl str::FromStr for FileLines {
         let mut m = HashMap::new();
         for js in v {
             let (s, r) = JsonSpan::into_tuple(js)?;
-            m.entry(s).or_insert_with(|| vec![]).push(r);
+            m.entry(s).or_insert_with(Vec::new).push(r);
         }
         Ok(FileLines::from_ranges(m))
     }
@@ -322,7 +322,7 @@ impl JsonSpan {
     fn into_tuple(self) -> Result<(FileName, Range), FileLinesError> {
         let (lo, hi) = self.range;
         let canonical = canonicalize_path_string(&self.file)
-            .ok_or_else(|| FileLinesError::CannotCanonicalize(self.file))?;
+            .ok_or(FileLinesError::CannotCanonicalize(self.file))?;
         Ok((canonical, Range::new(lo, hi)))
     }
 }

--- a/src/config/license.rs
+++ b/src/config/license.rs
@@ -3,7 +3,6 @@ use std::fs::File;
 use std::io;
 use std::io::Read;
 
-use regex;
 use regex::Regex;
 
 #[derive(Debug)]

--- a/src/emitter/diff.rs
+++ b/src/emitter/diff.rs
@@ -45,7 +45,7 @@ impl Emitter for DiffEmitter {
             return Ok(EmitterResult { has_diff: true });
         }
 
-        return Ok(EmitterResult { has_diff });
+        Ok(EmitterResult { has_diff })
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -261,15 +261,12 @@ pub(crate) fn format_expr(
             }
 
             fn needs_space_after_range(rhs: &ast::Expr) -> bool {
-                match rhs.kind {
-                    // Don't format `.. ..` into `....`, which is invalid.
-                    //
-                    // This check is unnecessary for `lhs`, because a range
-                    // starting from another range needs parentheses as `(x ..) ..`
-                    // (`x .. ..` is a range from `x` to `..`).
-                    ast::ExprKind::Range(None, _, _) => true,
-                    _ => false,
-                }
+                // Don't format `.. ..` into `....`, which is invalid.
+                //
+                // This check is unnecessary for `lhs`, because a range
+                // starting from another range needs parentheses as `(x ..) ..`
+                // (`x .. ..` is a range from `x` to `..`).
+                matches!(rhs.kind, ast::ExprKind::Range(None, _, _))
             }
 
             let default_sp_delim = |lhs: Option<&ast::Expr>, rhs: Option<&ast::Expr>| {
@@ -529,7 +526,7 @@ pub(crate) fn rewrite_block_with_visitor(
 
     let inner_attrs = attrs.map(inner_attributes);
     let label_str = rewrite_label(label);
-    visitor.visit_block(block, inner_attrs.as_ref().map(|a| &**a), has_braces);
+    visitor.visit_block(block, inner_attrs.as_deref(), has_braces);
     let visitor_context = visitor.get_context();
     context
         .skipped_range
@@ -593,7 +590,7 @@ pub(crate) fn rewrite_cond(
                 String::from("\n") + &shape.indent.block_only().to_string(context.config);
             control_flow
                 .rewrite_cond(context, shape, &alt_block_sep)
-                .and_then(|rw| Some(rw.0))
+                .map(|rw| rw.0)
         }),
     }
 }
@@ -1155,18 +1152,11 @@ pub(crate) fn is_empty_block(
 }
 
 pub(crate) fn stmt_is_expr(stmt: &ast::Stmt) -> bool {
-    match stmt.kind {
-        ast::StmtKind::Expr(..) => true,
-        _ => false,
-    }
+    matches!(stmt.kind, ast::StmtKind::Expr(..))
 }
 
 pub(crate) fn is_unsafe_block(block: &ast::Block) -> bool {
-    if let ast::BlockCheckMode::Unsafe(..) = block.rules {
-        true
-    } else {
-        false
-    }
+    matches!(block.rules, ast::BlockCheckMode::Unsafe(..))
 }
 
 pub(crate) fn rewrite_literal(

--- a/src/formatting/newline_style.rs
+++ b/src/formatting/newline_style.rs
@@ -77,7 +77,7 @@ fn convert_to_windows_newlines(formatted_text: &String) -> String {
     transformed
 }
 
-fn convert_to_unix_newlines(formatted_text: &String) -> String {
+fn convert_to_unix_newlines(formatted_text: &str) -> String {
     formatted_text.replace(WINDOWS_NEWLINE, UNIX_NEWLINE)
 }
 

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -126,11 +126,7 @@ impl BadIssueSeeker {
                     return Seeking::Number {
                         issue: Issue {
                             issue_type: IssueType::Todo,
-                            missing_number: if let ReportTactic::Unnumbered = self.report_todo {
-                                true
-                            } else {
-                                false
-                            },
+                            missing_number: matches!(self.report_todo, ReportTactic::Unnumbered),
                         },
                         part: NumberPart::OpenParen,
                     };
@@ -144,11 +140,7 @@ impl BadIssueSeeker {
                     return Seeking::Number {
                         issue: Issue {
                             issue_type: IssueType::Fixme,
-                            missing_number: if let ReportTactic::Unnumbered = self.report_fixme {
-                                true
-                            } else {
-                                false
-                            },
+                            missing_number: matches!(self.report_fixme, ReportTactic::Unnumbered),
                         },
                         part: NumberPart::OpenParen,
                     };
@@ -196,7 +188,7 @@ impl BadIssueSeeker {
                 }
             }
             NumberPart::Number => {
-                if c >= '0' && c <= '9' {
+                if ('0'..='9').contains(&c) {
                     part = NumberPart::CloseParen;
                 } else {
                     return IssueClassification::Bad(issue);

--- a/src/items.rs
+++ b/src/items.rs
@@ -742,7 +742,7 @@ pub(crate) fn format_impl(
                 // there is only one where-clause predicate
                 // recover the suppressed comma in single line where_clause formatting
                 if generics.where_clause.predicates.len() == 1 {
-                    result.push_str(",");
+                    result.push(',');
                 }
                 result.push_str(&format!("{}{{{}}}", sep, sep));
             } else {
@@ -1245,7 +1245,7 @@ impl<'a> Rewrite for TraitAliasBounds<'a> {
 
         let fits_single_line = !generic_bounds_str.contains('\n')
             && !where_str.contains('\n')
-            && generic_bounds_str.len() + where_str.len() + 1 <= shape.width;
+            && generic_bounds_str.len() + where_str.len() < shape.width;
         let space = if generic_bounds_str.is_empty() || where_str.is_empty() {
             Cow::from("")
         } else if fits_single_line {
@@ -1274,8 +1274,8 @@ pub(crate) fn format_trait_alias(
     let lhs = format!("{}trait {} =", vis_str, generics_str);
     // 1 = ";"
     let trait_alias_bounds = TraitAliasBounds {
-        generics,
         generic_bounds,
+        generics,
     };
     rewrite_assign_rhs(context, lhs, &trait_alias_bounds, shape.sub_width(1)?).map(|s| s + ";")
 }
@@ -2031,7 +2031,7 @@ impl Rewrite for ast::Param {
             let num_attrs = self.attrs.len();
             (
                 mk_sp(self.attrs[num_attrs - 1].span.hi(), self.pat.span.lo()),
-                param_attrs_result.contains("\n"),
+                param_attrs_result.contains('\n'),
             )
         } else {
             (mk_sp(self.span.lo(), self.span.lo()), false)
@@ -3303,22 +3303,16 @@ pub(crate) fn rewrite_extern_crate(
 
 /// Returns `true` for `mod foo;`, false for `mod foo { .. }`.
 pub(crate) fn is_mod_decl(item: &ast::Item) -> bool {
-    match item.kind {
-        ast::ItemKind::Mod(_, ast::ModKind::Loaded(_, ast::Inline::Yes, _)) => false,
-        _ => true,
-    }
+    !matches!(
+        item.kind,
+        ast::ItemKind::Mod(_, ast::ModKind::Loaded(_, ast::Inline::Yes, _))
+    )
 }
 
 pub(crate) fn is_use_item(item: &ast::Item) -> bool {
-    match item.kind {
-        ast::ItemKind::Use(_) => true,
-        _ => false,
-    }
+    matches!(item.kind, ast::ItemKind::Use(_))
 }
 
 pub(crate) fn is_extern_crate(item: &ast::Item) -> bool {
-    match item.kind {
-        ast::ItemKind::ExternCrate(..) => true,
-        _ => false,
-    }
+    matches!(item.kind, ast::ItemKind::ExternCrate(..))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ use std::panic;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use ignore;
 use rustc_ast::ast;
 use rustc_span::symbol;
 use thiserror::Error;
@@ -144,10 +143,7 @@ pub enum ErrorKind {
 
 impl ErrorKind {
     fn is_comment(&self) -> bool {
-        match self {
-            ErrorKind::LostComment => true,
-            _ => false,
-        }
+        matches!(self, ErrorKind::LostComment)
     }
 }
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -194,10 +194,7 @@ impl ListItem {
     // Returns `true` if the item causes something to be written.
     fn is_substantial(&self) -> bool {
         fn empty(s: &Option<String>) -> bool {
-            match *s {
-                Some(ref s) if !s.is_empty() => false,
-                _ => true,
-            }
+            !matches!(*s, Some(ref s) if !s.is_empty())
         }
 
         !(empty(&self.pre_comment) && empty(&self.item) && empty(&self.post_comment))
@@ -618,8 +615,8 @@ pub(crate) fn extract_post_comment(
     let post_snippet = post_snippet[..comment_end].trim();
     let post_snippet_trimmed = if post_snippet.starts_with(|c| c == ',' || c == ':') {
         post_snippet[1..].trim_matches(white_space)
-    } else if post_snippet.starts_with(separator) {
-        post_snippet[separator.len()..].trim_matches(white_space)
+    } else if let Some(stripped) = post_snippet.strip_prefix(separator) {
+        stripped.trim_matches(white_space)
     }
     // not comment or over two lines
     else if post_snippet.ends_with(',')
@@ -823,7 +820,7 @@ where
 pub(crate) fn total_item_width(item: &ListItem) -> usize {
     comment_len(item.pre_comment.as_ref().map(|x| &(*x)[..]))
         + comment_len(item.post_comment.as_ref().map(|x| &(*x)[..]))
-        + &item.item.as_ref().map_or(0, |s| unicode_str_width(&s))
+        + item.item.as_ref().map_or(0, |s| unicode_str_width(&s))
 }
 
 fn comment_len(comment: Option<&str>) -> usize {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -179,10 +179,10 @@ fn return_macro_parse_failure_fallback(
         .lines()
         .last()
         .map(|closing_line| {
-            closing_line.trim().chars().all(|ch| match ch {
-                '}' | ')' | ']' => true,
-                _ => false,
-            })
+            closing_line
+                .trim()
+                .chars()
+                .all(|ch| matches!(ch, '}' | ')' | ']'))
         })
         .unwrap_or(false);
     if is_like_block_indent_style {
@@ -690,25 +690,22 @@ fn delim_token_to_str(
 
 impl MacroArgKind {
     fn starts_with_brace(&self) -> bool {
-        match *self {
+        matches!(
+            *self,
             MacroArgKind::Repeat(DelimToken::Brace, _, _, _)
-            | MacroArgKind::Delimited(DelimToken::Brace, _) => true,
-            _ => false,
-        }
+                | MacroArgKind::Delimited(DelimToken::Brace, _)
+        )
     }
 
     fn starts_with_dollar(&self) -> bool {
-        match *self {
-            MacroArgKind::Repeat(..) | MacroArgKind::MetaVariable(..) => true,
-            _ => false,
-        }
+        matches!(
+            *self,
+            MacroArgKind::Repeat(..) | MacroArgKind::MetaVariable(..)
+        )
     }
 
     fn ends_with_space(&self) -> bool {
-        match *self {
-            MacroArgKind::Separator(..) => true,
-            _ => false,
-        }
+        matches!(*self, MacroArgKind::Separator(..))
     }
 
     fn has_meta_var(&self) -> bool {
@@ -1162,10 +1159,10 @@ fn force_space_before(tok: &TokenKind) -> bool {
 }
 
 fn ident_like(tok: &Token) -> bool {
-    match tok.kind {
-        TokenKind::Ident(..) | TokenKind::Literal(..) | TokenKind::Lifetime(_) => true,
-        _ => false,
-    }
+    matches!(
+        tok.kind,
+        TokenKind::Ident(..) | TokenKind::Literal(..) | TokenKind::Lifetime(_)
+    )
 }
 
 fn next_space(tok: &TokenKind) -> SpaceState {
@@ -1399,7 +1396,7 @@ impl MacroBranch {
         // Undo our replacement of macro variables.
         // FIXME: this could be *much* more efficient.
         for (old, new) in &substs {
-            if old_body.find(new).is_some() {
+            if old_body.contains(new) {
                 debug!("rewrite_macro_def: bailing matching variable: `{}`", new);
                 return None;
             }

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -230,8 +230,7 @@ impl<'a> FmtVisitor<'a> {
         let last_char = big_snippet
             .chars()
             .rev()
-            .skip_while(|rev_c| [' ', '\t'].contains(rev_c))
-            .next();
+            .find(|rev_c| ![' ', '\t'].contains(rev_c));
 
         let fix_indent = last_char.map_or(true, |rev_c| ['{', '\n'].contains(&rev_c));
         let mut on_same_line = false;
@@ -262,7 +261,7 @@ impl<'a> FmtVisitor<'a> {
         let comment_shape = Shape::legacy(comment_width, comment_indent);
 
         if on_same_line {
-            match subslice.find("\n") {
+            match subslice.find('\n') {
                 None => {
                     self.push_str(subslice);
                 }
@@ -299,8 +298,7 @@ impl<'a> FmtVisitor<'a> {
             match snippet[status.line_start..]
                 .chars()
                 // skip trailing whitespaces
-                .skip_while(|c| *c == ' ' || *c == '\t')
-                .next()
+                .find(|c| !(*c == ' ' || *c == '\t'))
             {
                 Some('\n') | Some('\r') => {
                     if !is_last_comment_block(subslice) {

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -126,21 +126,19 @@ impl<'a> OverflowableItem<'a> {
             OverflowableItem::MacroArg(MacroArg::Expr(expr)) => is_simple_expr(expr),
             OverflowableItem::NestedMetaItem(nested_meta_item) => match nested_meta_item {
                 ast::NestedMetaItem::Literal(..) => true,
-                ast::NestedMetaItem::MetaItem(ref meta_item) => match meta_item.kind {
-                    ast::MetaItemKind::Word => true,
-                    _ => false,
-                },
+                ast::NestedMetaItem::MetaItem(ref meta_item) => {
+                    matches!(meta_item.kind, ast::MetaItemKind::Word)
+                }
             },
             _ => false,
         }
     }
 
     pub(crate) fn is_expr(&self) -> bool {
-        match self {
-            OverflowableItem::Expr(..) => true,
-            OverflowableItem::MacroArg(MacroArg::Expr(..)) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            OverflowableItem::Expr(..) | OverflowableItem::MacroArg(MacroArg::Expr(..))
+        )
     }
 
     pub(crate) fn is_nested_call(&self) -> bool {
@@ -154,10 +152,7 @@ impl<'a> OverflowableItem<'a> {
     pub(crate) fn to_expr(&self) -> Option<&'a ast::Expr> {
         match self {
             OverflowableItem::Expr(expr) => Some(expr),
-            OverflowableItem::MacroArg(macro_arg) => match macro_arg {
-                MacroArg::Expr(ref expr) => Some(expr),
-                _ => None,
-            },
+            OverflowableItem::MacroArg(MacroArg::Expr(ref expr)) => Some(expr),
             _ => None,
         }
     }
@@ -178,10 +173,9 @@ impl<'a> OverflowableItem<'a> {
                     ast::NestedMetaItem::MetaItem(..) => true,
                 }
             }
-            OverflowableItem::SegmentParam(seg) => match seg {
-                SegmentParam::Type(ty) => can_be_overflowed_type(context, ty, len),
-                _ => false,
-            },
+            OverflowableItem::SegmentParam(SegmentParam::Type(ty)) => {
+                can_be_overflowed_type(context, ty, len)
+            }
             OverflowableItem::TuplePatField(pat) => can_be_overflowed_pat(context, pat, len),
             OverflowableItem::Ty(ty) => can_be_overflowed_type(context, ty, len),
             _ => false,

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -56,10 +56,7 @@ impl From<Vec<Mismatch>> for ModifiedLines {
         let chunks = mismatches.into_iter().map(|mismatch| {
             let lines = mismatch.lines.iter();
             let num_removed = lines
-                .filter(|line| match line {
-                    DiffLine::Resulting(_) => true,
-                    _ => false,
-                })
+                .filter(|line| matches!(line, DiffLine::Resulting(_)))
                 .count();
 
             let new_lines = mismatch.lines.into_iter().filter_map(|line| match line {
@@ -94,7 +91,7 @@ impl fmt::Display for ModifiedLines {
                 "{} {} {}",
                 chunk.line_number_orig,
                 chunk.lines_removed,
-                chunk.lines.iter().count()
+                chunk.lines.len()
             )?;
 
             for line in &chunk.lines {

--- a/src/skip.rs
+++ b/src/skip.rs
@@ -32,8 +32,8 @@ impl SkipContext {
     }
 }
 
-static RUSTFMT: &'static str = "rustfmt";
-static SKIP: &'static str = "skip";
+static RUSTFMT: &str = "rustfmt";
+static SKIP: &str = "skip";
 
 /// Say if you're playing with `rustfmt`'s skip attribute
 pub(crate) fn is_skip_attr(segments: &[ast::PathSegment]) -> bool {
@@ -46,7 +46,7 @@ pub(crate) fn is_skip_attr(segments: &[ast::PathSegment]) -> bool {
             segments[1].ident.to_string() == SKIP
                 && ["macros", "attributes"]
                     .iter()
-                    .any(|&n| n == &pprust::path_segment_to_string(&segments[2]))
+                    .any(|&n| n == pprust::path_segment_to_string(&segments[2]))
         }
         _ => false,
     }

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -18,7 +18,7 @@ use rustc_data_structures::sync::Lrc;
 
 // Append a newline to the end of each file.
 pub(crate) fn append_newline(s: &mut String) {
-    s.push_str("\n");
+    s.push('\n');
 }
 
 #[cfg(test)]

--- a/src/string.rs
+++ b/src/string.rs
@@ -57,7 +57,7 @@ impl<'a> StringFormat<'a> {
     /// This allows to fit more graphemes from the string on a line when
     /// SnippetState::EndWithLineFeed.
     fn max_width_without_indent(&self) -> Option<usize> {
-        Some(self.config.max_width().checked_sub(self.line_end.len())?)
+        self.config.max_width().checked_sub(self.line_end.len())
     }
 }
 
@@ -99,7 +99,7 @@ pub(crate) fn rewrite_string<'a>(
                 if is_new_line(grapheme) {
                     // take care of blank lines
                     result = trim_end_but_line_feed(fmt.trim_end, result);
-                    result.push_str("\n");
+                    result.push('\n');
                     if !is_bareline_ok && cur_start + i + 1 < graphemes.len() {
                         result.push_str(&indent_without_newline);
                         result.push_str(fmt.line_start);

--- a/src/syntux/parser.rs
+++ b/src/syntux/parser.rs
@@ -79,7 +79,7 @@ impl<'a> ParserBuilder<'a> {
                 rustc_span::FileName::Custom("stdin".to_owned()),
                 text,
             )
-            .map_err(|db| Some(db)),
+            .map_err(Some),
         }
     }
 }
@@ -196,8 +196,7 @@ impl<'a> Parser<'a> {
         mac: &'a ast::MacCall,
     ) -> Result<Vec<ast::Item>, &'static str> {
         let token_stream = mac.args.inner_tokens();
-        let mut parser =
-            rustc_parse::stream_to_parser(sess.inner(), token_stream.clone(), Some(""));
+        let mut parser = rustc_parse::stream_to_parser(sess.inner(), token_stream, Some(""));
 
         let mut items = vec![];
         let mut process_if_cfg = true;

--- a/src/types.rs
+++ b/src/types.rs
@@ -661,7 +661,7 @@ impl Rewrite for ast::Ty {
                 let mut_str = format_mutability(mt.mutbl);
                 let mut_len = mut_str.len();
                 let mut result = String::with_capacity(128);
-                result.push_str("&");
+                result.push('&');
                 let ref_hi = context.snippet_provider.span_after(self.span(), "&");
                 let mut cmnt_lo = ref_hi;
 
@@ -684,7 +684,7 @@ impl Rewrite for ast::Ty {
                     } else {
                         result.push_str(&lt_str);
                     }
-                    result.push_str(" ");
+                    result.push(' ');
                     cmnt_lo = lifetime.ident.span.hi();
                 }
 
@@ -1007,11 +1007,7 @@ fn join_bounds_inner(
                     true,
                 )
                 .map(|v| (v, trailing_span, extendable)),
-                _ => Some((
-                    String::from(strs) + &trailing_str,
-                    trailing_span,
-                    extendable,
-                )),
+                _ => Some((strs + &trailing_str, trailing_span, extendable)),
             }
         },
     )?;
@@ -1048,10 +1044,7 @@ fn rewrite_lifetime_param(
 ) -> Option<String> {
     let result = generic_params
         .iter()
-        .filter(|p| match p.kind {
-            ast::GenericParamKind::Lifetime => true,
-            _ => false,
-        })
+        .filter(|p| matches!(p.kind, ast::GenericParamKind::Lifetime))
         .map(|lt| lt.rewrite(context, shape))
         .collect::<Option<Vec<_>>>()?
         .join(", ");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -191,7 +191,7 @@ pub(crate) fn outer_attributes(attrs: &[ast::Attribute]) -> Vec<ast::Attribute> 
 
 #[inline]
 pub(crate) fn is_single_line(s: &str) -> bool {
-    s.chars().find(|&c| c == '\n').is_none()
+    !s.chars().any(|c| c == '\n')
 }
 
 #[inline]
@@ -260,8 +260,7 @@ fn is_skip(meta_item: &MetaItem) -> bool {
     match meta_item.kind {
         MetaItemKind::Word => {
             let path_str = pprust::path_to_string(&meta_item.path);
-            path_str == &*skip_annotation().as_str()
-                || path_str == &*depr_skip_annotation().as_str()
+            path_str == *skip_annotation().as_str() || path_str == *depr_skip_annotation().as_str()
         }
         MetaItemKind::List(ref l) => {
             meta_item.has_name(sym::cfg_attr) && l.len() == 2 && is_skip_nested(&l[1])

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -198,7 +198,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             let missing_span = self.next_span(hi);
             let snippet = self.snippet(missing_span);
             let len = CommentCodeSlices::new(snippet)
-                .nth(0)
+                .next()
                 .and_then(|(kind, _, s)| {
                     if kind == CodeCharKind::Normal {
                         s.rfind('\n')
@@ -293,7 +293,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     }
                     let span_in_between = mk_sp(last_hi, span.lo() + BytePos::from_usize(offset));
                     let snippet_in_between = self.snippet(span_in_between);
-                    let mut comment_on_same_line = !snippet_in_between.contains("\n");
+                    let mut comment_on_same_line = !snippet_in_between.contains('\n');
 
                     let mut comment_shape =
                         Shape::indented(self.block_indent, config).comment(config);
@@ -301,7 +301,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         self.push_str(" ");
                         // put the first line of the comment on the same line as the
                         // block's last line
-                        match sub_slice.find("\n") {
+                        match sub_slice.find('\n') {
                             None => {
                                 self.push_str(&sub_slice);
                             }
@@ -764,7 +764,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 let hi = self.snippet_provider.span_before(search_span, ";");
                 let target_span = mk_sp(mac.span().lo(), hi + BytePos(1));
                 let rewrite = rewrite.map(|rw| {
-                    if !rw.ends_with(";") {
+                    if !rw.ends_with(';') {
                         format!("{};", rw)
                     } else {
                         rw
@@ -921,7 +921,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         !is_skip_attr(segments)
     }
 
-    fn walk_mod_items(&mut self, items: &Vec<rustc_ast::ptr::P<ast::Item>>) {
+    fn walk_mod_items(&mut self, items: &[rustc_ast::ptr::P<ast::Item>]) {
         self.visit_items_with_reordering(&ptr_vec_to_ref_vec(&items));
     }
 
@@ -953,10 +953,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             // break the Stability Guarantee
             // N.B. This could be updated to utilize the version gates.
             let include_next_empty = if stmts.len() > 1 {
-                match (&stmts[0].as_ast_node().kind, &stmts[1].as_ast_node().kind) {
-                    (ast::StmtKind::Item(_), ast::StmtKind::Empty) => true,
-                    _ => false,
-                }
+                matches!(
+                    (&stmts[0].as_ast_node().kind, &stmts[1].as_ast_node().kind),
+                    (ast::StmtKind::Item(_), ast::StmtKind::Empty)
+                )
             } else {
                 false
             };


### PR DESCRIPTION
clippy::bind_instead_of_map
clippy::branches_sharing_code
clippy::collapsible_match
clippy::inconsistent_struct_constructor
clippy::int_plus_one
clippy::iter_count
clippy::iter_nth_zero
clippy::manual_range_contains
clippy::match_like_matches_macro
clippy::needless::collect
clippy::needless_question_mark
clippy::needless_return
clippy::op_ref
clippy::option_as_ref_deref
clippy::ptr_arg
clippy::redundant_clone
clippy::redundant_closure
clippy::redundant_static_lifetimes
clippy::search_is_some
clippy::#single_char_add_str
clippy::single_char_pattern
clippy::single_component_path_imports
clippy::single_match
clippy::skip_while_next
clippy::unnecessary_lazy_evaluations
clippy::unnecessary_unwrap
clippy::useless_conversion
clippy::useless_format