### PR TITLE
Backport PR #4658 and Fix issue #4551 - multilines comment indentation

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1001,24 +1001,29 @@ fn light_rewrite_comment(
     config: &Config,
     is_doc_comment: bool,
 ) -> String {
-    let lines: Vec<&str> = orig
+    let lines: Vec<String> = orig
         .lines()
         .map(|l| {
             // This is basically just l.trim(), but in the case that a line starts
             // with `*` we want to leave one space before it, so it aligns with the
             // `*` in `/*`.
             let first_non_whitespace = l.find(|c| !char::is_whitespace(c));
-            let left_trimmed = if let Some(fnw) = first_non_whitespace {
-                if l.as_bytes()[fnw] == b'*' && fnw > 0 {
-                    &l[fnw - 1..]
+            let (blank, left_trimmed) = if let Some(fnw) = first_non_whitespace {
+                if l.as_bytes()[fnw] == b'*' {
+                    // Ensure '*' is preceeded by blank and not by a tab.
+                    (" ", &l[fnw..])
                 } else {
-                    &l[fnw..]
+                    ("", &l[fnw..])
                 }
             } else {
-                ""
+                ("", "")
             };
             // Preserve markdown's double-space line break syntax in doc comment.
-            trim_end_unless_two_whitespaces(left_trimmed, is_doc_comment)
+            format!(
+                "{}{}",
+                blank,
+                trim_end_unless_two_whitespaces(left_trimmed, is_doc_comment),
+            )
         })
         .collect();
     lines.join(&format!("\n{}", offset.to_string(config)))

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -246,7 +246,10 @@ impl<'a> FmtVisitor<'a> {
             let indent_str = self.block_indent.to_string(self.config);
             self.push_str(&indent_str);
             self.block_indent
-        } else if self.config.version() == Version::Two && !snippet.starts_with('\n') {
+        } else if self.config.version() == Version::Two
+            && !snippet.starts_with('\n')
+            && !subslice.starts_with("/*")
+        {
             // The comment appears on the same line as the previous formatted code.
             // Assuming that comment is logically associated with that code, we want to keep it on
             // the same level and avoid mixing it with possible other comment.

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -296,7 +296,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
 
                     let mut comment_shape =
                         Shape::indented(self.block_indent, config).comment(config);
-                    if self.config.version() == Version::Two && comment_on_same_line {
+                    if self.config.version() == Version::Two
+                        && comment_on_same_line
+                        && !sub_slice.starts_with("/*")
+                    {
                         self.push_str(" ");
                         // put the first line of the comment on the same line as the
                         // block's last line

--- a/tests/source/issue-4551/one.rs
+++ b/tests/source/issue-4551/one.rs
@@ -1,0 +1,79 @@
+// rustfmt-version: One
+
+// From #4551
+
+fn main() {
+   /* Comment1 line 1
+	* Comment1 line 2 */
+    let ys = 1;/* Comment2 line 1
+		* Comment2 line 2 with preceeding tabs */
+}
+
+fn main() {
+   /* Comment1 line 1
+	* Comment1 line 2 */
+   // Following1 comment
+    let y1 = 6;/* Comment2 line 1
+            	* Comment2 line 2 - prefixed by spaces and 1 tab */
+				// Following2 comment
+    let y2 = 6;/* Comment3 line 1
+				* Comment3 line 2 - prefixed by spaces and 2 tabs */
+				/* Following3 comment */
+    let y3 = 8;/* Comment4 line 1
+                * Comment4 line 2  - prefixed by spaces */
+				/* Following4 comment
+				 * cont of Following4 comment */
+}
+
+// Other tests
+
+fn main() {
+    let x = 111; /* First Comment with spaces prefix for each line - line 1
+    * First Comment line 2
+    * First Comment line 3
+    */
+    // Following first comment
+}
+
+fn main() {
+    let x = 222; /* Second Comment with tab prefix for each line - line 1
+	* Second Comment line 2
+	* Second Comment line 3
+	*/
+	/* Following second comment line 1
+	* Following second comment line 2
+	* Following second comment line 3
+	*/
+}
+
+fn main() {
+let x = 333; /* Third Comment with spaces prefix for each line - line 1
+* Third Comment line 2
+* Third Comment line 3
+*/
+/* Following third comment line 1
+* Following third comment line 2
+* Following third comment line 3
+*/
+}
+
+fn main() {
+let x = 222; /* Second Comment line 1
+* Second Comment line 2
+* Second Comment line 3
+*/
+let y = 333; // Following second comment line 1
+// Following second comment line 2
+// Following second comment line 3
+}
+
+fn main() {
+    let y3 = 8;/* Comment4 line 1
+                * Comment4 line 2 */
+}
+
+fn main() {
+    let y3 = 8;/* Comment4 line 1
+                * Comment4 line 2 */
+	y4 = 9;
+}

--- a/tests/source/issue-4551/two.rs
+++ b/tests/source/issue-4551/two.rs
@@ -1,0 +1,79 @@
+// rustfmt-version: Two
+
+// From #4551
+
+fn main() {
+   /* Comment1 line 1
+	* Comment1 line 2 */
+    let ys = 1;/* Comment2 line 1
+		* Comment2 line 2 with preceeding tabs */
+}
+
+fn main() {
+   /* Comment1 line 1
+	* Comment1 line 2 */
+   // Following1 comment
+    let y1 = 6;/* Comment2 line 1
+            	* Comment2 line 2 - prefixed by spaces and 1 tab */
+				// Following2 comment
+    let y2 = 6;/* Comment3 line 1
+				* Comment3 line 2 - prefixed by spaces and 2 tabs */
+				/* Following3 comment */
+    let y3 = 8;/* Comment4 line 1
+                * Comment4 line 2  - prefixed by spaces */
+				/* Following4 comment
+				 * cont of Following4 comment */
+}
+
+// Other tests
+
+fn main() {
+    let x = 111; /* First Comment with spaces prefix for each line - line 1
+    * First Comment line 2
+    * First Comment line 3
+    */
+    // Following first comment
+}
+
+fn main() {
+    let x = 222; /* Second Comment with tab prefix for each line - line 1
+	* Second Comment line 2
+	* Second Comment line 3
+	*/
+	/* Following second comment line 1
+	* Following second comment line 2
+	* Following second comment line 3
+	*/
+}
+
+fn main() {
+let x = 333; /* Third Comment with spaces prefix for each line - line 1
+* Third Comment line 2
+* Third Comment line 3
+*/
+/* Following third comment line 1
+* Following third comment line 2
+* Following third comment line 3
+*/
+}
+
+fn main() {
+let x = 222; /* Second Comment line 1
+* Second Comment line 2
+* Second Comment line 3
+*/
+let y = 333; // Following second comment line 1
+// Following second comment line 2
+// Following second comment line 3
+}
+
+fn main() {
+    let y3 = 8;/* Comment4 line 1
+                * Comment4 line 2 */
+}
+
+fn main() {
+    let y3 = 8;/* Comment4 line 1
+                * Comment4 line 2 */
+	y4 = 9;
+}

--- a/tests/source/issue-4658/one/comment-multiline-indentation-hard-tabs.rs
+++ b/tests/source/issue-4658/one/comment-multiline-indentation-hard-tabs.rs
@@ -1,0 +1,49 @@
+// rustfmt-version: One
+// rustfmt-hard_tabs: true
+
+// Ensure multiline comments are indented properly,
+// including when second line is prefixed by tab or at the beginning of the line
+
+/* First comment line
+* second comment line - no prefix
+* last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+	/* First comment line
+	* second comment line - tab prefix
+	* last comment line */
+
+/* First comment line
+                    * second comment line - blank prefix
+* last comment line - no prefix */
+
+/* First comment line
+                 * second comment line - blank prefix
+          * last comment line */
+
+type T1 = TT<
+u32, /* First comment line
+* second comment line - no prefix
+* last comment line */
+>;
+
+type T2 = TT<
+u32, /* First comment line
+      * second comment line - blank prefix
+      * last comment line */
+>;
+
+type T2 = TT<
+u32, /* First comment line
+	* second comment line - tab prefix
+	* last comment line */
+>;
+
+type T3 = TT<
+u32,	/* First comment line
+		* second comment line - tab prefix
+		* last comment line */
+>;

--- a/tests/source/issue-4658/one/comment-multiline-indentation.rs
+++ b/tests/source/issue-4658/one/comment-multiline-indentation.rs
@@ -1,0 +1,49 @@
+// rustfmt-version: One
+// rustfmt-hard_tabs: false
+
+// Ensure multiline comments are indented properly,
+// including when second line is prefixed by tab or at the beginning of the line
+
+/* First comment line
+* second comment line - no prefix
+* last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+	/* First comment line
+	* second comment line - tab prefix
+	* last comment line */
+
+/* First comment line
+                    * second comment line - blank prefix
+* last comment line - no prefix */
+
+/* First comment line
+                 * second comment line - blank prefix
+          * last comment line */
+
+type T1 = TT<
+u32, /* First comment line
+* second comment line - no prefix
+* last comment line */
+>;
+
+type T2 = TT<
+u32, /* First comment line
+      * second comment line - blank prefix
+      * last comment line */
+>;
+
+type T2 = TT<
+u32, /* First comment line
+	* second comment line - tab prefix
+	* last comment line */
+>;
+
+type T3 = TT<
+u32,	/* First comment line
+		* second comment line - tab prefix
+		* last comment line */
+>;

--- a/tests/source/issue-4658/two/comment-multiline-indentation-hard-tabs.rs
+++ b/tests/source/issue-4658/two/comment-multiline-indentation-hard-tabs.rs
@@ -1,0 +1,49 @@
+// rustfmt-version: Two
+// rustfmt-hard_tabs: true
+
+// Ensure multiline comments are indented properly,
+// including when second line is prefixed by tab or at the beginning of the line
+
+/* First comment line
+* second comment line - no prefix
+* last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+	/* First comment line
+	* second comment line - tab prefix
+	* last comment line */
+
+/* First comment line
+                    * second comment line - blank prefix
+* last comment line - no prefix */
+
+/* First comment line
+                 * second comment line - blank prefix
+          * last comment line */
+
+type T1 = TT<
+u32, /* First comment line
+* second comment line - no prefix
+* last comment line */
+>;
+
+type T2 = TT<
+u32, /* First comment line
+      * second comment line - blank prefix
+      * last comment line */
+>;
+
+type T2 = TT<
+u32, /* First comment line
+	* second comment line - tab prefix
+	* last comment line */
+>;
+
+type T3 = TT<
+u32,	/* First comment line
+		* second comment line - tab prefix
+		* last comment line */
+>;

--- a/tests/source/issue-4658/two/comment-multiline-indentation.rs
+++ b/tests/source/issue-4658/two/comment-multiline-indentation.rs
@@ -1,0 +1,49 @@
+// rustfmt-version: Two
+// rustfmt-hard_tabs: false
+
+// Ensure multiline comments are indented properly,
+// including when second line is prefixed by tab or at the beginning of the line
+
+/* First comment line
+* second comment line - no prefix
+* last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+	/* First comment line
+	* second comment line - tab prefix
+	* last comment line */
+
+/* First comment line
+                    * second comment line - blank prefix
+* last comment line - no prefix */
+
+/* First comment line
+                 * second comment line - blank prefix
+          * last comment line */
+
+type T1 = TT<
+u32, /* First comment line
+* second comment line - no prefix
+* last comment line */
+>;
+
+type T2 = TT<
+u32, /* First comment line
+      * second comment line - blank prefix
+      * last comment line */
+>;
+
+type T2 = TT<
+u32, /* First comment line
+	* second comment line - tab prefix
+	* last comment line */
+>;
+
+type T3 = TT<
+u32,	/* First comment line
+		* second comment line - tab prefix
+		* last comment line */
+>;

--- a/tests/target/issue-4551/one.rs
+++ b/tests/target/issue-4551/one.rs
@@ -1,0 +1,79 @@
+// rustfmt-version: One
+
+// From #4551
+
+fn main() {
+    /* Comment1 line 1
+     * Comment1 line 2 */
+    let ys = 1; /* Comment2 line 1
+                 * Comment2 line 2 with preceeding tabs */
+}
+
+fn main() {
+    /* Comment1 line 1
+     * Comment1 line 2 */
+    // Following1 comment
+    let y1 = 6; /* Comment2 line 1
+                 * Comment2 line 2 - prefixed by spaces and 1 tab */
+    // Following2 comment
+    let y2 = 6; /* Comment3 line 1
+                 * Comment3 line 2 - prefixed by spaces and 2 tabs */
+    /* Following3 comment */
+    let y3 = 8; /* Comment4 line 1
+                 * Comment4 line 2  - prefixed by spaces */
+    /* Following4 comment
+     * cont of Following4 comment */
+}
+
+// Other tests
+
+fn main() {
+    let x = 111; /* First Comment with spaces prefix for each line - line 1
+                  * First Comment line 2
+                  * First Comment line 3
+                  */
+    // Following first comment
+}
+
+fn main() {
+    let x = 222; /* Second Comment with tab prefix for each line - line 1
+                  * Second Comment line 2
+                  * Second Comment line 3
+                  */
+    /* Following second comment line 1
+     * Following second comment line 2
+     * Following second comment line 3
+     */
+}
+
+fn main() {
+    let x = 333; /* Third Comment with spaces prefix for each line - line 1
+                  * Third Comment line 2
+                  * Third Comment line 3
+                  */
+    /* Following third comment line 1
+     * Following third comment line 2
+     * Following third comment line 3
+     */
+}
+
+fn main() {
+    let x = 222; /* Second Comment line 1
+                  * Second Comment line 2
+                  * Second Comment line 3
+                  */
+    let y = 333; // Following second comment line 1
+                 // Following second comment line 2
+                 // Following second comment line 3
+}
+
+fn main() {
+    let y3 = 8; /* Comment4 line 1
+                 * Comment4 line 2 */
+}
+
+fn main() {
+    let y3 = 8; /* Comment4 line 1
+                 * Comment4 line 2 */
+    y4 = 9;
+}

--- a/tests/target/issue-4551/two.rs
+++ b/tests/target/issue-4551/two.rs
@@ -1,0 +1,79 @@
+// rustfmt-version: Two
+
+// From #4551
+
+fn main() {
+    /* Comment1 line 1
+     * Comment1 line 2 */
+    let ys = 1; /* Comment2 line 1
+                 * Comment2 line 2 with preceeding tabs */
+}
+
+fn main() {
+    /* Comment1 line 1
+     * Comment1 line 2 */
+    // Following1 comment
+    let y1 = 6; /* Comment2 line 1
+                 * Comment2 line 2 - prefixed by spaces and 1 tab */
+    // Following2 comment
+    let y2 = 6; /* Comment3 line 1
+                 * Comment3 line 2 - prefixed by spaces and 2 tabs */
+    /* Following3 comment */
+    let y3 = 8; /* Comment4 line 1
+                 * Comment4 line 2  - prefixed by spaces */
+    /* Following4 comment
+     * cont of Following4 comment */
+}
+
+// Other tests
+
+fn main() {
+    let x = 111; /* First Comment with spaces prefix for each line - line 1
+                  * First Comment line 2
+                  * First Comment line 3
+                  */
+    // Following first comment
+}
+
+fn main() {
+    let x = 222; /* Second Comment with tab prefix for each line - line 1
+                  * Second Comment line 2
+                  * Second Comment line 3
+                  */
+    /* Following second comment line 1
+     * Following second comment line 2
+     * Following second comment line 3
+     */
+}
+
+fn main() {
+    let x = 333; /* Third Comment with spaces prefix for each line - line 1
+                  * Third Comment line 2
+                  * Third Comment line 3
+                  */
+    /* Following third comment line 1
+     * Following third comment line 2
+     * Following third comment line 3
+     */
+}
+
+fn main() {
+    let x = 222; /* Second Comment line 1
+                  * Second Comment line 2
+                  * Second Comment line 3
+                  */
+    let y = 333; // Following second comment line 1
+    // Following second comment line 2
+    // Following second comment line 3
+}
+
+fn main() {
+    let y3 = 8; /* Comment4 line 1
+                 * Comment4 line 2 */
+}
+
+fn main() {
+    let y3 = 8; /* Comment4 line 1
+                 * Comment4 line 2 */
+    y4 = 9;
+}

--- a/tests/target/issue-4658/one/comment-multiline-indentation-hard-tabs.rs
+++ b/tests/target/issue-4658/one/comment-multiline-indentation-hard-tabs.rs
@@ -1,0 +1,49 @@
+// rustfmt-version: One
+// rustfmt-hard_tabs: true
+
+// Ensure multiline comments are indented properly,
+// including when second line is prefixed by tab or at the beginning of the line
+
+/* First comment line
+ * second comment line - no prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - tab prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line - no prefix */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+type T1 = TT<
+	u32, /* First comment line
+	      * second comment line - no prefix
+	      * last comment line */
+>;
+
+type T2 = TT<
+	u32, /* First comment line
+	      * second comment line - blank prefix
+	      * last comment line */
+>;
+
+type T2 = TT<
+	u32, /* First comment line
+	      * second comment line - tab prefix
+	      * last comment line */
+>;
+
+type T3 = TT<
+	u32, /* First comment line
+	      * second comment line - tab prefix
+	      * last comment line */
+>;

--- a/tests/target/issue-4658/one/comment-multiline-indentation.rs
+++ b/tests/target/issue-4658/one/comment-multiline-indentation.rs
@@ -1,0 +1,49 @@
+// rustfmt-version: One
+// rustfmt-hard_tabs: false
+
+// Ensure multiline comments are indented properly,
+// including when second line is prefixed by tab or at the beginning of the line
+
+/* First comment line
+ * second comment line - no prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - tab prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line - no prefix */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+type T1 = TT<
+    u32, /* First comment line
+          * second comment line - no prefix
+          * last comment line */
+>;
+
+type T2 = TT<
+    u32, /* First comment line
+          * second comment line - blank prefix
+          * last comment line */
+>;
+
+type T2 = TT<
+    u32, /* First comment line
+          * second comment line - tab prefix
+          * last comment line */
+>;
+
+type T3 = TT<
+    u32, /* First comment line
+          * second comment line - tab prefix
+          * last comment line */
+>;

--- a/tests/target/issue-4658/two/comment-multiline-indentation-hard-tabs.rs
+++ b/tests/target/issue-4658/two/comment-multiline-indentation-hard-tabs.rs
@@ -1,0 +1,49 @@
+// rustfmt-version: Two
+// rustfmt-hard_tabs: true
+
+// Ensure multiline comments are indented properly,
+// including when second line is prefixed by tab or at the beginning of the line
+
+/* First comment line
+ * second comment line - no prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - tab prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line - no prefix */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+type T1 = TT<
+	u32, /* First comment line
+	      * second comment line - no prefix
+	      * last comment line */
+>;
+
+type T2 = TT<
+	u32, /* First comment line
+	      * second comment line - blank prefix
+	      * last comment line */
+>;
+
+type T2 = TT<
+	u32, /* First comment line
+	      * second comment line - tab prefix
+	      * last comment line */
+>;
+
+type T3 = TT<
+	u32, /* First comment line
+	      * second comment line - tab prefix
+	      * last comment line */
+>;

--- a/tests/target/issue-4658/two/comment-multiline-indentation.rs
+++ b/tests/target/issue-4658/two/comment-multiline-indentation.rs
@@ -1,0 +1,49 @@
+// rustfmt-version: Two
+// rustfmt-hard_tabs: false
+
+// Ensure multiline comments are indented properly,
+// including when second line is prefixed by tab or at the beginning of the line
+
+/* First comment line
+ * second comment line - no prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - tab prefix
+ * last comment line */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line - no prefix */
+
+/* First comment line
+ * second comment line - blank prefix
+ * last comment line */
+
+type T1 = TT<
+    u32, /* First comment line
+          * second comment line - no prefix
+          * last comment line */
+>;
+
+type T2 = TT<
+    u32, /* First comment line
+          * second comment line - blank prefix
+          * last comment line */
+>;
+
+type T2 = TT<
+    u32, /* First comment line
+          * second comment line - tab prefix
+          * last comment line */
+>;
+
+type T3 = TT<
+    u32, /* First comment line
+          * second comment line - tab prefix
+          * last comment line */
+>;


### PR DESCRIPTION
Fixes #4551

Backport #4658 and suggested fix for #4551.  The backport and the suggested fix are submitted in one PR, since fixing #4551 requires both, and if only one will be merged, then the issue will not be fixed.

The backport of #4658 handles the case when in the per-formatted code a tab precedes the `*` at the beginning of a second and following lines of a comment.  Copying the tab into the target code sometimes cased wrong indentation, so the tab is replaced with space.

The additional fix for #4551 is for **version Two** to properly handle the indentation of the second and following lines of a multiline comment, when the first comment line is in the **same line** of the previous statement.  In version Two, these lines were indented according to the statement indentation and the fix indents them to the first line.