### PR TITLE
Updated how nested function calls are overflowed

### DIFF
--- a/tests/source/issue_5356.rs
+++ b/tests/source/issue_5356.rs
@@ -1,0 +1,13 @@
+fn fail() {
+    {
+        {
+            if true {
+                return Err(SomeError::OutOfMemory(OutOfMemory::new(mem::size_of::<SomeType>())));
+            } else if true {
+                return Err(SomeError::OutOfMemory(OutOfMemory::new(core::mem::size_of::<SomeType>())));
+            } else {
+                return Err(SomeError::OutOfMemory(OutOfMemory::new(mem::size_of::<SomeType>(aaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbb, cccccccccccccc, dddddddddddddddddd, eeeeeeeeeeeeeeeee))));
+            }
+        }
+    }
+}

--- a/tests/target/issue_5356.rs
+++ b/tests/target/issue_5356.rs
@@ -1,0 +1,25 @@
+fn fail() {
+    {
+        {
+            if true {
+                return Err(SomeError::OutOfMemory(OutOfMemory::new(
+                    mem::size_of::<SomeType>()
+                )));
+            } else if true {
+                return Err(SomeError::OutOfMemory(OutOfMemory::new(
+                    core::mem::size_of::<SomeType>()
+                )));
+            } else {
+                return Err(SomeError::OutOfMemory(OutOfMemory::new(
+                    mem::size_of::<SomeType>(
+                        aaaaaaaaaaaaaaaaaa,
+                        bbbbbbbbbbbbbbbbbbbb,
+                        cccccccccccccc,
+                        dddddddddddddddddd,
+                        eeeeeeeeeeeeeeeee,
+                    ),
+                )));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5356

I feel like there's got to be a simpler way to handle this, so any recommendations on how we can update the implementation are greatly appreciated. I noticed that in the original issue the `callee` was being split overly multiple lines and tried to use that to conditionally determine whether we rewrite the expression as before by calling `expr.rewrite` or go down a path where we do some extra work to figure out how we'll rewrite the overflowing function call.

I found it a bit strange that in some cases we need to indent the shape, while in others we need to unindent it, but I imagine that has something to do with what's happening when `last_item_shape` is called. 