### PR TITLE
Remove empty lines from formatted string litteral

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -73,7 +73,7 @@ pub(crate) fn rewrite_string<'a>(
 
     // Strip line breaks.
     // With this regex applied, all remaining whitespaces are significant
-    let strip_line_breaks_re = Regex::new(r"([^\\](\\\\)*)\\[\n\r][[:space:]]*").unwrap();
+    let strip_line_breaks_re = Regex::new(r"(?m)(^|[^\\])(\\\\)*(\\[\n\r][[:space:]]*)+").unwrap();
     let stripped_str = strip_line_breaks_re.replace_all(orig, "$1");
 
     let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();

--- a/tests/source/format_strings/issue-2833.rs
+++ b/tests/source/format_strings/issue-2833.rs
@@ -2,13 +2,14 @@
 // rustfmt-max_width: 80
 
 fn test1() {
-    let expected = "but Doctor Watson has to have it taken out for him and \
-                    dusted,
+    let expected = "\
+but Doctor Watson has to have it taken out for him and dusted,
 ";
 }
 
 fn test2() {
-    let expected = "[Omitted long matching line]
+    let expected = "\
+[Omitted long matching line]
 but Doctor Watson has to have it taken out for him and dusted,
 ";
 }

--- a/tests/source/format_strings/issue-4323.rs
+++ b/tests/source/format_strings/issue-4323.rs
@@ -1,0 +1,39 @@
+// rustfmt-format_strings: true
+
+fn bench_contains_short_long(b: &mut Bencher) {
+    let haystack = "\
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis lorem sit amet dolor \
+ultricies condimentum. Praesent iaculis purus elit, ac malesuada quam malesuada in. Duis sed orci \
+eros. Suspendisse sit amet magna mollis, mollis nunc luctus, imperdiet mi. Integer fringilla non \
+sem ut lacinia. Fusce varius tortor a risus porttitor hendrerit. Morbi mauris dui, ultricies nec \
+tempus vel, gravida nec quam.
+
+Nam lectus enim, dapibus non nisi tempor, consectetur convallis massa. Maecenas eleifend dictum \
+feugiat. Etiam quis mauris vel risus luctus mattis a a nunc. Nullam orci quam, imperdiet id \
+vehicula in, porttitor ut nibh. Duis sagittis adipiscing nisl vitae congue. Donec mollis risus eu \
+leo suscipit, varius porttitor nulla porta. Pellentesque ut sem nec nisi euismod vehicula. Nulla \
+malesuada sollicitudin quam eu fermentum.";
+}
+
+fn bench_contains_short_long(b: &mut Bencher) {
+    let haystack = "\
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis lorem sit amet dolor \
+ultricies condimentum. Praesent iaculis purus elit, ac malesuada quam malesuada in. Duis sed orci \
+eros. Suspendisse sit amet magna mollis, mollis nunc luctus, imperdiet mi. Integer fringilla non \
+sem ut lacinia. Fusce varius tortor a risus porttitor hendrerit. Morbi mauris dui, ultricies nec \
+tempus vel, gravida nec quam.";
+}
+
+fn bench_contains_short_long(b: &mut Bencher) {
+    let haystack = "\
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis lorem sit amet dolor \
+\
+ultricies condimentum. Praesent iaculis purus elit, ac malesuada quam malesuada in. Duis sed orci \
+   \
+eros. Suspendisse sit amet magna mollis, mollis nunc luctus, imperdiet mi. Integer fringilla non \
+\
+\
+  \
+sem ut lacinia. Fusce varius tortor a risus porttitor hendrerit. Morbi mauris dui, ultricies nec \
+tempus vel, gravida nec quam.";
+}

--- a/tests/target/format_strings/issue-4323.rs
+++ b/tests/target/format_strings/issue-4323.rs
@@ -1,0 +1,34 @@
+// rustfmt-format_strings: true
+
+fn bench_contains_short_long(b: &mut Bencher) {
+    let haystack =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis lorem sit amet \
+         dolor ultricies condimentum. Praesent iaculis purus elit, ac malesuada quam malesuada \
+         in. Duis sed orci eros. Suspendisse sit amet magna mollis, mollis nunc luctus, imperdiet \
+         mi. Integer fringilla non sem ut lacinia. Fusce varius tortor a risus porttitor \
+         hendrerit. Morbi mauris dui, ultricies nec tempus vel, gravida nec quam.
+
+Nam lectus enim, dapibus non nisi tempor, consectetur convallis massa. Maecenas eleifend dictum \
+         feugiat. Etiam quis mauris vel risus luctus mattis a a nunc. Nullam orci quam, imperdiet \
+         id vehicula in, porttitor ut nibh. Duis sagittis adipiscing nisl vitae congue. Donec \
+         mollis risus eu leo suscipit, varius porttitor nulla porta. Pellentesque ut sem nec nisi \
+         euismod vehicula. Nulla malesuada sollicitudin quam eu fermentum.";
+}
+
+fn bench_contains_short_long(b: &mut Bencher) {
+    let haystack = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis \
+                    lorem sit amet dolor ultricies condimentum. Praesent iaculis purus elit, ac \
+                    malesuada quam malesuada in. Duis sed orci eros. Suspendisse sit amet magna \
+                    mollis, mollis nunc luctus, imperdiet mi. Integer fringilla non sem ut \
+                    lacinia. Fusce varius tortor a risus porttitor hendrerit. Morbi mauris dui, \
+                    ultricies nec tempus vel, gravida nec quam.";
+}
+
+fn bench_contains_short_long(b: &mut Bencher) {
+    let haystack = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis \
+                    lorem sit amet dolor ultricies condimentum. Praesent iaculis purus elit, ac \
+                    malesuada quam malesuada in. Duis sed orci eros. Suspendisse sit amet magna \
+                    mollis, mollis nunc luctus, imperdiet mi. Integer fringilla non sem ut \
+                    lacinia. Fusce varius tortor a risus porttitor hendrerit. Morbi mauris dui, \
+                    ultricies nec tempus vel, gravida nec quam.";
+}


### PR DESCRIPTION
Fixes #4323

Change the "format_string" `strip_line_breaks_re` RE so it will remove empty lines (including lines with spaces only):
1. Removing an empty line that starts the string literal, as suggested in the resolved issue (the added `^|` in `...(^|[^\\])...`.
2. Remove empty lines inside the string literal - the added `(?m)` and the `(...)+`.

Note that removing the first empty line conflicts with the resolution to #2833.  However, it seem to me that the new formatting is better and therefore I changed the test cases for that issue.  I did keep the original test case by moving it to `tests/source` and changing the `target` file.