### PR TITLE
Prevent removal of qualified path for tuple struct inside macro

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -226,8 +226,9 @@ impl Rewrite for Pat {
             PatKind::Path(ref q_self, ref path) => {
                 rewrite_path(context, PathContext::Expr, q_self.as_ref(), path, shape)
             }
-            PatKind::TupleStruct(_, ref path, ref pat_vec) => {
-                let path_str = rewrite_path(context, PathContext::Expr, None, path, shape)?;
+            PatKind::TupleStruct(ref q_self, ref path, ref pat_vec) => {
+                let path_str =
+                    rewrite_path(context, PathContext::Expr, q_self.as_ref(), path, shape)?;
                 rewrite_tuple_pat(pat_vec, Some(path_str), self.span, context, shape)
             }
             PatKind::Lit(ref expr) => expr.rewrite(context, shape),

--- a/tests/target/issue-5005/minimum_example.rs
+++ b/tests/target/issue-5005/minimum_example.rs
@@ -1,0 +1,9 @@
+#![feature(more_qualified_paths)]
+macro_rules! show {
+    ($ty:ty, $ex:expr) => {
+        match $ex {
+            <$ty>::A(_val) => println!("got a"), // formatting should not remove <$ty>::
+            <$ty>::B => println!("got b"),
+        }
+    };
+}


### PR DESCRIPTION
fixes #5005 

This was very similar to #4964 and the fix was to extract and pass along
the ``qself`` of the ``PatKind::TupleStruct``