### PR TITLE
Remove `mk_sp_lo_plus_one` function.

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -17,7 +17,7 @@ use crate::shape::Shape;
 use crate::source_map::SpanUtils;
 use crate::spanned::Spanned;
 use crate::types::{rewrite_path, PathContext};
-use crate::utils::{format_mutability, mk_sp, mk_sp_lo_plus_one, rewrite_ident};
+use crate::utils::{format_mutability, mk_sp, rewrite_ident};
 
 /// Returns `true` if the given pattern is "short".
 /// A short pattern is defined by the following grammar:
@@ -460,11 +460,9 @@ fn rewrite_tuple_pat(
         let sp = pat_vec[new_item_count - 1].span();
         let snippet = context.snippet(sp);
         let lo = sp.lo() + BytePos(snippet.find_uncommented("_").unwrap() as u32);
-        pat_vec[new_item_count - 1] = TuplePatField::Dotdot(mk_sp_lo_plus_one(lo));
-        (
-            &pat_vec[..new_item_count],
-            mk_sp(span.lo(), lo + BytePos(1)),
-        )
+        let hi = lo + BytePos(1);
+        pat_vec[new_item_count - 1] = TuplePatField::Dotdot(mk_sp(lo, hi));
+        (&pat_vec[..new_item_count], mk_sp(span.lo(), hi))
     } else {
         (&pat_vec[..], span)
     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -360,10 +360,6 @@ pub(crate) fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
     Span::new(lo, hi, SyntaxContext::root())
 }
 
-pub(crate) fn mk_sp_lo_plus_one(lo: BytePos) -> Span {
-    Span::new(lo, lo + BytePos(1), SyntaxContext::root())
-}
-
 // Returns `true` if the given span does not intersect with file lines.
 macro_rules! out_of_file_lines_range {
     ($self:ident, $span:expr) => {


### PR DESCRIPTION
This function is a footgun to usage since `lo+1` might not reside on a char boundary.

Previous before #4880 there're only two usages of this function. This pr removes the only remaining usage along-side with it.
