### PR TITLE
Remove extraneous newlines between outer attributes and mod items

### DIFF
--- a/tests/source/issue_5309.rs
+++ b/tests/source/issue_5309.rs
@@ -1,0 +1,31 @@
+//rustfmt-version:Two
+
+#[allow(unused)]
+
+fn a() {}
+
+#[allow(unused)]
+
+
+
+fn b() {}
+
+#[allow(unused)] // trailing comment
+
+fn c() {}
+
+#[allow(unused)] // trailing comment
+
+
+
+fn d() {}
+
+#[allow(unused)] /* trailing comment */
+
+fn e() {}
+
+#[allow(unused)] /* trailing comment */
+
+
+
+fn f() {}

--- a/tests/target/issue_5309.rs
+++ b/tests/target/issue_5309.rs
@@ -1,0 +1,19 @@
+//rustfmt-version:Two
+
+#[allow(unused)]
+fn a() {}
+
+#[allow(unused)]
+fn b() {}
+
+#[allow(unused)] // trailing comment
+fn c() {}
+
+#[allow(unused)] // trailing comment
+fn d() {}
+
+#[allow(unused)] /* trailing comment */
+fn e() {}
+
+#[allow(unused)] /* trailing comment */
+fn f() {}


### PR DESCRIPTION
Fixes #5309

Previously, rustfmt would not remove blank lines between attributes and
their corresponding items. The following would not be formatted:

```rust
#[allow(unused)]

fn main() {}
```

Now when `version=Two` is set rustfmt will remove the blank line:

```rust
#[allow(unused)]
fn main() {}
```