### PR TITLE
Feature/sliding imports

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -6,7 +6,7 @@ A possible content of `rustfmt.toml` or `.rustfmt.toml` might look like this:
 
 ```toml
 indent_style = "Block"
-reorder_imports = false
+reorder_imports = "Off"
 ```
 
 Each configuration option is either stable or unstable.
@@ -2034,14 +2034,14 @@ impl Iterator for Dummy {
 
 ## `reorder_imports`
 
-Reorder import and extern crate statements alphabetically in groups (a group is
+Reorder import and extern crate statements in groups (a group is
 separated by a newline).
 
-- **Default value**: `true`
-- **Possible values**: `true`, `false`
-- **Stable**: Yes
+- **Default value**: `"Alphabetically"`
+- **Possible values**: `"Alphabetically"`, `"Length"`, `"Off"`
+- **Stable**: No
 
-#### `true` (default):
+#### `"Alphabetically"` (default):
 
 ```rust
 use dolor;
@@ -2050,7 +2050,7 @@ use lorem;
 use sit;
 ```
 
-#### `false`:
+#### `"Off"`:
 
 ```rust
 use lorem;

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -296,6 +296,11 @@ macro_rules! create_config {
                     }
                 )+
             }
+            
+            /*#[allow(unreachable_pub)]
+            pub fn reorder_imports(&self) -> ReorderImports {
+                self.reorder_imports
+            }*/
 
             fn set_width_heuristics(&mut self, heuristics: WidthHeuristics) {
                 let max_width = self.max_width.2;

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -296,7 +296,6 @@ macro_rules! create_config {
                     }
                 )+
             }
-            
             /*#[allow(unreachable_pub)]
             pub fn reorder_imports(&self) -> ReorderImports {
                 self.reorder_imports

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,7 +90,8 @@ create_config! {
     merge_imports: bool, false, false, "(deprecated: use imports_granularity instead)";
 
     // Ordering
-    reorder_imports: bool, true, true, "Reorder import and extern crate statements alphabetically";
+    reorder_imports: ReorderImports, ReorderImports::Alphabetically, false,
+        "Reorder import and extern crate statements";
     reorder_modules: bool, true, true, "Reorder module statements alphabetically in group";
     reorder_impl_items: bool, false, false, "Reorder impl items";
 
@@ -583,7 +584,7 @@ imports_indent = "Block"
 imports_layout = "Mixed"
 imports_granularity = "Preserve"
 group_imports = "Preserve"
-reorder_imports = true
+reorder_imports = "Alphabetically"
 reorder_modules = true
 reorder_impl_items = false
 type_punctuation_density = "Wide"

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -457,3 +457,13 @@ pub enum MatchArmLeadingPipe {
     /// Preserve any existing leading pipes
     Preserve,
 }
+
+/// Reorder imports
+#[config_type]
+pub enum ReorderImports {
+    Alphabetically,
+
+    Length,
+
+    Off,
+}

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -367,7 +367,7 @@ impl UseTree {
                         Some(item.attrs.clone())
                     },
                 )
-                .normalize(context.config),
+                .normalize(),
             ),
             _ => None,
         }
@@ -480,7 +480,7 @@ impl UseTree {
     }
 
     // Do the adjustments that rustfmt does elsewhere to use paths.
-    pub(crate) fn normalize(mut self, config: &Config) -> UseTree {
+    pub(crate) fn normalize(mut self) -> UseTree {
         let mut last = self.path.pop().expect("Empty use tree?");
         // Hack around borrow checker.
         let mut normalize_sole_list = false;
@@ -545,7 +545,7 @@ impl UseTree {
                     for seg in &list[0].path {
                         self.path.push(seg.clone());
                     }
-                    return self.normalize(config);
+                    return self.normalize();
                 }
                 _ => unreachable!(),
             }
@@ -563,7 +563,6 @@ impl UseTree {
             } else if config.reorder_imports() == ReorderImports::Length {
                 list.sort_by(|a, b| compare_sliding_order(&a.to_string(), &b.to_string()))
             }
-            println!("list: {:?}", list);
             last = UseSegment::List(list);
         }
 
@@ -1362,98 +1361,67 @@ mod test {
 
     #[test]
     fn test_use_tree_normalize() {
+        assert_eq!(parse_use_tree("a::self").normalize(), parse_use_tree("a"));
         assert_eq!(
-            parse_use_tree("a::self").normalize(&Config::default()),
-            parse_use_tree("a")
-        );
-        assert_eq!(
-            parse_use_tree("a::self as foo").normalize(&Config::default()),
+            parse_use_tree("a::self as foo").normalize(),
             parse_use_tree("a as foo")
         );
         assert_eq!(
-            parse_use_tree("a::{self}").normalize(&Config::default()),
+            parse_use_tree("a::{self}").normalize(),
             parse_use_tree("a::{self}")
         );
+        assert_eq!(parse_use_tree("a::{b}").normalize(), parse_use_tree("a::b"));
         assert_eq!(
-            parse_use_tree("a::{b}").normalize(&Config::default()),
-            parse_use_tree("a::b")
-        );
-        assert_eq!(
-            parse_use_tree("a::{b, c::self}").normalize(&Config::default()),
+            parse_use_tree("a::{b, c::self}").normalize(),
             parse_use_tree("a::{b, c}")
         );
         assert_eq!(
-            parse_use_tree("a::{b as bar, c::self}").normalize(&Config::default()),
+            parse_use_tree("a::{b as bar, c::self}").normalize(),
             parse_use_tree("a::{b as bar, c}")
         );
     }
 
     #[test]
     fn test_use_tree_ord() {
+        assert!(parse_use_tree("a").normalize() < parse_use_tree("aa").normalize());
+        assert!(parse_use_tree("a").normalize() < parse_use_tree("a::a").normalize());
+        assert!(parse_use_tree("a").normalize() < parse_use_tree("*").normalize());
+        assert!(parse_use_tree("a").normalize() < parse_use_tree("{a, b}").normalize());
+        assert!(parse_use_tree("*").normalize() < parse_use_tree("{a, b}").normalize());
+
         assert!(
-            parse_use_tree("a").normalize(&Config::default())
-                < parse_use_tree("aa").normalize(&Config::default())
+            parse_use_tree("aaaaaaaaaaaaaaa::{bb, cc, dddddddd}").normalize()
+                < parse_use_tree("aaaaaaaaaaaaaaa::{bb, cc, ddddddddd}").normalize()
         );
         assert!(
-            parse_use_tree("a").normalize(&Config::default())
-                < parse_use_tree("a::a").normalize(&Config::default())
+            parse_use_tree("serde::de::{Deserialize}").normalize()
+                < parse_use_tree("serde_json").normalize()
         );
+        assert!(parse_use_tree("a::b::c").normalize() < parse_use_tree("a::b::*").normalize());
         assert!(
-            parse_use_tree("a").normalize(&Config::default())
-                < parse_use_tree("*").normalize(&Config::default())
-        );
-        assert!(
-            parse_use_tree("a").normalize(&Config::default())
-                < parse_use_tree("{a, b}").normalize(&Config::default())
-        );
-        assert!(
-            parse_use_tree("*").normalize(&Config::default())
-                < parse_use_tree("{a, b}").normalize(&Config::default())
+            parse_use_tree("foo::{Bar, Baz}").normalize()
+                < parse_use_tree("{Bar, Baz}").normalize()
         );
 
         assert!(
-            parse_use_tree("aaaaaaaaaaaaaaa::{bb, cc, dddddddd}").normalize(&Config::default())
-                < parse_use_tree("aaaaaaaaaaaaaaa::{bb, cc, ddddddddd}")
-                    .normalize(&Config::default())
+            parse_use_tree("foo::{qux as bar}").normalize()
+                < parse_use_tree("foo::{self as bar}").normalize()
         );
         assert!(
-            parse_use_tree("serde::de::{Deserialize}").normalize(&Config::default())
-                < parse_use_tree("serde_json").normalize(&Config::default())
+            parse_use_tree("foo::{qux as bar}").normalize()
+                < parse_use_tree("foo::{baz, qux as bar}").normalize()
         );
         assert!(
-            parse_use_tree("a::b::c").normalize(&Config::default())
-                < parse_use_tree("a::b::*").normalize(&Config::default())
-        );
-        assert!(
-            parse_use_tree("foo::{Bar, Baz}").normalize(&Config::default())
-                < parse_use_tree("{Bar, Baz}").normalize(&Config::default())
+            parse_use_tree("foo::{self as bar, baz}").normalize()
+                < parse_use_tree("foo::{baz, qux as bar}").normalize()
         );
 
-        assert!(
-            parse_use_tree("foo::{qux as bar}").normalize(&Config::default())
-                < parse_use_tree("foo::{self as bar}").normalize(&Config::default())
-        );
-        assert!(
-            parse_use_tree("foo::{qux as bar}").normalize(&Config::default())
-                < parse_use_tree("foo::{baz, qux as bar}").normalize(&Config::default())
-        );
-        assert!(
-            parse_use_tree("foo::{self as bar, baz}").normalize(&Config::default())
-                < parse_use_tree("foo::{baz, qux as bar}").normalize(&Config::default())
-        );
+        assert!(parse_use_tree("foo").normalize() < parse_use_tree("Foo").normalize());
+        assert!(parse_use_tree("foo").normalize() < parse_use_tree("foo::Bar").normalize());
 
         assert!(
-            parse_use_tree("foo").normalize(&Config::default())
-                < parse_use_tree("Foo").normalize(&Config::default())
-        );
-        assert!(
-            parse_use_tree("foo").normalize(&Config::default())
-                < parse_use_tree("foo::Bar").normalize(&Config::default())
-        );
-
-        assert!(
-            parse_use_tree("std::cmp::{d, c, b, a}").normalize(&Config::default())
-                < parse_use_tree("std::cmp::{b, e, g, f}").normalize(&Config::default())
+            parse_use_tree("std::cmp::{d, c, b, a}").normalize()
+                < parse_use_tree("std::cmp::{b, e, g, f}").normalize()
         );
     }
 

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -12,7 +12,7 @@ use rustc_ast::ast;
 use rustc_span::{symbol::sym, Span};
 
 use crate::config::{Config, GroupImportsTactic, ReorderImports};
-use crate::imports::{normalize_use_trees_with_granularity, UseSegment, UseTree, ImportsVector};
+use crate::imports::{normalize_use_trees_with_granularity, UseSegment, UseTree};
 use crate::items::{is_mod_decl, rewrite_extern_crate, rewrite_mod};
 use crate::lists::{itemize_list, write_list, ListFormatting, ListItem};
 use crate::rewrite::RewriteContext;
@@ -138,10 +138,10 @@ fn rewrite_reorderable_or_regroupable_items(
                 .map(|use_group| {
                     let item_vec: Vec<_> = use_group
                         .into_iter()
-                        .map(|use_tree| {println!("use_tree: {:?}", use_tree); ListItem {
+                        .map(|use_tree| ListItem {
                             item: use_tree.rewrite_top_level(context, nested_shape),
                             ..use_tree.list_item.unwrap_or_else(ListItem::empty)
-                        }})
+                        })
                         .collect();
                     wrap_reorderable_items(context, &item_vec, nested_shape)
                 })

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -11,7 +11,7 @@ use std::cmp::{Ord, Ordering};
 use rustc_ast::ast;
 use rustc_span::{symbol::sym, Span};
 
-use crate::config::{Config, GroupImportsTactic};
+use crate::config::{Config, GroupImportsTactic, ReorderImports};
 use crate::imports::{normalize_use_trees_with_granularity, UseSegment, UseTree};
 use crate::items::{is_mod_decl, rewrite_extern_crate, rewrite_mod};
 use crate::lists::{itemize_list, write_list, ListFormatting, ListItem};
@@ -119,7 +119,7 @@ fn rewrite_reorderable_or_regroupable_items(
                 GroupImportsTactic::StdExternalCrate => group_imports(normalized_items),
             };
 
-            if context.config.reorder_imports() {
+            if context.config.reorder_imports() == ReorderImports::Alphabetically {
                 regrouped_items.iter_mut().for_each(|items| items.sort())
             }
 
@@ -228,9 +228,9 @@ impl ReorderableItemKind {
 
     fn is_reorderable(self, config: &Config) -> bool {
         match self {
-            ReorderableItemKind::ExternCrate => config.reorder_imports(),
+            ReorderableItemKind::ExternCrate => config.reorder_imports() != ReorderImports::Off,
             ReorderableItemKind::Mod => config.reorder_modules(),
-            ReorderableItemKind::Use => config.reorder_imports(),
+            ReorderableItemKind::Use => config.reorder_imports() != ReorderImports::Off,
             ReorderableItemKind::Other => false,
         }
     }

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -146,7 +146,7 @@ fn rewrite_reorderable_or_regroupable_items(
                     wrap_reorderable_items(context, &item_vec, nested_shape)
                 })
                 .collect::<Option<Vec<_>>>()?;
-            println!("item_vec: {:?}", item_vec);
+
             let join_string = format!("\n\n{}", shape.indent.to_string(context.config));
             Some(item_vec.join(&join_string))
         }

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -19,7 +19,7 @@ use crate::rewrite::RewriteContext;
 use crate::shape::Shape;
 use crate::source_map::LineRangeUtils;
 use crate::spanned::Spanned;
-use crate::utils::{contains_skip, mk_sp};
+use crate::utils::{compare_sliding_order, contains_skip, mk_sp};
 use crate::visitor::FmtVisitor;
 
 /// Choose the ordering between the given two items.
@@ -121,6 +121,12 @@ fn rewrite_reorderable_or_regroupable_items(
 
             if context.config.reorder_imports() == ReorderImports::Alphabetically {
                 regrouped_items.iter_mut().for_each(|items| items.sort())
+            } else if context.config.reorder_imports() == ReorderImports::Length {
+                regrouped_items.iter_mut().for_each({
+                    |items| {
+                        items.sort_by(|a, b| compare_sliding_order(&a.to_string(), &b.to_string()))
+                    }
+                })
             }
 
             // 4 = "use ", 1 = ";"

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -818,6 +818,7 @@ fn handle_result(
         // Ignore LF and CRLF difference for Windows.
         if !string_eq_ignore_newline_repr(&fmt_text, &text) {
             let diff = make_diff(&text, &fmt_text, DIFF_CONTEXT_SIZE);
+            println!("diff: {:#?}", diff);
             assert!(
                 !diff.is_empty(),
                 "Empty diff? Maybe due to a missing a newline at the end of a file?"

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -818,7 +818,6 @@ fn handle_result(
         // Ignore LF and CRLF difference for Windows.
         if !string_eq_ignore_newline_repr(&fmt_text, &text) {
             let diff = make_diff(&text, &fmt_text, DIFF_CONTEXT_SIZE);
-            println!("diff: {:#?}", diff);
             assert!(
                 !diff.is_empty(),
                 "Empty diff? Maybe due to a missing a newline at the end of a file?"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cmp::Ordering;
 
 use rustc_ast::ast::{
     self, Attribute, CrateSugar, MetaItem, MetaItemKind, NestedMetaItem, NodeId, Path, Visibility,
@@ -692,6 +693,15 @@ impl NodeIdExt for NodeId {
 
 pub(crate) fn unicode_str_width(s: &str) -> usize {
     s.width()
+}
+
+pub(crate) fn compare_sliding_order(s1: &str, s2: &str) -> Ordering {
+    let mut is_equal = s1.len().cmp(&s2.len());
+    if Ordering::is_eq(is_equal) {
+        is_equal = s1.cmp(&s2);
+    }
+
+    is_equal
 }
 
 #[cfg(test)]

--- a/tests/config/issue-1111.toml
+++ b/tests/config/issue-1111.toml
@@ -1,1 +1,1 @@
-reorder_imports = true
+reorder_imports = "Alphabetically"

--- a/tests/config/small_tabs.toml
+++ b/tests/config/small_tabs.toml
@@ -8,5 +8,5 @@ trailing_comma = "Vertical"
 indent_style = "Block"
 report_todo = "Always"
 report_fixme = "Never"
-reorder_imports = false
+reorder_imports = "Off"
 format_strings = true

--- a/tests/source/configs/group_imports/One-no_reorder.rs
+++ b/tests/source/configs/group_imports/One-no_reorder.rs
@@ -1,5 +1,5 @@
 // rustfmt-group_imports: One
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 use chrono::Utc;
 use super::update::convert_publish_payload;
 

--- a/tests/source/configs/group_imports/StdExternalCrate-no_reorder.rs
+++ b/tests/source/configs/group_imports/StdExternalCrate-no_reorder.rs
@@ -1,5 +1,5 @@
 // rustfmt-group_imports: StdExternalCrate
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 
 use chrono::Utc;
 use super::update::convert_publish_payload;

--- a/tests/source/configs/reorder_imports/false.rs
+++ b/tests/source/configs/reorder_imports/false.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 // Reorder imports
 
 use lorem;

--- a/tests/source/configs/reorder_imports/true.rs
+++ b/tests/source/configs/reorder_imports/true.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: true
+// rustfmt-reorder_imports: Alphabetically
 // Reorder imports
 
 use lorem;

--- a/tests/source/issue-1120.rs
+++ b/tests/source/issue-1120.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: true
+// rustfmt-reorder_imports: Alphabetically
 
 // Ensure that a use at the start of an inline module is correctly formatted.
 mod foo {use bar;}

--- a/tests/source/issue-1124.rs
+++ b/tests/source/issue-1124.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: true
+// rustfmt-reorder_imports: Alphabetically
 
 use d; use c; use b; use a; 
 // The previous line has a space after the `use a;` 

--- a/tests/source/issue-3515.rs
+++ b/tests/source/issue-3515.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 
 use std :: fmt :: { self , Display } ;
 use std :: collections :: HashMap ;

--- a/tests/source/issue-3585/reorder_imports_disabled.rs
+++ b/tests/source/issue-3585/reorder_imports_disabled.rs
@@ -1,5 +1,5 @@
 // rustfmt-inline_attribute_width: 100
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 
 #[cfg(unix)]
 extern crate crateb;

--- a/tests/source/issue-3585/reorder_imports_enabled.rs
+++ b/tests/source/issue-3585/reorder_imports_enabled.rs
@@ -1,5 +1,5 @@
 // rustfmt-inline_attribute_width: 100
-// rustfmt-reorder_imports: true
+// rustfmt-reorder_imports: Alphabetically
 
 #[cfg(unix)]
 extern crate crateb;

--- a/tests/source/long-use-statement-issue-3154.rs
+++ b/tests/source/long-use-statement-issue-3154.rs
@@ -1,3 +1,3 @@
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 
 pub use self :: super :: super :: super :: root::mozilla::detail::StringClassFlags as nsTStringRepr_ClassFlags ;

--- a/tests/target/configs/group_imports/One-no_reorder.rs
+++ b/tests/target/configs/group_imports/One-no_reorder.rs
@@ -1,5 +1,5 @@
 // rustfmt-group_imports: One
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 use chrono::Utc;
 use super::update::convert_publish_payload;
 use juniper::{FieldError, FieldResult};

--- a/tests/target/configs/group_imports/StdExternalCrate-no_reorder.rs
+++ b/tests/target/configs/group_imports/StdExternalCrate-no_reorder.rs
@@ -1,5 +1,5 @@
 // rustfmt-group_imports: StdExternalCrate
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 
 use alloc::alloc::Layout;
 use std::sync::Arc;

--- a/tests/target/configs/reorder_imports/false.rs
+++ b/tests/target/configs/reorder_imports/false.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 // Reorder imports
 
 use lorem;

--- a/tests/target/configs/reorder_imports/true.rs
+++ b/tests/target/configs/reorder_imports/true.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: true
+// rustfmt-reorder_imports: Alphabetically
 // Reorder imports
 
 use dolor;

--- a/tests/target/issue-1120.rs
+++ b/tests/target/issue-1120.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: true
+// rustfmt-reorder_imports: Alphabetically
 
 // Ensure that a use at the start of an inline module is correctly formatted.
 mod foo {

--- a/tests/target/issue-1124.rs
+++ b/tests/target/issue-1124.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: true
+// rustfmt-reorder_imports: Alphabetically
 
 use a;
 use b;

--- a/tests/target/issue-3515.rs
+++ b/tests/target/issue-3515.rs
@@ -1,4 +1,4 @@
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 
 use std::fmt::{self, Display};
 use std::collections::HashMap;

--- a/tests/target/issue-3585/reorder_imports_disabled.rs
+++ b/tests/target/issue-3585/reorder_imports_disabled.rs
@@ -1,5 +1,5 @@
 // rustfmt-inline_attribute_width: 100
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 
 #[cfg(unix)] extern crate crateb;
 #[cfg(unix)] extern crate cratea;

--- a/tests/target/issue-3585/reorder_imports_enabled.rs
+++ b/tests/target/issue-3585/reorder_imports_enabled.rs
@@ -1,5 +1,5 @@
 // rustfmt-inline_attribute_width: 100
-// rustfmt-reorder_imports: true
+// rustfmt-reorder_imports: Alphabetically
 
 #[cfg(unix)] extern crate cratea;
 #[cfg(unix)] extern crate crateb;

--- a/tests/target/issue-4791/issue_4928.rs
+++ b/tests/target/issue-4791/issue_4928.rs
@@ -9,7 +9,7 @@
 // rustfmt-newline_style: Unix
 // rustfmt-normalize_doc_attributes: true
 // rustfmt-overflow_delimited_expr: true
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 // rustfmt-reorder_modules: true
 // rustfmt-struct_field_align_threshold: 20
 // rustfmt-tab_spaces: 4

--- a/tests/target/long-use-statement-issue-3154.rs
+++ b/tests/target/long-use-statement-issue-3154.rs
@@ -1,3 +1,3 @@
-// rustfmt-reorder_imports: false
+// rustfmt-reorder_imports: Off
 
 pub use self::super::super::super::root::mozilla::detail::StringClassFlags as nsTStringRepr_ClassFlags;


### PR DESCRIPTION
Once upon a time, when I was a junior developer in this c team, I had a fanatic team leader, who has preached his code style on us.
One of his principles refers to the order of the includes at the top of each file; instead of ordering them alphabetically or whatever, we had to sort them by the total length of each path:

#include <linux/bio.h>
#include <linux/uio.h>
#include <linux/blkdev.h>
#include <linux/kernel.h>
#include <linux/module.h>
#include <linux/sched/task_stack.h>

Then, me and another friend moved to another team, which code in rust. Everything in this language was more than perfect, besides the lack of the "sliding includes". So, after a search for the right configuration, i decided to code this feature to the rustfmt