### PR TITLE
Doc updates for --check

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To format individual files or arbitrary codes from stdin, the `rustfmt` binary s
 examples follow:
 
 - `rustfmt lib.rs main.rs` will format "lib.rs" and "main.rs" in place
-- `rustfmt` will read a code from stdin and write formatting to stdout
+- `rustfmt` will read a code from stdin and write formatting to stdout. When reading from stdin, `rustfmt` will not exit with an error code unless there were parsing errors or interal `rustfmt` errors.
   - `echo "fn     main() {}" | rustfmt` would emit "fn main() {}".
 
 For more information, including arguments and emit options, see `rustfmt --help`.
@@ -126,6 +126,11 @@ make any formatting changes to the input, and `1` if Rustfmt would make changes.
 In other modes, Rustfmt will exit with `1` if there was some error during
 formatting (for example a parsing or internal error) and `0` if formatting
 completed without error (whether or not changes were made).
+If Rustfmt decides formatting is required, a diff will be printed. The diff has
+the following format:
+ - Lines that start with `-` are poorly formatted.
+ - Lines that start with `+` are after formatting.
+ - All other lines are properly formated.
 
 
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -99,8 +99,10 @@ fn make_opts() -> Options {
     opts.optflag(
         "",
         "check",
-        "Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits \
-         with 1 and prints a diff if formatting is required.",
+        "Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits  \
+         with 1 and prints a diff if formatting is required. When reading a diff,  \
+         lines that start with '-' are poorly formatted, lines that start with '+' \
+         are after formatting, and all other lines are properly formatted.",
     );
     let is_nightly = is_nightly();
     let emit_opts = if is_nightly {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -99,10 +99,11 @@ fn make_opts() -> Options {
     opts.optflag(
         "",
         "check",
-        "Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits  \
-         with 1 and prints a diff if formatting is required. When reading a diff,  \
-         lines that start with '-' are poorly formatted, lines that start with '+' \
-         are after formatting, and all other lines are properly formatted.",
+        "Run in 'check' mode. Exits with 0 if input is formatted correctly or reading \
+         from stdin. Exits with 1 and prints a diff if formatting is required. When   \
+         reading a diff lines that start with '-' are poorly formatted, lines that    \
+         start with '+' are after formatting, and all other lines are properly        \
+         formatted.",
     );
     let is_nightly = is_nightly();
     let emit_opts = if is_nightly {


### PR DESCRIPTION
Fixes #5364 
Update documentation regarding the output of the diff. Describe the difference between lines starting with `+`, `-`, and ` `. Also added a snipped to the text printed by Rustfmt in the `check` optflag section.

Fixes #5376 
Also documented that Rustfmt will exit with code 0 when reading from stdin despite seeing formatting errors. I found evidence of this being a design decision here: https://github.com/rust-lang/rustfmt/pull/2495. I guess the emacs package for Rust passes through stdin when formatting, but requires a 0 exit code. Although I should note that this doesn't appear to be the case today. I observed emacs not caring when Rustfmt returned 1 due to formatting issues.