### PR TITLE
Set `package.metadata.rust-analyzer.rustc_private=true` in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ rustfmt-config_proc_macro = { version = "0.2", path = "config_proc_macro" }
 rustc-workspace-hack = "1.0.0"
 
 # Rustc dependencies are loaded from the sysroot, Cargo doesn't know about them.
+
+[package.metadata.rust-analyzer]
+# This package uses #[feature(rustc_private)]
+rustc_private = true


### PR DESCRIPTION
By setting this value in the Cargo.toml rust-analyzer understands that rustfmt uses compiler-internals using `extern crate`.

This is a universal step that all developers will need to take in order to get better type hints and code completion suggestions for compiler-internals in their editor.

**Note**: users will also need to install the `rustc-dev` component [via rustup](https://rust-lang.github.io/rustup/concepts/components.html) and add the following to their rust-analyzer configuration:

```json
{
    "rust-analyzer.rustcSource": "discover",
    "rust-analyzer.updates.channel": "nightly"
}
```