### PR TITLE
Prevent wrapping markdown headers in doc comments

### DIFF
--- a/tests/source/issue-5238/markdown_header_wrap_comments_false.rs
+++ b/tests/source/issue-5238/markdown_header_wrap_comments_false.rs
@@ -1,0 +1,11 @@
+// rustfmt-wrap_comments: false
+
+/// no markdown header so rustfmt should wrap this comment when `format_code_in_doc_comments = true` and `wrap_comments = true`
+fn not_documented_with_markdown_header() {
+    // This is just a normal inline comment so rustfmt should wrap this comment when `wrap_comments = true`
+}
+
+/// # We're using a markdown header here so rustfmt should refuse to wrap this comment in all circumstances
+fn documented_with_markdown_header() {
+    // # We're using a markdown header in an inline comment. rustfmt should be able to wrap this comment when `wrap_comments = true`
+}

--- a/tests/source/issue-5238/markdown_header_wrap_comments_true.rs
+++ b/tests/source/issue-5238/markdown_header_wrap_comments_true.rs
@@ -1,0 +1,11 @@
+// rustfmt-wrap_comments: true
+
+/// no markdown header so rustfmt should wrap this comment when `format_code_in_doc_comments = true` and `wrap_comments = true`
+fn not_documented_with_markdown_header() {
+    // This is just a normal inline comment so rustfmt should wrap this comment when `wrap_comments = true`
+}
+
+/// # We're using a markdown header here so rustfmt should refuse to wrap this comment in all circumstances
+fn documented_with_markdown_header() {
+    // # We're using a markdown header in an inline comment. rustfmt should be able to wrap this comment when `wrap_comments = true`
+}

--- a/tests/target/issue-5238/markdown_header_wrap_comments_false.rs
+++ b/tests/target/issue-5238/markdown_header_wrap_comments_false.rs
@@ -1,0 +1,11 @@
+// rustfmt-wrap_comments: false
+
+/// no markdown header so rustfmt should wrap this comment when `format_code_in_doc_comments = true` and `wrap_comments = true`
+fn not_documented_with_markdown_header() {
+    // This is just a normal inline comment so rustfmt should wrap this comment when `wrap_comments = true`
+}
+
+/// # We're using a markdown header here so rustfmt should refuse to wrap this comment in all circumstances
+fn documented_with_markdown_header() {
+    // # We're using a markdown header in an inline comment. rustfmt should be able to wrap this comment when `wrap_comments = true`
+}

--- a/tests/target/issue-5238/markdown_header_wrap_comments_true.rs
+++ b/tests/target/issue-5238/markdown_header_wrap_comments_true.rs
@@ -1,0 +1,14 @@
+// rustfmt-wrap_comments: true
+
+/// no markdown header so rustfmt should wrap this comment when
+/// `format_code_in_doc_comments = true` and `wrap_comments = true`
+fn not_documented_with_markdown_header() {
+    // This is just a normal inline comment so rustfmt should wrap this comment
+    // when `wrap_comments = true`
+}
+
+/// # We're using a markdown header here so rustfmt should refuse to wrap this comment in all circumstances
+fn documented_with_markdown_header() {
+    // # We're using a markdown header in an inline comment. rustfmt should be
+    // able to wrap this comment when `wrap_comments = true`
+}


### PR DESCRIPTION
Fixes #5238

A markdown header is defined by a string that starts with `#`.

Previously, rustfmt would wrap long markdown headers when
`wrap_comments=true`. This lead to issues when rendering these headers
in HTML using rustdoc.

Now, rustfmt leaves markdown headers alone when wrapping comments.