### PR TITLE
fallback to dir_path when relative external mod resolution fails

### DIFF
--- a/src/test/mod_resolver.rs
+++ b/src/test/mod_resolver.rs
@@ -64,3 +64,19 @@ fn fmt_out_of_line_test_modules() {
         ],
     )
 }
+
+#[test]
+fn fallback_and_try_to_resolve_external_submod_relative_to_current_dir_path() {
+    // See also https://github.com/rust-lang/rustfmt/issues/5198
+    verify_mod_resolution(
+        "tests/mod-resolver/issue-5198/lib.rs",
+        &[
+            "tests/mod-resolver/issue-5198/a.rs",
+            "tests/mod-resolver/issue-5198/lib/b.rs",
+            "tests/mod-resolver/issue-5198/lib/c/mod.rs",
+            "tests/mod-resolver/issue-5198/lib/c/e.rs",
+            "tests/mod-resolver/issue-5198/lib/c/d/f.rs",
+            "tests/mod-resolver/issue-5198/lib/c/d/g/mod.rs",
+        ],
+    )
+}

--- a/tests/mod-resolver/issue-5198/a.rs
+++ b/tests/mod-resolver/issue-5198/a.rs
@@ -1,0 +1,1 @@
+fn main(        ) {   println!("Hello World!")                         }

--- a/tests/mod-resolver/issue-5198/lib.rs
+++ b/tests/mod-resolver/issue-5198/lib.rs
@@ -1,0 +1,3 @@
+mod a;
+mod b;
+mod c;

--- a/tests/mod-resolver/issue-5198/lib/b.rs
+++ b/tests/mod-resolver/issue-5198/lib/b.rs
@@ -1,0 +1,1 @@
+fn main(        ) {   println!("Hello World!")                         }

--- a/tests/mod-resolver/issue-5198/lib/c/d.rs
+++ b/tests/mod-resolver/issue-5198/lib/c/d.rs
@@ -1,0 +1,3 @@
+mod e;
+mod f;
+mod g;

--- a/tests/mod-resolver/issue-5198/lib/c/d/explanation.txt
+++ b/tests/mod-resolver/issue-5198/lib/c/d/explanation.txt
@@ -1,0 +1,16 @@
+This file is contained in the './lib/c/d/' directory.
+
+The directory name './lib/c/d/' conflicts with the './lib/c/d.rs' file name.
+
+'./lib/c/d.rs' defines 3 external modules:
+
+    * mod e;
+    * mod f;
+    * mod g;
+
+Module resolution will fail if we look for './lib/c/d/e.rs' or './lib/c/d/e/mod.rs',
+so we should fall back to looking for './lib/c/e.rs', which correctly finds the modlue, that
+rustfmt should format.
+
+'./lib/c/d/f.rs' and './lib/c/d/g/mod.rs' exist at the default submodule paths so we should be able
+to resolve these modules with no problems.

--- a/tests/mod-resolver/issue-5198/lib/c/d/f.rs
+++ b/tests/mod-resolver/issue-5198/lib/c/d/f.rs
@@ -1,0 +1,1 @@
+fn main(        ) {   println!("Hello World!")                         }

--- a/tests/mod-resolver/issue-5198/lib/c/d/g/mod.rs
+++ b/tests/mod-resolver/issue-5198/lib/c/d/g/mod.rs
@@ -1,0 +1,1 @@
+fn main(        ) {   println!("Hello World!")                         }

--- a/tests/mod-resolver/issue-5198/lib/c/e.rs
+++ b/tests/mod-resolver/issue-5198/lib/c/e.rs
@@ -1,0 +1,1 @@
+fn main(        ) {   println!("Hello World!")                         }

--- a/tests/mod-resolver/issue-5198/lib/c/mod.rs
+++ b/tests/mod-resolver/issue-5198/lib/c/mod.rs
@@ -1,0 +1,3 @@
+mod d;
+
+fn main(        ) {   println!("Hello World!")                         }

--- a/tests/mod-resolver/issue-5198/lib/explanation.txt
+++ b/tests/mod-resolver/issue-5198/lib/explanation.txt
@@ -1,0 +1,16 @@
+This file is contained in the './lib' directory.
+
+The directory name './lib' conflicts with the './lib.rs' file name.
+
+'lib.rs' defines 3 external modules:
+
+    * mod a;
+    * mod b;
+    * mod c;
+
+Module resolution will fail if we look for './lib/a.rs' or './lib/a/mod.rs',
+so we should fall back to looking for './a.rs', which correctly finds the modlue that
+rustfmt should format.
+
+'./lib/b.rs' and './lib/c/mod.rs' exist at the default submodule paths so we should be able
+to resolve these modules with no problems.


### PR DESCRIPTION
We only want to fall back if two conditions are met:

1) Initial module resolution is performed relative to some nested directory.
2) Module resolution fails because of a ``ModError::FileNotFound`` error.

When these conditions are met we can try to fallback to searching for the module's file relative to the ``dir_path`` instead of the nested relative directory.

Fixes #5198

As demonstrated by 5198, it's possible that a directory name conflicts with a rust file name. For example, ``src/lib/`` and ``src/lib.rs``.

If ``src/lib.rs`` references an external module like ``mod foo;``, then module resolution will try to resolve ``foo`` to ``src/lib/foo.rs`` or ``src/lib/foo/mod.rs``. Module resolution would fail with a file not found error if the ``foo`` module were defined at ``src/foo.rs``.

When encountering these kinds of module resolution issues we now fall back to the current directory and attempt to resolve the module again.

Given the current example, this means that if we can't find the module ``foo`` at ``src/lib/foo.rs`` or ``src/lib/foo/mod.rs``, we'll attempt to resolve the module to ``src/foo.rs``.