### PR TITLE
Backport 4220

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1274,8 +1274,8 @@ pub(crate) fn format_struct_struct(
 
     let header_hi = struct_parts.ident.span.hi();
     let body_lo = if let Some(generics) = struct_parts.generics {
-        // Adjust the span to start at the end of the generic arguments before searching for the '{'
-        let span = span.with_lo(generics.span.hi());
+        // Adjust the span to start at the end of the where clause before searching for the '{'
+        let span = span.with_lo(generics.where_clause.span.hi());
         context.snippet_provider.span_after(span, "{")
     } else {
         context.snippet_provider.span_after(span, "{")

--- a/tests/target/issue-4218.rs
+++ b/tests/target/issue-4218.rs
@@ -1,0 +1,3 @@
+pub struct Arr
+where
+    [u8; { 10 / 2 }]: Send, {}


### PR DESCRIPTION
Handle const generic bounds in structs (#4220)

This backport slightly tweaks the implementation of #5274 by adjusting the span after the where clause.