### PR TITLE
Make it clear that unstable options are only available on a nightly toolchain

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -10,7 +10,7 @@ reorder_imports = false
 ```
 
 Each configuration option is either stable or unstable.
-Stable options can be used directly, while unstable options are opt-in.
+Stable options can always be used, while unstable ones are only available on a nightly toolchain, and opt-in.
 To enable unstable options, set `unstable_features = true` in `rustfmt.toml` or pass `--unstable-features` to rustfmt.
 
 # Configuration Options

--- a/Configurations.md
+++ b/Configurations.md
@@ -10,7 +10,7 @@ reorder_imports = false
 ```
 
 Each configuration option is either stable or unstable.
-Stable options can always be used, while unstable ones are only available on a nightly toolchain, and opt-in.
+Stable options can always be used, while unstable options are only available on a nightly toolchain and must be opted into.
 To enable unstable options, set `unstable_features = true` in `rustfmt.toml` or pass `--unstable-features` to rustfmt.
 
 # Configuration Options


### PR DESCRIPTION
For `rustfmt 1.4.38-stable (fe5b13d6 2022-05-18)`, if I run:
```bash
rustfmt --unstable-features
```
I get the following error:
```
Unrecognised option: 'unstable-features'
```

The "[Configuring Rustfmt](https://github.com/rust-lang/rustfmt/blob/243cec7a0b9cc0ba3fba6e5ed849b0635f3496db/README.md#configuring-rustfmt)" section of the `README.md` file says that in order to enable unstable options, it is necessary to use a nightly toolchain.

In this changeset, I suggest to copy that information as is to the "Configuring Rustfmt" document (i.e., to the `Configurations.md` file).
