### PR TITLE
In Configurations.md demonstrate both cases for noop selections

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1668,6 +1668,9 @@ pub enum Foo {}
 #### `false`:
 
 ```rust
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub enum Bar {}
+
 #[derive(Eq, PartialEq)]
 #[derive(Debug)]
 #[derive(Copy, Clone)]
@@ -1841,6 +1844,9 @@ Convert `#![doc]` and `#[doc]` attributes to `//!` and `///` doc comments.
 #![doc = "Example documentation"]
 
 #[doc = "Example item documentation"]
+pub enum Bar {}
+
+/// Example item documentation
 pub enum Foo {}
 ```
 
@@ -1955,6 +1961,8 @@ fn main() {
 #### `false`:
 ```rust
 fn main() {
+    (foo());
+
     ((((foo()))));
 }
 ```
@@ -1979,6 +1987,14 @@ impl Iterator for Dummy {
     }
 
     type Item = i32;
+}
+
+impl Iterator for Dummy {
+    type Item = i32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
 }
 ```
 
@@ -2536,7 +2552,8 @@ fn main() {
     let x = 1;
     let y = 2;
     let z = 3;
-    let a = Foo { x: x, y: y, z: z };
+    let a = Foo { x, y, z };
+    let b = Foo { x: x, y: y, z: z };
 }
 ```
 
@@ -2705,6 +2722,8 @@ Replace uses of the try! macro by the ? shorthand
 
 ```rust
 fn main() {
+    let lorem = ipsum.map(|dolor| dolor.sit())?;
+
     let lorem = try!(ipsum.map(|dolor| dolor.sit()));
 }
 ```
@@ -2776,6 +2795,12 @@ Break comments to fit on the line
 #### `false` (default):
 
 ```rust
+// Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+// sed do eiusmod tempor incididunt ut labore et dolore
+// magna aliqua. Ut enim ad minim veniam, quis nostrud
+// exercitation ullamco laboris nisi ut aliquip ex ea
+// commodo consequat.
+
 // Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 ```
 


### PR DESCRIPTION
Continuing on from discussion in https://github.com/rust-lang/rustfmt/issues/4948
This PR improves both the idempotentency test and the users comprehension of the documentation.

condense_wildcard_suffixes is an example where this approach is already used.
I'm not sure if the new code added to the noop cases should also be added to the non-noop cases as well. condense_wildcard_suffixes doesnt do that, so I did the same. Let me know if I should change that though.

I havent touched configuration that sorts elements into alphabetical order, as the unsorted elements in the noop case should demonstrate that its not touched by rustfmt just fine.

`brace_style: SameLineWhere` doesn't seem to fit its own description , so I just skipped that one...