### PR TITLE
Fix lost import with `Crate` granularity

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -622,7 +622,7 @@ impl UseTree {
     fn merge(&mut self, other: &UseTree, merge_by: SharedPrefix) {
         let mut prefix = 0;
         for (a, b) in self.path.iter().zip(other.path.iter()) {
-            if a.equal_except_alias(b) {
+            if *a == *b {
                 prefix += 1;
             } else {
                 break;
@@ -700,7 +700,7 @@ fn merge_use_trees_inner(trees: &mut Vec<UseTree>, use_tree: UseTree, merge_by: 
                 tree.path
                     .iter()
                     .zip(&use_tree.path)
-                    .take_while(|(a, b)| a.equal_except_alias(b))
+                    .take_while(|(a, b)| *a == *b)
                     .count()
             } else {
                 0

--- a/tests/source/imports_granularity_crate.rs
+++ b/tests/source/imports_granularity_crate.rs
@@ -33,5 +33,11 @@ use h::{a};
 use i::a::{self};
 use j::{a::{self}};
 
+use a::{c as cc, c};
+
+use a::{c as c1, c as c2};
+
+use a::{c, c as c1, c as c2};
+
 use {k::{a, b}, l::{a, b}};
 use {k::{c, d}, l::{c, d}};

--- a/tests/target/imports_granularity_crate.rs
+++ b/tests/target/imports_granularity_crate.rs
@@ -24,5 +24,11 @@ use h::a;
 use i::a::{self};
 use j::a::{self};
 
+use a::{c as cc, c};
+
+use a::{c as c1, c as c2};
+
+use a::{c, c as c1, c as c2};
+
 use k::{a, b, c, d};
 use l::{a, b, c, d};

--- a/tests/target/imports_granularity_one.rs
+++ b/tests/target/imports_granularity_one.rs
@@ -10,7 +10,8 @@ use {
 };
 
 use {
-    a::{self as x, aa, ab},
+    a as x,
+    a::{aa, ab},
     b::ba,
 };
 


### PR DESCRIPTION
Currently `use a::{c as cc, c};` will be formatted to `use a::c as cc;` when `Crate` granularity is set.

The regression was introduced in https://github.com/rust-lang/rustfmt/pull/4973