### PR TITLE
Replace `structopt` dependency by `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,15 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +37,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -110,17 +107,32 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -250,13 +262,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -292,6 +307,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,9 +339,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "libm"
@@ -344,6 +369,15 @@ name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "packed_simd_2"
@@ -381,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -457,6 +491,7 @@ dependencies = [
  "anyhow",
  "bytecount",
  "cargo_metadata",
+ "clap",
  "derive-new",
  "diff",
  "dirs",
@@ -471,7 +506,6 @@ dependencies = [
  "rustfmt-config_proc_macro",
  "serde",
  "serde_json",
- "structopt",
  "term",
  "thiserror",
  "toml",
@@ -543,39 +577,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -604,12 +614,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -672,12 +679,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0"
 bytecount = "0.6"
 cargo_metadata = "0.14"
+clap = { version = "3.1", features = ["derive"] }
 derive-new = "0.5"
 diff = "0.1"
 dirs = "4.0"
@@ -49,7 +50,6 @@ log = "0.4"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-structopt = "0.3"
 term = "0.7"
 thiserror = "1.0"
 toml = "0.5"

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -15,54 +15,59 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 
-use structopt::StructOpt;
+use clap::{CommandFactory, Parser};
 
 #[path = "test/mod.rs"]
 #[cfg(test)]
 mod cargo_fmt_tests;
 
-#[derive(StructOpt, Debug)]
-#[structopt(
+#[derive(Parser)]
+#[clap(
     bin_name = "cargo fmt",
     about = "This utility formats all bin and lib files of \
              the current crate using rustfmt."
 )]
 pub struct Opts {
     /// No output printed to stdout
-    #[structopt(short = "q", long = "quiet")]
+    #[clap(short = 'q', long = "quiet")]
     quiet: bool,
 
     /// Use verbose output
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short = 'v', long = "verbose")]
     verbose: bool,
 
     /// Print rustfmt version and exit
-    #[structopt(long = "version")]
+    #[clap(long = "version")]
     version: bool,
 
     /// Specify package to format
-    #[structopt(short = "p", long = "package", value_name = "package")]
+    #[clap(
+        short = 'p',
+        long = "package",
+        value_name = "package",
+        multiple_values = true
+    )]
     packages: Vec<String>,
 
     /// Specify path to Cargo.toml
-    #[structopt(long = "manifest-path", value_name = "manifest-path")]
+    #[clap(long = "manifest-path", value_name = "manifest-path")]
     manifest_path: Option<String>,
 
     /// Specify message-format: short|json|human
-    #[structopt(long = "message-format", value_name = "message-format")]
+    #[clap(long = "message-format", value_name = "message-format")]
     message_format: Option<String>,
 
     /// Options passed to rustfmt
     // 'raw = true' to make `--` explicit.
-    #[structopt(name = "rustfmt_options", raw(true))]
+    #[clap(name = "rustfmt_options", raw(true))]
     rustfmt_options: Vec<String>,
 
     /// Format all packages, and also their local path-based dependencies
-    #[structopt(long = "all")]
+    #[clap(long = "all")]
     format_all: bool,
 
     /// Run rustfmt in check mode
-    #[structopt(long = "check")]
+    #[clap(long = "check")]
     check: bool,
 }
 
@@ -87,7 +92,7 @@ fn execute() -> i32 {
         }
     });
 
-    let opts = Opts::from_iter(args);
+    let opts = Opts::parse_from(args);
 
     let verbosity = match (opts.verbose, opts.quiet) {
         (false, false) => Verbosity::Normal,
@@ -204,7 +209,7 @@ fn convert_message_format_to_rustfmt_args(
 
 fn print_usage_to_stderr(reason: &str) {
     eprintln!("{}", reason);
-    let app = Opts::clap();
+    let app = Opts::command();
     app.after_help("")
         .write_help(&mut io::stderr())
         .expect("failed to write to stderr");

--- a/src/cargo-fmt/test/mod.rs
+++ b/src/cargo-fmt/test/mod.rs
@@ -6,7 +6,7 @@ mod targets;
 #[test]
 fn default_options() {
     let empty: Vec<String> = vec![];
-    let o = Opts::from_iter(&empty);
+    let o = Opts::parse_from(&empty);
     assert_eq!(false, o.quiet);
     assert_eq!(false, o.verbose);
     assert_eq!(false, o.version);
@@ -20,7 +20,7 @@ fn default_options() {
 
 #[test]
 fn good_options() {
-    let o = Opts::from_iter(&[
+    let o = Opts::parse_from(&[
         "test",
         "-q",
         "-p",
@@ -47,8 +47,8 @@ fn good_options() {
 #[test]
 fn unexpected_option() {
     assert!(
-        Opts::clap()
-            .get_matches_from_safe(&["test", "unexpected"])
+        Opts::command()
+            .try_get_matches_from(&["test", "unexpected"])
             .is_err()
     );
 }
@@ -56,8 +56,8 @@ fn unexpected_option() {
 #[test]
 fn unexpected_flag() {
     assert!(
-        Opts::clap()
-            .get_matches_from_safe(&["test", "--flag"])
+        Opts::command()
+            .try_get_matches_from(&["test", "--flag"])
             .is_err()
     );
 }
@@ -65,20 +65,20 @@ fn unexpected_flag() {
 #[test]
 fn mandatory_separator() {
     assert!(
-        Opts::clap()
-            .get_matches_from_safe(&["test", "--emit"])
+        Opts::command()
+            .try_get_matches_from(&["test", "--emit"])
             .is_err()
     );
     assert!(
-        !Opts::clap()
-            .get_matches_from_safe(&["test", "--", "--emit"])
+        !Opts::command()
+            .try_get_matches_from(&["test", "--", "--emit"])
             .is_err()
     );
 }
 
 #[test]
 fn multiple_packages_one_by_one() {
-    let o = Opts::from_iter(&[
+    let o = Opts::parse_from(&[
         "test",
         "-p",
         "package1",
@@ -92,7 +92,7 @@ fn multiple_packages_one_by_one() {
 
 #[test]
 fn multiple_packages_grouped() {
-    let o = Opts::from_iter(&[
+    let o = Opts::parse_from(&[
         "test",
         "--package",
         "package1",
@@ -106,14 +106,18 @@ fn multiple_packages_grouped() {
 
 #[test]
 fn empty_packages_1() {
-    assert!(Opts::clap().get_matches_from_safe(&["test", "-p"]).is_err());
+    assert!(
+        Opts::command()
+            .try_get_matches_from(&["test", "-p"])
+            .is_err()
+    );
 }
 
 #[test]
 fn empty_packages_2() {
     assert!(
-        Opts::clap()
-            .get_matches_from_safe(&["test", "-p", "--", "--check"])
+        Opts::command()
+            .try_get_matches_from(&["test", "-p", "--", "--check"])
             .is_err()
     );
 }
@@ -121,8 +125,8 @@ fn empty_packages_2() {
 #[test]
 fn empty_packages_3() {
     assert!(
-        Opts::clap()
-            .get_matches_from_safe(&["test", "-p", "--verbose"])
+        Opts::command()
+            .try_get_matches_from(&["test", "-p", "--verbose"])
             .is_err()
     );
 }
@@ -130,8 +134,8 @@ fn empty_packages_3() {
 #[test]
 fn empty_packages_4() {
     assert!(
-        Opts::clap()
-            .get_matches_from_safe(&["test", "-p", "--check"])
+        Opts::command()
+            .try_get_matches_from(&["test", "-p", "--check"])
             .is_err()
     );
 }


### PR DESCRIPTION
StructOpt features have been integrated into clap v3, and it is now in maintenance mode.
The maintainer recommends migrating away from it: https://github.com/TeXitoi/structopt/issues/525

This touches argument parsing for `cargo fmt`. The behavior was kept the same.

There are visual differences in the `cargo fmt --help` output.

`cargo fmt --help` before:
```
This utility formats all bin and lib files of the current crate using rustfmt.

USAGE:
    cargo fmt [FLAGS] [OPTIONS] [-- <rustfmt_options>...]

FLAGS:
        --check      Run rustfmt in check mode
        --all        Format all packages, and also their local path-based dependencies
    -h, --help       Prints help information
    -q, --quiet      No output printed to stdout
    -v, --verbose    Use verbose output
        --version    Print rustfmt version and exit

OPTIONS:
        --manifest-path <manifest-path>      Specify path to Cargo.toml
        --message-format <message-format>    Specify message-format: short|json|human
    -p, --package <package>...               Specify package to format

ARGS:
    <rustfmt_options>...    Options passed to rustfmt
```


`cargo fmt --help` after:
```
This utility formats all bin and lib files of the current crate using rustfmt.

USAGE:
    cargo fmt [OPTIONS] [-- <rustfmt_options>...]

ARGS:
    <rustfmt_options>...    Options passed to rustfmt

OPTIONS:
        --all
            Format all packages, and also their local path-based dependencies

        --check
            Run rustfmt in check mode

    -h, --help
            Print help information

        --manifest-path <manifest-path>
            Specify path to Cargo.toml

        --message-format <message-format>
            Specify message-format: short|json|human

    -p, --package <package>...
            Specify package to format

    -q, --quiet
            No output printed to stdout

    -v, --verbose
            Use verbose output

        --version
            Print rustfmt version and exit
```