### PR TITLE
Support comments in trait bounds

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -160,6 +160,26 @@ pub(crate) fn combine_strs_with_missing_comments(
     shape: Shape,
     allow_extend: bool,
 ) -> Option<String> {
+    combine_lines_with_missing_comments(
+        context,
+        prev_str,
+        next_str,
+        span,
+        shape,
+        false,
+        allow_extend,
+    )
+}
+
+pub(crate) fn combine_lines_with_missing_comments(
+    context: &RewriteContext<'_>,
+    prev_str: &str,
+    next_str: &str,
+    span: Span,
+    shape: Shape,
+    allow_multiline_join: bool,
+    allow_extend: bool,
+) -> Option<String> {
     trace!(
         "combine_strs_with_missing_comments `{}` `{}` {:?} {:?}",
         prev_str,
@@ -171,7 +191,8 @@ pub(crate) fn combine_strs_with_missing_comments(
     let mut result =
         String::with_capacity(prev_str.len() + next_str.len() + shape.indent.width() + 128);
     result.push_str(prev_str);
-    let mut allow_one_line = !prev_str.contains('\n') && !next_str.contains('\n');
+    let contains_nl = prev_str.contains('\n') || next_str.contains('\n');
+    let mut allow_line_join = allow_multiline_join || !contains_nl;
     let first_sep =
         if prev_str.is_empty() || next_str.is_empty() || trimmed_last_line_width(prev_str) == 0 {
             ""
@@ -213,7 +234,11 @@ pub(crate) fn combine_strs_with_missing_comments(
     } else {
         let one_line_width = last_line_width(prev_str) + first_line_width(&missing_comment) + 1;
         if prefer_same_line && one_line_width <= shape.width {
-            Cow::from(" ")
+            if prev_str.ends_with(" ") {
+                Cow::from("")
+            } else {
+                Cow::from(" ")
+            }
         } else {
             indent.to_string_with_newline(config)
         }
@@ -221,14 +246,16 @@ pub(crate) fn combine_strs_with_missing_comments(
     result.push_str(&first_sep);
     result.push_str(&missing_comment);
 
-    let second_sep = if missing_comment.is_empty() || next_str.is_empty() {
+    let skip_second_sep =
+        missing_comment.is_empty() || next_str.is_empty() || next_str.starts_with("\n");
+    let second_sep = if skip_second_sep {
         Cow::from("")
     } else if missing_comment.starts_with("//") {
         indent.to_string_with_newline(config)
     } else {
         one_line_width += missing_comment.len() + first_sep.len() + 1;
-        allow_one_line &= !missing_comment.starts_with("//") && !missing_comment.contains('\n');
-        if prefer_same_line && allow_one_line && one_line_width <= shape.width {
+        allow_line_join &= !missing_comment.starts_with("//") && !missing_comment.contains('\n');
+        if prefer_same_line && allow_line_join && one_line_width <= shape.width {
             Cow::from(" ")
         } else {
             indent.to_string_with_newline(config)

--- a/src/items.rs
+++ b/src/items.rs
@@ -1043,28 +1043,56 @@ pub(crate) fn format_trait(
         let body_lo = context.snippet_provider.span_after(item.span, "{");
 
         let shape = Shape::indented(offset, context.config).offset_left(result.len())?;
+
+        let combine_comment_span =
+            |lo: BytePos, hi: BytePos, lhs: String, rhs: &str| -> Option<String> {
+                let span = mk_sp(lo, hi);
+
+                if contains_comment(context.snippet(span)) {
+                    combine_strs_with_missing_comments(context, &lhs, rhs, span, shape, true)
+                } else {
+                    Some(lhs + rhs)
+                }
+            };
+
         let generics_str =
             rewrite_generics(context, rewrite_ident(context, item.ident), generics, shape)?;
-        result.push_str(&generics_str);
 
-        // FIXME(#2055): rustfmt fails to format when there are comments between trait bounds.
+        // Recover the comment before ident.
+        let comment_lo = context.snippet_provider.span_after(item.span, "trait");
+        let comment_hi = item.ident.span.lo();
+        result = combine_comment_span(comment_lo, comment_hi, result, &generics_str)?;
+
         if !generic_bounds.is_empty() {
-            let ident_hi = context
-                .snippet_provider
-                .span_after(item.span, &item.ident.as_str());
-            let bound_hi = generic_bounds.last().unwrap().span().hi();
-            let snippet = context.snippet(mk_sp(ident_hi, bound_hi));
-            if contains_comment(snippet) {
-                return None;
-            }
+            // Recover the comment before the colon.
+            let comment_lo = generics.span.hi();
+            let comment_hi = context.snippet_provider.span_before(item.span, ":");
+            result = combine_comment_span(comment_lo, comment_hi, result, ":")?;
 
-            result = rewrite_assign_rhs_with(
+            // Recover the comment after the colon.
+            let comment_lo = context.snippet_provider.span_after(item.span, ":");
+            let comment_hi = generic_bounds[0].span().lo();
+            let comment_span = mk_sp(comment_lo, comment_hi);
+
+            result = rewrite_assign_rhs_with_comments(
                 context,
-                result + ":",
+                &result,
                 generic_bounds,
                 shape,
                 RhsTactics::ForceNextLineWithoutIndent,
+                comment_span,
+                true,
             )?;
+
+            // Recover the comment following the bounds.
+            let comment_lo = generic_bounds[generic_bounds.len() - 1].span().hi();
+            let comment_hi = if generics.where_clause.predicates.is_empty() {
+                body_lo - BytePos(1)
+            } else {
+                generics.where_clause.span.lo()
+            };
+
+            result = combine_comment_span(comment_lo, comment_hi, result, "")?;
         }
 
         // Rewrite where-clause.
@@ -1073,9 +1101,9 @@ pub(crate) fn format_trait(
 
             let where_budget = context.budget(last_line_width(&result));
             let pos_before_where = if generic_bounds.is_empty() {
-                generics.where_clause.span.lo()
+                generics.span.hi()
             } else {
-                generic_bounds[generic_bounds.len() - 1].span().hi()
+                generics.where_clause.span.lo()
             };
             let option = WhereClauseOption::snuggled(&generics_str);
             let where_clause_str = rewrite_where_clause(
@@ -1085,7 +1113,7 @@ pub(crate) fn format_trait(
                 Shape::legacy(where_budget, offset.block_only()),
                 where_on_new_line,
                 "{",
-                None,
+                Some(body_lo),
                 pos_before_where,
                 option,
             )?;
@@ -1100,26 +1128,11 @@ pub(crate) fn format_trait(
                 result.push_str(&where_indent.to_string_with_newline(context.config));
             }
             result.push_str(&where_clause_str);
-        } else {
-            let item_snippet = context.snippet(item.span);
-            if let Some(lo) = item_snippet.find('/') {
-                // 1 = `{`
-                let comment_hi = body_lo - BytePos(1);
-                let comment_lo = item.span.lo() + BytePos(lo as u32);
-                if comment_lo < comment_hi {
-                    match recover_missing_comment_in_span(
-                        mk_sp(comment_lo, comment_hi),
-                        Shape::indented(offset, context.config),
-                        context,
-                        last_line_width(&result),
-                    ) {
-                        Some(ref missing_comment) if !missing_comment.is_empty() => {
-                            result.push_str(missing_comment);
-                        }
-                        _ => (),
-                    }
-                }
-            }
+        } else if generic_bounds.is_empty() {
+            // 1 = `{`
+            let comment_lo = item.ident.span.hi();
+            let comment_hi = body_lo - BytePos(1);
+            result = combine_comment_span(comment_lo, comment_hi, result, "")?;
         }
 
         match context.config.brace_style() {

--- a/tests/source/issue-2055.rs
+++ b/tests/source/issue-2055.rs
@@ -1,0 +1,59 @@
+
+pub trait CommentAfterColon1: /* Comment */ Clone
+{
+    //
+}
+
+pub trait CommentAfterColon2: // Comment
+Clone
+{
+    //
+}
+
+pub trait CommentBeforeColon /*comment*/: Clone
+{
+    //
+}
+
+pub trait /*comment*/ CommentBeforeIdent1: Clone
+{
+    //
+}
+
+pub trait // comment
+CommentBeforeIdent2: Clone
+{
+    //
+}
+
+pub trait CommentsShort /*after ident*/: /*BA before*/ BA /*BA after*/ + /*BB before*/ BB /*BB after*/
+{
+    //
+}
+
+pub trait CommentsMultiline /*after ident*/: /*BA before*/ BA /*BA after*/ + /*BB before*/ BB /*BB after*/ + /*BC before*/ BC /*BC after*/ + /*BD before*/ BD /*BD after*/
+{
+    //
+}
+
+pub trait CommentsShortWhere<T1, T2>
+where T1: BA /*comment 1*/ + /*comment 2*/ BB + BC, /*comment 3*/ 
+      T2: BA /*comment 4*/ + /*comment 5*/ BB + BC, /*comment 6*/
+{
+    //
+}
+
+pub trait CommentsWhere<T1, T2>/*before where*/
+where T1: /*comment 1*/ BA /*comment 2*/ + /*comment 3*/ BB /*comment 4*/ + /*comment 5*/ BC /*comment 6*/ + /*comment 7*/ BB /*comment 8*/ + /*comment 9*/ BC, /*comment 10*/
+      T2: /*comment 11*/
+{
+    //
+}
+
+pub trait KitchenSink<T1, T2>/*before colon*/://after colon
+FromIterator<char> /*comment 1*/ + /*comment 2*/ Printer<'tcx, Error = fmt::Error, Path = Self, Region = Self, Type = Self, DynExistential = Self, Const = Self, > /*comment 3*/ + /*comment 4*/ fmt::Write /*comment 5*/ + /*comment 6*/ Clone /*comment 7*/ + /*comment 8*/ Default /*comment 9*/
+where T1: /*comment 10*/ BA /*comment 11*/ + /*comment 12*/ BB + BC /*comment 13*/ + /*comment 14*/ BB + /*comment 15*/ BC, /*comment 16*/
+T2: /*comment 17*/ BA /*comment 18*/ + /*comment 19*/ BB + BC /*comment 20*/ + /*comment 21*/ BB + /*comment 22*/ BC, /*comment 23*/
+{
+   //
+}

--- a/tests/target/issue-2055.rs
+++ b/tests/target/issue-2055.rs
@@ -1,0 +1,90 @@
+pub trait CommentAfterColon1: /* Comment */ Clone {
+    //
+}
+
+pub trait CommentAfterColon2: // Comment
+    Clone
+{
+    //
+}
+
+pub trait CommentBeforeColon /*comment*/ : Clone {
+    //
+}
+
+pub trait /*comment*/ CommentBeforeIdent1: Clone {
+    //
+}
+
+pub trait // comment
+CommentBeforeIdent2: Clone
+{
+    //
+}
+
+pub trait CommentsShort /*after ident*/ : /*BA before*/
+    BA /*BA after*/ + /*BB before*/ BB /*BB after*/
+{
+    //
+}
+
+pub trait CommentsMultiline /*after ident*/ : /*BA before*/
+    BA /*BA after*/
+    + /*BB before*/ BB /*BB after*/
+    + /*BC before*/ BC /*BC after*/
+    + /*BD before*/ BD /*BD after*/
+{
+    //
+}
+
+pub trait CommentsShortWhere<T1, T2>
+where
+    T1: BA /*comment 1*/ + /*comment 2*/ BB + BC, /*comment 3*/
+    T2: BA /*comment 4*/ + /*comment 5*/ BB + BC, /*comment 6*/
+{
+    //
+}
+
+pub trait CommentsWhere<T1, T2>
+/*before where*/
+where
+    T1: /*comment 1*/
+        BA /*comment 2*/
+            + /*comment 3*/ BB /*comment 4*/
+            + /*comment 5*/ BC /*comment 6*/
+            + /*comment 7*/ BB /*comment 8*/
+            + /*comment 9*/ BC, /*comment 10*/
+    T2:, /*comment 11*/
+{
+    //
+}
+
+pub trait KitchenSink<T1, T2> /*before colon*/ : //after colon
+    FromIterator<char> /*comment 1*/
+    + /*comment 2*/ Printer<
+        'tcx,
+        Error = fmt::Error,
+        Path = Self,
+        Region = Self,
+        Type = Self,
+        DynExistential = Self,
+        Const = Self,
+    > /*comment 3*/ + /*comment 4*/ fmt::Write /*comment 5*/
+    + /*comment 6*/ Clone /*comment 7*/
+    + /*comment 8*/ Default /*comment 9*/
+where
+    T1: /*comment 10*/
+        BA /*comment 11*/
+            + /*comment 12*/ BB
+            + BC /*comment 13*/
+            + /*comment 14*/ BB
+            + /*comment 15*/ BC, /*comment 16*/
+    T2: /*comment 17*/
+        BA /*comment 18*/
+            + /*comment 19*/ BB
+            + BC /*comment 20*/
+            + /*comment 21*/ BB
+            + /*comment 22*/ BC, /*comment 23*/
+{
+    //
+}

--- a/tests/target/trait.rs
+++ b/tests/target/trait.rs
@@ -86,11 +86,13 @@ trait Y // comment
 
 // #2055
 pub trait Foo:
-// A and C
-A + C
-// and B
+    // A and C
+    A
+    + C
+    // and B
     + B
-{}
+{
+}
 
 // #2158
 trait Foo {


### PR DESCRIPTION
I've split out the portion of #5004 that fixes #2055 into its own PR.

I took a look at #4666 and found a case that it handled that wasn't in my original PR (handling comments before the trait identifier). I've updated the code and tests to include that.

It was also suggested over there that I take a look at the `rustfmt-2.0.0-rc.2` for anything that might be related. The changes made in 27d5871700063f87f178c08ba7eccb611ee7ef45 are the closest I came across. If it seems appropriate, I can update this PR to include the changes in that commit modified to switch on`Version::Two`.