### PR TITLE
Fixes #5260

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -796,7 +796,7 @@ impl<'a> CommentRewrite<'a> {
         // 1) wrap_comments = true is configured
         // 2) The comment is not the start of a markdown header doc comment
         // 3) The comment width exceeds the shape's width
-        // 4) No URLS were found in the commnet
+        // 4) No URLS were found in the comment
         let should_wrap_comment = self.fmt.config.wrap_comments()
             && !is_markdown_header_doc_comment
             && unicode_str_width(line) > self.fmt.shape.width

--- a/tests/source/issue-5260.rs
+++ b/tests/source/issue-5260.rs
@@ -1,0 +1,14 @@
+// rustfmt-wrap_comments: true
+
+/// [MyType](VeryLongPathToMyType::NoLineBreak::Here::Okay::ThatWouldBeNice::Thanks)
+fn documented_with_longtype() {
+    // # We're using a long type link, rustfmt should not break line
+    // on the type when `wrap_comments = true`
+}
+
+/// VeryLongPathToMyType::JustMyType::But::VeryVery::Long::NoLineBreak::Here::Okay::ThatWouldBeNice::Thanks
+fn documented_with_verylongtype() {
+    // # We're using a long type link, rustfmt should not break line
+    // on the type when `wrap_comments = true`
+}
+

--- a/tests/target/issue-5260.rs
+++ b/tests/target/issue-5260.rs
@@ -1,0 +1,13 @@
+// rustfmt-wrap_comments: true
+
+/// [MyType](VeryLongPathToMyType::NoLineBreak::Here::Okay::ThatWouldBeNice::Thanks)
+fn documented_with_longtype() {
+    // # We're using a long type link, rustfmt should not break line
+    // on the type when `wrap_comments = true`
+}
+
+/// VeryLongPathToMyType::JustMyType::But::VeryVery::Long::NoLineBreak::Here::Okay::ThatWouldBeNice::Thanks
+fn documented_with_verylongtype() {
+    // # We're using a long type link, rustfmt should not break line
+    // on the type when `wrap_comments = true`
+}


### PR DESCRIPTION
Fixes #5260 by checking if it is part of a type '::'
Add possibility to run single test e.g. `TEST_FILE=5250 cargo test system` to run test files containing 5250
