### PR TITLE
Remove use of actions-rs

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -46,10 +46,7 @@ jobs:
         shell: bash
 
       - name: Build release binaries
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+        run: cargo build --release
 
       - name: Build archive
         shell: bash


### PR DESCRIPTION
actions-rs is currently inactive and has an issue like https://github.com/actions-rs/cargo/issues/216, we could directly invoke Cargo instead.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>