### PR TITLE
Allow `#[ignore]` tests to run in rustfmt's test suite

### DIFF
--- a/ci/build_and_test.bat
+++ b/ci/build_and_test.bat
@@ -1,4 +1,5 @@
 set "RUSTFLAGS=-D warnings"
+set "RUSTFMT_CI=1"
 
 :: Print version information
 rustc -Vv || exit /b 1

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 export RUSTFLAGS="-D warnings"
+export RUSTFMT_CI=1
 
 # Print version information
 rustc -Vv

--- a/config_proc_macro/src/lib.rs
+++ b/config_proc_macro/src/lib.rs
@@ -69,3 +69,16 @@ pub fn stable_only_test(_args: TokenStream, input: TokenStream) -> TokenStream {
         TokenStream::from_str("").unwrap()
     }
 }
+
+/// Used to conditionally output the TokenStream for tests that should be run as part of rustfmts
+/// test suite, but should be ignored when running in the rust-lang/rust test suite.
+#[proc_macro_attribute]
+pub fn rustfmt_only_ci_test(_args: TokenStream, input: TokenStream) -> TokenStream {
+    if option_env!("RUSTFMT_CI").is_some() {
+        input
+    } else {
+        let mut token_stream = TokenStream::from_str("#[ignore]").unwrap();
+        token_stream.extend(input);
+        token_stream
+    }
+}

--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -4,6 +4,8 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 
+use rustfmt_config_proc_macro::rustfmt_only_ci_test;
+
 /// Run the cargo-fmt executable and return its output.
 fn cargo_fmt(args: &[&str]) -> (String, String) {
     let mut bin_dir = env::current_exe().unwrap();
@@ -47,7 +49,7 @@ macro_rules! assert_that {
     };
 }
 
-#[ignore]
+#[rustfmt_only_ci_test]
 #[test]
 fn version() {
     assert_that!(&["--version"], starts_with("rustfmt "));
@@ -56,7 +58,7 @@ fn version() {
     assert_that!(&["--", "--version"], starts_with("rustfmt "));
 }
 
-#[ignore]
+#[rustfmt_only_ci_test]
 #[test]
 fn print_config() {
     assert_that!(
@@ -65,7 +67,7 @@ fn print_config() {
     );
 }
 
-#[ignore]
+#[rustfmt_only_ci_test]
 #[test]
 fn rustfmt_help() {
     assert_that!(&["--", "--help"], contains("Format Rust code"));
@@ -73,7 +75,7 @@ fn rustfmt_help() {
     assert_that!(&["--", "--help=config"], contains("Configuration Options:"));
 }
 
-#[ignore]
+#[rustfmt_only_ci_test]
 #[test]
 fn cargo_fmt_out_of_line_test_modules() {
     // See also https://github.com/rust-lang/rustfmt/issues/5119

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -5,6 +5,8 @@ use std::fs::remove_file;
 use std::path::Path;
 use std::process::Command;
 
+use rustfmt_config_proc_macro::rustfmt_only_ci_test;
+
 /// Run the rustfmt executable and return its output.
 fn rustfmt(args: &[&str]) -> (String, String) {
     let mut bin_dir = env::current_exe().unwrap();
@@ -47,7 +49,7 @@ macro_rules! assert_that {
     };
 }
 
-#[ignore]
+#[rustfmt_only_ci_test]
 #[test]
 fn print_config() {
     assert_that!(
@@ -76,7 +78,7 @@ fn print_config() {
     remove_file("minimal-config").unwrap();
 }
 
-#[ignore]
+#[rustfmt_only_ci_test]
 #[test]
 fn inline_config() {
     // single invocation


### PR DESCRIPTION
There are some tests in the rustfmt test suite that are ignored by default. I believe these tests are ignored because they have caused issues with the the `rust-lang/rust` test suite.

However, we recently experienced an issue (#5395) that would have been avoided had these tests been running.

With the introduction of the new `#[rustfmt_only_ci_test]` attribute macro we can run these tests when the `RUSTFMT_CI` environment variable is set, which will presumably only be set during rustfmts CI runs. When the environment variable is not set the `#[rustfmt_only_ci_test]` will be replaced with an `#[ignore]`.