### PR TITLE
Prevent adding trailing whitespace when rewriting ast::Param

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2014,9 +2014,15 @@ impl Rewrite for ast::Param {
                 {
                     result.push_str(&ty_str);
                 } else {
+                    let prev_str = if param_attrs_result.is_empty() {
+                        param_attrs_result
+                    } else {
+                        param_attrs_result + &shape.to_string_with_newline(context.config)
+                    };
+
                     result = combine_strs_with_missing_comments(
                         context,
-                        &(param_attrs_result + &shape.to_string_with_newline(context.config)),
+                        &prev_str,
                         param_name,
                         span,
                         shape,

--- a/tests/target/issue-5125/attributes_in_formal_fuction_parameter.rs
+++ b/tests/target/issue-5125/attributes_in_formal_fuction_parameter.rs
@@ -1,0 +1,6 @@
+fn foo(
+    #[unused] a: <u16 as intercom::type_system::ExternType<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ForeignType,
+) {
+}

--- a/tests/target/issue-5125/long_parameter_in_different_positions.rs
+++ b/tests/target/issue-5125/long_parameter_in_different_positions.rs
@@ -1,0 +1,24 @@
+fn middle(
+    a: usize,
+    b: <u16 as intercom::type_system::ExternType<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ForeignType,
+    c: bool,
+) {
+}
+
+fn last(
+    a: usize,
+    b: <u16 as intercom::type_system::ExternType<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ForeignType,
+) {
+}
+
+fn first(
+    a: <u16 as intercom::type_system::ExternType<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ForeignType,
+    b: usize,
+) {
+}

--- a/tests/target/issue-5125/minimum_example.rs
+++ b/tests/target/issue-5125/minimum_example.rs
@@ -1,0 +1,6 @@
+fn foo(
+    a: <u16 as intercom::type_system::ExternType<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ForeignType,
+) {
+}

--- a/tests/target/issue-5125/with_leading_and_inline_comments.rs
+++ b/tests/target/issue-5125/with_leading_and_inline_comments.rs
@@ -1,0 +1,7 @@
+fn foo(
+    // Pre Comment
+    a: <u16 as intercom::type_system::ExternType<
+        intercom::type_system::AutomationTypeSystem,
+    >>::ForeignType, // Inline comment
+) {
+}


### PR DESCRIPTION
Fixes #5125

Previously, a newline was always added, even if the parameter name was
not preceded by any param attrs.

Now a newline is only added if there were param attrs.