### PR TITLE
Fix for handling empty code block in doc comments

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -671,9 +671,15 @@ impl<'a> CommentRewrite<'a> {
                     }
                 };
                 if !code_block.is_empty() {
-                    self.result.push_str(&self.comment_line_separator);
-                    self.result
-                        .push_str(&Self::join_block(&code_block, &self.comment_line_separator));
+                    // Ensure no trailing blanks for empty code lines
+                    if code_block.trim_end().is_empty() {
+                        self.result
+                            .push_str(&self.comment_line_separator.trim_end());
+                    } else {
+                        self.result.push_str(&self.comment_line_separator);
+                        self.result
+                            .push_str(&Self::join_block(&code_block, &self.comment_line_separator));
+                    }
                 }
                 self.code_block_buffer.clear();
                 self.result.push_str(&self.comment_line_separator);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,13 @@ fn format_code_block(
         result
     }
 
+    if code_snippet.is_empty() {
+        return Some(FormattedSnippet {
+            snippet: String::new(),
+            non_formatted_ranges: vec![],
+        });
+    }
+
     // Wrap the given code block with `fn main()` if it does not have one.
     let snippet = enclose_in_main_block(code_snippet, config);
     let mut result = String::with_capacity(snippet.len());
@@ -397,38 +404,47 @@ fn format_code_block(
         .unwrap_or_else(|| formatted.snippet.len());
     let mut is_indented = true;
     let indent_str = Indent::from_width(config, config.tab_spaces()).to_string(config);
-    for (kind, ref line) in LineClasses::new(&formatted.snippet[FN_MAIN_PREFIX.len()..block_len]) {
-        if !is_first {
-            result.push('\n');
-        } else {
-            is_first = false;
-        }
-        let trimmed_line = if !is_indented {
-            line
-        } else if line.len() > config.max_width() {
-            // If there are lines that are larger than max width, we cannot tell
-            // whether we have succeeded but have some comments or strings that
-            // are too long, or we have failed to format code block. We will be
-            // conservative and just return `None` in this case.
-            return None;
-        } else if line.len() > indent_str.len() {
-            // Make sure that the line has leading whitespaces.
-            if line.starts_with(indent_str.as_ref()) {
-                let offset = if config.hard_tabs() {
-                    1
+
+    if FN_MAIN_PREFIX.len() >= block_len {
+        // Code block with empty lines - add one empty line
+        result.push_str("\n\n");
+    } else {
+        for (kind, ref line) in
+            LineClasses::new(&formatted.snippet[FN_MAIN_PREFIX.len()..block_len])
+        {
+            if !is_first {
+                result.push('\n');
+            } else {
+                is_first = false;
+            }
+            let trimmed_line = if !is_indented {
+                line
+            } else if line.len() > config.max_width() {
+                // If there are lines that are larger than max width, we cannot tell
+                // whether we have succeeded but have some comments or strings that
+                // are too long, or we have failed to format code block. We will be
+                // conservative and just return `None` in this case.
+                return None;
+            } else if line.len() > indent_str.len() {
+                // Make sure that the line has leading whitespaces.
+                if line.starts_with(indent_str.as_ref()) {
+                    let offset = if config.hard_tabs() {
+                        1
+                    } else {
+                        config.tab_spaces()
+                    };
+                    &line[offset..]
                 } else {
-                    config.tab_spaces()
-                };
-                &line[offset..]
+                    line
+                }
             } else {
                 line
-            }
-        } else {
-            line
-        };
-        result.push_str(trimmed_line);
-        is_indented = indent_next_line(kind, line, config);
+            };
+            result.push_str(trimmed_line);
+            is_indented = indent_next_line(kind, line, config);
+        }
     }
+
     Some(FormattedSnippet {
         snippet: result,
         non_formatted_ranges: formatted.non_formatted_ranges,

--- a/tests/source/issue-4793-empty-code-block-in-doc-comments.rs
+++ b/tests/source/issue-4793-empty-code-block-in-doc-comments.rs
@@ -1,0 +1,40 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```
+/// ```
+fn foo() {}
+
+/// ```
+///Something
+/// ```
+fn foo() {}
+
+/// ```
+///
+/// ```
+fn foo() {}
+
+fn foo() {
+/// ```
+///
+/// ```
+struct bar {}
+}
+
+/// ```
+/// fn com(){
+/// let i = 5;
+///
+/// let j = 6;
+/// }
+/// ```
+fn foo() {}
+
+fn foo() {
+/// ```
+///fn com(){
+///let i = 5;
+///}
+/// ```
+struct bar {}
+}

--- a/tests/target/issue-4793-empty-code-block-in-doc-comments.rs
+++ b/tests/target/issue-4793-empty-code-block-in-doc-comments.rs
@@ -1,0 +1,40 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```
+/// ```
+fn foo() {}
+
+/// ```
+/// Something
+/// ```
+fn foo() {}
+
+/// ```
+///
+/// ```
+fn foo() {}
+
+fn foo() {
+    /// ```
+    ///
+    /// ```
+    struct bar {}
+}
+
+/// ```
+/// fn com() {
+///     let i = 5;
+///
+///     let j = 6;
+/// }
+/// ```
+fn foo() {}
+
+fn foo() {
+    /// ```
+    /// fn com() {
+    ///     let i = 5;
+    /// }
+    /// ```
+    struct bar {}
+}


### PR DESCRIPTION
Suggested fix for issue #4793 for handling empty code block in doc comments (replacing PR #4895).  If the doc comments code block includes only empty lines than the output is one line with empty code (`///`).  If no code line was included between the two `///'''` then the output also does not include any code line.

A simpler solution could be to add `trim()` [here](https://github.com/rust-lang/rustfmt/blob/2837ca557fd5e9aaf9a7986072314e660cb3e7fa/src/comment.rs#L656), i.e to make it `_ if self.code_block_buffer.trim().is_empty() =>...`.  however it seem that changing `format_code_block()` is more robust.