### PR TITLE
Added new option "chain_count" to limit number of chained functions per line.

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -307,6 +307,58 @@ By default this option is set as a percentage of [`max_width`](#max_width) provi
 
 See also [`max_width`](#max_width) and [`use_small_heuristics`](#use_small_heuristics)
 
+## `chain_count`
+
+Maximum number of chained function calls to fit on one line.
+
+- **Default value**: `0`
+- **Possible values**: any positive integer less than `4294967296`, although anything larger than one quarter the value of [`chain_width`](#chain_width) will have no effect as the minimum size of a function chain is 4 (e.g. `.a()`).
+- **Stable**: No (tracking issue: [#2263](https://github.com/rust-lang/rustfmt/issues/2263))
+
+This option co-exists with [`chain_width`](#chain_width) and chained
+method calls will be wrapped if either option is triggered. Any line
+with more method chains than defined in this option will have every
+chained call put on a new line.
+
+Setting this option to `0` disables this rule, and `1` puts every single
+chained call onto a newline.
+
+#### `0` (default):
+
+```rust
+fn main() {
+    a.foo().bar().baz();
+}
+```
+
+#### `1`:
+
+```rust
+fn main() {
+    a.foo()
+        .bar()
+        .baz();
+}
+```
+
+#### `2`:
+
+```rust
+fn main() {
+    a.foo()
+        .bar()
+        .baz();
+}
+```
+
+#### `3`:
+
+```rust
+fn main() {
+    a.foo().bar().baz();
+}
+```
+
 ## `color`
 
 Whether to use colored output or not.

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -717,7 +717,10 @@ impl<'a> ChainFormatterShared<'a> {
     }
 
     fn join_rewrites(&self, context: &RewriteContext<'_>, child_shape: Shape) -> Option<String> {
-        let connector = if self.fits_single_line {
+        let force_multiline =
+            self.child_count > context.config.chain_count() && context.config.chain_count() != 0;
+
+        let connector = if self.fits_single_line && !force_multiline {
             // Yay, we can put everything on one line.
             Cow::from("")
         } else {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,6 +56,7 @@ create_config! {
     array_width: usize, 60, true,  "Maximum width of an array literal before falling \
         back to vertical formatting.";
     chain_width: usize, 60, true, "Maximum length of a chain to fit on a single line.";
+    chain_count: usize, 0, false, "Maximum number of chained method calls to fit on a single line.";
     single_line_if_else_max_width: usize, 50, true, "Maximum line length for single line if-else \
         expressions. A value of zero means always break if-else expressions.";
 
@@ -618,6 +619,7 @@ struct_lit_width = 18
 struct_variant_width = 35
 array_width = 60
 chain_width = 60
+chain_count = 0
 single_line_if_else_max_width = 50
 wrap_comments = false
 format_code_in_doc_comments = false

--- a/tests/config/issue-2263.toml
+++ b/tests/config/issue-2263.toml
@@ -1,0 +1,1 @@
+chain_count = 3

--- a/tests/source/chains.rs
+++ b/tests/source/chains.rs
@@ -214,6 +214,14 @@ impl Foo {
     }
 }
 
+// #2263
+// Limit chain functions per line.
+fn issue2263() {
+    let a = "test";
+
+    a.to_string().to_string().to_string();
+}
+
 // #2415
 // Avoid orphan in chain
 fn issue2415() {

--- a/tests/source/issue-2263.rs
+++ b/tests/source/issue-2263.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let foo = "foo";
+
+    foo.to_string().to_string();
+    foo.to_string().to_string().to_string();
+    foo.to_string()
+        .to_string()
+        .to_string();
+    foo.to_string().to_string().to_string().to_string();
+}

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -252,6 +252,14 @@ impl Foo {
     }
 }
 
+// #2263
+// Limit chain functions per line.
+fn issue2263() {
+    let a = "test";
+
+    a.to_string().to_string().to_string();
+}
+
 // #2415
 // Avoid orphan in chain
 fn issue2415() {

--- a/tests/target/issue-2263.rs
+++ b/tests/target/issue-2263.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let foo = "foo";
+
+    foo.to_string().to_string();
+    foo.to_string().to_string().to_string();
+    foo.to_string().to_string().to_string();
+    foo.to_string()
+        .to_string()
+        .to_string()
+        .to_string();
+}


### PR DESCRIPTION

See Issue #2263 

This PR adds a new option to limit the number of chained method calls based on the number of method calls in addition to the number of characters. This is my first PR to the rustfmt repository, so I apologise if anything about this PR is out of order or if any changes are needed. I want to get this done the right way.

This PR adds the new option `chain_count`, which is a `usize` type with a default value of `0`. This is the maximum number of chained method calls to put on a single line. Setting to `0` effectively disables the option, while setting it to `1` has the effect of forcing method chaining to be on new lines.

Setting the option to 2 would have the effect that the following would be fine:
```rust
a.b().c()
```
However this:
```rust
a.b().c().d()
```
would become this:
```rust
a.b()
    .c()
    .d()
```

I originally considered making an option `force_multiline_chains`, however did not persue this because setting `chain_count` to `1` has the same effect, and this way there is more freedom for those who would prefer have a couple before it wraps.

## Examples

#### `0` (default):

```rust
fn main() {
    a.foo().bar().baz();
}
```

#### `1`:

```rust
fn main() {
    a.foo()
        .bar()
        .baz();
}
```

#### `2`:

```rust
fn main() {
    a.foo()
        .bar()
        .baz();
}
```

#### `3`:

```rust
fn main() {
    a.foo().bar().baz();
}
```


## Interactions with Other Config Options

`chain_width` - Does not override. The chain will be made multiline if either of these rules are triggered.

`force_one_line_chain` - Overrides this option. (This was chosen arbitrarily and I am open to changing this 👍 )