### PR TITLE
Fixes wrong reformatting of qualified paths in struct patterns

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -244,8 +244,8 @@ impl Rewrite for Pat {
                     .collect();
                 Some(format!("[{}]", rw.join(", ")))
             }
-            PatKind::Struct(_, ref path, ref fields, ellipsis) => {
-                rewrite_struct_pat(path, fields, ellipsis, self.span, context, shape)
+            PatKind::Struct(ref qself, ref path, ref fields, ellipsis) => {
+                rewrite_struct_pat(qself, path, fields, ellipsis, self.span, context, shape)
             }
             PatKind::MacCall(ref mac) => {
                 rewrite_macro(mac, None, context, shape, MacroPosition::Pat)
@@ -258,6 +258,7 @@ impl Rewrite for Pat {
 }
 
 fn rewrite_struct_pat(
+    qself: &Option<ast::QSelf>,
     path: &ast::Path,
     fields: &[ast::PatField],
     ellipsis: bool,
@@ -267,7 +268,7 @@ fn rewrite_struct_pat(
 ) -> Option<String> {
     // 2 =  ` {`
     let path_shape = shape.sub_width(2)?;
-    let path_str = rewrite_path(context, PathContext::Expr, None, path, path_shape)?;
+    let path_str = rewrite_path(context, PathContext::Expr, qself.as_ref(), path, path_shape)?;
 
     if fields.is_empty() && !ellipsis {
         return Some(format!("{} {{}}", path_str));

--- a/tests/target/issue-4908-2.rs
+++ b/tests/target/issue-4908-2.rs
@@ -1,0 +1,20 @@
+#![feature(more_qualified_paths)]
+
+fn main() {
+    // destructure through a qualified path
+    let <Foo as A>::Assoc { br } = StructStruct { br: 2 };
+}
+
+struct StructStruct {
+    br: i8,
+}
+
+struct Foo;
+
+trait A {
+    type Assoc;
+}
+
+impl A for Foo {
+    type Assoc = StructStruct;
+}

--- a/tests/target/issue-4908.rs
+++ b/tests/target/issue-4908.rs
@@ -1,0 +1,34 @@
+#![feature(more_qualified_paths)]
+
+mod foo_bar {
+    pub enum Example {
+        Example1 {},
+        Example2 {},
+    }
+}
+
+fn main() {
+    foo!(crate::foo_bar::Example, Example1);
+
+    let i1 = foo_bar::Example::Example1 {};
+
+    assert_eq!(i1.foo_example(), 1);
+
+    let i2 = foo_bar::Example::Example2 {};
+
+    assert_eq!(i2.foo_example(), 2);
+}
+
+#[macro_export]
+macro_rules! foo {
+    ($struct:path, $variant:ident) => {
+        impl $struct {
+            pub fn foo_example(&self) -> i32 {
+                match self {
+                    <$struct>::$variant { .. } => 1,
+                    _ => 2,
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
Fixes #4908.

I also added the [example snippet for `more_qualified_paths`](https://doc.rust-lang.org/beta/unstable-book/language-features/more-qualified-paths.html) as a test case, and found that the current version formats wrongly outside of macros too (it didn't compile):

```diff
 #![feature(more_qualified_paths)]

 fn main() {
     // destructure through a qualified path
-    let <Foo as A>::Assoc { br } = StructStruct { br: 2 };
+    let A::Assoc { br } = StructStruct { br: 2 };
 }

```

Both are fixed in this PR :)