### PR TITLE
Do not treat errors in reading config as fatal

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -255,10 +255,8 @@ impl Config {
             current = fs::canonicalize(current)?;
 
             loop {
-                match get_toml_path(&current) {
-                    Ok(Some(path)) => return Ok(Some(path)),
-                    Err(e) => return Err(e),
-                    _ => (),
+                if let Ok(Some(path)) = get_toml_path(&current) {
+                    return Ok(Some(path));
                 }
 
                 // If the current directory has no parent, we're done searching.
@@ -269,7 +267,7 @@ impl Config {
 
             // If nothing was found, check in the home directory.
             if let Some(home_dir) = dirs::home_dir() {
-                if let Some(path) = get_toml_path(&home_dir)? {
+                if let Ok(Some(path)) = get_toml_path(&home_dir) {
                     return Ok(Some(path));
                 }
             }
@@ -277,7 +275,7 @@ impl Config {
             // If none was found ther either, check in the user's configuration directory.
             if let Some(mut config_dir) = dirs::config_dir() {
                 config_dir.push("rustfmt");
-                if let Some(path) = get_toml_path(&config_dir)? {
+                if let Ok(Some(path)) = get_toml_path(&config_dir) {
                     return Ok(Some(path));
                 }
             }


### PR DESCRIPTION
There are cases where `rustfmt`'s call to `fs::metadata()` will fail
(due to permissions) and panic. Such cases should not be treated as
fatal.

For example, an ancestor directory or the home directory may exist but
the user may not have permissions to list the contents of the directory.

Some build systems may set `HOME` to something like
`/var/empty/`, which may not be readable/executable for the build user.
In such cases, rustfmt will fail.

Example on a Linux system where the user cannot read the home directory:

```
$ ls -ld /opt/root-only
drwx------ - root 2022-01-19 15:26 /opt/root-only/

$ HOME=/opt/root-only rustfmt --check /dev/null
Permission denied (os error 13)
```