### PR TITLE
Backport 4304

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -607,16 +607,22 @@ impl<'a> CommentRewrite<'a> {
         cr
     }
 
-    fn join_block(s: &str, sep: &str) -> String {
+    fn join_block(s: &str, sep: &str, add_sep_prefix: bool) -> String {
         let mut result = String::with_capacity(s.len() + 128);
         let mut iter = s.lines().peekable();
-        while let Some(line) = iter.next() {
-            result.push_str(line);
-            result.push_str(match iter.peek() {
-                Some(next_line) if next_line.is_empty() => sep.trim_end(),
+        let get_sep = |line: Option<&&str>| -> &str {
+            match line {
+                Some(&"") => sep.trim_end(),
                 Some(..) => sep,
                 None => "",
-            });
+            }
+        };
+        if add_sep_prefix {
+            result.push_str(get_sep(iter.peek()));
+        }
+        while let Some(line) = iter.next() {
+            result.push_str(line);
+            result.push_str(get_sep(iter.peek()));
         }
         result
     }
@@ -634,10 +640,10 @@ impl<'a> CommentRewrite<'a> {
         if !self.code_block_buffer.is_empty() {
             // There is a code block that is not properly enclosed by backticks.
             // We will leave them untouched.
-            self.result.push_str(&self.comment_line_separator);
             self.result.push_str(&Self::join_block(
                 &trim_custom_comment_prefix(&self.code_block_buffer),
                 &self.comment_line_separator,
+                true, /* add_sep_prefix */
             ));
         }
 
@@ -660,10 +666,12 @@ impl<'a> CommentRewrite<'a> {
                 Some(s) => self.result.push_str(&Self::join_block(
                     &s,
                     &format!("{}{}", self.comment_line_separator, ib.line_start),
+                    false, /* add_sep_prefix */
                 )),
                 None => self.result.push_str(&Self::join_block(
                     &ib.original_block_as_string(),
                     &self.comment_line_separator,
+                    false, /* add_sep_prefix */
                 )),
             };
         }
@@ -715,10 +723,12 @@ impl<'a> CommentRewrite<'a> {
                 Some(s) => self.result.push_str(&Self::join_block(
                     &s,
                     &format!("{}{}", self.comment_line_separator, ib.line_start),
+                    false, /* add_sep_prefix */
                 )),
                 None => self.result.push_str(&Self::join_block(
                     &ib.original_block_as_string(),
                     &self.comment_line_separator,
+                    false, /* add_sep_prefix */
                 )),
             };
         } else if self.code_block_attr.is_some() {
@@ -741,9 +751,11 @@ impl<'a> CommentRewrite<'a> {
                     _ => trim_custom_comment_prefix(&self.code_block_buffer),
                 };
                 if !code_block.is_empty() {
-                    self.result.push_str(&self.comment_line_separator);
-                    self.result
-                        .push_str(&Self::join_block(&code_block, &self.comment_line_separator));
+                    self.result.push_str(&Self::join_block(
+                        &code_block,
+                        &self.comment_line_separator,
+                        true, /* add_sep_prefix */
+                    ));
                 }
                 self.code_block_buffer.clear();
                 self.result.push_str(&self.comment_line_separator);

--- a/tests/source/issue-4251.rs
+++ b/tests/source/issue-4251.rs
@@ -1,0 +1,6 @@
+// rustfmt-wrap_comments: true
+
+//! ```
+//! 
+//! use something;
+//! ```

--- a/tests/target/issue-4251.rs
+++ b/tests/target/issue-4251.rs
@@ -1,0 +1,6 @@
+// rustfmt-wrap_comments: true
+
+//! ```
+//!
+//! use something;
+//! ```


### PR DESCRIPTION
Do not add trailing space to empty lines in comment code blocks (#4304)

Currently, the first line pushed in a code block is a comment line
delimiter that includes a trailing space, even if the content of that
line is empty. Later lines are handled correctly because their content
is checked before adding the comment line delimiter. So, just apply the
same logic as is done for later lines to the first line.

Closes 4251