### PR TITLE
Handle `dyn*` syntax when rewriting `ast::TyKind::TraitObject`

### DIFF
--- a/tests/target/issue_5542.rs
+++ b/tests/target/issue_5542.rs
@@ -1,0 +1,10 @@
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+use core::fmt::Debug;
+
+fn main() {
+    let i = 42;
+    let dyn_i = i as dyn* Debug;
+    dbg!(dyn_i);
+}


### PR DESCRIPTION
Resolves #5542

Prior to rust-lang/rust#101212 the `ast::TraitObjectSyntax` enum only had two variants `Dyn` and `None`. The PR that introduced the `dyn*` syntax added a new variant `DynStar`, but did not update the formatting rules to account for the new variant.

Now the new `DynStar` variant is properly handled and is no longer removed by rustfmt.