### PR TITLE
Fix for handling empty code block in doc comment

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -726,7 +726,7 @@ impl<'a> CommentRewrite<'a> {
                 let code_block = match self.code_block_attr.as_ref().unwrap() {
                     CodeBlockAttribute::Rust
                         if self.fmt.config.format_code_in_doc_comments()
-                            && !self.code_block_buffer.is_empty() =>
+                            && !self.code_block_buffer.trim().is_empty() =>
                     {
                         let mut config = self.fmt.config.clone();
                         config.set().wrap_comments(false);

--- a/tests/source/issue-5234.rs
+++ b/tests/source/issue-5234.rs
@@ -1,0 +1,51 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```
+/// ```
+fn foo() {}
+
+/// ```
+///Something
+/// ```
+fn foo() {}
+
+/// ```
+///
+/// ```
+fn foo() {}
+
+
+/// /// ```
+fn foo() {}
+
+/// /// ```
+/// ```
+///
+/// ```
+/// ```
+fn foo() {}
+
+fn foo() {
+/// ```
+///
+/// ```
+struct bar {}
+}
+
+/// ```
+/// fn com(){
+/// let i = 5;
+///
+/// let j = 6;
+/// }
+/// ```
+fn foo() {}
+
+fn foo() {
+/// ```
+///fn com(){
+///let i = 5;
+///}
+/// ```
+struct bar {}
+}

--- a/tests/target/issue-5234.rs
+++ b/tests/target/issue-5234.rs
@@ -1,0 +1,47 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```
+/// ```
+fn foo() {}
+
+/// ```
+/// Something
+/// ```
+fn foo() {}
+
+/// ```
+/// ```
+fn foo() {}
+
+/// /// ```
+fn foo() {}
+
+/// /// ```
+/// ```
+/// ```
+/// ```
+fn foo() {}
+
+fn foo() {
+    /// ```
+    /// ```
+    struct bar {}
+}
+
+/// ```
+/// fn com() {
+///     let i = 5;
+///
+///     let j = 6;
+/// }
+/// ```
+fn foo() {}
+
+fn foo() {
+    /// ```
+    /// fn com() {
+    ///     let i = 5;
+    /// }
+    /// ```
+    struct bar {}
+}


### PR DESCRIPTION
Fixes #5234

Suggested fix is by trimming the code block, as discussed in (now obsolete) PR #4902.