### PR TITLE
Backport "Use a custom env var for log settings intead of default RUST_LOG"

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -59,7 +59,7 @@ example, the `issue-1111.rs` test file is configured by the file
 ## Debugging
 
 Some `rewrite_*` methods use the `debug!` macro for printing useful information.
-These messages can be printed by using the environment variable `RUST_LOG=rustfmt=DEBUG`.
+These messages can be printed by using the environment variable `RUSTFMT_LOG=rustfmt=DEBUG`.
 These traces can be helpful in understanding which part of the code was used
 and get a better grasp on the execution flow.
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -20,7 +20,7 @@ use crate::rustfmt::{
 };
 
 fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env("RUSTFMT_LOG").init();
     let opts = make_opts();
 
     let exit_code = match execute(&opts) {

--- a/src/format-diff/main.rs
+++ b/src/format-diff/main.rs
@@ -64,7 +64,7 @@ pub struct Opts {
 }
 
 fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env("RUSTFMT_LOG").init();
     let opts = Opts::from_args();
     if let Err(e) = run(opts) {
         println!("{}", e);

--- a/src/git-rustfmt/main.rs
+++ b/src/git-rustfmt/main.rs
@@ -170,7 +170,7 @@ impl Config {
 }
 
 fn main() {
-    env_logger::init();
+    env_logger::Builder::from_env("RUSTFMT_LOG").init();
 
     let opts = make_opts();
     let matches = opts


### PR DESCRIPTION
This backports
* #4458

A comment in there sounded like a backport was intended.