### PR TITLE
feat: nicer skip context for macro/attribute

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -337,7 +337,7 @@ impl Rewrite for ast::Attribute {
         } else {
             let should_skip = self
                 .ident()
-                .map(|s| context.skip_context.skip_attribute(s.name.as_str()))
+                .map(|s| context.skip_context.attributes.skip(s.name.as_str()))
                 .unwrap_or(false);
             let prefix = attr_prefix(self);
 
@@ -391,7 +391,7 @@ impl Rewrite for [ast::Attribute] {
 
         // Determine if the source text is annotated with `#[rustfmt::skip::attributes(derive)]`
         // or `#![rustfmt::skip::attributes(derive)]`
-        let skip_derives = context.skip_context.skip_attribute("derive");
+        let skip_derives = context.skip_context.attributes.skip("derive");
 
         // This is not just a simple map because we need to handle doc comments
         // (where we take as many doc comment attributes as possible) and possibly

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -157,7 +157,8 @@ pub(crate) fn rewrite_macro(
 ) -> Option<String> {
     let should_skip = context
         .skip_context
-        .skip_macro(context.snippet(mac.path.span));
+        .macros
+        .skip(context.snippet(mac.path.span));
     if should_skip {
         None
     } else {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -775,10 +775,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         for macro_selector in config.skip_macro_invocations().0 {
             match macro_selector {
                 MacroSelector::Name(name) => macro_names.push(name.to_string()),
-                MacroSelector::All => skip_context.macros.set_all(true),
+                MacroSelector::All => skip_context.macros.skip_all(),
             }
         }
-        skip_context.macros.append(macro_names);
+        skip_context.macros.extend(macro_names);
         FmtVisitor {
             parent_context: None,
             parse_sess: parse_session,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -775,10 +775,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         for macro_selector in config.skip_macro_invocations().0 {
             match macro_selector {
                 MacroSelector::Name(name) => macro_names.push(name.to_string()),
-                MacroSelector::All => skip_context.all_macros = true,
+                MacroSelector::All => skip_context.macros.set_all(true),
             }
         }
-        skip_context.update_macros(macro_names);
+        skip_context.macros.append(macro_names);
         FmtVisitor {
             parent_context: None,
             parse_sess: parse_session,


### PR DESCRIPTION
Follow up from https://github.com/rust-lang/rustfmt/pull/5347#discussion_r895000579 in discussion with @ytmimi 

Refactors the way named items are skipped such that:

- skipping each item is constant time
- implementation is the same for attributes/macros
- either all items can be skipped, or a set of named items

This should result in no change in behaviour.