### PR TITLE
Add unstable `format_brace_macros` option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1098,7 +1098,7 @@ See also [`format_macro_bodies`](#format_macro_bodies).
 
 ## `format_macro_bodies`
 
-Format the bodies of macros.
+Format the bodies of declarative macro definitions.
 
 - **Default value**: `true`
 - **Possible values**: `true`, `false`
@@ -1127,6 +1127,26 @@ macro_rules! foo {
 ```
 
 See also [`format_macro_matchers`](#format_macro_matchers).
+
+## `format_brace_macros`
+
+Format the contents of fn-like macro invocations that use brace delimiters.
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+- **Stable**: No
+
+#### `true` (default):
+
+```rust
+foo! { "bar" }
+```
+
+#### `false`:
+
+```rust
+foo! {"bar"}
+```
 
 ## `skip_macro_invocations`
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -71,7 +71,9 @@ create_config! {
     format_strings: bool, false, false, "Format string literals where necessary";
     format_macro_matchers: bool, false, false,
         "Format the metavariable matching patterns in macros";
-    format_macro_bodies: bool, true, false, "Format the bodies of macros";
+    format_macro_bodies: bool, true, false, "Format the bodies of declarative macro definitions";
+    format_brace_macros: bool, true, false,
+        "Format the contents of fn-like macro invocations that use brace delimiters";
     skip_macro_invocations: MacroSelectors, MacroSelectors::default(), false,
         "Skip formatting the bodies of macros invoked with the following names.";
     hex_literal_case: HexLiteralCase, HexLiteralCase::Preserve, false,
@@ -628,6 +630,7 @@ normalize_doc_attributes = false
 format_strings = false
 format_macro_matchers = false
 format_macro_bodies = true
+format_brace_macros = true
 skip_macro_invocations = []
 hex_literal_case = "Preserve"
 empty_item_single_line = true

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -268,6 +268,30 @@ pub(crate) fn rewrite_with_parens<'a, T: 'a + IntoOverflowableItem<'a>>(
     .rewrite(shape)
 }
 
+pub(crate) fn rewrite_undelimited<'a, T: 'a + IntoOverflowableItem<'a>>(
+    context: &'a RewriteContext<'_>,
+    ident: &'a str,
+    items: impl Iterator<Item = &'a T>,
+    shape: Shape,
+    span: Span,
+    item_max_width: usize,
+    force_separator_tactic: Option<SeparatorTactic>,
+) -> Option<String> {
+    Context::new(
+        context,
+        items,
+        ident,
+        shape,
+        span,
+        "",
+        "",
+        item_max_width,
+        force_separator_tactic,
+        None,
+    )
+    .rewrite(shape)
+}
+
 pub(crate) fn rewrite_with_angle_brackets<'a, T: 'a + IntoOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     ident: &'a str,

--- a/tests/source/configs/format_brace_macros/false.rs
+++ b/tests/source/configs/format_brace_macros/false.rs
@@ -1,0 +1,210 @@
+// rustfmt-format_brace_macros: false
+
+fn issue_1917() {
+    mod x {
+        quickcheck! {
+            fn test(a: String, s: String, b: String) -> TestResult {
+                if a.find(&s).is_none() {
+
+                    TestResult::from_bool(true)
+                } else {
+                    TestResult::discard()
+                }
+            }
+        }
+    }
+}
+
+fn foo() {
+    f! {r#"
+         test
+    "#};
+}
+
+x! {()}
+x! {#}
+x! {ident}
+
+macro_rules! moo1 {
+    () => {
+        bar! {
+"
+"
+        }
+    };
+}
+
+macro_rules! moo2 {
+    () => {
+        bar! {
+        "
+"
+        }
+    };
+}
+
+macro_rules! moo4 {
+    () => {
+        bar! {
+"
+    foo
+        bar
+baz"
+        }
+    };
+}
+
+macro_rules! impl_from_vector {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt | $source:ident) => {
+        impl From<$source> for $id {
+            #[inline]
+            fn from(source: $source) -> Self {
+                fn static_assert_same_number_of_lanes<T, U>()
+                where
+                    T: crate::sealed::Simd,
+                    U: crate::sealed::Simd<LanesType = T::LanesType>,
+                {
+                }
+                use llvm::simd_cast;
+                static_assert_same_number_of_lanes::<$id, $source>();
+                Simd(unsafe { simd_cast(source.0) })
+            }
+        }
+
+        // FIXME: `Into::into` is not inline, but due to
+        // the blanket impl in `std`, which is not
+        // marked `default`, we cannot override it here with
+        // specialization.
+        /*
+        impl Into<$id> for $source {
+            #[inline]
+            fn into(self) -> $id {
+                unsafe { simd_cast(self) }
+            }
+        }
+        */
+
+        test_if! {
+            $test_tt:
+            interpolate_idents! {
+                mod [$id _from_ $source] {
+                    use super::*;
+                    #[test]
+                    fn from() {
+                        assert_eq!($id::lanes(), $source::lanes());
+                        let source: $source = Default::default();
+                        let vec: $id = Default::default();
+
+                        let e = $id::from(source);
+                        assert_eq!(e, vec);
+
+                        let e: $id = source.into();
+                        assert_eq!(e, vec);
+                    }
+                }
+            }
+        }
+    };
+}
+
+// https://github.com/rust-lang/rustfmt/issues/3434
+html! { <div>
+Hello
+</div>}
+
+// https://github.com/rust-lang/rustfmt/issues/3445
+wrapper! {
+use std::  collections::HashMap;
+pub fn the (a: sdf )
+{
+    ( )
+}
+}
+
+// https://github.com/rust-lang/rustfmt/issues/5254
+widget! {
+    /// A frame around content
+    ///
+    /// This widget provides a simple abstraction: drawing a frame around its
+    /// contents.
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
+    #[derive(Clone, Debug, Default)]
+    #[handler(msg = <W as Handler>::Msg)]
+    #[widget{
+        layout = frame(self.inner, kas::theme::FrameStyle::Frame);
+    }]
+    pub struct Frame<W: Widget> {
+        #[widget_core]
+        core: CoreData,
+        #[widget]
+        pub inner: W,
+    }
+
+    // NOTE: `impl Self` is not valid Rust syntax, but rustfmt handles it fine
+    impl Self {
+        /// Construct a frame
+        #[inline]
+        pub fn new(inner: W) -> Self {
+            Frame {
+            core: Default::default(),
+                inner,
+            }
+        }
+    }
+}
+
+// https://users.rust-lang.org/t/rustfmt-skips-macro-arguments/74807
+macro_rules! identity {
+    ($x:expr) => {
+        $x
+    };
+}
+
+fn main() {
+    foo("first very very long argument", "second very very long argument");
+    identity! { foo("first very very long argument", "second very very long argument") };
+}
+
+#[tokio::main]
+fn main() {
+    // This gets formatted as expected
+    foo(
+    "first very very long argument",
+        "second very very long argument",
+    );
+    tokio::select! (
+        _ = futures::future::ready(true) => {
+            // This is left unchanged
+            foo("first very very long argument", "second very very long argument")
+        }
+    )
+}
+
+// https://github.com/rust-lang/rustfmt/issues/4611
+// Note that this is not currently formatted.
+tokio::select! {
+    result = reader => {
+        match result {
+            Ok(v) => {
+                eprintln!(
+                "message: {}",
+                v
+                );
+            },
+            Err(_) => {
+                eprintln!(
+                    "error: {}",
+                    e
+                );
+            },
+        }
+    },
+    _ = writer => {
+        // Comment
+        eprintln!(
+            "completed: {}",
+            some_other_field
+        );
+    }
+}

--- a/tests/source/configs/format_brace_macros/true.rs
+++ b/tests/source/configs/format_brace_macros/true.rs
@@ -1,0 +1,210 @@
+// rustfmt-format_brace_macros: true
+
+fn issue_1917() {
+    mod x {
+        quickcheck! {
+            fn test(a: String, s: String, b: String) -> TestResult {
+                if a.find(&s).is_none() {
+
+                    TestResult::from_bool(true)
+                } else {
+                    TestResult::discard()
+                }
+            }
+        }
+    }
+}
+
+fn foo() {
+    f! {r#"
+         test
+    "#};
+}
+
+x! {()}
+x! {#}
+x! {ident}
+
+macro_rules! moo1 {
+    () => {
+        bar! {
+"
+"
+        }
+    };
+}
+
+macro_rules! moo2 {
+    () => {
+        bar! {
+        "
+"
+        }
+    };
+}
+
+macro_rules! moo4 {
+    () => {
+        bar! {
+"
+    foo
+        bar
+baz"
+        }
+    };
+}
+
+macro_rules! impl_from_vector {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt | $source:ident) => {
+        impl From<$source> for $id {
+            #[inline]
+            fn from(source: $source) -> Self {
+                fn static_assert_same_number_of_lanes<T, U>()
+                where
+                    T: crate::sealed::Simd,
+                    U: crate::sealed::Simd<LanesType = T::LanesType>,
+                {
+                }
+                use llvm::simd_cast;
+                static_assert_same_number_of_lanes::<$id, $source>();
+                Simd(unsafe { simd_cast(source.0) })
+            }
+        }
+
+        // FIXME: `Into::into` is not inline, but due to
+        // the blanket impl in `std`, which is not
+        // marked `default`, we cannot override it here with
+        // specialization.
+        /*
+        impl Into<$id> for $source {
+            #[inline]
+            fn into(self) -> $id {
+                unsafe { simd_cast(self) }
+            }
+        }
+        */
+
+        test_if! {
+            $test_tt:
+            interpolate_idents! {
+                mod [$id _from_ $source] {
+                    use super::*;
+                    #[test]
+                    fn from() {
+                        assert_eq!($id::lanes(), $source::lanes());
+                        let source: $source = Default::default();
+                        let vec: $id = Default::default();
+
+                        let e = $id::from(source);
+                        assert_eq!(e, vec);
+
+                        let e: $id = source.into();
+                        assert_eq!(e, vec);
+                    }
+                }
+            }
+        }
+    };
+}
+
+// https://github.com/rust-lang/rustfmt/issues/3434
+html! { <div>
+Hello
+</div>}
+
+// https://github.com/rust-lang/rustfmt/issues/3445
+wrapper! {
+use std::  collections::HashMap;
+pub fn the (a: sdf )
+{
+    ( )
+}
+}
+
+// https://github.com/rust-lang/rustfmt/issues/5254
+widget! {
+    /// A frame around content
+    ///
+    /// This widget provides a simple abstraction: drawing a frame around its
+    /// contents.
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
+    #[derive(Clone, Debug, Default)]
+    #[handler(msg = <W as Handler>::Msg)]
+    #[widget{
+        layout = frame(self.inner, kas::theme::FrameStyle::Frame);
+    }]
+    pub struct Frame<W: Widget> {
+        #[widget_core]
+        core: CoreData,
+        #[widget]
+        pub inner: W,
+    }
+
+    // NOTE: `impl Self` is not valid Rust syntax, but rustfmt handles it fine
+    impl Self {
+        /// Construct a frame
+        #[inline]
+        pub fn new(inner: W) -> Self {
+            Frame {
+            core: Default::default(),
+                inner,
+            }
+        }
+    }
+}
+
+// https://users.rust-lang.org/t/rustfmt-skips-macro-arguments/74807
+macro_rules! identity {
+    ($x:expr) => {
+        $x
+    };
+}
+
+fn main() {
+    foo("first very very long argument", "second very very long argument");
+    identity! { foo("first very very long argument", "second very very long argument") };
+}
+
+#[tokio::main]
+fn main() {
+    // This gets formatted as expected
+    foo(
+    "first very very long argument",
+        "second very very long argument",
+    );
+    tokio::select! (
+        _ = futures::future::ready(true) => {
+            // This is left unchanged
+            foo("first very very long argument", "second very very long argument")
+        }
+    )
+}
+
+// https://github.com/rust-lang/rustfmt/issues/4611
+// Note that this is not currently formatted.
+tokio::select! {
+    result = reader => {
+        match result {
+            Ok(v) => {
+                eprintln!(
+                "message: {}",
+                v
+                );
+            },
+            Err(_) => {
+                eprintln!(
+                    "error: {}",
+                    e
+                );
+            },
+        }
+    },
+    _ = writer => {
+        // Comment
+        eprintln!(
+            "completed: {}",
+            some_other_field
+        );
+    }
+}

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -1,4 +1,5 @@
 // rustfmt-normalize_comments: true
+// rustfmt-format_brace_macros: false
 
  extern crate       foo    ;   
     extern crate       foo       as bar    ;   

--- a/tests/source/issue-2917/packed_simd.rs
+++ b/tests/source/issue-2917/packed_simd.rs
@@ -1,4 +1,5 @@
 // rustfmt-wrap_comments: true
+// rustfmt-format_brace_macros: false
 //! Implements `From` and `Into` for vector types.
 
 macro_rules! impl_from_vector {

--- a/tests/source/issue-3302.rs
+++ b/tests/source/issue-3302.rs
@@ -1,4 +1,5 @@
 // rustfmt-version: Two
+// rustfmt-format_brace_macros: false
 
 macro_rules! moo1 {
     () => {

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -1,5 +1,6 @@
 // rustfmt-normalize_comments: true
 // rustfmt-format_macro_matchers: true
+// rustfmt-format_brace_macros: false
 itemmacro!(this, is.now() .formatted(yay));
 
 itemmacro!(really, long.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb() .is.formatted());

--- a/tests/target/configs/format_brace_macros/false.rs
+++ b/tests/target/configs/format_brace_macros/false.rs
@@ -1,0 +1,213 @@
+// rustfmt-format_brace_macros: false
+
+fn issue_1917() {
+    mod x {
+        quickcheck! {
+            fn test(a: String, s: String, b: String) -> TestResult {
+                if a.find(&s).is_none() {
+
+                    TestResult::from_bool(true)
+                } else {
+                    TestResult::discard()
+                }
+            }
+        }
+    }
+}
+
+fn foo() {
+    f! {r#"
+         test
+    "#};
+}
+
+x! {()}
+x! {#}
+x! {ident}
+
+macro_rules! moo1 {
+    () => {
+        bar! {
+        "
+"
+        }
+    };
+}
+
+macro_rules! moo2 {
+    () => {
+        bar! {
+        "
+"
+        }
+    };
+}
+
+macro_rules! moo4 {
+    () => {
+        bar! {
+        "
+    foo
+        bar
+baz"
+        }
+    };
+}
+
+macro_rules! impl_from_vector {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt | $source:ident) => {
+        impl From<$source> for $id {
+            #[inline]
+            fn from(source: $source) -> Self {
+                fn static_assert_same_number_of_lanes<T, U>()
+                where
+                    T: crate::sealed::Simd,
+                    U: crate::sealed::Simd<LanesType = T::LanesType>,
+                {
+                }
+                use llvm::simd_cast;
+                static_assert_same_number_of_lanes::<$id, $source>();
+                Simd(unsafe { simd_cast(source.0) })
+            }
+        }
+
+        // FIXME: `Into::into` is not inline, but due to
+        // the blanket impl in `std`, which is not
+        // marked `default`, we cannot override it here with
+        // specialization.
+        /*
+        impl Into<$id> for $source {
+            #[inline]
+            fn into(self) -> $id {
+                unsafe { simd_cast(self) }
+            }
+        }
+        */
+
+        test_if! {
+            $test_tt:
+            interpolate_idents! {
+                mod [$id _from_ $source] {
+                    use super::*;
+                    #[test]
+                    fn from() {
+                        assert_eq!($id::lanes(), $source::lanes());
+                        let source: $source = Default::default();
+                        let vec: $id = Default::default();
+
+                        let e = $id::from(source);
+                        assert_eq!(e, vec);
+
+                        let e: $id = source.into();
+                        assert_eq!(e, vec);
+                    }
+                }
+            }
+        }
+    };
+}
+
+// https://github.com/rust-lang/rustfmt/issues/3434
+html! { <div>
+Hello
+</div>}
+
+// https://github.com/rust-lang/rustfmt/issues/3445
+wrapper! {
+use std::  collections::HashMap;
+pub fn the (a: sdf )
+{
+    ( )
+}
+}
+
+// https://github.com/rust-lang/rustfmt/issues/5254
+widget! {
+    /// A frame around content
+    ///
+    /// This widget provides a simple abstraction: drawing a frame around its
+    /// contents.
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
+    #[derive(Clone, Debug, Default)]
+    #[handler(msg = <W as Handler>::Msg)]
+    #[widget{
+        layout = frame(self.inner, kas::theme::FrameStyle::Frame);
+    }]
+    pub struct Frame<W: Widget> {
+        #[widget_core]
+        core: CoreData,
+        #[widget]
+        pub inner: W,
+    }
+
+    // NOTE: `impl Self` is not valid Rust syntax, but rustfmt handles it fine
+    impl Self {
+        /// Construct a frame
+        #[inline]
+        pub fn new(inner: W) -> Self {
+            Frame {
+            core: Default::default(),
+                inner,
+            }
+        }
+    }
+}
+
+// https://users.rust-lang.org/t/rustfmt-skips-macro-arguments/74807
+macro_rules! identity {
+    ($x:expr) => {
+        $x
+    };
+}
+
+fn main() {
+    foo(
+        "first very very long argument",
+        "second very very long argument",
+    );
+    identity! { foo("first very very long argument", "second very very long argument") };
+}
+
+#[tokio::main]
+fn main() {
+    // This gets formatted as expected
+    foo(
+        "first very very long argument",
+        "second very very long argument",
+    );
+    tokio::select! (
+        _ = futures::future::ready(true) => {
+            // This is left unchanged
+            foo("first very very long argument", "second very very long argument")
+        }
+    )
+}
+
+// https://github.com/rust-lang/rustfmt/issues/4611
+// Note that this is not currently formatted.
+tokio::select! {
+    result = reader => {
+        match result {
+            Ok(v) => {
+                eprintln!(
+                "message: {}",
+                v
+                );
+            },
+            Err(_) => {
+                eprintln!(
+                    "error: {}",
+                    e
+                );
+            },
+        }
+    },
+    _ = writer => {
+        // Comment
+        eprintln!(
+            "completed: {}",
+            some_other_field
+        );
+    }
+}

--- a/tests/target/configs/format_brace_macros/true.rs
+++ b/tests/target/configs/format_brace_macros/true.rs
@@ -1,0 +1,217 @@
+// rustfmt-format_brace_macros: true
+
+fn issue_1917() {
+    mod x {
+        quickcheck! {
+            fn test(a: String, s: String, b: String) -> TestResult {
+                if a.find(&s).is_none() {
+                    TestResult::from_bool(true)
+                } else {
+                    TestResult::discard()
+                }
+            }
+        }
+    }
+}
+
+fn foo() {
+    f! {
+        r#"
+         test
+    "#
+    };
+}
+
+x! { () }
+x! {#}
+x! { ident }
+
+macro_rules! moo1 {
+    () => {
+        bar! {
+            "
+"
+        }
+    };
+}
+
+macro_rules! moo2 {
+    () => {
+        bar! {
+            "
+"
+        }
+    };
+}
+
+macro_rules! moo4 {
+    () => {
+        bar! {
+            "
+    foo
+        bar
+baz"
+        }
+    };
+}
+
+macro_rules! impl_from_vector {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt | $source:ident) => {
+        impl From<$source> for $id {
+            #[inline]
+            fn from(source: $source) -> Self {
+                fn static_assert_same_number_of_lanes<T, U>()
+                where
+                    T: crate::sealed::Simd,
+                    U: crate::sealed::Simd<LanesType = T::LanesType>,
+                {
+                }
+                use llvm::simd_cast;
+                static_assert_same_number_of_lanes::<$id, $source>();
+                Simd(unsafe { simd_cast(source.0) })
+            }
+        }
+
+        // FIXME: `Into::into` is not inline, but due to
+        // the blanket impl in `std`, which is not
+        // marked `default`, we cannot override it here with
+        // specialization.
+        /*
+        impl Into<$id> for $source {
+            #[inline]
+            fn into(self) -> $id {
+                unsafe { simd_cast(self) }
+            }
+        }
+        */
+
+        test_if! {
+            $test_tt: interpolate_idents! {
+                mod [$id _from_ $source] {
+                    use super::*;
+                    #[test]
+                    fn from() {
+                        assert_eq!($id::lanes(), $source::lanes());
+                        let source: $source = Default::default();
+                        let vec: $id = Default::default();
+
+                        let e = $id::from(source);
+                        assert_eq!(e, vec);
+
+                        let e: $id = source.into();
+                        assert_eq!(e, vec);
+                    }
+                }
+            }
+        }
+    };
+}
+
+// https://github.com/rust-lang/rustfmt/issues/3434
+html! { <div>
+Hello
+</div>}
+
+// https://github.com/rust-lang/rustfmt/issues/3445
+wrapper! {
+    use std::collections::HashMap;
+    pub fn the(a: sdf) {
+        ()
+    }
+}
+
+// https://github.com/rust-lang/rustfmt/issues/5254
+widget! {
+    /// A frame around content
+    ///
+    /// This widget provides a simple abstraction: drawing a frame around its
+    /// contents.
+    #[autoimpl(Deref, DerefMut on self.inner)]
+    #[autoimpl(class_traits where W: trait on self.inner)]
+    #[derive(Clone, Debug, Default)]
+    #[handler(msg = <W as Handler>::Msg)]
+    #[widget{
+        layout = frame(self.inner, kas::theme::FrameStyle::Frame);
+    }]
+    pub struct Frame<W: Widget> {
+        #[widget_core]
+        core: CoreData,
+        #[widget]
+        pub inner: W,
+    }
+
+    // NOTE: `impl Self` is not valid Rust syntax, but rustfmt handles it fine
+    impl Self {
+        /// Construct a frame
+        #[inline]
+        pub fn new(inner: W) -> Self {
+            Frame {
+                core: Default::default(),
+                inner,
+            }
+        }
+    }
+}
+
+// https://users.rust-lang.org/t/rustfmt-skips-macro-arguments/74807
+macro_rules! identity {
+    ($x:expr) => {
+        $x
+    };
+}
+
+fn main() {
+    foo(
+        "first very very long argument",
+        "second very very long argument",
+    );
+    identity! {
+        foo(
+            "first very very long argument",
+            "second very very long argument",
+        )
+    };
+}
+
+#[tokio::main]
+fn main() {
+    // This gets formatted as expected
+    foo(
+        "first very very long argument",
+        "second very very long argument",
+    );
+    tokio::select! (
+        _ = futures::future::ready(true) => {
+            // This is left unchanged
+            foo("first very very long argument", "second very very long argument")
+        }
+    )
+}
+
+// https://github.com/rust-lang/rustfmt/issues/4611
+// Note that this is not currently formatted.
+tokio::select! {
+    result = reader => {
+        match result {
+            Ok(v) => {
+                eprintln!(
+                "message: {}",
+                v
+                );
+            },
+            Err(_) => {
+                eprintln!(
+                    "error: {}",
+                    e
+                );
+            },
+        }
+    },
+    _ = writer => {
+        // Comment
+        eprintln!(
+            "completed: {}",
+            some_other_field
+        );
+    }
+}

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -1,4 +1,5 @@
 // rustfmt-normalize_comments: true
+// rustfmt-format_brace_macros: false
 
 extern crate foo;
 extern crate foo as bar;

--- a/tests/target/issue-2917/packed_simd.rs
+++ b/tests/target/issue-2917/packed_simd.rs
@@ -1,4 +1,5 @@
 // rustfmt-wrap_comments: true
+// rustfmt-format_brace_macros: false
 //! Implements `From` and `Into` for vector types.
 
 macro_rules! impl_from_vector {

--- a/tests/target/issue-3302.rs
+++ b/tests/target/issue-3302.rs
@@ -1,4 +1,5 @@
 // rustfmt-version: Two
+// rustfmt-format_brace_macros: false
 
 macro_rules! moo1 {
     () => {

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -1,5 +1,6 @@
 // rustfmt-normalize_comments: true
 // rustfmt-format_macro_matchers: true
+// rustfmt-format_brace_macros: false
 itemmacro!(this, is.now().formatted(yay));
 
 itemmacro!(


### PR DESCRIPTION
This PR adds an unstable `format_brace_macros` option for formatting brace `{}` delimited macro invocations that parse as valid Rust code, with fallback to existing behavior.

## Motivation

Users consistently expect some degree of formatting in brace delimited macro invocations. (See links below for examples.)

## Discussion

It is true that the problem of formatting macro invocations is not solvable in the general case, but skipping formatting entirely is contrary to user expectations. `rustfmt` already uses heuristics for parentheses `()` delimited and bracket `[]` delimited macros, but does not currently attempt to format brace delimited macro invocations.

By putting this behind an unstable option, we can:

- Do better for many common cases.
- Formally collect a test suite of user-reported expectations.
- Develop an understanding of which non-standard macro syntaxes are common.
- Collect specific cases where formatting produces undesirable results.
- Encourage macro authors to create syntaxes that "play nice" with the formatting rules, or at least don't fail catastrophically.

Options are available for skipping formatting for individual macros, including `#[rustfmt::skip]` and the newer [`skip_macro_invocations`](https://rust-lang.github.io/rustfmt/?version=master&search=skip_macro_invocations#skip_macro_invocations) option, which can skip formatting for all invocations of a specified macro.


## Approach

Explicitly, this PR simply attempts to format brace-delimited fn-like macro calls

`foo! {"bar"}`

as they would be formatted if enclosed in parentheses, which is a common workaround:

`foo!({ "bar" })`

Yielding the final formatting result:

`foo! { "bar" }`

## Future work

- Better preserve AST; right now there are cases where e.g. trailing commas can be altered.
- Add additional heuristics for further formatting attempts, such as interpreting contents:
    - as body of a `match` expression
    - as body of a `struct` instantiation
    - where body of interior delimiters parses as Rust code
    - etc.

## See also

- https://github.com/rust-lang/rustfmt/discussions/5437
- https://github.com/rust-lang/rustfmt/issues/8
- https://github.com/rust-lang/rustfmt/issues/3445
- https://github.com/rust-lang/rustfmt/issues/4611
- https://github.com/servo/servo/issues/24696
- https://github.com/MaterializeInc/materialize/pull/12562
- Closes https://github.com/rust-lang/rustfmt/issues/5254
- Closes https://github.com/tokio-rs/async-stream/issues/68
