### PR TITLE
Fix issue where `cargo fmt --version` would not display version info

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 
-use clap::{CommandFactory, Parser};
+use clap::{AppSettings, CommandFactory, Parser};
 
 #[path = "test/mod.rs"]
 #[cfg(test)]
@@ -22,6 +22,7 @@ mod cargo_fmt_tests;
 
 #[derive(Parser)]
 #[clap(
+    global_setting(AppSettings::NoAutoVersion),
     bin_name = "cargo fmt",
     about = "This utility formats all bin and lib files of \
              the current crate using rustfmt."


### PR DESCRIPTION
Fixes #5395

In PR #5239 we switched from using `structopt` to `clap`. It seems that the default behavior for `clap` is to override the `--version` flag, which prevented our custom version display code from running.

The fix as outlined in https://github.com/clap-rs/clap/issues/3405 was to set
`#[clap(global_setting(AppSettings::NoAutoVersion))]` to prevent clap from setting its own default behavior for the `--version` flag.