### PR TITLE
Do no memoize `ast::ExprKind::MethodCall`

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -55,6 +55,11 @@ pub(crate) fn format_expr(
     context: &RewriteContext<'_>,
     shape: Shape,
 ) -> Option<String> {
+    // Memoizing method calls lead to cases where rustfmt's stability guarantees are violated.
+    // See https://github.com/rust-lang/rustfmt/issues/5399
+    if matches!(expr.kind, ast::ExprKind::MethodCall(..)) {
+        return format_expr_inner(expr, expr_type, context, shape);
+    }
     // when max_width is tight, we should check all possible formattings, in order to find
     // if we can fit expression in the limit. Doing it recursively takes exponential time
     // relative to input size, and people hit it with rustfmt takes minutes in #4476 #4867 #5128

--- a/tests/target/issue_5399.rs
+++ b/tests/target/issue_5399.rs
@@ -1,0 +1,50 @@
+// rustfmt-max_width: 140
+// This file should be left unchanged even when memozing certain expressions
+// See https://github.com/rust-lang/rustfmt/issues/5399
+
+impl NotificationRepository {
+    fn set_status_changed(
+        &self,
+        repo_tx_conn: &RepoTxConn,
+        rid: &RoutableId,
+        changed_at: NaiveDateTime,
+    ) -> NukeResult<Option<NotificationStatus>> {
+        repo_tx_conn.run(move |conn| {
+            let res = diesel::update(client_notification::table)
+                .filter(
+                    client_notification::routable_id.eq(DieselRoutableId(rid.clone())).and(
+                        client_notification::changed_at
+                            .lt(changed_at)
+                            .or(client_notification::changed_at.is_null()),
+                    ),
+                )
+                .set(client_notification::changed_at.eq(changed_at))
+                .returning((
+                    client_notification::id,
+                    client_notification::changed_at,
+                    client_notification::polled_at,
+                    client_notification::notified_at,
+                ))
+                .get_result::<(Uuid, Option<NaiveDateTime>, Option<NaiveDateTime>, Option<NaiveDateTime>)>(conn)
+                .optional()?;
+
+            match res {
+                Some(row) => {
+                    let client_id = client_contract::table
+                        .inner_join(client_notification::table)
+                        .filter(client_notification::id.eq(row.0))
+                        .select(client_contract::client_id)
+                        .get_result::<Uuid>(conn)?;
+
+                    Ok(Some(NotificationStatus {
+                        client_id: client_id.into(),
+                        changed_at: row.1,
+                        polled_at: row.2,
+                        notified_at: row.3,
+                    }))
+                }
+                None => Ok(None),
+            }
+        })
+    }
+}


### PR DESCRIPTION
Fixes #5399

Memoizing method calls lead to cases where rustfmt's stability guarantees were violated.

Excluding method calls is a small performance hit that we'll gladly pay to make sure we maintain our stability guarantees.

As of now it's unclear if there will be other `ast::ExprKind` nodes that will need to be excluded for a similar reason.