### PR TITLE
Preserve normalized comments after last list item

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -444,10 +444,15 @@ where
                 let offset = formatting.shape.indent + overhead;
                 let comment_shape = Shape::legacy(width, offset);
 
-                // Use block-style only for the last item or multiline comments.
-                let block_style = !formatting.ends_with_newline && last
-                    || comment.trim().contains('\n')
-                    || comment.trim().len() > width;
+                let block_style = if !formatting.ends_with_newline && last {
+                    true
+                } else if starts_with_newline(comment) {
+                    false
+                } else if comment.trim().contains('\n') || comment.trim().len() > width {
+                    true
+                } else {
+                    false
+                };
 
                 rewrite_comment(
                     comment.trim_start(),

--- a/tests/source/issue-4909/wrap-comments-not-normalized.rs
+++ b/tests/source/issue-4909/wrap-comments-not-normalized.rs
@@ -1,0 +1,108 @@
+// rustfmt-wrap_comments: true
+
+pub enum E {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E3 {
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+
+}
+
+pub struct S {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S3 {
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+}
+
+fn foo(
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo2(// Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo3(
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+
+) -> usize {
+    5
+}
+
+fn main() {
+    let v = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v2: Vec<i32> = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v3 = vec![
+        // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    ];
+}

--- a/tests/source/issue-4909/wrap-comments-true.rs
+++ b/tests/source/issue-4909/wrap-comments-true.rs
@@ -1,0 +1,109 @@
+// rustfmt-normalize_comments: true
+// rustfmt-wrap_comments: true
+
+pub enum E {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E3 {
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+
+}
+
+pub struct S {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S3 {
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+}
+
+fn foo(
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo2(// Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo3(
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+
+) -> usize {
+    5
+}
+
+fn main() {
+    let v = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v2: Vec<i32> = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v3 = vec![
+        // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage through the inclusion pipeline, or according to the descriptions
+    ];
+}

--- a/tests/target/issue-4909/wrap-comments-false.rs
+++ b/tests/target/issue-4909/wrap-comments-false.rs
@@ -1,0 +1,72 @@
+// rustfmt-normalize_comments: true
+
+pub enum E {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+fn foo(
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo2(// Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn main() {
+    let v = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v2: Vec<i32> = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+}

--- a/tests/target/issue-4909/wrap-comments-not-normalized.rs
+++ b/tests/target/issue-4909/wrap-comments-not-normalized.rs
@@ -1,0 +1,118 @@
+// rustfmt-wrap_comments: true
+
+pub enum E {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E3 {
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+}
+
+pub struct S {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S3 {
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+}
+
+fn foo(
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo2(// Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo3(
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn main() {
+    let v = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v2: Vec<i32> = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v3 = vec![
+        // Expand as needed, numbers should be ascending according to the stage through the
+        // inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage through the
+        // inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage through the
+        // inclusion pipeline, or according to the descriptions
+    ];
+}

--- a/tests/target/issue-4909/wrap-comments-true.rs
+++ b/tests/target/issue-4909/wrap-comments-true.rs
@@ -1,0 +1,119 @@
+// rustfmt-normalize_comments: true
+// rustfmt-wrap_comments: true
+
+pub enum E {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub enum E3 {
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    Variant1,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    Variant2,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+}
+
+pub struct S {
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S2 {
+    // This can be changed once https://github.com/rust-lang/rustfmt/issues/4854 is fixed
+// Expand as needed, numbers should be ascending according to the stage
+// through the inclusion pipeline, or according to the descriptions
+}
+
+pub struct S3 {
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    some_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    last_field: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+}
+
+fn foo(
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo2(// Expand as needed, numbers should be ascending according to the stage
+    // through the inclusion pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn foo3(
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    a: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+    b: usize,
+    // Expand as needed, numbers should be ascending according to the stage through the inclusion
+    // pipeline, or according to the descriptions
+) -> usize {
+    5
+}
+
+fn main() {
+    let v = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v2: Vec<i32> = vec![
+        // Expand as needed, numbers should be ascending according to the stage
+        // through the inclusion pipeline, or according to the descriptions
+    ];
+
+    let v3 = vec![
+        // Expand as needed, numbers should be ascending according to the stage through the
+        // inclusion pipeline, or according to the descriptions
+        1,
+        // Expand as needed, numbers should be ascending according to the stage through the
+        // inclusion pipeline, or according to the descriptions
+        2,
+        // Expand as needed, numbers should be ascending according to the stage through the
+        // inclusion pipeline, or according to the descriptions
+    ];
+}


### PR DESCRIPTION
Fixes #4909

This issue was that a multi-line comment starting on a new line after the last item of a list is considered a post-comment.
This adds a check for whether a post-comment in a list starts with a newline and doesn't force the comment to become a block comment in that case.