### PR TITLE
Fix/Inconsistent Struct Body Opening Brace Placement After Where Clause

### DIFF
--- a/tests/source/issue-5507/issue-5507-indent-style-block.rs
+++ b/tests/source/issue-5507/issue-5507-indent-style-block.rs
@@ -1,0 +1,18 @@
+struct EmptyBody<T>
+    where T: Eq {
+}
+
+struct LineComment<T>
+    where T: Eq {
+    // body
+}
+
+struct BlockComment<T>
+    where T: Eq {
+    /* block comment */
+}
+
+struct HasBody<T>
+    where T: Eq {
+    x: T
+}

--- a/tests/target/issue-5507/issue-5507-indent-style-block.rs
+++ b/tests/target/issue-5507/issue-5507-indent-style-block.rs
@@ -1,0 +1,25 @@
+struct EmptyBody<T>
+where
+    T: Eq,
+{}
+
+struct LineComment<T>
+where
+    T: Eq,
+{
+    // body
+}
+
+struct BlockComment<T>
+where
+    T: Eq,
+{
+    /* block comment */
+}
+
+struct HasBody<T>
+where
+    T: Eq,
+{
+    x: T,
+}


### PR DESCRIPTION
# Fixes #5507 