### PR TITLE
Fix for handling empty code block in doc comments

### DIFF
--- a/tests/source/issue-4793-empty-code-block-in-doc-comments.rs
+++ b/tests/source/issue-4793-empty-code-block-in-doc-comments.rs
@@ -1,0 +1,38 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```
+/// ```
+fn foo() {}
+
+/// ```
+///Something
+/// ```
+fn foo() {}
+
+/// ```
+///
+/// ```
+fn foo() {}
+
+fn foo() {
+/// ```
+///
+/// ```
+struct bar {}
+}
+
+/// ```
+/// fn com(){
+/// let i = 5;
+/// }
+/// ```
+fn foo() {}
+
+fn foo() {
+/// ```
+///fn com(){
+///let i = 5;
+///}
+/// ```
+struct bar {}
+}

--- a/tests/target/issue-4793-empty-code-block-in-doc-comments.rs
+++ b/tests/target/issue-4793-empty-code-block-in-doc-comments.rs
@@ -1,0 +1,38 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```
+/// ```
+fn foo() {}
+
+/// ```
+/// Something
+/// ```
+fn foo() {}
+
+/// ```
+///
+/// ```
+fn foo() {}
+
+fn foo() {
+    /// ```
+    ///
+    /// ```
+    struct bar {}
+}
+
+/// ```
+/// fn com() {
+///     let i = 5;
+/// }
+/// ```
+fn foo() {}
+
+fn foo() {
+    /// ```
+    /// fn com() {
+    ///     let i = 5;
+    /// }
+    /// ```
+    struct bar {}
+}


### PR DESCRIPTION
Suggested fix for issue #4793 for handling empty code block in doc comments.  If the doc comments code block includes only empty lines than the output is one line with empty code (`///`).  If no code line was included between the two `///'''` then the output also does not include any code line.

A simpler solution could be to add `trim()` [here](https://github.com/rust-lang/rustfmt/blob/2b3ca9995ddda396f590ac6ac5b53d7daf4927ea/src/formatting/comment.rs#L685), i.e to make it `_ if self.code_block_buffer.trim().is_empty() =>...`.  however it seem that changing `format_code_block()` is more robust.