### PR TITLE
chore(rustfmt): remove executable path from usage string

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -394,9 +394,8 @@ fn print_usage_to_stdout(opts: &Options, reason: &str) {
         format!("{}\n\n", reason)
     };
     let msg = format!(
-        "{}Format Rust code\n\nusage: {} [options] <file>...",
-        sep,
-        env::args_os().next().unwrap().to_string_lossy()
+        "{}Format Rust code\n\nusage: rustfmt [options] <file>...",
+        sep
     );
     println!("{}", opts.usage(&msg));
 }

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -108,11 +108,10 @@ fn inline_config() {
 }
 
 #[test]
-fn rustfmt_help() {
+fn rustfmt_usage_text() {
     let args = [
         "--help",
     ];
     let (stdout, _) = rustfmt(&args);
-    assert!(stdout.contains(&format!("Format Rust code")));
-    assert!(stdout.contains(&format!("usage: rustfmt [options] <file>...")));
+    assert!(stdout.contains(&format!("Format Rust code\n\nusage: rustfmt [options] <file>...")));
 }

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -106,3 +106,13 @@ fn inline_config() {
             && contains("format_strings = true")
     );
 }
+
+#[test]
+fn rustfmt_help() {
+    let args = [
+        "--help",
+    ];
+    let (stdout, _) = rustfmt(&args);
+    assert!(stdout.contains(&format!("Format Rust code")));
+    assert!(stdout.contains(&format!("usage: rustfmt [options] <file>...")));
+}


### PR DESCRIPTION
This PR removes the `rustfmt` executable path from usage string.

Fixes #5214 