### PR TITLE
fix formatting in new test

### DIFF
--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -109,9 +109,7 @@ fn inline_config() {
 
 #[test]
 fn rustfmt_usage_text() {
-    let args = [
-        "--help",
-    ];
+    let args = ["--help"];
     let (stdout, _) = rustfmt(&args);
-    assert!(stdout.contains(&format!("Format Rust code\n\nusage: rustfmt [options] <file>...")));
+    assert!(stdout.contains("Format Rust code\n\nusage: rustfmt [options] <file>..."));
 }


### PR DESCRIPTION
Minor fallout from #5216 being merged prior to #5212, since the former included a test function that wasn't properly formatted but also wasn't part of the self tests until the latter was introduced