### PR TITLE
Preserve visibility of fn items without body

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -323,6 +323,7 @@ impl<'a> FmtVisitor<'a> {
         ident: Ident,
         sig: &ast::FnSig,
         generics: &ast::Generics,
+        vis: &ast::Visibility,
         span: Span,
     ) -> Option<String> {
         // Drop semicolon or it will be interpreted as comment.
@@ -333,7 +334,7 @@ impl<'a> FmtVisitor<'a> {
             &context,
             indent,
             ident,
-            &FnSig::from_method_sig(sig, generics, DEFAULT_VISIBILITY),
+            &FnSig::from_method_sig(sig, generics, vis.clone()),
             span,
             FnBraceStyle::None,
         )?;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -569,6 +569,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                             item.ident,
                             &fn_signature,
                             generics,
+                            &item.vis,
                             item.span,
                         );
                         self.push_rewrite(item.span, rewrite);
@@ -639,13 +640,13 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             ast::AssocItemKind::Const(..) => self.visit_static(&StaticParts::from_trait_item(ti)),
             ast::AssocItemKind::Fn(ref fn_kind) => {
                 let ast::FnKind(defaultness, ref sig, ref generics, ref block) = **fn_kind;
+                let vis = ast::Visibility {
+                    kind: ast::VisibilityKind::Inherited,
+                    span: DUMMY_SP,
+                    tokens: None,
+                };
                 if let Some(ref body) = block {
                     let inner_attrs = inner_attributes(&ti.attrs);
-                    let vis = ast::Visibility {
-                        kind: ast::VisibilityKind::Inherited,
-                        span: DUMMY_SP,
-                        tokens: None,
-                    };
                     let fn_ctxt = visit::FnCtxt::Assoc(visit::AssocCtxt::Trait);
                     self.visit_fn(
                         visit::FnKind::Fn(fn_ctxt, ti.ident, sig, &vis, Some(body)),
@@ -658,7 +659,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 } else {
                     let indent = self.block_indent;
                     let rewrite =
-                        self.rewrite_required_fn(indent, ti.ident, sig, generics, ti.span);
+                        self.rewrite_required_fn(indent, ti.ident, sig, generics, &vis, ti.span);
                     self.push_rewrite(ti.span, rewrite);
                 }
             }
@@ -708,7 +709,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 } else {
                     let indent = self.block_indent;
                     let rewrite =
-                        self.rewrite_required_fn(indent, ii.ident, sig, generics, ii.span);
+                        self.rewrite_required_fn(indent, ii.ident, sig, generics, &ii.vis, ii.span);
                     self.push_rewrite(ii.span, rewrite);
                 }
             }

--- a/tests/target/fn-without-body.rs
+++ b/tests/target/fn-without-body.rs
@@ -1,0 +1,9 @@
+// Tests fns without function body
+
+pub fn foo(a: AAA, b: BBB) -> RetType;
+
+pub(crate) fn foo(a: AAA, b: BBB) -> RetType;
+
+impl Foo {
+    pub fn foo(a: AAA);
+}


### PR DESCRIPTION
While it may not make sense in grammar to allow fn items without body to have visibility, as they are semantically only used as required methods in trait definition, I believe it is not on rustfmt to make this judgement. Such usage should be warned by clippy or rustc if desirable.

On the other hand, this may be used in macros, in which case the visibility is important, see for example #4631 and [delegate-attr](https://crates.io/crates/delegate-attr).

This fixes #4631.