### PR TITLE
Add tests for issue 2534

### DIFF
--- a/tests/target/issue-2534/format_macro_matchers_false.rs
+++ b/tests/target/issue-2534/format_macro_matchers_false.rs
@@ -1,0 +1,6 @@
+// rustfmt-format_macro_matchers: false
+
+macro_rules! foo {
+    ($a:ident : $b:ty) => {};
+    ($a:ident $b:ident $c:ident) => {};
+}

--- a/tests/target/issue-2534/format_macro_matchers_true.rs
+++ b/tests/target/issue-2534/format_macro_matchers_true.rs
@@ -1,0 +1,6 @@
+// rustfmt-format_macro_matchers: true
+
+macro_rules! foo {
+    ($a:ident : $b:ty) => {};
+    ($a:ident $b:ident $c:ident) => {};
+}


### PR DESCRIPTION
Closes #2534

The behavior described in the original issue can no longer be reproduced. The tests show that to be the case regardless of if `format_macro_matchers` is `true` or `false`.