### PR TITLE
Wrap cast expr in parens when the ty ends with empty angle brackets

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::cmp::min;
+use std::ops::Deref;
 
 use itertools::Itertools;
 use rustc_ast::token::{Delimiter, LitKind};
@@ -95,6 +96,7 @@ pub(crate) fn format_expr(
         ast::ExprKind::Binary(op, ref lhs, ref rhs) => {
             // FIXME: format comments between operands and operator
             rewrite_all_pairs(expr, shape, context).or_else(|| {
+                let wrap_lhs_in_parns = lhs_needs_parens(&op, lhs);
                 rewrite_pair(
                     &**lhs,
                     &**rhs,
@@ -102,6 +104,7 @@ pub(crate) fn format_expr(
                     context,
                     shape,
                     context.config.binop_separator(),
+                    wrap_lhs_in_parns,
                 )
             })
         }
@@ -240,6 +243,7 @@ pub(crate) fn format_expr(
             context,
             shape,
             SeparatorPlace::Front,
+            false,
         ),
         ast::ExprKind::Type(ref expr, ref ty) => rewrite_pair(
             &**expr,
@@ -248,6 +252,7 @@ pub(crate) fn format_expr(
             context,
             shape,
             SeparatorPlace::Back,
+            false,
         ),
         ast::ExprKind::Index(ref expr, ref index) => {
             rewrite_index(&**expr, &**index, context, shape)
@@ -259,6 +264,7 @@ pub(crate) fn format_expr(
             context,
             shape,
             SeparatorPlace::Back,
+            false,
         ),
         ast::ExprKind::Range(ref lhs, ref rhs, limits) => {
             let delim = match limits {
@@ -313,6 +319,7 @@ pub(crate) fn format_expr(
                         context,
                         shape,
                         context.config.binop_separator(),
+                        false,
                     )
                 }
                 (None, Some(rhs)) => {
@@ -407,6 +414,35 @@ pub(crate) fn format_expr(
             );
             combine_strs_with_missing_comments(context, &attrs_str, &expr_str, span, shape, false)
         })
+}
+
+/// Check if we need to wrap the lhs of a binary expression in parens to avoid compilation errors.
+/// See <https://github.com/rust-lang/rustfmt/issues/4621>
+pub(crate) fn lhs_needs_parens(op: &ast::BinOp, lhs: &ast::Expr) -> bool {
+    let is_lt_or_shl = matches!(op.node, ast::BinOpKind::Shl | ast::BinOpKind::Lt);
+    if !is_lt_or_shl {
+        return false;
+    }
+    matches!(
+        lhs.kind,
+        ast::ExprKind::Cast(_, ref ty) if ty_ends_with_empty_angle_brackets(ty)
+    )
+}
+
+/// Check if they type ends with an empty generic argument list e.g. `i32<>`.
+fn ty_ends_with_empty_angle_brackets(ty: &ast::Ty) -> bool {
+    if let ast::TyKind::Path(_, path) = &ty.kind {
+        matches!(
+            path.segments.last(),
+            Some(ast::PathSegment {args: Some(generic_args), ..})
+            if matches!(
+                generic_args.deref(),
+                ast::GenericArgs::AngleBracketed(bracket_args) if bracket_args.args.is_empty()
+            )
+        )
+    } else {
+        false
+    }
 }
 
 pub(crate) fn rewrite_array<'a, T: 'a + IntoOverflowableItem<'a>>(

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -217,6 +217,7 @@ impl Rewrite for Pat {
                     context,
                     shape,
                     SeparatorPlace::Front,
+                    false,
                 )
             }
             PatKind::Ref(ref pat, mutability) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -809,6 +809,7 @@ impl Rewrite for ast::Ty {
                 context,
                 shape,
                 SeparatorPlace::Back,
+                false,
             ),
             ast::TyKind::Infer => {
                 if shape.width >= 1 {

--- a/tests/source/issue-4621/do_not_wrap_in_parens.rs
+++ b/tests/source/issue-4621/do_not_wrap_in_parens.rs
@@ -1,0 +1,13 @@
+fn less_than_or_equal_operand() {
+    let x: u32 = 100;
+    if x as i32<> <= 0 {
+        // ...
+    }
+}
+
+fn long_binary_op_chain_no_wrap() {
+    let x: u32 = 100;
+    if x as i32 <= 0 && x as i32 <= 0 && x as i32 <= 0 && x as i32 <= 0 && x as i32 <= 0 && x as i32 <= 0 && x as i32 <= 0 {
+        // ...
+    }
+}

--- a/tests/source/issue-4621/wrap_in_parens.rs
+++ b/tests/source/issue-4621/wrap_in_parens.rs
@@ -1,0 +1,27 @@
+fn less_than_operand() {
+    let x: u32 = 100;
+    if x as i32<> < 0 {
+        // ...
+    }
+}
+
+fn left_shift_operand() {
+    let x: u32 = 100;
+    if x as i32<> << 1 < 0 {
+        // ...
+    }
+}
+
+fn long_binary_op_chain_wrap_all() {
+    let x: u32 = 100;
+    if x as i32<> < 0 && x as i32<> < 0 && x as i32<> << 1 < 0 && x as i32<> << 1 < 0 && x as i32<> << 1 < 0 && x as i32<> << 1 < 0 {
+        // ...
+    }
+}
+
+fn long_binary_op_chain_wrap_some() {
+    let x: u32 = 100;
+    if x as i32<> < 0 && x as i32<> <= 0 && x as i32<> << 1 < 0 && x as i32<> <= 0 && x as i32<> << 1 < 0 {
+        // ...
+    }
+}

--- a/tests/target/issue-4621/do_not_wrap_in_parens.rs
+++ b/tests/target/issue-4621/do_not_wrap_in_parens.rs
@@ -1,0 +1,20 @@
+fn less_than_or_equal_operand() {
+    let x: u32 = 100;
+    if x as i32 <= 0 {
+        // ...
+    }
+}
+
+fn long_binary_op_chain_no_wrap() {
+    let x: u32 = 100;
+    if x as i32 <= 0
+        && x as i32 <= 0
+        && x as i32 <= 0
+        && x as i32 <= 0
+        && x as i32 <= 0
+        && x as i32 <= 0
+        && x as i32 <= 0
+    {
+        // ...
+    }
+}

--- a/tests/target/issue-4621/wrap_in_parens.rs
+++ b/tests/target/issue-4621/wrap_in_parens.rs
@@ -1,0 +1,38 @@
+fn less_than_operand() {
+    let x: u32 = 100;
+    if (x as i32) < 0 {
+        // ...
+    }
+}
+
+fn left_shift_operand() {
+    let x: u32 = 100;
+    if (x as i32) << 1 < 0 {
+        // ...
+    }
+}
+
+fn long_binary_op_chain_wrap_all() {
+    let x: u32 = 100;
+    if (x as i32) < 0
+        && (x as i32) < 0
+        && (x as i32) << 1 < 0
+        && (x as i32) << 1 < 0
+        && (x as i32) << 1 < 0
+        && (x as i32) << 1 < 0
+    {
+        // ...
+    }
+}
+
+fn long_binary_op_chain_wrap_some() {
+    let x: u32 = 100;
+    if (x as i32) < 0
+        && x as i32 <= 0
+        && (x as i32) << 1 < 0
+        && x as i32 <= 0
+        && (x as i32) << 1 < 0
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
Fixes #4621

Previously rustfmt would remove empty angle brackets from cast expressions e.g. `x as i32<>` => `x as i32`. This lead to code that could not compile when the cast occurred in an if statement.

The advice from the compiler was to wrap the cast in parentheses, which is now the behavior rustfmt employs.