### PR TITLE
stabilize `disable_all_formatting`

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -521,11 +521,13 @@ fn main() {
 
 ## `disable_all_formatting`
 
-Don't reformat anything
+Don't reformat anything.
+
+Note that this option may be soft-deprecated in the future once the [ignore](#ignore) option is stabilized. Nightly toolchain users are encouraged to use [ignore](#ignore) instead when possible.
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
-- **Stable**: No (tracking issue: #3388)
+- **Stable**: Yes
 
 ## `edition`
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -155,7 +155,7 @@ create_config! {
         "Require a specific version of rustfmt";
     unstable_features: bool, false, false,
             "Enables unstable features. Only available on nightly channel";
-    disable_all_formatting: bool, false, false, "Don't reformat anything";
+    disable_all_formatting: bool, false, true, "Don't reformat anything";
     skip_children: bool, false, false, "Don't reformat out of line modules";
     hide_parse_errors: bool, false, false, "Hide errors from the parser";
     error_on_line_overflow: bool, false, false, "Error if unable to get all lines within max_width";

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -469,11 +469,6 @@ fn stdin_works_with_modified_lines() {
 #[test]
 fn stdin_disable_all_formatting_test() {
     init_log();
-    match option_env!("CFG_RELEASE_CHANNEL") {
-        None | Some("nightly") => {}
-        // These tests require nightly.
-        _ => return,
-    }
     let input = String::from("fn main() { println!(\"This should not be formatted.\"); }");
     let mut child = Command::new(rustfmt().to_str().unwrap())
         .stdin(Stdio::piped())


### PR DESCRIPTION
I realize that this was previously considered and then declined in favor of stabilizing `ignore`. However, it's been more than two years since that was last discussed, and `ignore` remains unstabilized with some outstanding issues that need to be resolved first.

I completely agree with the strategic target of having `ignore` in place which will obviate the need for this option, but for years now projects that have opted to not utilize rustfmt haven't had a viable way to prevent unintentional and undesired formatting changes from contributors, and this has been an unnecessary source of friction given the presence of this option and its readiness for stabilization.

As such, I'm going to stabilize this with disclaimers about deferring to `ignore` when possible and that this will likely be soft deprecated (warning emitted, automatically mapped to `ignore`) whenever we actually manage to get `ignore` stabilized.