### PR TITLE
Add context to get_toml_path() error

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -26,7 +26,7 @@ fn main() {
     let exit_code = match execute(&opts) {
         Ok(code) => code,
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("{:#}", e);
             1
         }
     };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -364,7 +364,9 @@ fn get_toml_path(dir: &Path) -> Result<Option<PathBuf>, Error> {
             // find the project file yet, and continue searching.
             Err(e) => {
                 if e.kind() != ErrorKind::NotFound {
-                    return Err(e);
+                    let ctx = format!("Failed to get metadata for config file {:?}", &config_file);
+                    let err = anyhow::Error::new(e).context(ctx);
+                    return Err(Error::new(ErrorKind::Other, err));
                 }
             }
             _ => {}


### PR DESCRIPTION
Handles #5188 

## Before Change
```
$ cargo b --bin rustfmt && HOME=/root ./target/debug/rustfmt --check /dev/null
Permission denied (os error 13)
```

## After Change
```
$ cargo b --bin rustfmt && HOME=/root ./target/debug/rustfmt --check /dev/null
Failed to get metadata for config file "/root/.rustfmt.toml": Permission denied (os error 13)
```