### PR TITLE
Add configuration option for wrapping of assignment right-hand side

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1992,6 +1992,69 @@ use dolor;
 use sit;
 ```
 
+## `righthand_indentation_strategy`
+
+Controls how the right-hand side of an assignment should be formatted if the expression does not fit on a single line. If the expression fits on the same line, this option is ignored.
+
+- **Default value**: `Heuristic`
+- **Possible values**: `Heuristic`, `SameLineAsLHS`, `NewlineIndentRHS`
+- **Stable**: No
+
+#### `Heuristic` (default):
+
+Use a heuristic approach to determine whether or not an expression should be on the same line as the left-hand side or moved to the next line.
+
+```rust
+fn main() {
+    let foo = bar().baz();
+
+    let bar: SomeWideResult + Send + Sync =
+        some_long_function_call().some_even_longer_function_call();
+
+    let baz = vec![1, 2, 3, 4, 5, 6, 7]
+        .into_iter()
+        .map(|x| x + 1)
+        .fold(0, |sum, i| sum + 1);
+}
+```
+
+#### `SameLineAsLHS`:
+
+If there is some valid formatting that allows part of the expression to be on the same line as the left-hand side, prefer that over a newline-indent.
+
+```rust
+fn main() {
+    let foo = bar().baz();
+
+    let bar: SomeWideResult + Send + Sync = some_long_function_call()
+        .some_even_longer_function_call();
+
+    let baz = vec![1, 2, 3, 4, 5, 6, 7]
+        .into_iter()
+        .map(|x| x + 1)
+        .fold(0, |sum, i| sum + 1);
+}
+```
+
+#### `NewlineIndentRHS`
+
+If there is some valid formatting that allows the expression to be placed indented on the next line, prefer that over placing it next to the left-hand side.
+
+```rust
+fn main() {
+    let foo = bar().baz();
+
+    let bar: SomeWideResult + Send + Sync =
+        some_long_function_call().some_even_longer_function_call();
+
+    let baz =
+        vec![1, 2, 3, 4, 5, 6, 7]
+            .into_iter()
+            .map(|x| x + 1)
+            .fold(0, |sum, i| sum + 1);
+}
+```
+
 ## `group_imports`
 
 Controls the strategy for how imports are grouped together.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -136,6 +136,9 @@ create_config! {
     inline_attribute_width: usize, 0, false,
         "Write an item and its attribute on the same line \
         if their combined width is below a threshold";
+    righthand_indentation_strategy: RightHandIndentationStrategy,
+        RightHandIndentationStrategy::Heuristic, false,
+        "Determines how the right-hand side of an assignment and pattern is indented.";
 
     // Options that can change the source code beyond whitespace/blocks (somewhat linty things)
     merge_derives: bool, true, true, "Merge multiple `#[derive(...)]` into a single one";
@@ -604,6 +607,7 @@ blank_lines_lower_bound = 0
 edition = "2015"
 version = "One"
 inline_attribute_width = 0
+righthand_indentation_strategy = "Heuristic"
 merge_derives = true
 use_try_shorthand = false
 use_field_init_shorthand = false

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -442,3 +442,44 @@ pub enum MatchArmLeadingPipe {
     /// Preserve any existing leading pipes
     Preserve,
 }
+
+/// Controls how "right-hand" expressions (assignment and match bodies)
+/// should be rendered if the right-hand side does not fit on a single line
+/// but might possibly fit on a single line if we newline-indent.
+#[config_type]
+pub enum RightHandIndentationStrategy {
+    /// Use the `prefer_next_line` heuristic (default behavior, equivalent to old
+    /// rustfmt versions that did not support this option).
+    ///
+    /// let foo =
+    ///    bar().baz().boo();
+    ///
+    /// | SomeEnum =>
+    ///    bar().baz().boo()
+    Heuristic,
+    /// If the expression doesn't fit on a single line, split it but leave the first
+    /// line on the same line as the left-hand (even if indenting may have the expression
+    /// fit entirely):
+    ///
+    /// let foo = bar()
+    ///    .baz()
+    ///    .boo();
+    ///
+    /// | SomeEnum => bar()
+    ///    .baz()
+    ///    .boo()
+    SameLineAsLHS,
+    /// If the expression doesn't fit on a single line, split it and indent the first
+    /// line on the line below the left-hand.
+    ///
+    /// let foo =
+    ///     bar()
+    ///         .baz()
+    ///         .boo();
+    ///
+    /// | SomeEnum =>
+    ///     bar()
+    ///         .baz()
+    ///         .boo()
+    NewlineIndentRHS,
+}


### PR DESCRIPTION
This PR adds a new configuration option called `righthand_indentation_strategy` (WIP name) that allows configuring of how rustfmt will emit assignment statements if the value does not fit on a single line.

There's three options. `Heuristic` will use the same heuristics as the current rustfmt, and is the default. `SameLineAsLHS` will always attempt to place the first part of the expression on the same line as the left-hand, as long as that does not exceed the maximum width. `NewlineIndentRHS` does the opposite, instead preferring to always newline-indent the expression if it does not fit entirely on the same line as the lhs.

A short example (where `|` represents the max indentation width):

```rust
// Heuristic		|
let _ = foo().bar;  |
let _ =             |
    foo().bar().a;  |
let _ = foo()       | 
    .bar()          |
    .baz();         |
                    |
// SameLineAsLHS    |
let _ = foo().bar;  |
let _ = foo()       |
    .bar()          |
    .a;             |
let _ = foo()       | 
    .bar()          |
    .baz();         |
                    |
// NewlineIndentRHS |
let _ = foo().bar;  |
let _ =             |
    foo().bar().a;  |
let _ =             |
    foo()           |
        .bar()      |
        .baz();     |
```

There are better examples showing the exact differences in Configurations.md.

---

This PR addresses #3514, both the original request (`NewlineIndentRHS`) as well as [the comment](https://github.com/rust-lang/rustfmt/issues/3514#issuecomment-720175287) by @seanpianka (`SameLineAsLHS`, which was also the configuration option I wanted myself). As far as I can see the changes should be backwards-compatible and always produce legal formatting.

---

There are some things I didn't fully know what to do with, so I'm counting on some guidance from you here. In particular:

**Configuration name**. I don't like the current name, since it talks about indentation (we're only doing different indentation in `NewlineIndentRHS`). Possibly something like `assignment_wrapping_behavior`?

**TODO Items**. There's several todo items in the code that relate to situations in which we're only able to format the code in one way even though the user specifically asks for a different way. Consider the following example, with a tab width of **12** (extreme example):

```rust
                       |
let a = some_long_name(|1).foo.bar;
                       |
```

This is how it'd look formatted with both `NewlineIndentRHS` and `SameLineAsLHS`:

```rust
// NewlineIndentRHS
let a =                |
            some_long_n|ame(1)
                       |.foo
                       |.bar;
                       |
// SameLineAsLHS       |
let a = some_long_name(|
            1          |
)                      |
.foo                   |
.bar;                  |
```

If the user has `NewlineIndentRHS`, then we have two options. Either we can fail entirely (since we weren't able to format within the width they wanted), or we can fall back to the same-line layout that _does_ work. Right now I've opted to do the second (and the documentation is written with this approach in mind), but I can also see the argument for failing entirely. The current TODOs in the code refer to this situation (and the inverse, where we're able to do things on the newline but not on the same line).

Let me know your thoughts! As far as I can see, the changes should be isolated to just assigns and backwards compatible.