### PR TITLE
Add field-access-same-line config option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -641,6 +641,33 @@ trailing whitespaces.
 - **Possible values**: `true`, `false`
 - **Stable**: No (tracking issue: #3392)
 
+## `field_access_same_line`
+
+Put subsequent field accesses on the same line in long expression chains.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: No (tracking issue: none)
+
+#### `false` (default):
+
+```rust
+fn main() {
+    self.serializer
+        .writer
+        .write_u32::<LittleEndian>(array_offset)?;
+}
+```
+
+#### `true`:
+
+```rust
+fn main() {
+    self.serializer.writer
+        .write_u32::<LittleEndian>(array_offset)?;
+}
+```
+
 ## `fn_args_layout`
 
 Control the layout of arguments in a function

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,6 +53,8 @@ create_config! {
     array_width: usize, 60, true,  "Maximum width of an array literal before falling \
         back to vertical formatting.";
     chain_width: usize, 60, true, "Maximum length of a chain to fit on a single line.";
+    field_access_same_line: bool, false, false, "Put subsequent field accesses in a chain on the \
+        same line.";
     single_line_if_else_max_width: usize, 50, true, "Maximum line length for single line if-else \
         expressions. A value of zero means always break if-else expressions.";
 
@@ -559,6 +561,7 @@ struct_lit_width = 18
 struct_variant_width = 35
 array_width = 60
 chain_width = 60
+field_access_same_line = false
 single_line_if_else_max_width = 50
 wrap_comments = false
 format_code_in_doc_comments = false

--- a/tests/source/field_access_same_line.rs
+++ b/tests/source/field_access_same_line.rs
@@ -1,0 +1,44 @@
+// rustfmt-field_access_same_line: true
+
+fn main() {
+    variable
+        .field
+        .field
+        .function()
+        .field
+        .function()
+        .field
+        .0
+        .field
+        .function()
+        .0
+        .function()
+        .function()
+        .0
+        .0
+        .0
+        .0
+        .0
+        .0
+        .field
+        .field
+        .field
+        .field
+        .field
+        .field
+        .field
+        .field
+        .field
+        .field
+        .field
+        .field
+        .field // test
+        .field
+        .field
+        .field // test
+        .field
+        .field
+        .field // test
+        // test
+        .function();
+}

--- a/tests/source/field_access_same_line.rs
+++ b/tests/source/field_access_same_line.rs
@@ -40,5 +40,10 @@ fn main() {
         .field
         .field // test
         // test
-        .function();
+        .function()
+        .field
+        .0
+        .field[5][6]
+        .1
+        .test[3];
 }

--- a/tests/target/field_access_same_line.rs
+++ b/tests/target/field_access_same_line.rs
@@ -15,5 +15,7 @@ fn main() {
         .field.field.field // test
         .field.field.field // test
         // test
-        .function();
+        .function()
+        .field.0.field[5][6]
+        .1.test[3];
 }

--- a/tests/target/field_access_same_line.rs
+++ b/tests/target/field_access_same_line.rs
@@ -1,0 +1,19 @@
+// rustfmt-field_access_same_line: true
+
+fn main() {
+    variable.field.field
+        .function()
+        .field
+        .function()
+        .field.0.field
+        .function()
+        .0
+        .function()
+        .function()
+        .0 .0 .0 .0 .0 .0.field.field.field.field.field.field.field.field.field.field.field.field
+        .field // test
+        .field.field.field // test
+        .field.field.field // test
+        // test
+        .function();
+}


### PR DESCRIPTION
Resolves #3641.

Adds a new configuration option `field-access-same-line`, which puts subsequent field accesses in chains on the same line. For example:

```rust
self.serializer
    .writer
    .write_u32::<LittleEndian>(array_offset)?;
```
turns into 
```rust
self.serializer.writer
    .write_u32::<LittleEndian>(array_offset)?;
```

A more elaborate test case is in the tests directory.

Field accesses with indexing (e.g. `self.field[5].field`) in them are not correctly put on a single line, because, apparently, rustfmt splits chains into multiple separate `Chain` objects when there is indexing in it. I don't know the motivation behind this and I think it's too complicated for me as a newcomer to the codebase to fix.