### PR TITLE
Prevent unlimitted indentations in macro body formatting

### DIFF
--- a/tests/source/issue-4609/one.rs
+++ b/tests/source/issue-4609/one.rs
@@ -1,0 +1,94 @@
+// rustfmt-version: One
+
+// Original issue - parameters in macro call
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            }
+        }
+    };
+}
+
+outer!($);
+
+fn main() {
+    inner!("hi");
+}
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d    s);
+            }
+        }
+    };
+}
+
+// Variations of the original issue
+
+macro_rules! outer {
+($d:tt) => {
+macro_rules! inner {
+($d s:expr) => {
+println!("{}", $d s);
+}
+}
+};
+}
+
+macro_rules! outer {
+($d:tt) => {
+macro_rules! inner {
+($d s:expr) => {
+println!("{}", $d    s);
+}
+}
+};
+}
+
+fn main() {
+macro_rules! outer {
+($ d:tt) => {
+macro_rules! inner {
+($ d s:expr) => {
+println!("INNER1: {}", $d s);
+println!("INNER2: {}", $ s);
+}
+}
+};
+}
+
+outer!($);
+
+inner!("hi");
+}
+    
+// Consecutive identities in macro body
+
+fn main() {
+macro_rules! uniop {
+($op:tt, $s:expr) => {
+$op $s
+};
+}
+let x = uniop!(!, true);
+println!("{}", x);
+let x = uniop!(-, 7);
+println!("{}", x);
+}
+
+fn main() {
+macro_rules! binop {
+($l:expr, $op:tt, $r:expr) => {
+$l             $op                $r
+};
+}
+let x = binop!(10, -, 7);
+println!("{}", x);
+let x = binop!(10, +, 7);
+println!("{}", x);
+}

--- a/tests/source/issue-4609/two.rs
+++ b/tests/source/issue-4609/two.rs
@@ -1,0 +1,94 @@
+// rustfmt-version: Two
+
+// Original issue - parameters in macro call
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            }
+        }
+    };
+}
+
+outer!($);
+
+fn main() {
+    inner!("hi");
+}
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d    s);
+            }
+        }
+    };
+}
+
+// Variations of the original issue
+
+macro_rules! outer {
+($d:tt) => {
+macro_rules! inner {
+($d s:expr) => {
+println!("{}", $d s);
+}
+}
+};
+}
+
+macro_rules! outer {
+($d:tt) => {
+macro_rules! inner {
+($d s:expr) => {
+println!("{}", $d    s);
+}
+}
+};
+}
+
+fn main() {
+macro_rules! outer {
+($ d:tt) => {
+macro_rules! inner {
+($ d s:expr) => {
+println!("INNER1: {}", $d s);
+println!("INNER2: {}", $ s);
+}
+}
+};
+}
+
+outer!($);
+
+inner!("hi");
+}
+    
+// Consecutive identities in macro body
+
+fn main() {
+macro_rules! uniop {
+($op:tt, $s:expr) => {
+$op $s
+};
+}
+let x = uniop!(!, true);
+println!("{}", x);
+let x = uniop!(-, 7);
+println!("{}", x);
+}
+
+fn main() {
+macro_rules! binop {
+($l:expr, $op:tt, $r:expr) => {
+$l             $op                $r
+};
+}
+let x = binop!(10, -, 7);
+println!("{}", x);
+let x = binop!(10, +, 7);
+println!("{}", x);
+}

--- a/tests/target/issue-4609/one.rs
+++ b/tests/target/issue-4609/one.rs
@@ -1,0 +1,94 @@
+// rustfmt-version: One
+
+// Original issue - parameters in macro call
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            };
+        }
+    };
+}
+
+outer!($);
+
+fn main() {
+    inner!("hi");
+}
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            };
+        }
+    };
+}
+
+// Variations of the original issue
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            };
+        }
+    };
+}
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            };
+        }
+    };
+}
+
+fn main() {
+    macro_rules! outer {
+        ($ d:tt) => {
+            macro_rules! inner {
+                ($ d s:expr) => {
+                    println!("INNER1: {}", $d s);
+                    println!("INNER2: {}", $ s);
+                };
+            }
+        };
+    }
+
+    outer!($);
+
+    inner!("hi");
+}
+
+// Consecutive identities in macro body
+
+fn main() {
+    macro_rules! uniop {
+        ($op:tt, $s:expr) => {
+            $op $s
+        };
+    }
+    let x = uniop!(!, true);
+    println!("{}", x);
+    let x = uniop!(-, 7);
+    println!("{}", x);
+}
+
+fn main() {
+    macro_rules! binop {
+        ($l:expr, $op:tt, $r:expr) => {
+            $l $op $r
+        };
+    }
+    let x = binop!(10, -, 7);
+    println!("{}", x);
+    let x = binop!(10, +, 7);
+    println!("{}", x);
+}

--- a/tests/target/issue-4609/two.rs
+++ b/tests/target/issue-4609/two.rs
@@ -1,0 +1,94 @@
+// rustfmt-version: Two
+
+// Original issue - parameters in macro call
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            };
+        }
+    };
+}
+
+outer!($);
+
+fn main() {
+    inner!("hi");
+}
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            };
+        }
+    };
+}
+
+// Variations of the original issue
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            };
+        }
+    };
+}
+
+macro_rules! outer {
+    ($d:tt) => {
+        macro_rules! inner {
+            ($d s:expr) => {
+                println!("{}", $d s);
+            };
+        }
+    };
+}
+
+fn main() {
+    macro_rules! outer {
+        ($ d:tt) => {
+            macro_rules! inner {
+                ($ d s:expr) => {
+                    println!("INNER1: {}", $d s);
+                    println!("INNER2: {}", $ s);
+                };
+            }
+        };
+    }
+
+    outer!($);
+
+    inner!("hi");
+}
+
+// Consecutive identities in macro body
+
+fn main() {
+    macro_rules! uniop {
+        ($op:tt, $s:expr) => {
+            $op $s
+        };
+    }
+    let x = uniop!(!, true);
+    println!("{}", x);
+    let x = uniop!(-, 7);
+    println!("{}", x);
+}
+
+fn main() {
+    macro_rules! binop {
+        ($l:expr, $op:tt, $r:expr) => {
+            $l $op $r
+        };
+    }
+    let x = binop!(10, -, 7);
+    println!("{}", x);
+    let x = binop!(10, +, 7);
+    println!("{}", x);
+}


### PR DESCRIPTION
Fixes  #4609

Suggested fix for an issue of unlimited macro body indentation when repeating the formatting.

The root cause of the problem is that `$d` is set as `'$'` in the outer macro, and therefore the `$d s` parameter in the inner macro is translated to `$ s` which is the same as `$s`.  However, rustfmt handles the `$d s` parameter to `println!` macro calls an two parameters and is expecting a `,` between them.

A similar issue exists in the following example, where the problem is now in the macro body:
```rust
macro_rules! binop {
    ($l:expr, $op:tt, $r:expr) => {
        $l $op $r
    };
}
```
In this case rustfmt tries to format the `$l $op $r` as an expression.

The proposed solution is to handle such cases of consecutive identities as one identity during formatting.  E.g. the `$l $op $r` is handled as `$l_$op_$r` (or `zl_zop_zr`) during formatting.  This is done by modifying `replace_names()` to handle also these cases.

One drawback of this approach is that the concatenated consecutive identities cannot be split between lines during formatting.  However, I believe that this is better than having the unlimited indentation issue.

The fix does not handle `_` at the beginning of a name.  This is because in the existing code a `_` causes termination of a `$name` - see [this condition](https://github.com/rust-lang/rustfmt/blob/7432422008f8be71df989e357d949072c77e9060/src/macros.rs#L500)  that does consider `_` as valid char in a `$name`.  I am not sure if this is a bug or not.  In addition, [this test line](https://github.com/rust-lang/rustfmt/blob/7432422008f8be71df989e357d949072c77e9060/tests/source/issue-2917/packed_simd.rs#L37) may also indicate that `_` at the beginning of a identifier name that follows `$name` is legal (I don't know rust well enough ....).

Note that other cases of macro formatting failure can still cause unlimited indentations.  For example [rust issue 88959](https://github.com/rust-lang/rust/issues/88959).  The issue there is that the `*` is translated to the `*` operation which is illegal outside of an expression during the formatting.