### PR TITLE
Fix tabs having a fixed width internally

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -559,7 +559,7 @@ impl<'a> FormatLines<'a> {
     fn char(&mut self, c: char, kind: FullCodeCharKind) {
         self.newline_count = 0;
         self.line_len += if c == '\t' {
-            self.config.tab_spaces()
+            self.config.tab_spaces() - self.line_len % self.config.tab_spaces()
         } else {
             1
         };

--- a/tests/target/configs/error_on_unformatted/false_with_error_on_line_overflow.rs
+++ b/tests/target/configs/error_on_unformatted/false_with_error_on_line_overflow.rs
@@ -1,0 +1,8 @@
+// rustfmt-error_on_unformatted: true
+// rustfmt-error_on_line_overflow: true
+
+// Part of #4968. This line has a width of 100, so it should be fine, but rustfmt panicked.
+fn panic_with_tabs() {
+    let a = "tab here:	Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonu est \
+             est, consetetur sadipscing";
+}


### PR DESCRIPTION
Ref #4968. Tabs were always counted to have a width of config.tab_spaces.
Since they actually can have less than that depending on the line's
previous contents, rustfmt would sometimes complain about the line
length even if the line did actually fit.