### PR TITLE
Replace match expression with match! macro

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -367,31 +367,29 @@ where
             result.push_str(&comment);
 
             if !inner_item.is_empty() {
-                match tactic {
-                    DefinitiveListTactic::SpecialMacro(_)
-                    | DefinitiveListTactic::Vertical
-                    | DefinitiveListTactic::Mixed => {
-                        // We cannot keep pre-comments on the same line if the comment is normalized
-                        let keep_comment = if formatting.config.normalize_comments()
-                            || item.pre_comment_style == ListItemCommentStyle::DifferentLine
-                        {
-                            false
-                        } else {
-                            // We will try to keep the comment on the same line with the item here.
-                            // 1 = ` `
-                            let total_width = total_item_width(item) + item_sep_len + 1;
-                            total_width <= formatting.shape.width
-                        };
-                        if keep_comment {
-                            result.push(' ');
-                        } else {
-                            result.push('\n');
-                            result.push_str(indent_str);
-                            // This is the width of the item (without comments).
-                            line_len = item.item.as_ref().map_or(0, |s| unicode_str_width(&s));
-                        }
+                use DefinitiveListTactic::*;
+                if matches!(tactic, Vertical | Mixed | SpecialMacro(_)) {
+                    // We cannot keep pre-comments on the same line if the comment is normalized.
+                    let keep_comment = if formatting.config.normalize_comments()
+                        || item.pre_comment_style == ListItemCommentStyle::DifferentLine
+                    {
+                        false
+                    } else {
+                        // We will try to keep the comment on the same line with the item here.
+                        // 1 = ` `
+                        let total_width = total_item_width(item) + item_sep_len + 1;
+                        total_width <= formatting.shape.width
+                    };
+                    if keep_comment {
+                        result.push(' ');
+                    } else {
+                        result.push('\n');
+                        result.push_str(indent_str);
+                        // This is the width of the item (without comments).
+                        line_len = item.item.as_ref().map_or(0, |s| unicode_str_width(&s));
                     }
-                    _ => result.push(' '),
+                } else {
+                    result.push(' ')
                 }
             }
             item_max_width = None;


### PR DESCRIPTION
This is a follow up to 5f4811ed7bc600e0cbe40c962e8933adb9baaddf

The ``matches!`` macro expresses the condition more succinctly and avoids
the extra level of indentation introduced with the match arm body.