### PR TITLE
Fix incorrect string indentation in macro defs with `format_strings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes issue where wrapped strings would be incorrectly indented in macro defs when `format_strings` was enabled [#4036](https://github.com/rust-lang/rustfmt/issues/4036)
+
 ## [1.4.38] 2021-10-20
 
 ### Changed

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -646,9 +646,22 @@ pub(crate) fn trim_left_preserve_layout(
 }
 
 /// Based on the given line, determine if the next line can be indented or not.
-/// This allows to preserve the indentation of multi-line literals.
-pub(crate) fn indent_next_line(kind: FullCodeCharKind, _line: &str, config: &Config) -> bool {
-    !(kind.is_string() || (config.version() == Version::Two && kind.is_commented_string()))
+/// This allows to preserve the indentation of multi-line literals when
+/// re-inserted a code block that has been formatted separately from the rest
+/// of the code, such as code in macro defs or code blocks doc comments.
+pub(crate) fn indent_next_line(kind: FullCodeCharKind, line: &str, config: &Config) -> bool {
+    if kind.is_string() {
+        // If the string ends with '\', the string has been wrapped over
+        // multiple lines. If `format_strings = true`, then the indentation of
+        // strings wrapped over multiple lines will have been adjusted while
+        // formatting the code block, therefore the string's indentation needs
+        // to be adjusted for the code surrounding the code block.
+        config.format_strings() && line.ends_with('\\')
+    } else if config.version() == Version::Two {
+        !kind.is_commented_string()
+    } else {
+        true
+    }
 }
 
 pub(crate) fn is_empty_line(s: &str) -> bool {

--- a/tests/source/issue-4036/one.rs
+++ b/tests/source/issue-4036/one.rs
@@ -1,0 +1,11 @@
+// rustfmt-format_strings: true
+
+macro_rules! test {
+    () => {
+        fn from() {
+            None.expect(
+                "We asserted that `buffer.len()` is exactly `$n` so we can expect `ApInt::from_iter` to be successful.",
+            )
+        }
+    };
+}

--- a/tests/source/issue-4036/three.rs
+++ b/tests/source/issue-4036/three.rs
@@ -1,0 +1,12 @@
+// rustfmt-format_strings: true
+// rustfmt-hard_tabs: true
+
+macro_rules! test {
+    () => {
+        fn from() {
+            None.expect(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            )
+        }
+    };
+}

--- a/tests/source/issue-4036/two.rs
+++ b/tests/source/issue-4036/two.rs
@@ -1,0 +1,11 @@
+// rustfmt-format_strings: true
+
+macro_rules! test {
+    () => {
+        fn from() {
+            None.expect(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            )
+        }
+    };
+}

--- a/tests/target/issue-4036/one.rs
+++ b/tests/target/issue-4036/one.rs
@@ -1,0 +1,12 @@
+// rustfmt-format_strings: true
+
+macro_rules! test {
+    () => {
+        fn from() {
+            None.expect(
+                "We asserted that `buffer.len()` is exactly `$n` so we can expect \
+                 `ApInt::from_iter` to be successful.",
+            )
+        }
+    };
+}

--- a/tests/target/issue-4036/three.rs
+++ b/tests/target/issue-4036/three.rs
@@ -1,0 +1,17 @@
+// rustfmt-format_strings: true
+// rustfmt-hard_tabs: true
+
+macro_rules! test {
+	() => {
+		fn from() {
+			None.expect(
+				"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor \
+				 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis \
+				 nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \
+				 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu \
+				 fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in \
+				 culpa qui officia deserunt mollit anim id est laborum.",
+			)
+		}
+	};
+}

--- a/tests/target/issue-4036/two.rs
+++ b/tests/target/issue-4036/two.rs
@@ -1,0 +1,16 @@
+// rustfmt-format_strings: true
+
+macro_rules! test {
+    () => {
+        fn from() {
+            None.expect(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor \
+                 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis \
+                 nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \
+                 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu \
+                 fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in \
+                 culpa qui officia deserunt mollit anim id est laborum.",
+            )
+        }
+    };
+}


### PR DESCRIPTION
Fixes #4036