### PR TITLE
Allow formatting `Anonymous{Struct, Union}` declarations

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -6,7 +6,7 @@ use std::cmp::{max, min, Ordering};
 use regex::Regex;
 use rustc_ast::visit;
 use rustc_ast::{ast, ptr};
-use rustc_span::{symbol, BytePos, Span, DUMMY_SP};
+use rustc_span::{symbol, BytePos, Span};
 
 use crate::attr::filter_inline_attrs;
 use crate::comment::{
@@ -31,12 +31,7 @@ use crate::stmt::Stmt;
 use crate::utils::*;
 use crate::vertical::rewrite_with_alignment;
 use crate::visitor::FmtVisitor;
-
-const DEFAULT_VISIBILITY: ast::Visibility = ast::Visibility {
-    kind: ast::VisibilityKind::Inherited,
-    span: DUMMY_SP,
-    tokens: None,
-};
+use crate::DEFAULT_VISIBILITY;
 
 fn type_annotation_separator(config: &Config) -> &str {
     colon_spaces(config)
@@ -976,7 +971,7 @@ impl<'a> StructParts<'a> {
         format_header(context, self.prefix, self.ident, self.vis, offset)
     }
 
-    fn from_variant(variant: &'a ast::Variant) -> Self {
+    pub(crate) fn from_variant(variant: &'a ast::Variant) -> Self {
         StructParts {
             prefix: "",
             ident: variant.ident,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use std::rc::Rc;
 
 use ignore;
 use rustc_ast::ast;
-use rustc_span::symbol;
+use rustc_span::{symbol, DUMMY_SP};
 use thiserror::Error;
 
 use crate::comment::LineClasses;
@@ -95,6 +95,11 @@ mod types;
 mod vertical;
 pub(crate) mod visitor;
 
+const DEFAULT_VISIBILITY: ast::Visibility = ast::Visibility {
+    kind: ast::VisibilityKind::Inherited,
+    span: DUMMY_SP,
+    tokens: None,
+};
 /// The various errors that can occur during formatting. Note that not all of
 /// these can currently be propagated to clients.
 #[derive(Error, Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,14 +2,14 @@ use std::iter::ExactSizeIterator;
 use std::ops::Deref;
 
 use rustc_ast::ast::{self, FnRetTy, Mutability};
-use rustc_span::{symbol::kw, BytePos, Pos, Span};
+use rustc_span::{symbol::kw, symbol::Ident, BytePos, Pos, Span};
 
-use crate::comment::{combine_strs_with_missing_comments, contains_comment};
 use crate::config::lists::*;
 use crate::config::{IndentStyle, TypeDensity, Version};
 use crate::expr::{
     format_expr, rewrite_assign_rhs, rewrite_call, rewrite_tuple, rewrite_unary_prefix, ExprType,
 };
+use crate::items::StructParts;
 use crate::lists::{
     definitive_tactic, itemize_list, write_list, ListFormatting, ListItem, Separator,
 };
@@ -23,6 +23,11 @@ use crate::spanned::Spanned;
 use crate::utils::{
     colon_spaces, extra_offset, first_line_width, format_extern, format_mutability,
     last_line_extendable, last_line_width, mk_sp, rewrite_ident,
+};
+use crate::DEFAULT_VISIBILITY;
+use crate::{
+    comment::{combine_strs_with_missing_comments, contains_comment},
+    items::format_struct_struct,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -763,6 +768,54 @@ impl Rewrite for ast::Ty {
             }
             ast::TyKind::Tup(ref items) => {
                 rewrite_tuple(context, items.iter(), self.span, shape, items.len() == 1)
+            }
+            ast::TyKind::AnonymousStruct(ref fields, recovered) => {
+                let ident = Ident::new(
+                    kw::Struct,
+                    mk_sp(self.span.lo(), self.span.lo() + BytePos(6)),
+                );
+                let data = ast::VariantData::Struct(fields.clone(), recovered);
+                let variant = ast::Variant {
+                    attrs: vec![],
+                    id: self.id,
+                    span: self.span,
+                    vis: DEFAULT_VISIBILITY,
+                    ident,
+                    data,
+                    disr_expr: None,
+                    is_placeholder: false,
+                };
+                format_struct_struct(
+                    &context,
+                    &StructParts::from_variant(&variant),
+                    fields,
+                    shape.indent,
+                    None,
+                )
+            }
+            ast::TyKind::AnonymousUnion(ref fields, recovered) => {
+                let ident = Ident::new(
+                    kw::Union,
+                    mk_sp(self.span.lo(), self.span.lo() + BytePos(5)),
+                );
+                let data = ast::VariantData::Struct(fields.clone(), recovered);
+                let variant = ast::Variant {
+                    attrs: vec![],
+                    id: self.id,
+                    span: self.span,
+                    vis: DEFAULT_VISIBILITY,
+                    ident,
+                    data,
+                    disr_expr: None,
+                    is_placeholder: false,
+                };
+                format_struct_struct(
+                    &context,
+                    &StructParts::from_variant(&variant),
+                    fields,
+                    shape.indent,
+                    None,
+                )
             }
             ast::TyKind::Path(ref q_self, ref path) => {
                 rewrite_path(context, PathContext::Type, q_self.as_ref(), path, shape)


### PR DESCRIPTION
A single https://github.com/rust-lang/rust/commit/64acb7d92135ae722dfce89f0ca9d7cf6576de66 commit from the https://github.com/rust-lang/rust/pull/84571 that modified the subtree there.

r? @calebcartwright 