### PR TITLE
Treat empty doc comments that precede doc attributes as significant

### DIFF
--- a/tests/source/issue-5073/non_consecutive_doc_comment_and_attr_wrap_comments_false.rs
+++ b/tests/source/issue-5073/non_consecutive_doc_comment_and_attr_wrap_comments_false.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: false
+
+//! Text
+//!
+
+#![doc = include_str!("something.md")]
+//!
+//! More text

--- a/tests/source/issue-5073/non_consecutive_doc_comment_and_attr_wrap_comments_true.rs
+++ b/tests/source/issue-5073/non_consecutive_doc_comment_and_attr_wrap_comments_true.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: true
+
+//! Text
+//!
+
+#![doc = include_str!("something.md")]
+//!
+//! More text

--- a/tests/target/issue-5073/non_consecutive_doc_comment_and_attr_wrap_comments_false.rs
+++ b/tests/target/issue-5073/non_consecutive_doc_comment_and_attr_wrap_comments_false.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: false
+
+//! Text
+//!
+
+#![doc = include_str!("something.md")]
+//!
+//! More text

--- a/tests/target/issue-5073/non_consecutive_doc_comment_and_attr_wrap_comments_true.rs
+++ b/tests/target/issue-5073/non_consecutive_doc_comment_and_attr_wrap_comments_true.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments: true
+
+//! Text
+
+#![doc = include_str!("something.md")]
+//!
+//! More text

--- a/tests/target/issue-5073/significant_empty_comment_wrap_commet_false.rs
+++ b/tests/target/issue-5073/significant_empty_comment_wrap_commet_false.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments: false
+
+//! Text
+//!
+#![doc = include_str!("something.md")]
+//!
+//! More text

--- a/tests/target/issue-5073/significant_empty_comment_wrap_commet_true.rs
+++ b/tests/target/issue-5073/significant_empty_comment_wrap_commet_true.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments: true
+
+//! Text
+//!
+#![doc = include_str!("something.md")]
+//!
+//! More text


### PR DESCRIPTION
Fixes #5073

Normally we would want to remove any empty trailing doc comments
however, as highlighted by 5073 by removing these trailing comments
rustfmt is interfering with tools like rustdoc.

Checks have been added to allow rustfmt to keep empty trailing comments
when using ``wrap_comments = true`` if and only if the empty trailing
comments immideatly precede a doc attribute.