### PR TITLE
group_imports: test and document non-consecutive imports

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2061,11 +2061,15 @@ use sit;
 
 ## `group_imports`
 
-Controls the strategy for how imports are grouped together.
+Controls the strategy for how consecutive imports are grouped together.
+
+Controls the strategy for grouping sets of consecutive imports. Imports may contain newlines between imports and still be grouped together as a single set, but other statements between imports will result in different grouping sets.
 
 - **Default value**: `Preserve`
 - **Possible values**: `Preserve`, `StdExternalCrate`, `One`
 - **Stable**: No (tracking issue: [#5083](https://github.com/rust-lang/rustfmt/issues/5083))
+
+Each set of imports (one or more `use` statements, optionally separated by newlines) will be formatted independently. Other statements such as `mod ...` or `extern crate ...` will cause imports to not be grouped together.
 
 #### `Preserve` (default):
 

--- a/tests/source/configs/group_imports/StdExternalCrate-non_consecutive.rs
+++ b/tests/source/configs/group_imports/StdExternalCrate-non_consecutive.rs
@@ -1,0 +1,27 @@
+// rustfmt-group_imports: StdExternalCrate
+use chrono::Utc;
+use super::update::convert_publish_payload;
+
+
+
+
+
+use juniper::{FieldError, FieldResult};
+
+use uuid::Uuid;
+use alloc::alloc::Layout;
+
+extern crate uuid;
+
+
+
+
+
+use std::sync::Arc;
+
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/target/configs/group_imports/StdExternalCrate-non_consecutive.rs
+++ b/tests/target/configs/group_imports/StdExternalCrate-non_consecutive.rs
@@ -1,0 +1,18 @@
+// rustfmt-group_imports: StdExternalCrate
+use alloc::alloc::Layout;
+
+use chrono::Utc;
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+
+use super::update::convert_publish_payload;
+
+extern crate uuid;
+
+use core::f32;
+use std::sync::Arc;
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use crate::models::Event;


### PR DESCRIPTION
Closes #4767

Clarifies the documented configuration options for `group_imports`, to make clear how non-consecutive imports are handled (they aren't).

This was raised in #4767 as a potential bug, so updating docs and tests to make clear it is expected behaviour.