### PR TITLE
Add unstable option `self_shorthand`

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2204,6 +2204,44 @@ specific version of rustfmt is used in your CI, use this option.
 - **Possible values**: any published version (e.g. `"0.3.8"`)
 - **Stable**: No (tracking issue: [#3386](https://github.com/rust-lang/rustfmt/issues/3386))
 
+## `self_shorthand`
+
+Convert explicit `self: Self` to `self` in method definitions.
+If the `ty` is something that dereferences to `Self` e.g. `Box<Self>`,
+then the `ty` is left unchanged to preserve the semantics of the code.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: No (tracking issue: [N/A]())
+
+#### `false` (default):
+
+```rust
+struct Foo;
+
+impl Foo {
+    fn by_value(self: Self) {}
+    fn by_ref(self: &Self) {}
+    fn by_ref_mut(self: &mut Self) {}
+    fn with_lifetime<'a>(self: &'a Self) {}
+    fn by_box(self: Box<Self>) {}
+}
+```
+
+#### `true`:
+
+```rust
+struct Foo;
+
+impl Foo {
+    fn by_value(self) {}
+    fn by_ref(&self) {}
+    fn by_ref_mut(&mut self) {}
+    fn with_lifetime<'a>(&'a self) {}
+    fn by_box(self: Box<Self>) {}
+}
+```
+
 ## `short_array_element_width_threshold`
 
 The width threshold for an array element to be considered "short".

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -149,6 +149,8 @@ create_config! {
     force_explicit_abi: bool, true, true, "Always print the abi for extern items";
     condense_wildcard_suffixes: bool, false, false, "Replace strings of _ wildcards by a single .. \
                                                      in tuple patterns";
+    self_shorthand: bool, false, false,
+        "Convert explicit `self: Self` to `self` in method definitions";
 
     // Control options (changes the operation of rustfmt, rather than the formatting)
     color: Color, Color::Auto, false,
@@ -617,6 +619,7 @@ use_try_shorthand = false
 use_field_init_shorthand = false
 force_explicit_abi = true
 condense_wildcard_suffixes = false
+self_shorthand = false
 color = "Auto"
 required_version = "{}"
 unstable_features = false

--- a/src/types.rs
+++ b/src/types.rs
@@ -700,23 +700,22 @@ impl Rewrite for ast::Ty {
 
                 let before_ty_span = mk_sp(cmnt_lo, mt.ty.span.lo());
                 if contains_comment(context.snippet(before_ty_span)) {
-                    result = combine_strs_with_missing_comments(
+                    return combine_strs_with_missing_comments(
                         context,
                         result.trim_end(),
                         &mt.ty.rewrite(context, shape)?,
                         before_ty_span,
                         shape,
                         true,
-                    )?;
-                } else {
-                    let used_width = last_line_width(&result);
-                    let budget = shape.width.checked_sub(used_width)?;
-                    let ty_str = mt
-                        .ty
-                        .rewrite(context, Shape::legacy(budget, shape.indent + used_width))?;
-                    result.push_str(&ty_str);
+                    );
                 }
 
+                let used_width = last_line_width(&result);
+                let budget = shape.width.checked_sub(used_width)?;
+                let ty_str = mt
+                    .ty
+                    .rewrite(context, Shape::legacy(budget, shape.indent + used_width))?;
+                result.push_str(&ty_str);
                 Some(result)
             }
             // FIXME: we drop any comments here, even though it's a silly place to put

--- a/src/types.rs
+++ b/src/types.rs
@@ -94,7 +94,6 @@ pub(crate) fn rewrite_path(
 }
 
 /// Determine if the `ast::TyKind` is an explicit `Self`.
-#[allow(dead_code)]
 pub(crate) fn is_self_upper(kind: &ast::TyKind) -> bool {
     match kind {
         ast::TyKind::Path(_, ref path) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -93,6 +93,19 @@ pub(crate) fn rewrite_path(
     )
 }
 
+/// Determine if the `ast::TyKind` is an explicit `Self`.
+#[allow(dead_code)]
+pub(crate) fn is_self_upper(kind: &ast::TyKind) -> bool {
+    match kind {
+        ast::TyKind::Path(_, ref path) => {
+            // The first segment will be `Self` if it's `kw::SelfUpper`
+            path.segments[0].ident.name == kw::SelfUpper
+        }
+        ast::TyKind::Rptr(_, ast::MutTy { ty, .. }) => is_self_upper(&ty.kind),
+        _ => false,
+    }
+}
+
 fn rewrite_path_segments<'a, I>(
     path_context: PathContext,
     mut buffer: String,

--- a/tests/source/configs/self_shorthand/true.rs
+++ b/tests/source/configs/self_shorthand/true.rs
@@ -1,0 +1,52 @@
+// rustfmt-self_shorthand: true
+struct Peach;
+
+impl Peach {
+    fn apple(self: Self) {}
+    fn orange(mut self: Self) {}
+    fn banana(self: &Self) {}
+    fn lemon<'a>(self: &'a Self) {}
+    fn pear<'a>(self: &'a mut Self) {}
+    fn chaenomeles(self: &mut Self) {}
+}
+
+struct PeachWithComments;
+
+impl PeachWithComments {
+    fn apple(/* pre self */ self: /* pre Self */ Self /* post Self */) {}
+    fn orange(/* pre mut */ mut /* post mut - pre self */ self: Self /* post Self */) {}
+    fn banana(self: /* pre ref */ &Self /* post Self */) {}
+    fn lemon<'a>(self: &/* post ref */'a Self) {}
+    fn pear<'a>(self: &'a/* post lt - pre mut */ mut Self ) {}
+    fn chaenomeles(self: &mut /* pre mut */ Self) {}
+}
+
+struct PeachWithMultiParams;
+
+impl PeachWithMultiParams {
+    fn apple(self: Self, a: String, b: String) {}
+    fn orange(mut self: Self, a: String, b: String) {}
+    fn banana(self: &Self, a: String, b: String) {}
+    fn lemon<'a>(self: &'a Self, a: String, b: String) {}
+    fn pear<'a>(self: &'a mut Self, a: String, b: String) {}
+    fn chaenomeles(self: &mut Self, a: String, b: String) {}
+}
+
+// Example from https://doc.rust-lang.org/stable/reference/items/associated-items.html#methods
+struct Example;
+type Alias = Example;
+trait Trait { type Output; }
+impl Trait for Example { type Output = Example; }
+impl Example {
+    fn by_value(self: Self) {}
+    fn by_ref(self: &Self) {}
+    fn by_ref_mut(self: &mut Self) {}
+    fn by_box(self: Box<Self>) {}
+    fn by_rc(self: Rc<Self>) {}
+    fn by_arc(self: Arc<Self>) {}
+    fn by_pin(self: Pin<&Self>) {}
+    fn explicit_type(self: Arc<Example>) {}
+    fn with_lifetime<'a>(self: &'a Self) {}
+    fn nested<'a>(self: &mut &'a Arc<Rc<Box<Alias>>>) {}
+    fn via_projection(self: <Example as Trait>::Output) {}
+}

--- a/tests/target/configs/self_shorthand/false.rs
+++ b/tests/target/configs/self_shorthand/false.rs
@@ -1,0 +1,34 @@
+// rustfmt-self_shorthand: false
+struct Peach;
+
+impl Peach {
+    fn apple(self: Self) {}
+    fn orange(mut self: Self) {}
+    fn banana(self: &Self) {}
+    fn lemon<'a>(self: &'a Self) {}
+    fn pear<'a>(self: &'a mut Self) {}
+    fn chaenomeles(self: &mut Self) {}
+}
+
+// example from https://doc.rust-lang.org/stable/reference/items/associated-items.html#methods
+struct Example;
+type Alias = Example;
+trait Trait {
+    type Output;
+}
+impl Trait for Example {
+    type Output = Example;
+}
+impl Example {
+    fn by_value(self: Self) {}
+    fn by_ref(self: &Self) {}
+    fn by_ref_mut(self: &mut Self) {}
+    fn by_box(self: Box<Self>) {}
+    fn by_rc(self: Rc<Self>) {}
+    fn by_arc(self: Arc<Self>) {}
+    fn by_pin(self: Pin<&Self>) {}
+    fn explicit_type(self: Arc<Example>) {}
+    fn with_lifetime<'a>(self: &'a Self) {}
+    fn nested<'a>(self: &mut &'a Arc<Rc<Box<Alias>>>) {}
+    fn via_projection(self: <Example as Trait>::Output) {}
+}

--- a/tests/target/configs/self_shorthand/true.rs
+++ b/tests/target/configs/self_shorthand/true.rs
@@ -1,0 +1,56 @@
+// rustfmt-self_shorthand: true
+struct Peach;
+
+impl Peach {
+    fn apple(self) {}
+    fn orange(mut self) {}
+    fn banana(&self) {}
+    fn lemon<'a>(&'a self) {}
+    fn pear<'a>(&'a mut self) {}
+    fn chaenomeles(&mut self) {}
+}
+
+struct PeachWithComments;
+
+impl PeachWithComments {
+    fn apple(/* pre self */ /* pre Self */ self /* post Self */) {}
+    fn orange(/* pre mut */ mut /* post mut - pre self */ self /* post Self */) {}
+    fn banana(/* pre ref */ &self /* post Self */) {}
+    fn lemon<'a>(& /* post ref */ 'a self) {}
+    fn pear<'a>(&'a /* post lt - pre mut */ mut self) {}
+    fn chaenomeles(&mut /* pre mut */ self) {}
+}
+
+struct PeachWithMultiParams;
+
+impl PeachWithMultiParams {
+    fn apple(self, a: String, b: String) {}
+    fn orange(mut self, a: String, b: String) {}
+    fn banana(&self, a: String, b: String) {}
+    fn lemon<'a>(&'a self, a: String, b: String) {}
+    fn pear<'a>(&'a mut self, a: String, b: String) {}
+    fn chaenomeles(&mut self, a: String, b: String) {}
+}
+
+// Example from https://doc.rust-lang.org/stable/reference/items/associated-items.html#methods
+struct Example;
+type Alias = Example;
+trait Trait {
+    type Output;
+}
+impl Trait for Example {
+    type Output = Example;
+}
+impl Example {
+    fn by_value(self) {}
+    fn by_ref(&self) {}
+    fn by_ref_mut(&mut self) {}
+    fn by_box(self: Box<Self>) {}
+    fn by_rc(self: Rc<Self>) {}
+    fn by_arc(self: Arc<Self>) {}
+    fn by_pin(self: Pin<&Self>) {}
+    fn explicit_type(self: Arc<Example>) {}
+    fn with_lifetime<'a>(&'a self) {}
+    fn nested<'a>(self: &mut &'a Arc<Rc<Box<Alias>>>) {}
+    fn via_projection(self: <Example as Trait>::Output) {}
+}


### PR DESCRIPTION
This new option allows rustfmt to convert explicit `self: Self` types in
method definitions to `self`:

* `self: Self` -> `self`
* `self: &Self` -> `&self`
* `self: &'a Self` -> `&'a self`
* `mut self: Self` -> `mut self`
* `self: &mut Self` -> `&mut self`
* `self: &'a mut Self` -> `&'a mut self`

~Note: Don't merge until a tracking issue has been added for `self_shorthand`.~
Closes #5257