### PR TITLE
Remove useless conditional compilation

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -978,12 +978,6 @@ fn rustfmt() -> PathBuf {
     // Chop off `deps`.
     me.pop();
 
-    // If we run `cargo test --release`, we might only have a release build.
-    if cfg!(release) {
-        // `../release/`
-        me.pop();
-        me.push("release");
-    }
     me.push("rustfmt");
     assert!(
         me.is_file() || me.with_extension("exe").is_file(),


### PR DESCRIPTION
Context: `rustc` added a few month ago `--check-cfg` support and enable it in the `rust-lang/rust` repo for every build.

I found out that `rustfmt` has a `cfg!(release)` condition that was triggering the unstable `unexpected_cfgs` lint. The problem is that nothing (nor `rustc`, nor `cargo`, or anything` is setting the `release` cfg.

This PR removes the code behind the cfg. I have tested the patch with and without `--release`, with and without running the tests.