### PR TITLE
Prevent duplicate comma when formatting struct pattern with ".."

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -318,10 +318,12 @@ fn rewrite_struct_pat(
     let mut fields_str = write_list(&item_vec, &fmt)?;
     let one_line_width = h_shape.map_or(0, |shape| shape.width);
 
+    let has_trailing_comma = fmt.needs_trailing_separator();
+
     if ellipsis {
         if fields_str.contains('\n') || fields_str.len() > one_line_width {
             // Add a missing trailing comma.
-            if context.config.trailing_comma() == SeparatorTactic::Never {
+            if !has_trailing_comma {
                 fields_str.push(',');
             }
             fields_str.push('\n');
@@ -329,8 +331,7 @@ fn rewrite_struct_pat(
         } else {
             if !fields_str.is_empty() {
                 // there are preceding struct fields being matched on
-                if tactic == DefinitiveListTactic::Vertical {
-                    // if the tactic is Vertical, write_list already added a trailing ,
+                if has_trailing_comma {
                     fields_str.push(' ');
                 } else {
                     fields_str.push_str(", ");

--- a/tests/target/issue-5066/multi_line_struct_trailing_comma_always_struct_lit_width_0.rs
+++ b/tests/target/issue-5066/multi_line_struct_trailing_comma_always_struct_lit_width_0.rs
@@ -1,0 +1,10 @@
+// rustfmt-trailing_comma: Always
+// rustfmt-struct_lit_single_line: false
+// rustfmt-struct_lit_width: 0
+
+fn main() {
+    let Foo {
+        a,
+        ..
+    } = b;
+}

--- a/tests/target/issue-5066/multi_line_struct_trailing_comma_never_struct_lit_width_0.rs
+++ b/tests/target/issue-5066/multi_line_struct_trailing_comma_never_struct_lit_width_0.rs
@@ -1,0 +1,10 @@
+// rustfmt-trailing_comma: Never
+// rustfmt-struct_lit_single_line: false
+// rustfmt-struct_lit_width: 0
+
+fn main() {
+    let Foo {
+        a,
+        ..
+    } = b;
+}

--- a/tests/target/issue-5066/multi_line_struct_with_trailing_comma_always.rs
+++ b/tests/target/issue-5066/multi_line_struct_with_trailing_comma_always.rs
@@ -1,0 +1,10 @@
+// rustfmt-trailing_comma: Always
+// rustfmt-struct_lit_single_line: false
+
+// There is an issue with how this is formatted.
+// formatting should look like ./multi_line_struct_trailing_comma_always_struct_lit_width_0.rs
+fn main() {
+    let Foo {
+        a, ..
+    } = b;
+}

--- a/tests/target/issue-5066/multi_line_struct_with_trailing_comma_never.rs
+++ b/tests/target/issue-5066/multi_line_struct_with_trailing_comma_never.rs
@@ -1,0 +1,10 @@
+// rustfmt-trailing_comma: Never
+// rustfmt-struct_lit_single_line: false
+
+// There is an issue with how this is formatted.
+// formatting should look like ./multi_line_struct_trailing_comma_never_struct_lit_width_0.rs
+fn main() {
+    let Foo {
+        a, ..
+    } = b;
+}

--- a/tests/target/issue-5066/with_trailing_comma_always.rs
+++ b/tests/target/issue-5066/with_trailing_comma_always.rs
@@ -1,0 +1,5 @@
+// rustfmt-trailing_comma: Always
+
+fn main() {
+    let Foo { a, .. } = b;
+}

--- a/tests/target/issue-5066/with_trailing_comma_never.rs
+++ b/tests/target/issue-5066/with_trailing_comma_never.rs
@@ -1,0 +1,5 @@
+// rustfmt-trailing_comma: Never
+
+fn main() {
+    let Foo { a, .. } = b;
+}


### PR DESCRIPTION
Fixes #5066

When a struct pattern that contained a ".." was formatted, it was
assumed that a trailing comma should always be added if the struct
fields weren't formatted vertically.

Now, a trailing comma is only added if not already included in the
reformatted struct fields.