### PR TITLE
Fix/comments inside trait generics gets duplicated

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1084,7 +1084,12 @@ pub(crate) fn format_trait(
             let item_snippet = context.snippet(item.span);
             if let Some(lo) = item_snippet.find('/') {
                 // 1 = `{`
-                let comment_hi = body_lo - BytePos(1);
+                //let comment_hi = body_lo - BytePos(1);
+                let comment_hi = if generics.params.len() > 0 {
+                    generics.span.lo() - BytePos(5)
+                } else {
+                    body_lo - BytePos(1)
+                };
                 let comment_lo = item.span.lo() + BytePos(lo as u32);
                 if comment_lo < comment_hi {
                     match recover_missing_comment_in_span(

--- a/src/items.rs
+++ b/src/items.rs
@@ -1085,7 +1085,7 @@ pub(crate) fn format_trait(
             if let Some(lo) = item_snippet.find('/') {
                 // 1 = `{`
                 let comment_hi = if generics.params.len() > 0 {
-                    generics.span.lo() - BytePos(5)
+                    generics.span.lo() - BytePos(1)
                 } else {
                     body_lo - BytePos(1)
                 };

--- a/src/items.rs
+++ b/src/items.rs
@@ -1084,7 +1084,6 @@ pub(crate) fn format_trait(
             let item_snippet = context.snippet(item.span);
             if let Some(lo) = item_snippet.find('/') {
                 // 1 = `{`
-                //let comment_hi = body_lo - BytePos(1);
                 let comment_hi = if generics.params.len() > 0 {
                     generics.span.lo() - BytePos(5)
                 } else {

--- a/tests/target/issue-5358.rs
+++ b/tests/target/issue-5358.rs
@@ -1,0 +1,4 @@
+// Test /* comment */ inside trait generics gets duplicated.
+trait Test</* comment */ T> {}
+
+trait TestTwo</* comment */ T, /* comment */ V> {}

--- a/tests/target/issue-5358.rs
+++ b/tests/target/issue-5358.rs
@@ -1,4 +1,4 @@
-// Test /* comment */ inside trait generics gets duplicated.
+// Test /* comment */ inside trait generics does not get duplicated.
 trait Test</* comment */ T> {}
 
 trait TestTwo</* comment */ T, /* comment */ V> {}


### PR DESCRIPTION
# Fixes #5358 
* Now the value of `comment_hi` is equals to the `generic.span.lo` if there actually are any generic parameters, otherwise it will kept the value previously defined.