### PR TITLE
Pass `--locked` when installing rustfmt in integration tests

### DIFF
--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -15,7 +15,7 @@ set -ex
 # it again.
 #
 #which cargo-fmt || cargo install --force
-CFG_RELEASE=nightly CFG_RELEASE_CHANNEL=nightly cargo install --path . --force
+CFG_RELEASE=nightly CFG_RELEASE_CHANNEL=nightly cargo install --path . --force --locked
 
 echo "Integration tests for: ${INTEGRATION}"
 cargo fmt -- --version


### PR DESCRIPTION
There was recently an issue where `cargo install` was installing a newer version of a dependency than the one listed in our Cargo.toml. The newer version added deprecation warnings that caused our continuous integration tests to break.

As mentioned in the `cargo help install` docs, passing the `--locked` flag should force cargo to use the `Cargo.lock` file included with the repository.

ref: https://github.com/rust-lang/rustfmt/pull/5384#issuecomment-1154158644