### PR TITLE
Add Together option to group_imports

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2011,7 +2011,7 @@ use sit;
 Controls the strategy for how imports are grouped together.
 
 - **Default value**: `Preserve`
-- **Possible values**: `Preserve`, `StdExternalCrate`
+- **Possible values**: `Preserve`, `StdExternalCrate`, `Together`
 - **Stable**: No
 
 #### `Preserve` (default):
@@ -2055,6 +2055,23 @@ use uuid::Uuid;
 use super::schema::{Context, Payload};
 use super::update::convert_publish_payload;
 use crate::models::Event;
+```
+
+#### `Together`:
+
+Discard existing import groups, and create a single group for everything
+
+```rust
+use super::schema::{Context, Payload};
+use super::update::convert_publish_payload;
+use crate::models::Event;
+use alloc::alloc::Layout;
+use broker::database::PooledConnection;
+use chrono::Utc;
+use core::f32;
+use juniper::{FieldError, FieldResult};
+use std::sync::Arc;
+use uuid::Uuid;
 ```
 
 ## `reorder_modules`

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -112,6 +112,8 @@ pub enum GroupImportsTactic {
     ///  2. other imports
     ///  3. `self` / `crate` / `super` imports
     StdExternalCrate,
+    /// Discard existing groups, and create a single group for everything
+    Together,
 }
 
 #[config_type]

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -117,7 +117,9 @@ fn rewrite_reorderable_or_regroupable_items(
             };
 
             let mut regrouped_items = match context.config.group_imports() {
-                GroupImportsTactic::Preserve => vec![normalized_items],
+                GroupImportsTactic::Preserve | GroupImportsTactic::Together => {
+                    vec![normalized_items]
+                }
                 GroupImportsTactic::StdExternalCrate => group_imports(normalized_items),
             };
 

--- a/tests/source/configs/group_imports/Together-merge_imports.rs
+++ b/tests/source/configs/group_imports/Together-merge_imports.rs
@@ -1,0 +1,17 @@
+// rustfmt-group_imports: Together
+// rustfmt-imports_granularity: Crate
+use chrono::Utc;
+use super::update::convert_publish_payload;
+
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+use alloc::alloc::Layout;
+
+use std::sync::Arc;
+use alloc::vec::Vec;
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/source/configs/group_imports/Together-nested.rs
+++ b/tests/source/configs/group_imports/Together-nested.rs
@@ -1,0 +1,7 @@
+// rustfmt-group_imports: Together
+mod test {
+    use crate::foo::bar;
+
+    use std::path;
+    use crate::foo::bar2;
+}

--- a/tests/source/configs/group_imports/Together-no_reorder.rs
+++ b/tests/source/configs/group_imports/Together-no_reorder.rs
@@ -1,0 +1,16 @@
+// rustfmt-group_imports: Together
+// rustfmt-reorder_imports: false
+use chrono::Utc;
+use super::update::convert_publish_payload;
+
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+use alloc::alloc::Layout;
+
+use std::sync::Arc;
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/source/configs/group_imports/Together.rs
+++ b/tests/source/configs/group_imports/Together.rs
@@ -1,0 +1,15 @@
+// rustfmt-group_imports: Together
+use chrono::Utc;
+use super::update::convert_publish_payload;
+
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+use alloc::alloc::Layout;
+
+use std::sync::Arc;
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/target/configs/group_imports/Together-merge_imports.rs
+++ b/tests/target/configs/group_imports/Together-merge_imports.rs
@@ -1,0 +1,14 @@
+// rustfmt-group_imports: Together
+// rustfmt-imports_granularity: Crate
+use super::{
+    schema::{Context, Payload},
+    update::convert_publish_payload,
+};
+use crate::models::Event;
+use alloc::{alloc::Layout, vec::Vec};
+use broker::database::PooledConnection;
+use chrono::Utc;
+use core::f32;
+use juniper::{FieldError, FieldResult};
+use std::sync::Arc;
+use uuid::Uuid;

--- a/tests/target/configs/group_imports/Together-nested.rs
+++ b/tests/target/configs/group_imports/Together-nested.rs
@@ -1,0 +1,6 @@
+// rustfmt-group_imports: Together
+mod test {
+    use crate::foo::bar;
+    use crate::foo::bar2;
+    use std::path;
+}

--- a/tests/target/configs/group_imports/Together-no_reorder.rs
+++ b/tests/target/configs/group_imports/Together-no_reorder.rs
@@ -1,0 +1,12 @@
+// rustfmt-group_imports: Together
+// rustfmt-reorder_imports: false
+use chrono::Utc;
+use super::update::convert_publish_payload;
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+use alloc::alloc::Layout;
+use std::sync::Arc;
+use broker::database::PooledConnection;
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/target/configs/group_imports/Together.rs
+++ b/tests/target/configs/group_imports/Together.rs
@@ -1,0 +1,11 @@
+// rustfmt-group_imports: Together
+use super::schema::{Context, Payload};
+use super::update::convert_publish_payload;
+use crate::models::Event;
+use alloc::alloc::Layout;
+use broker::database::PooledConnection;
+use chrono::Utc;
+use core::f32;
+use juniper::{FieldError, FieldResult};
+use std::sync::Arc;
+use uuid::Uuid;


### PR DESCRIPTION
I gave a go at implementing my feature request at https://github.com/rust-lang/rustfmt/issues/4962, an option to group imports into one group. I mostly just copied the StdExternalCrate implementation.