### PR TITLE
Use the traits added to the Rust 2021 Edition prelude

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -10,7 +10,6 @@ use std::ffi::OsStr;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
-use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;


### PR DESCRIPTION
Follow up https://github.com/rust-lang/rust/pull/96861.

This PR uses the traits added to the Rust 2021 Edition prelude.

> The `TryInto`, `TryFrom` and `FromIterator` traits are now part of the prelude.

https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html