### PR TITLE
fix unused test imports on non-nightly, prevent regression

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,6 +40,10 @@ jobs:
         rustc -Vv
         cargo -V
         cargo build
+      env:
+        RUSTFLAGS: '-D warnings'
 
     - name: test
       run: cargo test
+      env:
+        RUSTFLAGS: '-D warnings'

--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -32,16 +32,15 @@ impl IgnorePathSet {
 
 #[cfg(test)]
 mod test {
-    use std::path::{Path, PathBuf};
-
-    use crate::config::{Config, FileName};
-    use crate::ignore_path::IgnorePathSet;
-
     use rustfmt_config_proc_macro::nightly_only_test;
 
     #[nightly_only_test]
     #[test]
     fn test_ignore_path_set() {
+        use crate::config::{Config, FileName};
+        use crate::ignore_path::IgnorePathSet;
+        use std::path::{Path, PathBuf};
+
         let config =
             Config::from_toml(r#"ignore = ["foo.rs", "bar_dir/*"]"#, Path::new("")).unwrap();
         let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![warn(unreachable_pub)]
 #![recursion_limit = "256"]
 #![allow(clippy::match_like_matches_macro)]
-#![allow(unreachable_pub)]
 
 #[macro_use]
 extern crate derive_new;


### PR DESCRIPTION
Our CI has been silently generating warnings about unused imports on the one matrix leg where we trick it into thinking it's running on stable. That was happening because we had imports at the test mod level which were used by the single, nightly-only test contained within that mod.

This caused a bit of a hiccup on the beta build, so both fixing the underlying issue and adding CI checks so that it won't happen again