### PR TITLE
Add test for issue 3937

### DIFF
--- a/tests/target/issue_3937.rs
+++ b/tests/target/issue_3937.rs
@@ -1,0 +1,13 @@
+// rustfmt-format_code_in_doc_comments:true
+
+struct Foo {
+    // a: i32,
+    //
+    // b: i32,
+}
+
+struct Foo {
+    a: i32,
+    //
+    // b: i32,
+}


### PR DESCRIPTION
ref #3937

~~It's unclear which change fixed the `format_code_in_doc_comments=true`
issue brought up in this issue, however~~ I'm unable to reproduce the
error on the current master.

The added test cases should serve to prevent a regression.

Edit: ref #4420 describes the `format_code_in_doc_comments=true` issue and #5091 fixed that issue, so it's also responsible for fixing the `format_code_in_doc_comments=true` behavior described in #3937