### PR TITLE
Implement formatting for let_chains

### DIFF
--- a/tests/source/let_chains.rs
+++ b/tests/source/let_chains.rs
@@ -1,0 +1,9 @@
+fn main() {
+    if let Some( 1) = Some(1)
+&&
+let Some(2 ) = Some( 2 ) 
+&&true && let true = false &&
+let false = true{
+        let _x=1+ 1; let _y  =2;
+    }
+}

--- a/tests/target/let_chains.rs
+++ b/tests/target/let_chains.rs
@@ -1,0 +1,11 @@
+fn main() {
+    if let Some(1) = Some(1)
+        && let Some(2) = Some(2)
+        && true
+        && let true = false
+        && let false = true
+    {
+        let _x = 1 + 1;
+        let _y = 2;
+    }
+}


### PR DESCRIPTION
Currently, if-statements with let chains in them are completely skipped, because `format_expr` fails on the `ExprKind::Let`.

Implement it by copying some logic from `ControlFlow::rewrite_pat_expr`. Then, simplify `ControlFlow` by removing explicit support for `if let`/`while let`, instead delegating to `format_expr`. Some logic still remains to support `for <pat> in <expr>`, however.