### PR TITLE
Handling fn empty where and comments after return type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "atty"
@@ -61,18 +61,18 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 dependencies = [
  "packed_simd_2",
 ]
 
 [[package]]
 name = "camino"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
 dependencies = [
  "serde",
 ]
@@ -107,16 +107,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "ed6db9e867166a43a53f7199b5e4d1f522a1e5bd626654be263c999ce59df39a"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -136,13 +136,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.8"
+name = "clap_lex"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -239,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -250,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -263,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
@@ -308,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -327,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "lazy_static"
@@ -339,9 +348,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libm"
@@ -351,39 +360,36 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
  "libm",
@@ -415,18 +421,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -453,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -464,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rustc-workspace-hack"
@@ -516,15 +522,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "same-file"
@@ -537,27 +543,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -566,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
@@ -583,13 +589,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -620,18 +626,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -649,12 +655,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-segmentation"
@@ -667,12 +679,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unicode_categories"
@@ -699,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/tests/source/issue-5407/one.rs
+++ b/tests/source/issue-5407/one.rs
@@ -1,0 +1,148 @@
+// rustfmt-version: One
+
+// Original - return-type and empty "where" - no comments
+mod inner {
+fn foo1() -> String
+where {
+String::new()
+}
+}
+
+mod inner {
+fn foo2() -> String
+{
+String::new()
+}
+}
+
+// Return-type with no "where" - one comment
+fn main () {
+fn foo1() -> String /* same-line with ret-type and brace comment */ {
+}
+}
+
+fn main () {
+fn foo2() -> String /* same-line with ret-type comment - brace in new-line */
+{
+}
+}
+
+fn main () {
+fn foo3() -> String
+/* new-line comment - brace in new-line */
+{
+}
+}
+
+fn main () {
+fn foo4() -> String // same-line with ret-type comment
+{
+}
+}
+
+// Return-type and empty "where" - one comment
+fn main () {
+fn foo1() -> String /* same-line with ret-type/where/brace brace pre-where comment */ where {
+}
+}
+
+fn main () {
+fn foo2() -> String /* same-line with ret-type/where pre-where comment - brace in new-line */ where
+{
+}
+}
+
+fn main () {
+fn foo3() -> String /* same-line with ret-type pre-where comment - where in new-line */
+where {
+}
+}
+
+fn main () {
+fn foo4() -> String
+/* new-line pre-where comment - where in new-line */
+where {
+}
+}
+
+fn main () {
+fn foo5() -> String // same-line with ret-type pre-where comment
+where
+{
+}
+}
+
+fn main () {
+fn foo6() -> String
+// new-line pre-where comment
+where
+{
+}
+}
+
+// Return-type and empty "where" - two inline comments
+fn main () {
+fn foo1() -> String /* pre-where same-line */ where /* post-where same line */ {
+}
+}
+
+fn main () {
+fn foo2() -> String
+/* pre-where new-line */ where /* post-where same line */ {
+}
+}
+
+fn main () {
+fn foo3() -> String /* pre-where same with ret - where in new */
+where /* post-where same line */ {
+}
+}
+
+fn main () {
+fn foo4() -> String /* pre-where same with ret - where in new */
+where
+/* post-where new line - brace in same */ {
+}
+}
+
+fn main () {
+fn foo5() -> String
+/* pre-where new line - where in new */
+where
+/* post-where new line - brace in same */ {
+}
+}
+
+fn main () {
+fn foo6() -> String
+/* pre-where new line - where in new */
+where
+/* post-where new line - brace in new */
+{
+}
+}
+
+// Return-type and empty "where" - two one-line comments
+fn main () {
+fn foo1() -> String // pre-where same with ret - where in new
+where // post-where same with where - brace in new
+{
+}
+}
+
+fn main () {
+fn foo2() -> String
+// pre-where new line
+where // post-where same with where - brace in new
+{
+}
+}
+
+// Return-type and empty "where" - more comments
+fn main() {
+fn foo<F>(foo2: F) -> String /* pre-where same with ret - where in new */
+where /* post-where same with where - following in new" */
+F: Fn() /* comment after where declaration */
+{
+}
+}

--- a/tests/source/issue-5407/two.rs
+++ b/tests/source/issue-5407/two.rs
@@ -1,0 +1,148 @@
+// rustfmt-version: Two
+
+// Original - return-type and empty "where" - no comments
+mod inner {
+fn foo1() -> String
+where {
+String::new()
+}
+}
+
+mod inner {
+fn foo2() -> String
+{
+String::new()
+}
+}
+
+// Return-type with no "where" - one comment
+fn main () {
+fn foo1() -> String /* same-line with ret-type and brace comment */ {
+}
+}
+
+fn main () {
+fn foo2() -> String /* same-line with ret-type comment - brace in new-line */
+{
+}
+}
+
+fn main () {
+fn foo3() -> String
+/* new-line comment - brace in new-line */
+{
+}
+}
+
+fn main () {
+fn foo4() -> String // same-line with ret-type comment
+{
+}
+}
+
+// Return-type and empty "where" - one comment
+fn main () {
+fn foo1() -> String /* same-line with ret-type/where/brace brace pre-where comment */ where {
+}
+}
+
+fn main () {
+fn foo2() -> String /* same-line with ret-type/where pre-where comment - brace in new-line */ where
+{
+}
+}
+
+fn main () {
+fn foo3() -> String /* same-line with ret-type pre-where comment - where in new-line */
+where {
+}
+}
+
+fn main () {
+fn foo4() -> String
+/* new-line pre-where comment - where in new-line */
+where {
+}
+}
+
+fn main () {
+fn foo5() -> String // same-line with ret-type pre-where comment
+where
+{
+}
+}
+
+fn main () {
+fn foo6() -> String
+// new-line pre-where comment
+where
+{
+}
+}
+
+// Return-type and empty "where" - two inline comments
+fn main () {
+fn foo1() -> String /* pre-where same-line */ where /* post-where same line */ {
+}
+}
+
+fn main () {
+fn foo2() -> String
+/* pre-where new-line */ where /* post-where same line */ {
+}
+}
+
+fn main () {
+fn foo3() -> String /* pre-where same with ret - where in new */
+where /* post-where same line */ {
+}
+}
+
+fn main () {
+fn foo4() -> String /* pre-where same with ret - where in new */
+where
+/* post-where new line - brace in same */ {
+}
+}
+
+fn main () {
+fn foo5() -> String
+/* pre-where new line - where in new */
+where
+/* post-where new line - brace in same */ {
+}
+}
+
+fn main () {
+fn foo6() -> String
+/* pre-where new line - where in new */
+where
+/* post-where new line - brace in new */
+{
+}
+}
+
+// Return-type and empty "where" - two one-line comments
+fn main () {
+fn foo1() -> String // pre-where same with ret - where in new
+where // post-where same with where - brace in new
+{
+}
+}
+
+fn main () {
+fn foo2() -> String
+// pre-where new line
+where // post-where same with where - brace in new
+{
+}
+}
+
+// Return-type and empty "where" - more comments
+fn main() {
+fn foo<F>(foo2: F) -> String /* pre-where same with ret - where in new */
+where /* post-where same with where - following in new" */
+F: Fn() /* comment after where declaration */
+{
+}
+}

--- a/tests/target/issue-5407/one.rs
+++ b/tests/target/issue-5407/one.rs
@@ -1,0 +1,134 @@
+// rustfmt-version: One
+
+// Original - return-type and empty "where" - no comments
+mod inner {
+    fn foo1() -> String {
+        String::new()
+    }
+}
+
+mod inner {
+    fn foo2() -> String {
+        String::new()
+    }
+}
+
+// Return-type with no "where" - one comment
+fn main() {
+    fn foo1() -> String /* same-line with ret-type and brace comment */ {}
+}
+
+fn main() {
+    fn foo2() -> String /* same-line with ret-type comment - brace in new-line */ {}
+}
+
+fn main() {
+    fn foo3() -> String
+    /* new-line comment - brace in new-line */
+    {
+    }
+}
+
+fn main() {
+    fn foo4() -> String // same-line with ret-type comment
+    {
+    }
+}
+
+// Return-type and empty "where" - one comment
+fn main() {
+    fn foo1() -> String /* same-line with ret-type/where/brace brace pre-where comment */ {}
+}
+
+fn main() {
+    fn foo2() -> String /* same-line with ret-type/where pre-where comment - brace in new-line */ {}
+}
+
+fn main() {
+    fn foo3() -> String /* same-line with ret-type pre-where comment - where in new-line */ {}
+}
+
+fn main() {
+    fn foo4() -> String
+    /* new-line pre-where comment - where in new-line */
+    {
+    }
+}
+
+fn main() {
+    fn foo5() -> String // same-line with ret-type pre-where comment
+    {
+    }
+}
+
+fn main() {
+    fn foo6() -> String
+    // new-line pre-where comment
+    {
+    }
+}
+
+// Return-type and empty "where" - two inline comments
+fn main() {
+    fn foo1() -> String /* pre-where same-line */ /* post-where same line */ {}
+}
+
+fn main() {
+    fn foo2() -> String
+    /* pre-where new-line */ /* post-where same line */ {
+    }
+}
+
+fn main() {
+    fn foo3() -> String /* pre-where same with ret - where in new */
+    /* post-where same line */ {
+    }
+}
+
+fn main() {
+    fn foo4() -> String /* pre-where same with ret - where in new */
+    /* post-where new line - brace in same */ {
+    }
+}
+
+fn main() {
+    fn foo5() -> String
+    /* pre-where new line - where in new */
+    /* post-where new line - brace in same */ {
+    }
+}
+
+fn main() {
+    fn foo6() -> String
+    /* pre-where new line - where in new */
+    /* post-where new line - brace in new */
+    {
+    }
+}
+
+// Return-type and empty "where" - two one-line comments
+fn main() {
+    fn foo1() -> String // pre-where same with ret - where in new
+    // post-where same with where - brace in new
+    {
+    }
+}
+
+fn main() {
+    fn foo2() -> String
+    // pre-where new line
+    // post-where same with where - brace in new
+    {
+    }
+}
+
+// Return-type and empty "where" - more comments
+fn main() {
+    fn foo<F>(foo2: F) -> String
+    /* pre-where same with ret - where in new */
+    where
+        /* post-where same with where - following in new" */
+        F: Fn(), /* comment after where declaration */
+    {
+    }
+}

--- a/tests/target/issue-5407/two.rs
+++ b/tests/target/issue-5407/two.rs
@@ -1,0 +1,134 @@
+// rustfmt-version: Two
+
+// Original - return-type and empty "where" - no comments
+mod inner {
+    fn foo1() -> String {
+        String::new()
+    }
+}
+
+mod inner {
+    fn foo2() -> String {
+        String::new()
+    }
+}
+
+// Return-type with no "where" - one comment
+fn main() {
+    fn foo1() -> String /* same-line with ret-type and brace comment */ {}
+}
+
+fn main() {
+    fn foo2() -> String /* same-line with ret-type comment - brace in new-line */ {}
+}
+
+fn main() {
+    fn foo3() -> String
+    /* new-line comment - brace in new-line */
+    {
+    }
+}
+
+fn main() {
+    fn foo4() -> String // same-line with ret-type comment
+    {
+    }
+}
+
+// Return-type and empty "where" - one comment
+fn main() {
+    fn foo1() -> String /* same-line with ret-type/where/brace brace pre-where comment */ {}
+}
+
+fn main() {
+    fn foo2() -> String /* same-line with ret-type/where pre-where comment - brace in new-line */ {}
+}
+
+fn main() {
+    fn foo3() -> String /* same-line with ret-type pre-where comment - where in new-line */ {}
+}
+
+fn main() {
+    fn foo4() -> String
+    /* new-line pre-where comment - where in new-line */
+    {
+    }
+}
+
+fn main() {
+    fn foo5() -> String // same-line with ret-type pre-where comment
+    {
+    }
+}
+
+fn main() {
+    fn foo6() -> String
+    // new-line pre-where comment
+    {
+    }
+}
+
+// Return-type and empty "where" - two inline comments
+fn main() {
+    fn foo1() -> String /* pre-where same-line */ /* post-where same line */ {}
+}
+
+fn main() {
+    fn foo2() -> String
+    /* pre-where new-line */ /* post-where same line */ {
+    }
+}
+
+fn main() {
+    fn foo3() -> String /* pre-where same with ret - where in new */
+    /* post-where same line */ {
+    }
+}
+
+fn main() {
+    fn foo4() -> String /* pre-where same with ret - where in new */
+    /* post-where new line - brace in same */ {
+    }
+}
+
+fn main() {
+    fn foo5() -> String
+    /* pre-where new line - where in new */
+    /* post-where new line - brace in same */ {
+    }
+}
+
+fn main() {
+    fn foo6() -> String
+    /* pre-where new line - where in new */
+    /* post-where new line - brace in new */
+    {
+    }
+}
+
+// Return-type and empty "where" - two one-line comments
+fn main() {
+    fn foo1() -> String // pre-where same with ret - where in new
+    // post-where same with where - brace in new
+    {
+    }
+}
+
+fn main() {
+    fn foo2() -> String
+    // pre-where new line
+    // post-where same with where - brace in new
+    {
+    }
+}
+
+// Return-type and empty "where" - more comments
+fn main() {
+    fn foo<F>(foo2: F) -> String
+    /* pre-where same with ret - where in new */
+    where
+        /* post-where same with where - following in new" */
+        F: Fn(), /* comment after where declaration */
+    {
+    }
+}


### PR DESCRIPTION
Proposed fix for issue #5407.  Although the original issue is about fn empty where clause indentation, the issue is actually about handling of comments after fn return type.  This is because with current code the empty where was handled as a post return type comment.

In addition, there are related issues with handling comments for fn empty where clause without return type.  Therefore the fix handles the cases of fn return type without where clause, empty where clause without return type, and return type with empty where clause.