### PR TITLE
group_imports: add `ExternalCrate`

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2066,7 +2066,7 @@ Controls the strategy for how consecutive imports are grouped together.
 Controls the strategy for grouping sets of consecutive imports. Imports may contain newlines between imports and still be grouped together as a single set, but other statements between imports will result in different grouping sets.
 
 - **Default value**: `Preserve`
-- **Possible values**: `Preserve`, `StdExternalCrate`, `One`
+- **Possible values**: `Preserve`, `StdExternalCrate`, `One`, `ExternalCrate`
 - **Stable**: No (tracking issue: [#5083](https://github.com/rust-lang/rustfmt/issues/5083))
 
 Each set of imports (one or more `use` statements, optionally separated by newlines) will be formatted independently. Other statements such as `mod ...` or `extern crate ...` will cause imports to not be grouped together.
@@ -2129,6 +2129,26 @@ use core::f32;
 use juniper::{FieldError, FieldResult};
 use std::sync::Arc;
 use uuid::Uuid;
+```
+
+#### `ExternalCrate`:
+
+Discard existing import groups, and create two groups for:
+1. `std`, `core`, `alloc`, and external crates,
+2. `self`, `super` and `crate` imports.
+
+```rust
+use alloc::alloc::Layout;
+use broker::database::PooledConnection;
+use chrono::Utc;
+use core::f32;
+use juniper::{FieldError, FieldResult};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use super::schema::{Context, Payload};
+use super::update::convert_publish_payload;
+use crate::models::Event;
 ```
 
 ## `reorder_modules`

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -114,6 +114,10 @@ pub enum GroupImportsTactic {
     StdExternalCrate,
     /// Discard existing groups, and create a single group for everything
     One,
+    /// Discard existing groups, and create new groups for
+    ///  1. imports from other crates
+    ///  2. `self` / `crate` / `super` imports
+    ExternalCrate,
 }
 
 #[config_type]

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -116,7 +116,8 @@ fn rewrite_reorderable_or_regroupable_items(
                 GroupImportsTactic::Preserve | GroupImportsTactic::One => {
                     vec![normalized_items]
                 }
-                GroupImportsTactic::StdExternalCrate => group_imports(normalized_items),
+                GroupImportsTactic::StdExternalCrate => group_imports(normalized_items, true),
+                GroupImportsTactic::ExternalCrate => group_imports(normalized_items, false),
             };
 
             if context.config.reorder_imports() {
@@ -172,7 +173,7 @@ fn contains_macro_use_attr(item: &ast::Item) -> bool {
 
 /// Divides imports into three groups, corresponding to standard, external
 /// and local imports. Sorts each subgroup.
-fn group_imports(uts: Vec<UseTree>) -> Vec<Vec<UseTree>> {
+fn group_imports(uts: Vec<UseTree>, separate_std: bool) -> Vec<Vec<UseTree>> {
     let mut std_imports = Vec::new();
     let mut external_imports = Vec::new();
     let mut local_imports = Vec::new();
@@ -184,7 +185,7 @@ fn group_imports(uts: Vec<UseTree>) -> Vec<Vec<UseTree>> {
         }
         match &ut.path[0] {
             UseSegment::Ident(id, _) => match id.as_ref() {
-                "std" | "alloc" | "core" => std_imports.push(ut),
+                "std" | "alloc" | "core" if separate_std => std_imports.push(ut),
                 _ => external_imports.push(ut),
             },
             UseSegment::Slf(_) | UseSegment::Super(_) | UseSegment::Crate(_) => {

--- a/tests/source/configs/group_imports/ExternalCrate-merge_imports.rs
+++ b/tests/source/configs/group_imports/ExternalCrate-merge_imports.rs
@@ -1,0 +1,17 @@
+// rustfmt-group_imports: ExternalCrate
+// rustfmt-imports_granularity: Crate
+use chrono::Utc;
+use super::update::convert_publish_payload;
+
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+use alloc::alloc::Layout;
+
+use std::sync::Arc;
+use alloc::vec::Vec;
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/source/configs/group_imports/ExternalCrate-nested.rs
+++ b/tests/source/configs/group_imports/ExternalCrate-nested.rs
@@ -1,0 +1,7 @@
+// rustfmt-group_imports: ExternalCrate
+mod test {
+    use crate::foo::bar;
+    use std::path;
+    use crate::foo::bar2;
+    use chrono::Utc;
+}

--- a/tests/source/configs/group_imports/ExternalCrate-no_reorder.rs
+++ b/tests/source/configs/group_imports/ExternalCrate-no_reorder.rs
@@ -1,0 +1,17 @@
+// rustfmt-group_imports: ExternalCrate
+// rustfmt-reorder_imports: false
+
+use chrono::Utc;
+use super::update::convert_publish_payload;
+
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+use alloc::alloc::Layout;
+
+use std::sync::Arc;
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/source/configs/group_imports/ExternalCrate-non_consecutive.rs
+++ b/tests/source/configs/group_imports/ExternalCrate-non_consecutive.rs
@@ -1,0 +1,27 @@
+// rustfmt-group_imports: ExternalCrate
+use chrono::Utc;
+use super::update::convert_publish_payload;
+
+
+
+
+
+use juniper::{FieldError, FieldResult};
+
+use uuid::Uuid;
+use alloc::alloc::Layout;
+
+extern crate uuid;
+
+
+
+
+
+use std::sync::Arc;
+
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/source/configs/group_imports/ExternalCrate.rs
+++ b/tests/source/configs/group_imports/ExternalCrate.rs
@@ -1,0 +1,15 @@
+// rustfmt-group_imports: ExternalCrate
+use chrono::Utc;
+use super::update::convert_publish_payload;
+
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+use alloc::alloc::Layout;
+
+use std::sync::Arc;
+
+use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+use crate::models::Event;

--- a/tests/target/configs/group_imports/ExternalCrate-merge_imports.rs
+++ b/tests/target/configs/group_imports/ExternalCrate-merge_imports.rs
@@ -1,0 +1,15 @@
+// rustfmt-group_imports: ExternalCrate
+// rustfmt-imports_granularity: Crate
+use alloc::{alloc::Layout, vec::Vec};
+use broker::database::PooledConnection;
+use chrono::Utc;
+use core::f32;
+use juniper::{FieldError, FieldResult};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use super::{
+    schema::{Context, Payload},
+    update::convert_publish_payload,
+};
+use crate::models::Event;

--- a/tests/target/configs/group_imports/ExternalCrate-nested.rs
+++ b/tests/target/configs/group_imports/ExternalCrate-nested.rs
@@ -1,0 +1,8 @@
+// rustfmt-group_imports: ExternalCrate
+mod test {
+    use chrono::Utc;
+    use std::path;
+
+    use crate::foo::bar;
+    use crate::foo::bar2;
+}

--- a/tests/target/configs/group_imports/ExternalCrate-no_reorder.rs
+++ b/tests/target/configs/group_imports/ExternalCrate-no_reorder.rs
@@ -1,0 +1,14 @@
+// rustfmt-group_imports: ExternalCrate
+// rustfmt-reorder_imports: false
+
+use chrono::Utc;
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+use alloc::alloc::Layout;
+use std::sync::Arc;
+use broker::database::PooledConnection;
+use core::f32;
+
+use super::update::convert_publish_payload;
+use super::schema::{Context, Payload};
+use crate::models::Event;

--- a/tests/target/configs/group_imports/ExternalCrate-non_consecutive.rs
+++ b/tests/target/configs/group_imports/ExternalCrate-non_consecutive.rs
@@ -1,0 +1,16 @@
+// rustfmt-group_imports: ExternalCrate
+use alloc::alloc::Layout;
+use chrono::Utc;
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+
+use super::update::convert_publish_payload;
+
+extern crate uuid;
+
+use broker::database::PooledConnection;
+use core::f32;
+use std::sync::Arc;
+
+use super::schema::{Context, Payload};
+use crate::models::Event;

--- a/tests/target/configs/group_imports/ExternalCrate.rs
+++ b/tests/target/configs/group_imports/ExternalCrate.rs
@@ -1,0 +1,12 @@
+// rustfmt-group_imports: ExternalCrate
+use alloc::alloc::Layout;
+use broker::database::PooledConnection;
+use chrono::Utc;
+use core::f32;
+use juniper::{FieldError, FieldResult};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use super::schema::{Context, Payload};
+use super::update::convert_publish_payload;
+use crate::models::Event;


### PR DESCRIPTION
This is similar to the existing `StdExternalCrate`, but doesn't give `std`, `core`, and `alloc` their own group. Conceptually, `std` and friends are just external libraries (though they have some magical abilities thanks to lang items and `rustc_attrs`), so this is the style I naturally gravitated towards. I'm not sure how common this pattern is throughout the ecosystem, unfortunately, and [it even took one person by surprise when I brought it up](https://www.reddit.com/r/rust/comments/uol60r/why_are_most_of_rustfmt_features_unstable/i8tv319/). Nevertheless, [at least four people seem to agree with this ordering at the time of writing](https://www.reddit.com/r/rust/comments/uol60r/why_are_most_of_rustfmt_features_unstable/i8ikjze/), so I do hope this option will be useful to someone other than me.