### PR TITLE
Fix #5489 - allow CONST and macrro metavariable as attribute value

### DIFF
--- a/tests/source/issue-5489.rs
+++ b/tests/source/issue-5489.rs
@@ -1,0 +1,143 @@
+// rustfmt-format_macro_matchers: true
+
+// Original issue #5489 case - macro metavariable ($name) as attribute value.
+use clap::Parser;
+
+macro_rules! generate_the_struct {
+    ($a:literal) => {
+		#[derive(Parser)]
+        pub struct Struct {
+            #[clap(
+                long = "--alpha-beta-gamma",
+                env = "ALPHA_BETA_GAMMA",
+                default_value = $a,
+            )]
+            alpha_beta_gamma: usize,
+        }
+    };
+}
+
+fn main() {
+    generate_the_struct!("77777");
+    let s = Struct { alpha_beta_gamma: 66666 };
+    println!("{}", s.alpha_beta_gamma);
+}
+
+//
+// Other case with macro metavariables ($name) as attribute value.
+macro_rules! generate_the_struct {
+(  $a:literal  ) => {
+#[derive(Parser)]
+pub struct Struct {
+#[  clap(
+long   =   "--alpha-beta-gamma",
+env   =   "ALPHA_BETA_GAMMA",
+default_value   =   $a,
+)]
+alpha_beta_gamma:   usize,
+}
+};
+}
+
+macro_rules! generate_the_struct {
+($bbbbb:literal) => {
+#[derive(Parser)]
+pub struct Struct {
+#[  clap(
+default_value(   $bbbbb    )
+)]
+aaaaa: str,
+}
+};
+}
+
+macro_rules! generate_the_struct {
+(  $bbbbb:literal  ,  $ccccc:literal  ) => {
+#[  clap(
+default_value   =   $bbbbb  , other_value   =   $ccccc  ,
+)   ]
+const aaaaa: str;
+};
+}
+    
+macro_rules! generate_the_struct {
+(  $bbbbb:literal  ,  $ccccc:literal  ) => {
+#[  clap(
+default_value   =   $bbbbb  , other_value   =   $ccccc  , lit   =   "Lit"  ,
+)   ]
+const aaaaa: str;
+};
+}
+    
+//
+// Cases with COSNT as attribute value.
+const CONSTVAR: usize = 8;
+#[  clap(
+default_value   =   CONSTVAR
+)]
+const aaaaa: str;
+
+macro_rules! generate_the_struct {
+($a:literal) => {
+#[  derive(Parser)]
+pub struct Struct {
+#[  clap(
+long   =   "--alpha-beta-gamma",
+env   =   CONSTVAR,
+)]
+alpha_beta_gamma: usize,
+}
+};
+}   
+
+macro_rules! generate_the_struct {
+($a:literal) => {
+#[derive(Parser)]
+pub struct Struct {
+#[  clap(
+long   =   "--alpha-beta-gamma",
+env   =   CONSTVAR,
+default_value   =   $a,
+)]
+alpha_beta_gamma: usize,
+}
+};
+}
+
+//
+// Variations of #2470 from `macro_rules.rs`.
+macro foo($type_name:   ident, $docs:    expr) {
+#[  doc=    "Lit"  ]
+pub struct $type_name;
+}
+
+macro foo($type_name: ident, $docs: expr) {
+# [    doc =         $docs    ]
+pub struct $type_name;
+}
+
+macro foo($type_name: ident, $docs: expr) {
+# [   $docs    ]
+pub struct $type_name;
+}
+
+//
+// Cases with no macro metavariable ($name) or CONST as attribute value
+macro_rules! generate_the_struct {
+($a:literal) => {
+#[derive(Parser)]
+pub struct Struct {
+#[  clap(
+long   =   "--alpha-beta-gamma",
+env   =   "ALPHA_BETA_GAMMA",
+default_value   =   "Lit",
+)]
+alpha_beta_gamma: usize,
+}
+};
+}
+
+#[  clap(
+default_value    =    "Lit"
+)]
+const aaaaa: str;

--- a/tests/target/issue-5489.rs
+++ b/tests/target/issue-5489.rs
@@ -1,0 +1,128 @@
+// rustfmt-format_macro_matchers: true
+
+// Original issue #5489 case - macro metavariable ($name) as attribute value.
+use clap::Parser;
+
+macro_rules! generate_the_struct {
+    ($a:literal) => {
+        #[derive(Parser)]
+        pub struct Struct {
+            #[clap(
+                long = "--alpha-beta-gamma",
+                env = "ALPHA_BETA_GAMMA",
+                default_value = $a,
+            )]
+            alpha_beta_gamma: usize,
+        }
+    };
+}
+
+fn main() {
+    generate_the_struct!("77777");
+    let s = Struct {
+        alpha_beta_gamma: 66666,
+    };
+    println!("{}", s.alpha_beta_gamma);
+}
+
+//
+// Other case with macro metavariables ($name) as attribute value.
+macro_rules! generate_the_struct {
+    ($a:literal) => {
+        #[derive(Parser)]
+        pub struct Struct {
+            #[clap(
+                long = "--alpha-beta-gamma",
+                env = "ALPHA_BETA_GAMMA",
+                default_value = $a,
+            )]
+            alpha_beta_gamma: usize,
+        }
+    };
+}
+
+macro_rules! generate_the_struct {
+    ($bbbbb:literal) => {
+        #[derive(Parser)]
+        pub struct Struct {
+            #[clap(default_value($bbbbb))]
+            aaaaa: str,
+        }
+    };
+}
+
+macro_rules! generate_the_struct {
+    ($bbbbb:literal, $ccccc:literal) => {
+        #[clap(default_value = $bbbbb, other_value = $ccccc,)]
+        const aaaaa: str;
+    };
+}
+
+macro_rules! generate_the_struct {
+    ($bbbbb:literal, $ccccc:literal) => {
+        #[clap(default_value = $bbbbb, other_value = $ccccc, lit = "Lit",)]
+        const aaaaa: str;
+    };
+}
+
+//
+// Cases with COSNT as attribute value.
+const CONSTVAR: usize = 8;
+#[clap(default_value = CONSTVAR)]
+const aaaaa: str;
+
+macro_rules! generate_the_struct {
+    ($a:literal) => {
+        #[derive(Parser)]
+        pub struct Struct {
+            #[clap(long = "--alpha-beta-gamma", env = CONSTVAR,)]
+            alpha_beta_gamma: usize,
+        }
+    };
+}
+
+macro_rules! generate_the_struct {
+    ($a:literal) => {
+        #[derive(Parser)]
+        pub struct Struct {
+            #[clap(long = "--alpha-beta-gamma", env = CONSTVAR, default_value = $a,)]
+            alpha_beta_gamma: usize,
+        }
+    };
+}
+
+//
+// Variations of #2470 from `macro_rules.rs`.
+macro foo($type_name:ident, $docs:expr) {
+    #[doc = "Lit"]
+    pub struct $type_name;
+}
+
+macro foo($type_name:ident, $docs:expr) {
+    #[doc = $docs]
+    pub struct $type_name;
+}
+
+macro foo($type_name:ident, $docs:expr) {
+    #[$docs]
+    pub struct $type_name;
+}
+
+//
+// Cases with no macro metavariable ($name) or CONST as attribute value
+macro_rules! generate_the_struct {
+    ($a:literal) => {
+        #[derive(Parser)]
+        pub struct Struct {
+            #[clap(
+                long = "--alpha-beta-gamma",
+                env = "ALPHA_BETA_GAMMA",
+                default_value = "Lit"
+            )]
+            alpha_beta_gamma: usize,
+        }
+    };
+}
+
+#[clap(default_value = "Lit")]
+const aaaaa: str;

--- a/tests/target/macro_rules.rs
+++ b/tests/target/macro_rules.rs
@@ -174,7 +174,7 @@ macro_rules! m [
 // #2470
 macro foo($type_name:ident, $docs:expr) {
     #[allow(non_camel_case_types)]
-    #[doc=$docs]
+    #[doc = $docs]
     #[derive(Debug, Clone, Copy)]
     pub struct $type_name;
 }


### PR DESCRIPTION
Suggested fix for #5489 - allow macro `metavariable` as attribute value.  In addition, allow also `CONST` as attribute value.  The suggested fix is actually a workaround to a **preferred** fix of `Attribute:meta()` that current is not supporting these types as attribute value.

The fix handles attribute values assignments of the following forms:
- `#[$name]` in macro or `#[CONST]`
- `#[id(att1 = $name, attr2 = CONST, ...)]`

It may be that not all the possible cases are covered, but hopefully at least most of the practically used cases are covered.

Note that `tests/target/macro_rules.rs` was modified, as `#[doc=$docs]` is now properly formatted to `#[doc = $docs]`.