### PR TITLE
Add missing line to `use_field_init_shorthand` "true" example

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2777,6 +2777,7 @@ fn main() {
     let y = 2;
     let z = 3;
     let a = Foo { x, y, z };
+    let b = Foo { x, y, z };
 }
 ```
 


### PR DESCRIPTION
The last declaration (`let b = ...`) is where all the difference between the
"false" and "true" cases lies, but it was omitted from the "true" example for
unknown reasons.

Assuming it was by accident, this patch adds the last line from the "false"
example to the "true" example, formatted as it would have been with
`use_field_init_shorthand = true`.