### PR TITLE
test for issue 3164

### DIFF
--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -98,3 +98,22 @@ fn cargo_fmt_out_of_line_test_modules() {
         assert!(stdout.contains(&format!("Diff in {}", path.display())))
     }
 }
+
+#[rustfmt_only_ci_test]
+#[test]
+fn cargo_fmt_emits_error_on_line_overflow_true() {
+    // See also https://github.com/rust-lang/rustfmt/issues/3164
+    let args = [
+        "--check",
+        "--manifest-path",
+        "tests/cargo-fmt/source/issue_3164/Cargo.toml",
+        "--",
+        "--config",
+        "error_on_line_overflow=true",
+    ];
+
+    let (_stdout, stderr) = cargo_fmt(&args);
+    assert!(stderr.contains(
+        "line formatted, but exceeded maximum width (maximum: 100 (see `max_width` option)"
+    ))
+}

--- a/tests/cargo-fmt/source/issue_3164/Cargo.toml
+++ b/tests/cargo-fmt/source/issue_3164/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "issue_3164"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/cargo-fmt/source/issue_3164/src/main.rs
+++ b/tests/cargo-fmt/source/issue_3164/src/main.rs
@@ -1,0 +1,13 @@
+#[allow(unused_macros)]
+macro_rules! foo {
+    ($id:ident) => {
+        macro_rules! bar {
+            ($id2:tt) => {
+                #[cfg(any(target_feature = $id2, target_feature = $id2, target_feature = $id2, target_feature = $id2, target_feature = $id2))]
+                fn $id() {}
+            };
+        }
+    };
+}
+
+fn main() {}

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -159,3 +159,18 @@ fn mod_resolution_error_path_attribute_does_not_exist() {
     // The path attribute points to a file that does not exist
     assert!(stderr.contains("does_not_exist.rs does not exist"));
 }
+
+#[test]
+fn rustfmt_emits_error_on_line_overflow_true() {
+    // See also https://github.com/rust-lang/rustfmt/issues/3164
+    let args = [
+        "--config",
+        "error_on_line_overflow=true",
+        "tests/cargo-fmt/source/issue_3164/src/main.rs",
+    ];
+
+    let (_stdout, stderr) = rustfmt(&args);
+    assert!(stderr.contains(
+        "line formatted, but exceeded maximum width (maximum: 100 (see `max_width` option)"
+    ))
+}


### PR DESCRIPTION
Closes #3164

Show that when `error_on_line_overflow=true` is set in the rustfmt.toml that an error message is written to stderr.