### PR TITLE
Search for struct body span after any generic arguments

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1273,7 +1273,13 @@ pub(crate) fn format_struct_struct(
     result.push_str(&header_str);
 
     let header_hi = struct_parts.ident.span.hi();
-    let body_lo = context.snippet_provider.span_after(span, "{");
+    let body_lo = if let Some(generics) = struct_parts.generics {
+        // Adjust the span to start at the end of the generic arguments before searching for the '{'
+        let span = span.with_lo(generics.span.hi());
+        context.snippet_provider.span_after(span, "{")
+    } else {
+        context.snippet_provider.span_after(span, "{")
+    };
 
     let generics_str = match struct_parts.generics {
         Some(g) => format_generics(

--- a/tests/target/issue_5273.rs
+++ b/tests/target/issue_5273.rs
@@ -1,0 +1,3 @@
+struct Example<const N: usize = { 1048576 }> {
+    //
+}


### PR DESCRIPTION
Fixes #5273

Previously, rustfmt searched for the start of a struct body after the opening `{`. In most cases this works just fine, but const values can also be defined inside `{ }`, which lead to issues when rewriting the struct body (as highlighted by the linked issue).

Now, rustfmt will search for the `{` after the generic argument list to guarantee that the `{` it finds is the start of the struct body.