### PR TITLE
Fix configuration documentation site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -116,20 +116,22 @@
                   if (this.version !== this.oldVersion) {
                     const ConfigurationMdUrl =
                       `https://raw.githubusercontent.com/rust-lang/rustfmt/${this.version}/Configurations.md`;
+                    let res;
                     try {
-                      const res = await axios.get(ConfigurationMdUrl);
-                      const {
-                        about,
-                        configurationAbout,
-                        configurationDescriptions
-                      } = parseMarkdownAst(res.data);
-                      this.aboutHtml = marked.parser(about);
-                      this.configurationAboutHtml = marked.parser(configurationAbout);
-                      this.configurationDescriptions = configurationDescriptions;
-                      this.oldVersion = this.version;
-                    } catch(error) {
-                        this.aboutHtml = "<p>Failed to get configuration options for this version, please select the version from the dropdown above.</p>";
+                      res = await axios.get(ConfigurationMdUrl).catch(e => { throw e });
+                    } catch(e) {
+                      this.handleReqFailure(e);
+                      return;
                     }
+                    const {
+                      about,
+                      configurationAbout,
+                      configurationDescriptions
+                    } = parseMarkdownAst(res.data);
+                    this.aboutHtml = marked.parser(about);
+                    this.configurationAboutHtml = marked.parser(configurationAbout);
+                    this.configurationDescriptions = configurationDescriptions;
+                    this.oldVersion = this.version;
                   }
 
                   const ast = this.configurationDescriptions
@@ -172,7 +174,13 @@
                 }
               },
               created: async function() {
-                const {data: tags} = await axios.get(RusfmtTagsUrl);
+                let tags;
+                try {
+                  tags = (await axios.get(RusfmtTagsUrl)).data;
+                } catch(e) {
+                  this.handleReqFailure(e);
+                  return;
+                }
                 const reMajorVersion = /v(\d+)/;
                 const tagOptions = tags
                   .map(tag => tag.name)
@@ -188,6 +196,30 @@
                     this.scrolledOnce = true;
                   }
                 });
+              },
+              methods: {
+                handleReqFailure(e) {
+                  if (e.response.status === 404) {
+                    this.aboutHtml =
+                      "<p>Failed to get configuration options for this version, please select the version from the dropdown above.</p>";
+                  } else if (
+                    e.response.status === 403 &&
+                    e.response.headers["X-RateLimit-Remaining"] === 0
+                  ) {
+                    const resetDate = new Date(
+                      e.response.headers['X-RateLimit-Reset'] * 1000
+                    ).toLocaleString();
+                    this.aboutHtml =
+                      `<p>You have hit the GitHub API rate limit; documentation cannot be updated.` +
+                      `<p>The rate limit will be reset at ${resetDate}.</p>`;
+                  } else {
+                    this.aboutHtml =
+                      `<p>Ecountered an error when fetching documentation data:</p>` +
+                      `<pre><code>${e.response.data}</code></pre>` +
+                      `<p>We would appreciate <a href="https://github.com/rust-lang/rustfmt/issues/new?template=bug_report.md">a bug report</a>.` +
+                      `<p>Try refreshing the page.</p>`;
+                  }
+                }
               }
             });
             const extractDepthOnes = (ast) => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -108,7 +108,8 @@
                 shouldStable: false,
                 version: versionNumber,
                 oldVersion: undefined,
-                versionOptions: ['master']
+                versionOptions: ['master'],
+                scrolledOnce: false,
               },
               asyncComputed: {
                 async outputHtml() {
@@ -156,11 +157,11 @@
                   renderer.heading = function(text, level) {
                     const id = htmlToId(text);
                     return `<h${level}>
-                              <a href="#${id}" name="${id}" class="header-link">${text}</a>
+                              <a id="${id}" href="#${id}" name="${id}" class="header-link">${text}</a>
                             </h${level}>`;
                   };
 
-                  return marked.parser(ast, {
+                  const html = marked.parser(ast, {
                     highlight(code, lang) {
                       return hljs.highlight(lang ? lang : 'rust', code).value;
                     },
@@ -168,6 +169,8 @@
                     headerPrefix: '',
                     renderer,
                   });
+                  document.dispatchEvent(new Event('htmlbuilt'));
+                  return html;
                 }
               },
               created: async function() {
@@ -178,12 +181,15 @@
                   .filter(tag => tag.startsWith('v'));
                 this.versionOptions = this.versionOptions.concat(tagOptions);
               },
-              mounted() {
+              updated: function() {
                 if (UrlHash === '') return;
-                const target = document.querySelector(`#${UrlHash}`);
-                if (target != null) {
-                  target.scrollIntoView(true);
-                }
+                this.$nextTick(() => {
+                  const target = document.querySelector(`#${UrlHash}`);
+                  if (target != null && !this.scrolledOnce) {
+                    target.scrollIntoView(true);
+                    this.scrolledOnce = true;
+                  }
+                });
               }
             });
             const extractDepthOnes = (ast) => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -181,10 +181,12 @@
                   this.handleReqFailure(e);
                   return;
                 }
-                const reMajorVersion = /v(\d+)/;
+
+                const excludedTagVersions = new Set(['v0.7', 'v0.8.1']);
+
                 const tagOptions = tags
                   .map(tag => tag.name)
-                  .filter(tag => tag.startsWith('v'));
+                  .filter(tag => tag.startsWith('v') && !excludedTagVersions.has(tag));
                 this.versionOptions = this.versionOptions.concat(tagOptions);
               },
               updated() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,6 +41,15 @@
         .searchCondition > div {
           margin-right: 30px;
         }
+        .header-link {
+          position: relative;
+        }
+        .header-link:hover::before {
+          position: absolute;
+          left: -2em;
+          padding-right: 0.5em;
+          content: '\2002\00a7\2002';
+        }
       </style>
     </head>
     <body>
@@ -137,12 +146,27 @@
                       }, []);
                   ast.links = {};
 
+                  queryParams.set('version', this.version);
+                  queryParams.set('search', this.searchCondition);
+                  const curUrl = window.location.pathname +
+                    '?' + queryParams.toString() + window.location.hash;
+                  history.pushState(null, '', curUrl);
+
+                  const renderer = new marked.Renderer();
+                  renderer.heading = function(text, level) {
+                    const id = htmlToId(text);
+                    return `<h${level}>
+                              <a href="#${id}" name="${id}" class="header-link">${text}</a>
+                            </h${level}>`;
+                  };
+
                   return marked.parser(ast, {
                     highlight(code, lang) {
                       return hljs.highlight(lang ? lang : 'rust', code).value;
                     },
                     headerIds: true,
-                    headerPrefix: ''
+                    headerPrefix: '',
+                    renderer,
                   });
                 }
               },
@@ -156,13 +180,10 @@
               },
               mounted() {
                 if (UrlHash === '') return;
-                const interval = setInterval(() => {
-                  const target = document.querySelector(`#${UrlHash}`);
-                  if (target != null) {
-                    target.scrollIntoView(true);
-                    clearInterval(interval);
-                  }
-                }, 100);
+                const target = document.querySelector(`#${UrlHash}`);
+                if (target != null) {
+                  target.scrollIntoView(true);
+                }
               }
             });
             const extractDepthOnes = (ast) => {
@@ -227,6 +248,11 @@
                 configurationAbout: configurationAbout.value,
                 configurationDescriptions
               };
+            }
+            function htmlToId(text) {
+              const tmpl = document.createElement('template');
+              tmpl.innerHTML = text.trim();
+              return encodeURIComponent(CSS.escape(tmpl.content.textContent));
             }
         </script>
     </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -161,7 +161,7 @@
                             </h${level}>`;
                   };
 
-                  const html = marked.parser(ast, {
+                  return marked.parser(ast, {
                     highlight(code, lang) {
                       return hljs.highlight(lang ? lang : 'rust', code).value;
                     },
@@ -169,8 +169,6 @@
                     headerPrefix: '',
                     renderer,
                   });
-                  document.dispatchEvent(new Event('htmlbuilt'));
-                  return html;
                 }
               },
               created: async function() {
@@ -181,7 +179,7 @@
                   .filter(tag => tag.startsWith('v'));
                 this.versionOptions = this.versionOptions.concat(tagOptions);
               },
-              updated: function() {
+              updated() {
                 if (UrlHash === '') return;
                 this.$nextTick(() => {
                   const target = document.querySelector(`#${UrlHash}`);

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,13 +79,16 @@
         <script>
             const RusfmtTagsUrl = 'https://api.github.com/repos/rust-lang/rustfmt/tags';
             const UrlHash = window.location.hash.replace(/^#/, '');
+            const queryParams = new URLSearchParams(window.location.search);
+            const searchParam = queryParams.get('search');
+            const searchTerm = null !== searchParam ? searchParam : '';
             new Vue({
               el: '#app',
               data: {
                 aboutHtml: '',
                 configurationAboutHtml: '',
                 configurationDescriptions: [],
-                searchCondition: UrlHash,
+                searchCondition: searchTerm,
                 shouldStable: false,
                 version: 'master',
                 oldVersion: undefined,
@@ -126,7 +129,9 @@
                   return marked.parser(ast, {
                     highlight(code, lang) {
                       return hljs.highlight(lang ? lang : 'rust', code).value;
-                    }
+                    },
+                    headerIds: true,
+                    headerPrefix: ''
                   });
                 }
               },

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,6 +82,13 @@
             const queryParams = new URLSearchParams(window.location.search);
             const searchParam = queryParams.get('search');
             const searchTerm = null !== searchParam ? searchParam : '';
+            const versionParam = queryParams.get('version');
+            const parseVersionParam = (version) => {
+              if (version === 'master') return 'master';
+              if (version.startsWith('v')) return version;
+              return `v${version}`;
+            };
+            const versionNumber = null !== versionParam ? parseVersionParam(versionParam) : 'master';
             new Vue({
               el: '#app',
               data: {
@@ -90,7 +97,7 @@
                 configurationDescriptions: [],
                 searchCondition: searchTerm,
                 shouldStable: false,
-                version: 'master',
+                version: versionNumber,
                 oldVersion: undefined,
                 versionOptions: ['master']
               },
@@ -99,16 +106,20 @@
                   if (this.version !== this.oldVersion) {
                     const ConfigurationMdUrl =
                       `https://raw.githubusercontent.com/rust-lang/rustfmt/${this.version}/Configurations.md`;
-                    const res = await axios.get(ConfigurationMdUrl);
-                    const {
-                      about,
-                      configurationAbout,
-                      configurationDescriptions
-                    } = parseMarkdownAst(res.data);
-                    this.aboutHtml = marked.parser(about);
-                    this.configurationAboutHtml = marked.parser(configurationAbout);
-                    this.configurationDescriptions = configurationDescriptions;
-                    this.oldVersion = this.version;
+                    try {
+                      const res = await axios.get(ConfigurationMdUrl);
+                      const {
+                        about,
+                        configurationAbout,
+                        configurationDescriptions
+                      } = parseMarkdownAst(res.data);
+                      this.aboutHtml = marked.parser(about);
+                      this.configurationAboutHtml = marked.parser(configurationAbout);
+                      this.configurationDescriptions = configurationDescriptions;
+                      this.oldVersion = this.version;
+                    } catch(error) {
+                        this.aboutHtml = "<p>Failed to get configuration options for this version, please select the version from the dropdown above.</p>";
+                    }
                   }
 
                   const ast = this.configurationDescriptions

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,6 @@
           </article>
         </div>
         <script>
-            const MajorVersionBounds = {min: 1, max: 2};
             const RusfmtTagsUrl = 'https://api.github.com/repos/rust-lang/rustfmt/tags';
             const UrlHash = window.location.hash.replace(/^#/, '');
             new Vue({
@@ -129,17 +128,7 @@
                 const reMajorVersion = /v(\d+)/;
                 const tagOptions = tags
                   .map(tag => tag.name)
-                  .filter(tag => {
-                    const versionMatches = tag.match(reMajorVersion);
-                    if (!versionMatches || !versionMatches[1]) {
-                      return false;
-                    }
-                    const majorVersion = +versionMatches[1];
-                    // There are some superfluous version tags (e.g. a v8.1 tag), so we do some
-                    // sanity checking of the tags here.
-                    return majorVersion >= MajorVersionBounds.min &&
-                      majorVersion <= MajorVersionBounds.max;
-                  });
+                  .filter(tag => tag.startsWith('v'));
                 this.versionOptions = this.versionOptions.concat(tagOptions);
               },
               mounted() {
@@ -172,7 +161,7 @@
                   const lastIndex = stack.length - 1;
                   stack[lastIndex].push(next);
                   return stack;
-                }, 
+                },
                 [[]]);
               });
             }
@@ -209,7 +198,7 @@
                 configurationAbout, ...configurationDescriptions
               ] = configurations;
               configurationAbout.value.links = {};
-              
+
               return {
                 about,
                 configurationAbout: configurationAbout.value,

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,9 @@
                       console.log(err);
                     return;
                   }
-                  this.version = latest.name;
+                  if (versionParam == null) {
+                    this.version = latest.name;
+                  }
                 },
                 async outputHtml() {
                   if (this.version !== this.oldVersion) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,6 +87,7 @@
         </div>
         <script>
             const RusfmtTagsUrl = 'https://api.github.com/repos/rust-lang/rustfmt/tags';
+            const RustfmtLatestUrl = 'https://api.github.com/repos/rust-lang/rustfmt/releases/latest';
             const UrlHash = window.location.hash.replace(/^#/, '');
             const queryParams = new URLSearchParams(window.location.search);
             const searchParam = queryParams.get('search');
@@ -112,6 +113,16 @@
                 scrolledOnce: false,
               },
               asyncComputed: {
+                async updateVersion() {
+                  let latest;
+                  try {
+                    latest = (await axios.get(RustfmtLatestUrl)).data;
+                  } catch(err) {
+                      console.log(err);
+                    return;
+                  }
+                  this.version = latest.name;
+                },
                 async outputHtml() {
                   if (this.version !== this.oldVersion) {
                     const ConfigurationMdUrl =

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,11 @@
     <head>
       <meta name="viewport" content="width=device-width">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.css" />
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/github-gist.min.css">
       <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/vue@2.6.10/dist/vue.js"></script>
       <script src="https://unpkg.com/vue-async-computed@3.8.1"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/highlight.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"></script>
       <style>
         @media (max-width: 767px) {
@@ -120,7 +122,12 @@
                         return stack.concat(value);
                       }, []);
                   ast.links = {};
-                  return marked.parser(ast);
+
+                  return marked.parser(ast, {
+                    highlight(code, lang) {
+                      return hljs.highlight(lang ? lang : 'rust', code).value;
+                    }
+                  });
                 }
               },
               created: async function() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -155,7 +155,9 @@
                     head: val[0].text,
                     value: val,
                     stable: val.some((elem) => {
-                      return !!elem.text && elem.text.includes("**Stable**: Yes")
+                      return elem.type === "list" &&
+                        !!elem.raw &&
+                        elem.raw.includes("**Stable**: Yes");
                     }),
                     text: val.reduce((result, next) => {
                       return next.text != null

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.css" />
       <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/vue@2.6.10/dist/vue.js"></script>
+      <script src="https://unpkg.com/vue-async-computed@3.8.1"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"></script>
       <style>
         @media (max-width: 767px) {
@@ -59,6 +60,14 @@
                   <label for="stable">stable: </label>
                   <input type="checkbox" id="stable" v-model="shouldStable">
               </div>
+              <div>
+                  <label for="version">version: </label>
+                  <select name="version" id="version" v-model="version">
+                    <option v-for="option in versionOptions" v-bind:value="option">
+                      {{ option }}
+                    </option>
+                  </select>
+              </div>
             </div>
             <div v-html="aboutHtml"></div>
             <div v-html="configurationAboutHtml"></div>
@@ -66,53 +75,72 @@
           </article>
         </div>
         <script>
-            const ConfigurationMdUrl = 'https://raw.githubusercontent.com/rust-lang/rustfmt/master/Configurations.md';
+            const MajorVersionBounds = {min: 1, max: 2};
+            const RusfmtTagsUrl = 'https://api.github.com/repos/rust-lang/rustfmt/tags';
             const UrlHash = window.location.hash.replace(/^#/, '');
             new Vue({
               el: '#app',
-              data() {
-                const configurationDescriptions = [];
-                configurationDescriptions.links = {};
-                return {
-                  aboutHtml: '',
-                  configurationAboutHtml: '',
-                  searchCondition: UrlHash,
-                  configurationDescriptions,
-                  shouldStable: false
-                }
+              data: {
+                aboutHtml: '',
+                configurationAboutHtml: '',
+                configurationDescriptions: [],
+                searchCondition: UrlHash,
+                shouldStable: false,
+                version: 'master',
+                oldVersion: undefined,
+                versionOptions: ['master']
               },
-              computed: {
-                outputHtml() {
+              asyncComputed: {
+                async outputHtml() {
+                  if (this.version !== this.oldVersion) {
+                    const ConfigurationMdUrl =
+                      `https://raw.githubusercontent.com/rust-lang/rustfmt/${this.version}/Configurations.md`;
+                    const res = await axios.get(ConfigurationMdUrl);
+                    const {
+                      about,
+                      configurationAbout,
+                      configurationDescriptions
+                    } = parseMarkdownAst(res.data);
+                    this.aboutHtml = marked.parser(about);
+                    this.configurationAboutHtml = marked.parser(configurationAbout);
+                    this.configurationDescriptions = configurationDescriptions;
+                    this.oldVersion = this.version;
+                  }
+
                   const ast = this.configurationDescriptions
-                                  .filter(({ head, text, stable }) => {
-                                    
-                                    if (
-                                      text.includes(this.searchCondition) === false &&
-                                      head.includes(this.searchCondition) === false
-                                    ) {
-                                      return false;
-                                    }
-                                    return (this.shouldStable)
-                                      ? stable === true
-                                      : true;
-                                  })
-                                  .reduce((stack, { value }) => {
-                                    return stack.concat(value);
-                                  }, []);
+                      .filter(({ head, text, stable }) => {
+                        if (text.includes(this.searchCondition) === false &&
+                          head.includes(this.searchCondition) === false) {
+                          return false;
+                        }
+                        return (this.shouldStable)
+                          ? stable === true
+                          : true;
+                      })
+                      .reduce((stack, { value }) => {
+                        return stack.concat(value);
+                      }, []);
                   ast.links = {};
                   return marked.parser(ast);
                 }
               },
               created: async function() {
-                const res = await axios.get(ConfigurationMdUrl);
-                const { 
-                  about,
-                  configurationAbout,
-                  configurationDescriptions
-                } = parseMarkdownAst(res.data);
-                this.aboutHtml = marked.parser(about);
-                this.configurationAboutHtml = marked.parser(configurationAbout);
-                this.configurationDescriptions = configurationDescriptions;
+                const {data: tags} = await axios.get(RusfmtTagsUrl);
+                const reMajorVersion = /v(\d+)/;
+                const tagOptions = tags
+                  .map(tag => tag.name)
+                  .filter(tag => {
+                    const versionMatches = tag.match(reMajorVersion);
+                    if (!versionMatches || !versionMatches[1]) {
+                      return false;
+                    }
+                    const majorVersion = +versionMatches[1];
+                    // There are some superfluous version tags (e.g. a v8.1 tag), so we do some
+                    // sanity checking of the tags here.
+                    return majorVersion >= MajorVersionBounds.min &&
+                      majorVersion <= MajorVersionBounds.max;
+                  });
+                this.versionOptions = this.versionOptions.concat(tagOptions);
               },
               mounted() {
                 if (UrlHash === '') return;


### PR DESCRIPTION
This got out of sync when we swapped the default branch (refs #4801) so cherry-picking the various commits that had improved our configuration documentation site on the 2.0 rc branch