### PR TITLE
Prevent trailing whitespace in where clause bound predicate

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1962,6 +1962,9 @@ fn choose_rhs<R: Rewrite>(
     has_rhs_comment: bool,
 ) -> Option<String> {
     match orig_rhs {
+        Some(ref new_str) if new_str.is_empty() => {
+            return Some(String::new());
+        }
         Some(ref new_str)
             if !new_str.contains('\n') && unicode_str_width(new_str) <= shape.width =>
         {

--- a/tests/target/issue-5012/trailing_comma_always.rs
+++ b/tests/target/issue-5012/trailing_comma_always.rs
@@ -1,0 +1,8 @@
+// rustfmt-trailing_comma: Always
+
+pub struct Matrix<T, const R: usize, const C: usize,>
+where
+    [T; R * C]:,
+{
+    contents: [T; R * C],
+}

--- a/tests/target/issue-5012/trailing_comma_never.rs
+++ b/tests/target/issue-5012/trailing_comma_never.rs
@@ -1,0 +1,8 @@
+// rustfmt-trailing_comma: Never
+
+pub struct Matrix<T, const R: usize, const C: usize>
+where
+    [T; R * C]:
+{
+    contents: [T; R * C]
+}

--- a/tests/target/issue_4850.rs
+++ b/tests/target/issue_4850.rs
@@ -1,0 +1,4 @@
+impl ThisIsALongStructNameToPushTheWhereToWrapLolololol where
+    [(); this_is_a_long_const_function_name()]:
+{
+}


### PR DESCRIPTION
Resolves #5012
Resolves #4850

This behavior was noticed when using the ``trailing_comma = "Never"``
configuration option (5012).

This behavior was also noticed when using default configurations (4850).

rustfmt would add a trailing space to where clause bounds that had an
empty right hand side.

Now no trailing space is added to the end of these where clause bounds.