### PR TITLE
Ensure code fences are placed on their own line in doc comments

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -760,7 +760,17 @@ impl<'a> CommentRewrite<'a> {
         self.code_block_attr = None;
         self.item_block = None;
         if let Some(stripped) = line.strip_prefix("```") {
-            self.code_block_attr = Some(CodeBlockAttribute::new(stripped))
+            // The current line is the start of a code fence, and we want to make sure that
+            // code fences always start on their own line.
+            if self.buffer_contains_comment() && !self.result.ends_with('\n') {
+                self.result.push_str(&self.comment_line_separator);
+                self.result.push_str(line)
+            } else {
+                // the comment buffer is empty, so we can just write the line
+                self.result.push_str(line)
+            }
+            self.code_block_attr = Some(CodeBlockAttribute::new(stripped));
+            return false;
         } else if self.fmt.config.wrap_comments() && ItemizedBlock::is_itemized_line(line) {
             let ib = ItemizedBlock::new(line);
             self.item_block = Some(ib);

--- a/tests/source/issue-5244/wrap_comments_true.rs
+++ b/tests/source/issue-5244/wrap_comments_true.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments:true
+
+/// Here is me writing some documentation that is too long oh me oh my now some code please!
+/// ```
+/// test
+/// ```
+fn foo() {}

--- a/tests/target/issue-5244/wrap_comments_false.rs
+++ b/tests/target/issue-5244/wrap_comments_false.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments:false
+
+/// Here is me writing some documentation that is too long oh me oh my now some code please!
+/// ```
+/// test
+/// ```
+fn foo() {}

--- a/tests/target/issue-5244/wrap_comments_true.rs
+++ b/tests/target/issue-5244/wrap_comments_true.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments:true
+
+/// Here is me writing some documentation that is too long oh me oh my now some
+/// code please!
+/// ```
+/// test
+/// ```
+fn foo() {}


### PR DESCRIPTION
Fixes #5244

When `wrap_comments=true` was set there was a chance that the line right before the comment would be wrapped. When this happened, rustfmt didn't place a newline between the wrapped line and the code fence. This placed the start of the code fence on the same line as the previously wrapped line.

Now, rustfmt adds a newline when necessary to ensure that code fences are placed on their own lines.