### PR TITLE
Remove spurious line in `use_try_shorthand` example

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2757,8 +2757,6 @@ Replace uses of the try! macro by the ? shorthand
 
 ```rust
 fn main() {
-    let lorem = ipsum.map(|dolor| dolor.sit())?;
-
     let lorem = try!(ipsum.map(|dolor| dolor.sit()));
 }
 ```


### PR DESCRIPTION
The `use_try_shorthand` documentation included a line that was seemingly spurious.

The line     `let lorem = ipsum.map(|dolor| dolor.sit())?;` is the shorthand version which should not be part of the example illustrating the behavior when the `use_try_shorthand` option is off.

