### PR TITLE
Preserve semicolon after macro call inside foreign mod

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -112,6 +112,7 @@ fn rewrite_macro_name(
 fn return_macro_parse_failure_fallback(
     context: &RewriteContext<'_>,
     indent: Indent,
+    position: MacroPosition,
     span: Span,
 ) -> Option<String> {
     // Mark this as a failure however we format it
@@ -140,7 +141,11 @@ fn return_macro_parse_failure_fallback(
     ));
 
     // Return the snippet unmodified if the macro is not block-like
-    Some(context.snippet(span).to_owned())
+    let mut snippet = context.snippet(span).to_owned();
+    if position == MacroPosition::Item {
+        snippet.push(';');
+    }
+    Some(snippet)
 }
 
 pub(crate) fn rewrite_macro(
@@ -233,7 +238,12 @@ fn rewrite_macro_inner(
     } = match parse_macro_args(context, ts, style, is_forced_bracket) {
         Some(args) => args,
         None => {
-            return return_macro_parse_failure_fallback(context, shape.indent, mac.span());
+            return return_macro_parse_failure_fallback(
+                context,
+                shape.indent,
+                position,
+                mac.span(),
+            );
         }
     };
 

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -77,3 +77,16 @@ libc::c_long;
 extern {
 
 }
+
+macro_rules! x {
+    ($tt:tt) => {};
+}
+
+extern "macros" {
+    x!(ident);
+    // x!(#); FIXME
+    x![ident];
+    // x![#]; FIXME
+    x! {ident}
+    x! {#}
+}

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -84,9 +84,9 @@ macro_rules! x {
 
 extern "macros" {
     x!(ident);
-    // x!(#); FIXME
+    x!(#);
     x![ident];
-    // x![#]; FIXME
+    x![#];
     x! {ident}
     x! {#}
 }

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -82,3 +82,16 @@ extern "C" {
 }
 
 extern "C" {}
+
+macro_rules! x {
+    ($tt:tt) => {};
+}
+
+extern "macros" {
+    x!(ident);
+    // x!(#); FIXME
+    x![ident];
+    // x![#]; FIXME
+    x! {ident}
+    x! {#}
+}

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -89,9 +89,9 @@ macro_rules! x {
 
 extern "macros" {
     x!(ident);
-    // x!(#); FIXME
+    x!(#);
     x![ident];
-    // x![#]; FIXME
+    x![#];
     x! {ident}
     x! {#}
 }


### PR DESCRIPTION
Fixes #5281.

### Before:

```console
$ echo 'extern { x!(-); x!(x); }' | cargo run --bin rustfmt
extern "C" {
    x!(-)
    x!(x);
}
```

### After:

```console
$ echo 'extern { x!(-); x!(x); }' | cargo run --bin rustfmt
extern "C" {
    x!(-);
    x!(x);
}
```