### PR TITLE
license should be from relative dir

### DIFF
--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -390,7 +390,7 @@ macro_rules! create_config {
                 if self.was_set().license_template_path() {
                     let lt_path = self.license_template_path();
                     if lt_path.len() > 0 {
-                        match license::load_and_compile_template(&lt_path) {
+                        match license::load_and_compile_template(self.get_ignore(), &lt_path) {
                             Ok(re) => self.license_template = Some(re),
                             Err(msg) => eprintln!("Warning for license template file {:?}: {}",
                                                 lt_path, msg),

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -64,6 +64,8 @@ macro_rules! create_config {
             // if a license_template_path has been specified, successfully read, parsed and compiled
             // into a regex, it will be stored here
             pub license_template: Option<Regex>,
+            // The location from which to resolve relative dirs.
+            root_dir: Option<PathBuf>,
             // For each config item, we store a bool indicating whether it has
             // been accessed and the value, and a bool whether the option was
             // manually initialised, or taken from the default,
@@ -166,6 +168,7 @@ macro_rules! create_config {
                 self.set_license_template();
                 self.set_ignore(dir);
                 self.set_merge_imports();
+                self.set_root_dir(dir);
                 self
             }
 
@@ -390,7 +393,7 @@ macro_rules! create_config {
                 if self.was_set().license_template_path() {
                     let lt_path = self.license_template_path();
                     if lt_path.len() > 0 {
-                        match license::load_and_compile_template(self.get_ignore(), &lt_path) {
+                        match license::load_and_compile_template(&self.root_dir, &lt_path) {
                             Ok(re) => self.license_template = Some(re),
                             Err(msg) => eprintln!("Warning for license template file {:?}: {}",
                                                 lt_path, msg),
@@ -403,6 +406,10 @@ macro_rules! create_config {
 
             fn set_ignore(&mut self, dir: &Path) {
                 self.ignore.2.add_prefix(dir);
+            }
+
+            fn set_root_dir(&mut self, dir: &Path) {
+                self.root_dir = Some(dir.to_path_buf());
             }
 
             fn set_merge_imports(&mut self) {
@@ -438,6 +445,7 @@ macro_rules! create_config {
             fn default() -> Config {
                 Config {
                     license_template: None,
+                    root_dir: None,
                     $(
                         $i: (Cell::new(false), false, $def, $stb),
                     )+

--- a/src/config/license.rs
+++ b/src/config/license.rs
@@ -211,7 +211,16 @@ impl TemplateParser {
     }
 }
 
-pub(crate) fn load_and_compile_template(path: &str) -> Result<Regex, LicenseError> {
+pub(crate) fn load_and_compile_template(base_dir: &str, path: &str) -> Result<Regex, LicenseError> {
+    let mut path = Path(path);
+    if path.is_relative() {
+        // The tempate path needs to be resolved relative to the .rustfmt config file
+        // rather than whatever dir cargo fmt was run from.
+        let current = std::env::current_dir().expect("pwd");
+        std::env::set_current_dir(base_dir);
+        path = path.canonicalize();
+        std::env::set_current_dir(current).expect("change pwd");
+    }
     let mut lt_file = File::open(&path)?;
     let mut lt_str = String::new();
     lt_file.read_to_string(&mut lt_str)?;

--- a/src/config/license.rs
+++ b/src/config/license.rs
@@ -211,15 +211,22 @@ impl TemplateParser {
     }
 }
 
-pub(crate) fn load_and_compile_template(base_dir: &str, path: &str) -> Result<Regex, LicenseError> {
-    let mut path = Path(path);
+pub(crate) fn load_and_compile_template(
+    root_dir: &Option<std::path::PathBuf>,
+    path: &str,
+) -> Result<Regex, LicenseError> {
+    let mut path = std::path::PathBuf::from(path);
     if path.is_relative() {
-        // The tempate path needs to be resolved relative to the .rustfmt config file
-        // rather than whatever dir cargo fmt was run from.
-        let current = std::env::current_dir().expect("pwd");
-        std::env::set_current_dir(base_dir);
-        path = path.canonicalize();
-        std::env::set_current_dir(current).expect("change pwd");
+        if let Some(root_dir) = root_dir {
+            // The tempate path needs to be resolved relative to the .rustfmt config file
+            // rather than whatever dir cargo fmt was run from.
+            let current = std::env::current_dir().expect("pwd");
+            std::env::set_current_dir(root_dir).expect("alter pwd");
+            if let Ok(abs_path) = path.canonicalize() {
+                path = abs_path;
+            }
+            std::env::set_current_dir(current).expect("change pwd");
+        }
     }
     let mut lt_file = File::open(&path)?;
     let mut lt_str = String::new();


### PR DESCRIPTION
As mentioned in #3352, if the license file is set and we're not in the root dir when calling `cargo fmt` it currently falls in a heap. 