### PR TITLE
Do not flatten match arm block with leading attributes

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -322,7 +322,11 @@ fn flatten_arm_body<'a>(
     if let Some(block) = block_can_be_flattened(context, body) {
         if let ast::StmtKind::Expr(ref expr) = block.stmts[0].kind {
             if let ast::ExprKind::Block(..) = expr.kind {
-                flatten_arm_body(context, expr, None)
+                if expr.attrs.is_empty() {
+                    flatten_arm_body(context, expr, None)
+                } else {
+                    (true, body)
+                }
             } else {
                 let cond_becomes_muti_line = opt_shape
                     .and_then(|shape| rewrite_cond(context, expr, shape))

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -568,3 +568,22 @@ fn issue_3774() {
         }
     }
 }
+
+// #4109
+fn issue_4109() {
+    match () {
+        _ => {
+#[cfg(debug_assertions)]
+{
+println!("Foo");
+}
+}
+}
+
+match () {
+_ => {
+#[allow(unsafe_code)]
+unsafe {}
+}
+}
+}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -608,3 +608,22 @@ fn issue_3774() {
         }
     }
 }
+
+// #4109
+fn issue_4109() {
+    match () {
+        _ => {
+            #[cfg(debug_assertions)]
+            {
+                println!("Foo");
+            }
+        }
+    }
+
+    match () {
+        _ => {
+            #[allow(unsafe_code)]
+            unsafe {}
+        }
+    }
+}


### PR DESCRIPTION
This is a backport of #4124.

Fixes #4109