### PR TITLE
Prevent rustfmt from adding ``impl Trait`` definitions to types

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1521,10 +1521,7 @@ pub(crate) fn rewrite_type_alias<'a, 'b>(
     // https://rustc-dev-guide.rust-lang.org/opaque-types-type-alias-impl-trait.html
     // https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/items.md#type-aliases
     match (visitor_kind, ty_opt) {
-        (Item(_), None) => {
-            let op_ty = OpaqueType { bounds };
-            rewrite_ty(rw_info, Some(bounds), Some(&op_ty), vis)
-        }
+        (Item(_), None) => rewrite_ty::<OpaqueType<'_>>(rw_info, Some(bounds), None, vis),
         (Item(_), Some(ty)) => rewrite_ty(rw_info, Some(bounds), Some(&*ty), vis),
         (AssocImplItem(_), _) => {
             let result = if let Some(ast::Ty {

--- a/tests/target/issue-5086/minimum_example.rs
+++ b/tests/target/issue-5086/minimum_example.rs
@@ -1,0 +1,1 @@
+type Type: Bound;


### PR DESCRIPTION
Fixes #5086
