### PR TITLE
fix: do not wrap reference-style doc links

### DIFF
--- a/tests/target/issue-5095.rs
+++ b/tests/target/issue-5095.rs
@@ -1,0 +1,27 @@
+// rustfmt-wrap_comments: true
+
+pub mod a_long_name {
+    pub mod b_long_name {
+        pub mod c_long_name {
+            pub mod d_long_name {
+                pub mod e_long_name {
+                    pub struct Bananas;
+                    impl Bananas {
+                        pub fn fantastic() {}
+                    }
+
+                    pub mod f_long_name {
+                        pub struct Apples;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Check out [my other struct] ([`Bananas`]) and [the method it has].
+///
+/// [my other struct]: a_long_name::b_long_name::c_long_name::d_long_name::e_long_name::f_long_name::Apples
+/// [`Bananas`]: a_long_name::b_long_name::c_long_name::d_long_name::e_long_name::Bananas::fantastic()
+/// [the method it has]: a_long_name::b_long_name::c_long_name::d_long_name::e_long_name::Bananas::fantastic()
+pub struct A;


### PR DESCRIPTION
Changes the behaviour of `wrap_comments` to ignore reference link lines.

I've put this `Regex` behind a `lazy_static` to avoid compiling it each time `has_url` is run (every comment line?) which is relatively slow:

* Initialising the `Regex` where it is used:
  ```
  test has_url ... bench:      33,346 ns/iter (+/- 17,023)
  ```

* Using a global with `lazy_static`:
  ```
  test has_url ... bench:         141 ns/iter (+/- 2)
  ```

There's a few more places this optimisation can be applied - I'd be happy to open a follow-up PR to change them all if you're happy with the approach :+1:

Fixes #5095, #4933.

---

* fix: do not wrap reference-style doc links (d85fd07e)

      Prevents wrap_comments from incorrectly wrapping reference-style doc links.

