### PR TITLE
Retain trailing comments in module when using rustfmt::skip attribute

### DIFF
--- a/src/modules.rs
+++ b/src/modules.rs
@@ -16,7 +16,7 @@ use crate::syntux::parser::{
     Directory, DirectoryOwnership, ModError, ModulePathSuccess, Parser, ParserError,
 };
 use crate::syntux::session::ParseSess;
-use crate::utils::contains_skip;
+use crate::utils::{contains_skip, mk_sp};
 
 mod visitor;
 
@@ -137,10 +137,12 @@ impl<'ast, 'sess, 'c> ModResolver<'ast, 'sess> {
             self.visit_mod_from_ast(&krate.items)?;
         }
 
+        let snippet_provider = self.parse_sess.snippet_provider(krate.span);
+
         self.file_map.insert(
             root_filename,
             Module::new(
-                krate.span,
+                mk_sp(snippet_provider.start_pos(), snippet_provider.end_pos()),
                 None,
                 Cow::Borrowed(&krate.items),
                 Cow::Borrowed(&krate.attrs),

--- a/tests/target/issue-5033/minimum_example.rs
+++ b/tests/target/issue-5033/minimum_example.rs
@@ -1,0 +1,8 @@
+// leading comment
+
+#![rustfmt::skip]
+fn main() {
+    println!("main"); // commented
+}
+
+// post comment

--- a/tests/target/issue-5033/nested_modules.rs
+++ b/tests/target/issue-5033/nested_modules.rs
@@ -1,0 +1,11 @@
+#![rustfmt::skip]
+
+mod a {
+    mod b {
+
+    }
+
+    // trailing comment b
+}
+
+// trailing comment a


### PR DESCRIPTION
Refs #5033

Trailing comments at the end of the root Module were removed because the
module span did not extend until the end of the file.

The root Module's span now encompasses the entire file, which ensures
that no comments are lost when using ``#![rustfmt::skip]``