### PR TITLE
Fix for 4824 - multi comments cause internal error

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -278,11 +278,10 @@ impl<'a> FmtVisitor<'a> {
                     let first_line = &subslice[..offset];
                     self.push_str(first_line);
                     self.push_str(&comment_indent.to_string_with_newline(self.config));
-
-                    let other_lines = &subslice[offset + 1..];
+                    let other_lines = &subslice[offset + 1..].trim_start();
                     let comment_str =
                         rewrite_comment(other_lines, false, comment_shape, self.config)
-                            .unwrap_or_else(|| String::from(other_lines));
+                            .unwrap_or_else(|| other_lines.to_string());
                     self.push_str(&comment_str);
                 }
             }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -313,7 +313,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                                 self.push_str(&self.block_indent.to_string_with_newline(config));
 
                                 // put the other lines below it, shaping it as needed
-                                let other_lines = &sub_slice[offset + 1..];
+                                let other_lines = &sub_slice[offset + 1..].trim_start();
                                 let comment_str =
                                     rewrite_comment(other_lines, false, comment_shape, config);
                                 match comment_str {

--- a/tests/source/issue-4824/one.rs
+++ b/tests/source/issue-4824/one.rs
@@ -1,0 +1,71 @@
+// rustfmt-version: One
+
+//  Original issue test case
+
+#[cfg(windows)]
+fn main() {
+use common_util::get_version_for_rc;
+use std::env;
+use winres::{VersionInfo, WindowsResource};
+
+println!("cargo:rerun-if-changed=favicon.ico");
+println!("cargo:rerun-if-changed=Cargo.toml"); // rerun when version changed
+/*let profile = env::var("PROFILE").unwrap();
+if profile == "release"*/ {
+let mut res = WindowsResource::new();
+res.set_icon("favicon.ico");
+let version = get_version_for_rc!();
+res.set_version_info(VersionInfo::PRODUCTVERSION, version);
+res.set_version_info(VersionInfo::FILEVERSION, version);
+res.compile().unwrap();
+}
+}
+
+#[cfg(not(windows))]
+fn main() {}
+
+// Other test cases
+
+fn main() {
+let a = 1; // One line comment
+/* Block comment */
+true
+}
+
+fn main() {
+let a = 1; /* Block comment */
+// One line comment
+true
+}
+
+fn main() {
+let a = 1; // One line comment
+/* Block comment */
+}
+
+fn main() {
+let a = 1; /* Block comment */
+// One line comment
+}
+
+fn main() {
+// One line comment
+/* Block comment */
+true
+}
+
+fn main() {
+/* Block comment */
+// One line comment
+true
+}
+
+fn main() {
+// One line comment
+/* Block comment */
+}
+
+fn main() {
+/* Block comment */
+// One line comment
+}

--- a/tests/source/issue-4824/two.rs
+++ b/tests/source/issue-4824/two.rs
@@ -1,0 +1,71 @@
+// rustfmt-version: Two
+
+//  Original issue test case
+
+#[cfg(windows)]
+fn main() {
+use common_util::get_version_for_rc;
+use std::env;
+use winres::{VersionInfo, WindowsResource};
+
+println!("cargo:rerun-if-changed=favicon.ico");
+println!("cargo:rerun-if-changed=Cargo.toml"); // rerun when version changed
+/*let profile = env::var("PROFILE").unwrap();
+if profile == "release"*/ {
+let mut res = WindowsResource::new();
+res.set_icon("favicon.ico");
+let version = get_version_for_rc!();
+res.set_version_info(VersionInfo::PRODUCTVERSION, version);
+res.set_version_info(VersionInfo::FILEVERSION, version);
+res.compile().unwrap();
+}
+}
+
+#[cfg(not(windows))]
+fn main() {}
+
+// Other test cases
+
+fn main() {
+let a = 1; // One line comment
+/* Block comment */
+true
+}
+
+fn main() {
+let a = 1; /* Block comment */
+// One line comment
+true
+}
+
+fn main() {
+let a = 1; // One line comment
+/* Block comment */
+}
+
+fn main() {
+let a = 1; /* Block comment */
+// One line comment
+}
+
+fn main() {
+// One line comment
+/* Block comment */
+true
+}
+
+fn main() {
+/* Block comment */
+// One line comment
+true
+}
+
+fn main() {
+// One line comment
+/* Block comment */
+}
+
+fn main() {
+/* Block comment */
+// One line comment
+}

--- a/tests/target/issue-4824/one.rs
+++ b/tests/target/issue-4824/one.rs
@@ -1,0 +1,72 @@
+// rustfmt-version: One
+
+//  Original issue test case
+
+#[cfg(windows)]
+fn main() {
+    use common_util::get_version_for_rc;
+    use std::env;
+    use winres::{VersionInfo, WindowsResource};
+
+    println!("cargo:rerun-if-changed=favicon.ico");
+    println!("cargo:rerun-if-changed=Cargo.toml"); // rerun when version changed
+                                                   /*let profile = env::var("PROFILE").unwrap();
+                                                   if profile == "release"*/
+    {
+        let mut res = WindowsResource::new();
+        res.set_icon("favicon.ico");
+        let version = get_version_for_rc!();
+        res.set_version_info(VersionInfo::PRODUCTVERSION, version);
+        res.set_version_info(VersionInfo::FILEVERSION, version);
+        res.compile().unwrap();
+    }
+}
+
+#[cfg(not(windows))]
+fn main() {}
+
+// Other test cases
+
+fn main() {
+    let a = 1; // One line comment
+               /* Block comment */
+    true
+}
+
+fn main() {
+    let a = 1; /* Block comment */
+    // One line comment
+    true
+}
+
+fn main() {
+    let a = 1; // One line comment
+               /* Block comment */
+}
+
+fn main() {
+    let a = 1; /* Block comment */
+    // One line comment
+}
+
+fn main() {
+    // One line comment
+    /* Block comment */
+    true
+}
+
+fn main() {
+    /* Block comment */
+    // One line comment
+    true
+}
+
+fn main() {
+    // One line comment
+    /* Block comment */
+}
+
+fn main() {
+    /* Block comment */
+    // One line comment
+}

--- a/tests/target/issue-4824/two.rs
+++ b/tests/target/issue-4824/two.rs
@@ -1,0 +1,72 @@
+// rustfmt-version: Two
+
+//  Original issue test case
+
+#[cfg(windows)]
+fn main() {
+    use common_util::get_version_for_rc;
+    use std::env;
+    use winres::{VersionInfo, WindowsResource};
+
+    println!("cargo:rerun-if-changed=favicon.ico");
+    println!("cargo:rerun-if-changed=Cargo.toml"); // rerun when version changed
+    /*let profile = env::var("PROFILE").unwrap();
+    if profile == "release"*/
+    {
+        let mut res = WindowsResource::new();
+        res.set_icon("favicon.ico");
+        let version = get_version_for_rc!();
+        res.set_version_info(VersionInfo::PRODUCTVERSION, version);
+        res.set_version_info(VersionInfo::FILEVERSION, version);
+        res.compile().unwrap();
+    }
+}
+
+#[cfg(not(windows))]
+fn main() {}
+
+// Other test cases
+
+fn main() {
+    let a = 1; // One line comment
+    /* Block comment */
+    true
+}
+
+fn main() {
+    let a = 1; /* Block comment */
+    // One line comment
+    true
+}
+
+fn main() {
+    let a = 1; // One line comment
+    /* Block comment */
+}
+
+fn main() {
+    let a = 1; /* Block comment */
+    // One line comment
+}
+
+fn main() {
+    // One line comment
+    /* Block comment */
+    true
+}
+
+fn main() {
+    /* Block comment */
+    // One line comment
+    true
+}
+
+fn main() {
+    // One line comment
+    /* Block comment */
+}
+
+fn main() {
+    /* Block comment */
+    // One line comment
+}


### PR DESCRIPTION
Closes #4824

The suggested fix is in two code changes done for Version Two - by adding `trim_start()` before passing a comments string to `rewrite_comment()`.

A more robust fix may be to do the `trim_start()` (or even `trim()`) inside `rewrite_comment()` (for Version Two), but I didn't evaluate the overall use of `rewrite_comment()` to make sure this is o.k.