### PR TITLE
Fix #5533: Prefer light_rewrite_comment if it is not a doccomment

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -365,7 +365,11 @@ fn identify_comment(
             trim_left_preserve_layout(first_group, shape.indent, config)?
         } else if !config.normalize_comments()
             && !config.wrap_comments()
-            && !config.format_code_in_doc_comments()
+            && !(
+                // `format_code_in_doc_comments` should only take effect on doc comments,
+                // so we only consider it when this comment block is a doc comment block.
+                is_doc_comment && config.format_code_in_doc_comments()
+            )
         {
             light_rewrite_comment(first_group, shape.indent, config, is_doc_comment)
         } else {

--- a/tests/target/issue-5568.rs
+++ b/tests/target/issue-5568.rs
@@ -1,0 +1,14 @@
+// rustfmt-max_width: 119
+// rustfmt-format_code_in_doc_comments: true
+
+mod libs {
+    fn mrbgems_sources() {
+        [
+            "mrbgems/mruby-compiler/core/codegen.c", // Ruby parser and bytecode generation
+            "mrbgems/mruby-compiler/core/y.tab.c",   // Ruby parser and bytecode generation
+            "mrbgems/mruby-metaprog/src/metaprog.c", // APIs on Kernel and Module for accessing classes and variables
+            "mrbgems/mruby-method/src/method.c",     // `Method`, `UnboundMethod`, and method APIs on Kernel and Module
+            "mrbgems/mruby-pack/src/pack.c",         // Array#pack and String#unpack
+        ]
+    }
+}

--- a/tests/target/issue_5533.rs
+++ b/tests/target/issue_5533.rs
@@ -1,0 +1,6 @@
+// rustfmt-format_code_in_doc_comments: true
+
+struct TestStruct {
+    position_currency: String, // Currency for position of this contract. If not null, 1 contract = 1 positionCurrency.
+    pu: Option<i64>, // Previous event update sequense ("u" of previous message), -1 also means None
+}

--- a/tests/target/issue_5907.rs
+++ b/tests/target/issue_5907.rs
@@ -1,0 +1,6 @@
+// rustfmt-format_code_in_doc_comments: true
+
+// ```
+// [
+// ]
+// ```


### PR DESCRIPTION
This pull request adapts the plan 2 of [@ytmimi's comment](https://github.com/rust-lang/rustfmt/issues/5533#issuecomment-1238224735), and it won't touch any comment which is not a documentation comment now.

However, it did not fixed the root cause (which is partially indicated in Plan 1): [`block_comment` is `true` if the length is too long…?](https://github.com/rust-lang/rustfmt/blob/38659ec6ad5f341cf8eb3139725bf695872c6de7/src/lists.rs#L363). As it seems not related to #5533, it may be fixed in another PR.

<img width="908" alt="image" src="https://user-images.githubusercontent.com/28441561/188687175-31787e59-72d5-4500-b968-45fba8bc300c.png">
