### PR TITLE
Always remove block comment closers when converting into inline comment

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -865,6 +865,7 @@ fn rewrite_comment_inner(
     is_doc_comment: bool,
 ) -> Option<String> {
     let mut rewriter = CommentRewrite::new(orig, block_style, shape, config);
+    let is_line_comment = rewriter.style.is_line_comment();
 
     let line_breaks = count_newlines(orig.trim_end());
     let lines = orig
@@ -873,7 +874,11 @@ fn rewrite_comment_inner(
         .map(|(i, mut line)| {
             line = trim_end_unless_two_whitespaces(line.trim_start(), is_doc_comment);
             // Drop old closer.
-            if i == line_breaks && line.ends_with("*/") && !line.starts_with("//") {
+            // When converting block comments to line comments always remove block comment closers
+            if (i == line_breaks || is_line_comment)
+                && line.ends_with("*/")
+                && !line.starts_with("//")
+            {
                 line = line[..(line.len() - 2)].trim_end();
             }
 

--- a/tests/source/issue-4971/normalize_comments_true.rs
+++ b/tests/source/issue-4971/normalize_comments_true.rs
@@ -1,0 +1,23 @@
+// rustfmt-normalize_comments:true
+
+struct A {
+    x: usize,
+    /* protected int[] observed; */
+    /* (int, int)[] stack; */
+}
+
+struct B {
+    x: usize,
+    /* protected int[] observed;
+     * some more details here */
+    /* (int, int)[] stack; */
+}
+
+struct C {
+    x: usize,
+    /* protected int[] observed;
+     * some more details here;
+    /* nested comment; */
+     */
+    /* (int, int)[] stack; */
+}

--- a/tests/target/issue-4971/normalize_comments_false.rs
+++ b/tests/target/issue-4971/normalize_comments_false.rs
@@ -1,0 +1,23 @@
+// rustfmt-normalize_comments:false
+
+struct A {
+    x: usize,
+    /* protected int[] observed; */
+    /* (int, int)[] stack; */
+}
+
+struct B {
+    x: usize,
+    /* protected int[] observed;
+     * some more details here */
+    /* (int, int)[] stack; */
+}
+
+struct C {
+    x: usize,
+    /* protected int[] observed;
+     * some more details here;
+    /* nested comment; */
+     */
+    /* (int, int)[] stack; */
+}

--- a/tests/target/issue-4971/normalize_comments_true.rs
+++ b/tests/target/issue-4971/normalize_comments_true.rs
@@ -1,0 +1,23 @@
+// rustfmt-normalize_comments:true
+
+struct A {
+    x: usize,
+    // protected int[] observed;
+    // (int, int)[] stack;
+}
+
+struct B {
+    x: usize,
+    // protected int[] observed;
+    // some more details here
+    // (int, int)[] stack;
+}
+
+struct C {
+    x: usize,
+    // protected int[] observed;
+    // some more details here;
+    // nested comment;
+    //
+    // (int, int)[] stack;
+}


### PR DESCRIPTION
Fixes #4971

Previously we would only remove the last block comment closer `*/` from a set of block comments. This failed to remove block comment closers from adjacent block comments and nested block comments when converting them into inline comments with `normalize_comments = true`.

Now we'll always remove block comment closers when converting into inline comments with `normalize_comments = true`.