### PR TITLE
Don't drop a DiagnosticBuilder (#5413)

### DIFF
--- a/src/parse/macros/cfg_if.rs
+++ b/src/parse/macros/cfg_if.rs
@@ -44,7 +44,11 @@ fn parse_cfg_if_inner<'a>(
             // See also https://github.com/rust-lang/rust/pull/79433
             parser
                 .parse_attribute(rustc_parse::parser::attr::InnerAttrPolicy::Permitted)
-                .map_err(|_| "Failed to parse attributes")?;
+                .map_err(|err| {
+                    err.cancel();
+                    parser.sess.span_diagnostic.reset_err_count();
+                    "Failed to parse attributes"
+                })?;
         }
 
         if !parser.eat(&TokenKind::OpenDelim(Delimiter::Brace)) {


### PR DESCRIPTION
I've implemented this fix under the assumption that the error here was not being dropped (causing the panic) intentionally because the rest of the function returns an `Err` with a message rather than panicking.