### PR TITLE
Add <title> to docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <html>
     <head>
       <meta name="viewport" content="width=device-width">
+      <title>Rustfmt</title>
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.css" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/github-gist.min.css">
       <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>


### PR DESCRIPTION
Added a title tag since the document currently has no title set.

<img width="517" alt="スクリーンショット 2021-09-01 20 18 28" src="https://user-images.githubusercontent.com/1457682/131663937-6f4f6274-97a4-45c8-b076-d4151d6ca0d5.png">

It seems that the h1 tag is showing up in the search results.

<img width="649" alt="スクリーンショット 2021-09-01 20 21 50" src="https://user-images.githubusercontent.com/1457682/131663949-b67aa36b-b71f-4a75-9b00-136b2fa64a22.png">