### PR TITLE
Don't wrap comments that are part of a table

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -940,7 +940,7 @@ fn has_url(s: &str) -> bool {
         || REFERENCE_LINK_URL.is_match(s)
 }
 
-/// Returns true if the given string may be part of a Markdown talble.
+/// Returns true if the given string may be part of a Markdown table.
 fn is_table_item(mut s: &str) -> bool {
     // This function may return false positive, but should get its job done in most cases (i.e.
     // markdown tables with two column delimiters).

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -804,7 +804,8 @@ impl<'a> CommentRewrite<'a> {
         let should_wrap_comment = self.fmt.config.wrap_comments()
             && !is_markdown_header_doc_comment
             && unicode_str_width(line) > self.fmt.shape.width
-            && !has_url(line);
+            && !has_url(line)
+            && !is_table_item(line);
 
         if should_wrap_comment {
             match rewrite_string(line, &self.fmt, self.max_width) {
@@ -937,6 +938,18 @@ fn has_url(s: &str) -> bool {
         || s.contains("ftp://")
         || s.contains("file://")
         || REFERENCE_LINK_URL.is_match(s)
+}
+
+/// Returns true if the given string may be part of a Markdown talble.
+fn is_table_item(mut s: &str) -> bool {
+    // This function may return false positive, but should get its job done in most cases (i.e.
+    // markdown tables with two column delimiters).
+    s = s.trim_start();
+    return s.starts_with('|')
+        && match s.rfind('|') {
+            Some(0) | None => false,
+            _ => true,
+        };
 }
 
 /// Given the span, rewrite the missing comment inside it if available.

--- a/tests/target/issue-4210-disabled.rs
+++ b/tests/target/issue-4210-disabled.rs
@@ -1,0 +1,15 @@
+// rustfmt-wrap_comments: false
+
+/// Table that is > 80 symbols:
+///
+/// | table | xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx |
+/// |-------|-----------------------------------------------------------------------------|
+/// | val   | x                                                                           |
+pub struct Item;
+
+/// Table value that is > 80 symbols:
+///
+/// | table    | heading
+/// |----------|-----------------------------------------------------------------------------
+/// | long val | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+pub struct Item2;

--- a/tests/target/issue-4210.rs
+++ b/tests/target/issue-4210.rs
@@ -7,9 +7,9 @@
 /// | val   | x                                                                           |
 pub struct Item;
 
-/// Table that is > 80 symbols:
+/// Table value that is > 80 symbols:
 ///
-/// | table | xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-/// |-------|-----------------------------------------------------------------------------
-/// | val   | x                                                                          
-pub struct Item;
+/// | table    | heading
+/// |----------|-----------------------------------------------------------------------------
+/// | long val | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+pub struct Item2;

--- a/tests/target/issue-4210.rs
+++ b/tests/target/issue-4210.rs
@@ -1,0 +1,15 @@
+// rustfmt-wrap_comments: true
+
+/// Table that is > 80 symbols:
+///
+/// | table | xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx |
+/// |-------|-----------------------------------------------------------------------------|
+/// | val   | x                                                                           |
+pub struct Item;
+
+/// Table that is > 80 symbols:
+///
+/// | table | xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+/// |-------|-----------------------------------------------------------------------------
+/// | val   | x                                                                          
+pub struct Item;


### PR DESCRIPTION
Closes #4210

This is a trivial cherry-pick of https://github.com/rust-lang/rustfmt/pull/4214 onto the new `master` branch.