### PR TITLE
Fix and verify tracking issue links

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2206,7 +2206,7 @@ Don't reformat out of line modules
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
-- **Stable**: No (tracking issue: [#3389](https://github.com/rust-lang/rustfmt/issues/3386))
+- **Stable**: No (tracking issue: [#3389](https://github.com/rust-lang/rustfmt/issues/3389))
 
 ## `single_line_if_else_max_width`
 

--- a/src/test/configuration_snippet.rs
+++ b/src/test/configuration_snippet.rs
@@ -290,3 +290,33 @@ fn get_code_blocks() -> Vec<ConfigCodeBlock> {
 
     code_blocks
 }
+
+#[test]
+fn check_unstable_option_tracking_issue_numbers() {
+    // Ensure that tracking issue links point to the correct issue number
+    let tracking_issue =
+        regex::Regex::new(r"\(tracking issue: \[#(?P<number>\d+)\]\((?P<link>\S+)\)\)")
+            .expect("failed creating configuration pattern");
+
+    let lines = BufReader::new(
+        fs::File::open(Path::new(CONFIGURATIONS_FILE_NAME))
+            .unwrap_or_else(|_| panic!("couldn't read file {}", CONFIGURATIONS_FILE_NAME)),
+    )
+    .lines()
+    .map(Result::unwrap)
+    .enumerate();
+
+    for (idx, line) in lines {
+        if let Some(capture) = tracking_issue.captures(&line) {
+            let number = capture.name("number").unwrap().as_str();
+            let link = capture.name("link").unwrap().as_str();
+            assert!(
+                link.ends_with(number),
+                "{} on line {} does not point to issue #{}",
+                link,
+                idx + 1,
+                number,
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR makes two changes:
* Fixes the tracking issue link for `skip_children` to point to the correct tracking issue
* Adds a new test to ensure tracking links match the displayed reference number. 