### PR TITLE
Backport 3971 test cases

### DIFF
--- a/tests/config/issue-3956.toml
+++ b/tests/config/issue-3956.toml
@@ -1,0 +1,5 @@
+ignore = [
+  "tests/**/issue-3956/graphics.rs",
+  "tests/**/issue-3956/graphics_emu.rs"
+]
+recursive = true

--- a/tests/target/issue-3956/graphics.rs
+++ b/tests/target/issue-3956/graphics.rs
@@ -1,0 +1,2 @@
+// rustfmt-config: issue-3956.toml
+pub struct A;

--- a/tests/target/issue-3956/graphics_emu.rs
+++ b/tests/target/issue-3956/graphics_emu.rs
@@ -1,0 +1,2 @@
+// rustfmt-config: issue-3956.toml
+pub struct B;

--- a/tests/target/issue-3956/lib.rs
+++ b/tests/target/issue-3956/lib.rs
@@ -1,0 +1,4 @@
+// rustfmt-config: issue-3956.toml
+#[cfg_attr(windows, path = "graphics.rs")]
+#[cfg_attr(not(windows), path = "graphics_emu.rs")]
+mod graphics;


### PR DESCRIPTION
fix not to overwrite on other platforms (#3971)

It's likely that PR #4100 implemented a similar fix, which resolved the original issue. The test cases from PR #3971 seemed useful to backport.