### PR TITLE
Allow `--edition 2021` to be passed to rustfmt

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -689,6 +689,7 @@ fn edition_from_edition_str(edition_str: &str) -> Result<Edition> {
     match edition_str {
         "2015" => Ok(Edition::Edition2015),
         "2018" => Ok(Edition::Edition2018),
+        "2021" => Ok(Edition::Edition2021),
         _ => Err(format_err!("Invalid value for `--edition`")),
     }
 }


### PR DESCRIPTION
Support for Rust 2021 was added in #4618, but it wasn't actually made available through `rustfmt`'s command line. This should let people who are testing Rust 2021 on nightly rustc run `cargo fmt` again. Please let me know if I should add a test for this or if this should be gated somehow!