### PR TITLE
Handle DefinitiveListTactic::SpecialMacro when writing pre-comments

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -367,29 +367,31 @@ where
             result.push_str(&comment);
 
             if !inner_item.is_empty() {
-                if tactic == DefinitiveListTactic::Vertical || tactic == DefinitiveListTactic::Mixed
-                {
-                    // We cannot keep pre-comments on the same line if the comment if normalized.
-                    let keep_comment = if formatting.config.normalize_comments()
-                        || item.pre_comment_style == ListItemCommentStyle::DifferentLine
-                    {
-                        false
-                    } else {
-                        // We will try to keep the comment on the same line with the item here.
-                        // 1 = ` `
-                        let total_width = total_item_width(item) + item_sep_len + 1;
-                        total_width <= formatting.shape.width
-                    };
-                    if keep_comment {
-                        result.push(' ');
-                    } else {
-                        result.push('\n');
-                        result.push_str(indent_str);
-                        // This is the width of the item (without comments).
-                        line_len = item.item.as_ref().map_or(0, |s| unicode_str_width(&s));
+                match tactic {
+                    DefinitiveListTactic::SpecialMacro(_)
+                    | DefinitiveListTactic::Vertical
+                    | DefinitiveListTactic::Mixed => {
+                        // We cannot keep pre-comments on the same line if the comment is normalized
+                        let keep_comment = if formatting.config.normalize_comments()
+                            || item.pre_comment_style == ListItemCommentStyle::DifferentLine
+                        {
+                            false
+                        } else {
+                            // We will try to keep the comment on the same line with the item here.
+                            // 1 = ` `
+                            let total_width = total_item_width(item) + item_sep_len + 1;
+                            total_width <= formatting.shape.width
+                        };
+                        if keep_comment {
+                            result.push(' ');
+                        } else {
+                            result.push('\n');
+                            result.push_str(indent_str);
+                            // This is the width of the item (without comments).
+                            line_len = item.item.as_ref().map_or(0, |s| unicode_str_width(&s));
+                        }
                     }
-                } else {
-                    result.push(' ');
+                    _ => result.push(' '),
                 }
             }
             item_max_width = None;

--- a/tests/source/issue-4615/minimum_example.rs
+++ b/tests/source/issue-4615/minimum_example.rs
@@ -1,0 +1,4 @@
+info!(//debug
+    "{}: sending function_code={:04x} data={:04x} crc=0x{:04X} data={:02X?}",
+    self.name, function_code, data, crc, output_cmd
+);

--- a/tests/target/issue-4615/minimum_example.rs
+++ b/tests/target/issue-4615/minimum_example.rs
@@ -1,0 +1,5 @@
+info!(
+    //debug
+    "{}: sending function_code={:04x} data={:04x} crc=0x{:04X} data={:02X?}",
+    self.name, function_code, data, crc, output_cmd
+);


### PR DESCRIPTION
Resolves #4615

Previously only ``Vertical`` and ``Mixed`` enum variants of ``DefinitiveListTactic``
were considered when rewriting pre-comments for inner items in
``lists::write_list``.

Because we failed to considering the ``SpecialMacro`` variant we ended up in
a scenario where a ``ListItem`` with a ``pre_comment`` and a ``pre_comment_style``
of ``ListItemCommentStyle::DifferentLine`` was written on the same line as the
list item itself.

Now we apply the same pre-comment formatting to ``SpecialMacro``, ``Vertical``,
and ``Mixed`` variants of ``DefinitiveListTactic``.