### PR TITLE
Remove `failure` from integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,6 @@ jobs:
           tempdir,
           futures-rs,
           rust-clippy,
-          failure,
         ]
         include:
           # Allowed Failures
@@ -62,9 +61,6 @@ jobs:
           # it appears to have been passing for quite some time.
           # Original comment was: temporal build failure due to breaking changes in the nightly compiler
           - integration: rust-semverver
-            allow-failure: true
-          # Can be moved back to include section after https://github.com/rust-lang-nursery/failure/pull/298 is merged
-          - integration: failure
             allow-failure: true
 
     steps:

--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -91,14 +91,28 @@ case ${INTEGRATION} in
         cd -
         ;;
     crater)
-        git clone --depth=1 https://github.com/rust-lang-nursery/${INTEGRATION}.git
+        git clone --depth=1 https://github.com/rust-lang/${INTEGRATION}.git
         cd ${INTEGRATION}
         show_head
         check_fmt_with_lib_tests
         cd -
         ;;
+    bitflags)
+        git clone --depth=1 https://github.com/bitflags/${INTEGRATION}.git
+        cd ${INTEGRATION}
+        show_head
+        check_fmt_with_all_tests
+        cd -
+        ;;
+    error-chain | tempdir)
+        git clone --depth=1 https://github.com/rust-lang-deprecated/${INTEGRATION}.git
+        cd ${INTEGRATION}
+        show_head
+        check_fmt_with_all_tests
+        cd -
+        ;;
     *)
-        git clone --depth=1 https://github.com/rust-lang-nursery/${INTEGRATION}.git
+        git clone --depth=1 https://github.com/rust-lang/${INTEGRATION}.git
         cd ${INTEGRATION}
         show_head
         check_fmt_with_all_tests


### PR DESCRIPTION
The failure crate has been deprecated and the integration failure no longer gets fixed, so removed.
This also clean-ups Git repo URLs in integration tests.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>