### PR TITLE
Fix #5488 - prevent shorthand init for tuple struct

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1716,9 +1716,11 @@ pub(crate) fn rewrite_field(
         let overhead = name.len() + separator.len();
         let expr_shape = shape.offset_left(overhead)?;
         let expr = field.expr.rewrite(context, expr_shape);
-
+        let is_lit = matches!(field.expr.kind, ast::ExprKind::Lit(_));
         match expr {
-            Some(ref e) if e.as_str() == name && context.config.use_field_init_shorthand() => {
+            Some(ref e)
+                if !is_lit && e.as_str() == name && context.config.use_field_init_shorthand() =>
+            {
                 Some(attrs_str + name)
             }
             Some(e) => Some(format!("{}{}{}{}", attrs_str, name, separator, e)),

--- a/tests/source/issue-5488.rs
+++ b/tests/source/issue-5488.rs
@@ -1,0 +1,17 @@
+// rustfmt-use_field_init_shorthand: true
+
+struct MyStruct(u32);
+struct AnotherStruct {
+    a: u32,
+}
+
+fn main() {
+    // Since MyStruct is a tuple struct, it should not be shorthanded to
+    // MyStruct { 0 } even if use_field_init_shorthand is enabled.
+    let instance = MyStruct { 0: 0 };
+
+    // Since AnotherStruct is not a tuple struct, the shorthand should
+    // apply.
+    let a = 10;
+    let instance = AnotherStruct { a: a };
+}

--- a/tests/target/issue-5488.rs
+++ b/tests/target/issue-5488.rs
@@ -1,0 +1,17 @@
+// rustfmt-use_field_init_shorthand: true
+
+struct MyStruct(u32);
+struct AnotherStruct {
+    a: u32,
+}
+
+fn main() {
+    // Since MyStruct is a tuple struct, it should not be shorthanded to
+    // MyStruct { 0 } even if use_field_init_shorthand is enabled.
+    let instance = MyStruct { 0: 0 };
+
+    // Since AnotherStruct is not a tuple struct, the shorthand should
+    // apply.
+    let a = 10;
+    let instance = AnotherStruct { a };
+}


### PR DESCRIPTION
Closes #5488

Fix for #5488. Before applying shorthand initialization for structs,
check if identifier is a literal (e.g. tuple struct). If yes, then do
not apply short hand initialization.

Added test case to validate the changes for the fix.