### PR TITLE
`rustfmt`: Use `edition` form `Cargo.toml` rather than always `2015` (DO NOT MERGE)

### DIFF
--- a/src/git-rustfmt/main.rs
+++ b/src/git-rustfmt/main.rs
@@ -57,7 +57,7 @@ fn get_files(input: &str) -> Vec<&str> {
 }
 
 fn fmt_files(files: &[&str]) -> i32 {
-    let (config, _) =
+    let (config, _, _) =
         load_config::<NullOptions>(Some(Path::new(".")), None).expect("couldn't load config");
 
     let mut exit_code = 0;

--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -42,8 +42,12 @@ mod test {
     #[nightly_only_test]
     #[test]
     fn test_ignore_path_set() {
-        let config =
-            Config::from_toml(r#"ignore = ["foo.rs", "bar_dir/*"]"#, Path::new("")).unwrap();
+        let config = Config::from_toml(
+            Some(r#"ignore = ["foo.rs", "bar_dir/*"]"#),
+            Some(Path::new("")),
+            None,
+        )
+        .unwrap();
         let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
 
         assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/foo.rs"))));

--- a/src/parse/session.rs
+++ b/src/parse/session.rs
@@ -344,7 +344,9 @@ mod tests {
         }
 
         fn get_ignore_list(config: &str) -> IgnoreList {
-            Config::from_toml(config, Path::new("")).unwrap().ignore()
+            Config::from_toml(Some(config), Some(Path::new("")), None)
+                .unwrap()
+                .ignore()
         }
 
         #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -694,7 +694,7 @@ fn idempotent_check(
 ) -> Result<FormatReport, IdempotentCheckError> {
     let sig_comments = read_significant_comments(filename);
     let config = if let Some(ref config_file_path) = opt_config {
-        Config::from_toml_path(config_file_path).expect("`rustfmt.toml` not found")
+        Config::from_toml_path(Some(config_file_path), None).expect("`rustfmt.toml` not found")
     } else {
         read_config(filename)
     };
@@ -737,7 +737,8 @@ fn get_config(config_file: Option<&Path>) -> Config {
         .read_to_string(&mut def_config)
         .expect("Couldn't read config");
 
-    Config::from_toml(&def_config, Path::new("tests/config/")).expect("invalid TOML")
+    Config::from_toml(Some(&def_config), Some(Path::new("tests/config/")), None)
+        .expect("invalid TOML")
 }
 
 // Reads significant comments of the form: `// rustfmt-key: value` into a hash map.


### PR DESCRIPTION
This patch shows an example solution to #4074, where `rustfmt` will fetch the `edition` from the source of truth: `Cargo.toml`. This is meant as a point of discussion rather than a serious fix.

For example, this allows `rustfmt` to be run against files in the `rust-lang/rustfmt` repository itself and automatically detect the correct edition of `2018` as configured in `Cargo.toml`, rather than using the incorrect default of `2015` like it does today.

From discussion in #4074, it sounds like the current preference is to not have `rustfmt` be the user-facing tool for formatting individual files and to instead have a different command for that? But in the meantime this provides a reference for one way that it could be done.

Note that if this were a serious PR I would also have written tests for the change, including the missing tests for the current scan for `rustfmt.toml`, but again this is just meant to be an example to show how the lookup logic could work and per discussion it isn't expected to be accepted.

As of this patch, the `edition` selection order is as follows:
1. `--edition` provided as an argument
2. `edition` from any `rustfmt.toml` in the directory tree or on the host system (IMO this should be deprecated)
3. `package.edition` from `Cargo.toml` in the directory tree (NEW)
4. `2015`