### PR TITLE
Updating outdated links

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -138,7 +138,7 @@ format.
 
 There are different nodes for every kind of item and expression in Rust. For
 more details see the source code in the compiler -
-[ast.rs](https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_ast/ast.rs.html) - and/or the
+[ast.rs](https://github.com/rust-lang/rust/blob/master/compiler/rustc_ast/src/ast.rs) - and/or the
 [docs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/ast/index.html).
 
 Many nodes in the AST (but not all, annoyingly) have a `Span`. A `Span` is a

--- a/Contributing.md
+++ b/Contributing.md
@@ -138,8 +138,8 @@ format.
 
 There are different nodes for every kind of item and expression in Rust. For
 more details see the source code in the compiler -
-[ast.rs](https://dxr.mozilla.org/rust/source/src/libsyntax/ast.rs) - and/or the
-[docs](https://doc.rust-lang.org/nightly/nightly-rustc/syntax/ast/index.html).
+[ast.rs](https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_ast/ast.rs.html) - and/or the
+[docs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/ast/index.html).
 
 Many nodes in the AST (but not all, annoyingly) have a `Span`. A `Span` is a
 range in the source code, it can easily be converted to a snippet of source

--- a/README.md
+++ b/README.md
@@ -230,5 +230,5 @@ Apache License (Version 2.0).
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 
 [rust]: https://github.com/rust-lang/rust
-[fmt rfcs]: https://github.com/rust-lang-nursery/fmt-rfcs
-[style guide]: https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md
+[fmt rfcs]: https://github.com/rust-dev-tools/fmt-rfcs
+[style guide]: https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md


### PR DESCRIPTION
Updating the links to the docs and source code for `ast.rs`. Seems like it was moved to a new crate at some point.

EDIT: also updating some links in the README ([comment below](https://github.com/rust-lang/rustfmt/pull/4869#issuecomment-860965546))