### PR TITLE
Add a few missing tracking issues in Configurations.md

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1701,7 +1701,7 @@ How imports should be grouped into `use` statements. Imports will be merged or s
 
 - **Default value**: `Preserve`
 - **Possible values**: `Preserve`, `Crate`, `Module`, `Item`, `One`
-- **Stable**: No (tracking issue: [#5082](https://github.com/rust-lang/rustfmt/issues/5082))
+- **Stable**: No (tracking issue: [#4991](https://github.com/rust-lang/rustfmt/issues/4991))
 
 #### `Preserve` (default):
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -933,7 +933,7 @@ if any of the first five lines contains `@generated` marker.
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
-- **Stable**: No
+- **Stable**: No (tracking issue: [#5080](https://github.com/rust-lang/rustfmt/issues/5080))
 
 ## `format_macro_matchers`
 
@@ -1064,7 +1064,7 @@ Control the case of the letters in hexadecimal literal values
 
 - **Default value**: `Preserve`
 - **Possible values**: `Upper`, `Lower`
-- **Stable**: No
+- **Stable**: No (tracking issue: [#5081](https://github.com/rust-lang/rustfmt/issues/5081))
 
 ## `hide_parse_errors`
 
@@ -1701,7 +1701,7 @@ How imports should be grouped into `use` statements. Imports will be merged or s
 
 - **Default value**: `Preserve`
 - **Possible values**: `Preserve`, `Crate`, `Module`, `Item`, `One`
-- **Stable**: No
+- **Stable**: No (tracking issue: [#5082](https://github.com/rust-lang/rustfmt/issues/5082))
 
 #### `Preserve` (default):
 
@@ -2063,7 +2063,7 @@ Controls the strategy for how imports are grouped together.
 
 - **Default value**: `Preserve`
 - **Possible values**: `Preserve`, `StdExternalCrate`, `One`
-- **Stable**: No
+- **Stable**: No (tracking issue: [#5083](https://github.com/rust-lang/rustfmt/issues/5083))
 
 #### `Preserve` (default):
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rustfmt/pull/5052.

I went through all the unstable opts in Configurations.md, reopened some existing tracking issues, and created new ones where necessary.

I also verified the stable yes/no annotations actually match the code, they did.

I noticed the following options from the code do not appear in configurations.md, @calebcartwright let me know whether that should be changed.
* file_lines ("Lines to format; this is not supported in rustfmt.toml and can only be specified  via the --file-lines option")
* newline_style ("Unix or Windows line endings")
* verbose ("How much to information to emit to the user")
* width_heuristics ("'small' heuristic values")
