### PR TITLE
Remove extra whitespace after match arrow

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -436,6 +436,9 @@ fn rewrite_match_body(
             };
 
         let block_sep = match context.config.control_brace_style() {
+            ControlBraceStyle::AlwaysNextLine if !context.config.match_arm_blocks() => {
+                format!("{}", body_prefix)
+            }
             ControlBraceStyle::AlwaysNextLine => format!("{}{}", alt_block_sep, body_prefix),
             _ if body_prefix.is_empty() => "".to_owned(),
             _ if forbid_same_line || !arrow_comment.is_empty() => {

--- a/tests/source/issue-4844.rs
+++ b/tests/source/issue-4844.rs
@@ -1,0 +1,13 @@
+// rustfmt-control_brace_style: AlwaysNextLine
+// rustfmt-match_arm_blocks: false
+
+fn main() {
+    let fooooooo = "100000000000000000000000";
+    let _bar = match fooooooo
+    {
+        "100000000000000000000000" =>
+
+            fooooooo.len() == 1 && fooooooo.contains("222222222222222222"),
+        _ => unreachable!("Should not happen"),
+    };
+}

--- a/tests/target/issue-4844.rs
+++ b/tests/target/issue-4844.rs
@@ -1,0 +1,12 @@
+// rustfmt-control_brace_style: AlwaysNextLine
+// rustfmt-match_arm_blocks: false
+
+fn main() {
+    let fooooooo = "100000000000000000000000";
+    let _bar = match fooooooo
+    {
+        "100000000000000000000000" =>
+            fooooooo.len() == 1 && fooooooo.contains("222222222222222222"),
+        _ => unreachable!("Should not happen"),
+    };
+}


### PR DESCRIPTION
Fixes #4844

When using `control_brace_style = 'AlwaysNextLine'` and `match_arm_blocks = false`, rustfmt would add extra whitespace if the match body didn't fit on one line.

This adds a check for this case.