### PR TITLE
Trailing comma on match block goes missing when guard is on its own line

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -409,6 +409,7 @@ fn rewrite_match_body(
             }
             result.push_str(&nested_indent_str);
             result.push_str(&body_str);
+            result.push_str(&comma);
             return Some(result);
         }
 

--- a/tests/source/match-block-trailing-comma.rs
+++ b/tests/source/match-block-trailing-comma.rs
@@ -8,6 +8,14 @@ fn foo() {
             "line1";
             "line2"
         }
+        ThisIsA::Guard if true => {
+            "line1";
+            "line2"
+        }
+        ThisIsA::ReallyLongPattern(ThatWillForce::TheGuard, ToWrapOnto::TheFollowingLine) if true => {
+            "line1";
+            "line2"
+        }
         b => (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
               bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb),
     }

--- a/tests/target/match-block-trailing-comma.rs
+++ b/tests/target/match-block-trailing-comma.rs
@@ -8,6 +8,16 @@ fn foo() {
             "line1";
             "line2"
         },
+        ThisIsA::Guard if true => {
+            "line1";
+            "line2"
+        },
+        ThisIsA::ReallyLongPattern(ThatWillForce::TheGuard, ToWrapOnto::TheFollowingLine)
+            if true =>
+        {
+            "line1";
+            "line2"
+        },
         b => (
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
             bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,


### PR DESCRIPTION
After making some changes to a guard on a match arm, I noticed that `rustfmt` was removing a comma from the end of the block even though I had  `match_block_trailing_comma` set to `true`. Here's an example program where you can see the behaviour:

```rust
fn main() {
    let val = Some(5);

    match val {
        Some(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ) if abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ < 1000 => {
            println!("a");
        },
        Some(a) if a > 1000 => {
            println!("b");
        },
        Some(_) => {
            println!("c");
        },
        None => {
            println!("d");
        },
    }
}
```

Running `rustfmt --emit stdout --config match_block_trailing_comma=true test.rs` on this file, you can see that all branches but the one where the guard needed to be wrapped keep the comma:

```rust
fn main() {
    let val = Some(5);

    match val {
        Some(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ)
            if abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ < 1000 =>
        {
            println!("a");
        }
        Some(a) if a > 1000 => {
            println!("b");
        },
        Some(_) => {
            println!("c");
        },
        None => {
            println!("d");
        },
    }
}
```