### PR TITLE
refactor/cleanup duplicative Impl handling code

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -485,9 +485,9 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         if should_visit_node_again {
             match item.kind {
                 ast::ItemKind::Use(ref tree) => self.format_import(item, tree),
-                ast::ItemKind::Impl { .. } => {
+                ast::ItemKind::Impl(ref iimpl) => {
                     let block_indent = self.block_indent;
-                    let rw = self.with_context(|ctx| format_impl(ctx, item, block_indent));
+                    let rw = self.with_context(|ctx| format_impl(ctx, item, iimpl, block_indent));
                     self.push_rewrite(item.span, rw);
                 }
                 ast::ItemKind::Trait(..) => {


### PR DESCRIPTION
Diff looks noisier than it actually is. We had multiple duplicative checks for the `Impl` item kind with if/else and `unreachable!` blocks to get at the underlying boxed Impl which added both noise and extra indentation layers. This change instead grabs the Impl at the top and passes it down to the underlying functions.

Also includes a first step at trying to simplify the reordering logic of assoc items in impls in prep for extracting out some reusable bits to support traits as well.