### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/check_diff.yml
+++ b/.github/workflows/check_diff.yml
@@ -15,6 +15,9 @@ on:
         description: 'Optional comma separated list of rustfmt config options to pass when running the feature branch'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   diff_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources

--- a/.github/workflows/rustdoc_check.yml
+++ b/.github/workflows/rustdoc_check.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   rustdoc_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -6,8 +6,13 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-release:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     name: build-release
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: windows-latest


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/rust-lang/rustfmt/actions/runs/3169477245/jobs/5161415515#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- check_diff.yml
- integration.yml
- linux.yml
- mac.yml
- rustdoc_check.yml
- upload-assets.yml
- windows.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>