### PR TITLE
Stabilize `match_block_trailing_comma`

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1626,7 +1626,7 @@ Put a trailing comma after a block based match arm (non-block arms are not affec
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
-- **Stable**: No (tracking issue: #3380)
+- **Stable**: Yes
 
 #### `false` (default):
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,7 +127,7 @@ create_config! {
         "Add trailing semicolon after break, continue and return";
     trailing_comma: SeparatorTactic, SeparatorTactic::Vertical, false,
         "How to handle trailing commas for lists";
-    match_block_trailing_comma: bool, false, false,
+    match_block_trailing_comma: bool, false, true,
         "Put a trailing comma after a block based match arm (non-block arms are not affected)";
     blank_lines_upper_bound: usize, 1, false,
         "Maximum number of blank lines which can be put between items";


### PR DESCRIPTION
Backport of stabilization from 2.x for the upcoming 1.4.38 release, refs #3380