### PR TITLE
Feature: add reorder_type_constraints option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2148,6 +2148,18 @@ mod sit;
 **Note** `mod` with `#[macro_export]` will not be reordered since that could change the semantics
 of the original source code.
 
+## `reorder_type_constraints`
+
+Reorder type constraints alphabetically in group.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: No
+
+#### `true`
+
+#### `false` (default)
+
 ## `required_version`
 
 Require a specific version of rustfmt. If you want to make sure that the

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -89,6 +89,8 @@ create_config! {
     reorder_imports: bool, true, true, "Reorder import and extern crate statements alphabetically";
     reorder_modules: bool, true, true, "Reorder module statements alphabetically in group";
     reorder_impl_items: bool, false, false, "Reorder impl items";
+    reorder_type_constraints: bool, false, false,
+        "Reorder type constraints alphabetically in group";
 
     // Spaces around punctuation
     type_punctuation_density: TypeDensity, TypeDensity::Wide, false,
@@ -550,6 +552,7 @@ group_imports = "Preserve"
 reorder_imports = true
 reorder_modules = true
 reorder_impl_items = false
+reorder_type_constraints = false
 type_punctuation_density = "Wide"
 space_before_colon = false
 space_after_colon = true

--- a/src/items.rs
+++ b/src/items.rs
@@ -2721,7 +2721,22 @@ fn rewrite_generics(
         return Some(ident.to_owned());
     }
 
-    let params = generics.params.iter();
+    let mut params_vec = generics.params.clone();
+    if context.config.reorder_type_constraints() {
+        for param in params_vec.iter_mut() {
+            param.bounds.sort_by_key(|bound| match bound {
+                ast::GenericBound::Trait(poly_trait_ref, _) => poly_trait_ref
+                    .trait_ref
+                    .path
+                    .segments
+                    .iter()
+                    .map(|s| s.ident.to_string())
+                    .collect::<String>(),
+                ast::GenericBound::Outlives(lifetime) => lifetime.ident.to_string(),
+            })
+        }
+    }
+    let params = params_vec.iter();
     overflow::rewrite_with_angle_brackets(context, ident, params, shape, generics.span)
 }
 

--- a/tests/source/issue-5116/a.rs
+++ b/tests/source/issue-5116/a.rs
@@ -1,0 +1,5 @@
+// rustfmt-reorder_type_constraints: true
+
+fn foo<T: PartialEq + Copy + Debug + 'static + Clone>(a: T) {
+    todo!();
+}

--- a/tests/target/issue-5116/a.rs
+++ b/tests/target/issue-5116/a.rs
@@ -1,0 +1,5 @@
+// rustfmt-reorder_type_constraints: true
+
+fn foo<T: 'static + Clone + Copy + Debug + PartialEq>(a: T) {
+    todo!();
+}


### PR DESCRIPTION
This PR addresses #5116 

It reorders constraints on generics alphabetically. Treatment of comments interleaved with constraints is yet to be done.

Tips for improvements, special test cases, etc, are highly appreciated.

Thanks to @ytmimi for tips on how to implement this feature.