### PR TITLE
Option to not create a new line before await (await-same-line)

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -41,6 +41,39 @@ By default this option is set as a percentage of [`max_width`](#max_width) provi
 
 See also [`max_width`](#max_width) and [`use_small_heuristics`](#use_small_heuristics)
 
+## `await_same_line`
+
+Put `.await` on the same line as the preceding expression in long expression chains.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: No (tracking issue: none)
+
+#### `false` (default):
+
+```rust
+fn main() {
+    async_function()
+        .await
+        .async_function()
+        .await?
+        .async_function()
+        .await
+        .some_field;
+}
+```
+
+#### `true`:
+
+```rust
+fn main() {
+    async_function().await
+        .async_function().await?
+        .async_function().await
+        .some_field;
+}
+```
+
 ## `binop_separator`
 
 Where to put a binary operator when a binary expression goes multiline.

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -93,7 +93,27 @@ pub(crate) fn rewrite_chain(
 
 #[derive(Debug)]
 enum CommentPosition {
+    /// Comment group is not contained on their own lines:
+    ///
+    /// ```
+    /// function() // comment
+    ///     // comment
+    ///     .function()
+    ///
+    /// function() /* comment */ .function()
+    ///
+    /// function()
+    ///     /* comment */ .function()
+    /// ```
     Back,
+    /// Comment group is contained on their own lines:
+    ///
+    /// ```
+    /// function()
+    ///     // comment
+    ///     // comment
+    ///     .function()
+    /// ```
     Top,
 }
 
@@ -670,20 +690,27 @@ impl<'a> ChainFormatterShared<'a> {
         let children_iter = self.children.iter();
         let iter = rewrite_iter.zip(children_iter);
 
+        let mut prev_item_was_comment = false;
         for (rewrite, chain_item) in iter {
             match chain_item.kind {
                 ChainItemKind::Comment(_, CommentPosition::Back) => result.push(' '),
                 ChainItemKind::Comment(_, CommentPosition::Top) => result.push_str(&connector),
                 ChainItemKind::Await if context.config.await_same_line() => {
-                    let current_line_len = result.len() - result.rfind('\n').unwrap_or(0);
-                    // If adding .await on the same line would overflow max width, do emit connector
-                    if current_line_len + rewrite.len() > child_shape.width {
+                    let would_overflow_line = {
+                        let current_line_len = result.len() - result.rfind('\n').unwrap_or(0);
+                        current_line_len + rewrite.len() > child_shape.width
+                    };
+                    // Don't put .await on same line if it would overflow max width or if it's
+                    // preceded by a comment (`/* comment */.await` is weird)
+                    if would_overflow_line || prev_item_was_comment {
                         result.push_str(&connector)
                     }
                 }
                 _ => result.push_str(&connector),
             }
             result.push_str(&rewrite);
+
+            prev_item_was_comment = matches!(chain_item.kind, ChainItemKind::Comment(..));
         }
 
         Some(result)

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -674,6 +674,13 @@ impl<'a> ChainFormatterShared<'a> {
             match chain_item.kind {
                 ChainItemKind::Comment(_, CommentPosition::Back) => result.push(' '),
                 ChainItemKind::Comment(_, CommentPosition::Top) => result.push_str(&connector),
+                ChainItemKind::Await if context.config.await_same_line() => {
+                    let current_line_len = result.len() - result.rfind('\n').unwrap_or(0);
+                    // If adding .await on the same line would overflow max width, do emit connector
+                    if current_line_len + rewrite.len() > child_shape.width {
+                        result.push_str(&connector)
+                    }
+                }
                 _ => result.push_str(&connector),
             }
             result.push_str(&rewrite);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,6 +53,7 @@ create_config! {
     array_width: usize, 60, true,  "Maximum width of an array literal before falling \
         back to vertical formatting.";
     chain_width: usize, 60, true, "Maximum length of a chain to fit on a single line.";
+    await_same_line: bool, false, false, "Put .await in chains on the same line";
     single_line_if_else_max_width: usize, 50, true, "Maximum line length for single line if-else \
         expressions. A value of zero means always break if-else expressions.";
 
@@ -559,6 +560,7 @@ struct_lit_width = 18
 struct_variant_width = 35
 array_width = 60
 chain_width = 60
+await_same_line = false
 single_line_if_else_max_width = 50
 wrap_comments = false
 format_code_in_doc_comments = false

--- a/tests/source/await_same_line.rs
+++ b/tests/source/await_same_line.rs
@@ -1,0 +1,23 @@
+// rustfmt-await_same_line: true
+
+fn main() {
+    async_function()
+        .await??
+        .field
+        .async_function()
+        .await?
+        .async_function_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg()
+        .await
+        .field /* a */
+        .await /* b */
+        .await // c
+        .await
+        .function_with_args(
+            arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7, arg_8, arg_9,
+        )
+        .await
+        .function_with_args(
+            arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7, arg_8, arg_9, arg_10,
+        )
+        .await;
+}

--- a/tests/source/await_same_line.rs
+++ b/tests/source/await_same_line.rs
@@ -16,8 +16,10 @@ fn main() {
             arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7, arg_8, arg_9,
         )
         .await
-        .function_with_args(
-            arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7, arg_8, arg_9, arg_10,
-        )
+        /* comment */
+        .await
+        .await /* comment */
+        .await
+        .async_function() /* comment */
         .await;
 }

--- a/tests/target/await_same_line.rs
+++ b/tests/target/await_same_line.rs
@@ -1,0 +1,16 @@
+// rustfmt-await_same_line: true
+
+fn main() {
+    async_function().await??
+        .field
+        .async_function().await?
+        .async_function_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg()
+        .await
+        .field.await.await.await
+        .function_with_args(
+            arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7, arg_8, arg_9,
+        ).await
+        .function_with_args(
+            arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7, arg_8, arg_9, arg_10,
+        ).await;
+}

--- a/tests/target/await_same_line.rs
+++ b/tests/target/await_same_line.rs
@@ -6,11 +6,16 @@ fn main() {
         .async_function().await?
         .async_function_longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg()
         .await
-        .field.await.await.await
+        .field /* a */
+        .await /* b */
+        .await // c
+        .await
         .function_with_args(
             arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7, arg_8, arg_9,
         ).await
-        .function_with_args(
-            arg_1, arg_2, arg_3, arg_4, arg_5, arg_6, arg_7, arg_8, arg_9, arg_10,
-        ).await;
+        /* comment */
+        .await.await /* comment */
+        .await
+        .async_function() /* comment */
+        .await;
 }


### PR DESCRIPTION
I've taken a shot at implementing #4425 as a first-time contribution.

Tasks left to do:
- [x] Decide how to handle line and block comments in front of `.await`
- [ ] Make tests run with await-same-line instead of default config somehow
- [x] Add documentation to Configurations.md