### PR TITLE
Set `ctx.inside_macro` based on `FmtVisitor.parent_context` in  `FmtVisitor::get_context`

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1001,10 +1001,11 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     }
 
     pub(crate) fn get_context(&self) -> RewriteContext<'_> {
+        let inside_macro = self.parent_context.map_or(false, |ctx| ctx.inside_macro());
         RewriteContext {
             parse_sess: self.parse_sess,
             config: self.config,
-            inside_macro: Rc::new(Cell::new(false)),
+            inside_macro: Rc::new(Cell::new(inside_macro)),
             use_block: Cell::new(false),
             is_if_else_block: Cell::new(false),
             force_one_line_chain: Cell::new(false),

--- a/tests/target/issue-1468.rs
+++ b/tests/target/issue-1468.rs
@@ -14,13 +14,13 @@ fn issue1468() {
                 return (
                     DecoderResult::Malformed(1, 0),
                     unread_handle_trail.unread(),
-                    handle.written(),
+                    handle.written()
                 );
             }
             return (
                 DecoderResult::Malformed(2, 0),
                 unread_handle_trail.consumed(),
-                handle.written(),
+                handle.written()
             );
         } else {
             unreachable!();

--- a/tests/target/issue_5526.rs
+++ b/tests/target/issue_5526.rs
@@ -1,0 +1,11 @@
+construct_runtime!(
+    pub struct Runtime
+    where
+        Block = Block,
+        NodeBlock = generic::Block<Header, sp_runtime::OpaqueExtrinsic>,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        Council: pallet_collective::<Instance1>,
+        TechnicalCommittee: pallet_collective::<Instance2>,
+    }
+);


### PR DESCRIPTION
Fixes #5526

When creating new contexts with `FmtVisitor::get_context` we set the value of `ctx.inside_macro` based on the `parent_context` if it exists. This helps us remember that we're inside of a macro when creating new `RewriteContext` from recursively created `FmtVisitors`.

A similar issue to #5526 was reported in #3139, and remembering that we're inside of a macro in this way helps us go down a code path that resolved #3139 and was implemented in PR #3142.
