### PR TITLE
Leverage itemized blocks to support formatting markdown block quotes

### DIFF
--- a/tests/source/issue-5157/indented_itemized_markdown_blockquote.rs
+++ b/tests/source/issue-5157/indented_itemized_markdown_blockquote.rs
@@ -1,0 +1,4 @@
+// rustfmt-wrap_comments: true
+
+///        > For each sample received, the middleware internally maintains a sample_state relative to each DataReader. The sample_state can either be READ or NOT_READ.
+fn block_quote() {}

--- a/tests/source/issue-5157/nested_itemized_markdown_blockquote.rs
+++ b/tests/source/issue-5157/nested_itemized_markdown_blockquote.rs
@@ -1,0 +1,10 @@
+// rustfmt-wrap_comments: true
+
+/// > For each sample received, the middleware internally maintains a sample_state relative to each DataReader. The sample_state can either be READ or NOT_READ.
+///
+/// > > For each sample received, the middleware internally maintains a sample_state relative to each DataReader. The sample_state can either be READ or NOT_READ.
+///
+/// > > > For each sample received, the middleware internally maintains a sample_state relative to each DataReader. The sample_state can either be READ or NOT_READ.
+///
+/// > > > > > > > > For each sample received, the middleware internally maintains a sample_state relative to each DataReader. The sample_state can either be READ or NOT_READ.
+fn block_quote() {}

--- a/tests/source/issue-5157/support_itemized_markdown_blockquote.rs
+++ b/tests/source/issue-5157/support_itemized_markdown_blockquote.rs
@@ -1,0 +1,4 @@
+// rustfmt-wrap_comments: true
+
+/// > For each sample received, the middleware internally maintains a sample_state relative to each DataReader. The sample_state can either be READ or NOT_READ.
+fn block_quote() {}

--- a/tests/target/issue-5157/indented_itemized_markdown_blockquote.rs
+++ b/tests/target/issue-5157/indented_itemized_markdown_blockquote.rs
@@ -1,0 +1,6 @@
+// rustfmt-wrap_comments: true
+
+///        > For each sample received, the middleware internally maintains a
+///        > sample_state relative to each DataReader. The sample_state can
+///        > either be READ or NOT_READ.
+fn block_quote() {}

--- a/tests/target/issue-5157/nested_itemized_markdown_blockquote.rs
+++ b/tests/target/issue-5157/nested_itemized_markdown_blockquote.rs
@@ -1,0 +1,18 @@
+// rustfmt-wrap_comments: true
+
+/// > For each sample received, the middleware internally maintains a
+/// > sample_state relative to each DataReader. The sample_state can either be
+/// > READ or NOT_READ.
+///
+/// > > For each sample received, the middleware internally maintains a
+/// > > sample_state relative to each DataReader. The sample_state can either be
+/// > > READ or NOT_READ.
+///
+/// > > > For each sample received, the middleware internally maintains a
+/// > > > sample_state relative to each DataReader. The sample_state can either
+/// > > > be READ or NOT_READ.
+///
+/// > > > > > > > > For each sample received, the middleware internally
+/// > > > > > > > > maintains a sample_state relative to each DataReader. The
+/// > > > > > > > > sample_state can either be READ or NOT_READ.
+fn block_quote() {}

--- a/tests/target/issue-5157/support_itemized_markdown_blockquote.rs
+++ b/tests/target/issue-5157/support_itemized_markdown_blockquote.rs
@@ -1,0 +1,6 @@
+// rustfmt-wrap_comments: true
+
+/// > For each sample received, the middleware internally maintains a
+/// > sample_state relative to each DataReader. The sample_state can either be
+/// > READ or NOT_READ.
+fn block_quote() {}


### PR DESCRIPTION
Fixes #5157

Doc comments support markdown, but rustfmt didn't previously assign any
semantic value to leading ``'> '`` in comments. This lead to poor formatting
when using ``wrap_comments=true``.

Now, rustfmt treats block quotes as itemized blocks, which greatly
improves how block quotes are formatted when ``wrap_comments=true``.