### PR TITLE
Consider Imports Reorder config when merging Use Trees

### DIFF
--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -11,7 +11,7 @@ use std::cmp::{Ord, Ordering};
 use rustc_ast::ast;
 use rustc_span::{symbol::sym, Span};
 
-use crate::config::{Config, GroupImportsTactic};
+use crate::config::{Config, GroupImportsTactic, ImportGranularity};
 use crate::imports::{normalize_use_trees_with_granularity, UseSegmentKind, UseTree};
 use crate::items::{is_mod_decl, rewrite_extern_crate, rewrite_mod};
 use crate::lists::{itemize_list, write_list, ListFormatting, ListItem};
@@ -110,6 +110,7 @@ fn rewrite_reorderable_or_regroupable_items(
             normalized_items = normalize_use_trees_with_granularity(
                 normalized_items,
                 context.config.imports_granularity(),
+                context.config.reorder_imports(),
             );
 
             let mut regrouped_items = match context.config.group_imports() {
@@ -240,7 +241,10 @@ impl ReorderableItemKind {
             ReorderableItemKind::ExternCrate
             | ReorderableItemKind::Mod
             | ReorderableItemKind::Other => false,
-            ReorderableItemKind::Use => config.group_imports() != GroupImportsTactic::Preserve,
+            ReorderableItemKind::Use => {
+                config.group_imports() != GroupImportsTactic::Preserve
+                    || config.imports_granularity() != ImportGranularity::Preserve
+            }
         }
     }
 

--- a/tests/source/imports_granularity_and_reorder/crate_no_reorder.rs
+++ b/tests/source/imports_granularity_and_reorder/crate_no_reorder.rs
@@ -1,0 +1,28 @@
+// rustfmt-imports_granularity: Crate
+// rustfmt-reorder_imports: false
+
+use a::b::c::d::e;
+
+use a::b::c::{
+d::e
+};
+
+use a::b::{
+d, c,
+};
+
+use a::b::{
+w::{d, c},
+};
+
+use a::b::{
+z, x, y,
+u::{b, a},
+w::{d, c},
+};
+
+use z123::foo;
+use z123::baz;
+
+use z123::baz;
+use z123::foo;

--- a/tests/source/imports_granularity_and_reorder/crate_reorder.rs
+++ b/tests/source/imports_granularity_and_reorder/crate_reorder.rs
@@ -1,0 +1,28 @@
+// rustfmt-imports_granularity: Crate
+// rustfmt-reorder_imports: true
+
+use a::b::c::d::e;
+
+use a::b::c::{
+d::e
+};
+
+use a::b::{
+d, c,
+};
+
+use a::b::{
+w::{d, c},
+};
+
+use a::b::{
+z, x, y,
+u::{b, a},
+w::{d, c},
+};
+
+use z123::foo;
+use z123::baz;
+
+use z123::baz;
+use z123::foo;

--- a/tests/source/imports_granularity_and_reorder/preserve_no_reorder.rs
+++ b/tests/source/imports_granularity_and_reorder/preserve_no_reorder.rs
@@ -1,0 +1,28 @@
+// rustfmt-imports_granularity: Preserve
+// rustfmt-reorder_imports: false
+
+use a::b::c::d::e;
+
+use a::b::c::{
+d::e
+};
+
+use a::b::{
+d, c,
+};
+
+use a::b::{
+w::{d, c},
+};
+
+use a::b::{
+z, x, y,
+u::{b, a},
+w::{d, c},
+};
+
+use z123::foo;
+use z123::baz;
+
+use z123::baz;
+use z123::foo;

--- a/tests/source/imports_granularity_and_reorder/preserve_reorder.rs
+++ b/tests/source/imports_granularity_and_reorder/preserve_reorder.rs
@@ -1,0 +1,24 @@
+// rustfmt-imports_granularity: Preserve
+// rustfmt-reorder_imports: true
+
+use a::b::c::d::e;
+
+use a::b::{
+d, c,
+};
+
+use a::b::{
+w::{d, c},
+};
+
+use a::b::{
+z, x, y,
+u::{b, a},
+w::{d, c},
+};
+
+use z123::foo;
+use z123::baz;
+
+use z123::baz;
+use z123::foo;

--- a/tests/target/imports_granularity_and_reorder/crate_no_reorder.rs
+++ b/tests/target/imports_granularity_and_reorder/crate_no_reorder.rs
@@ -1,0 +1,20 @@
+// rustfmt-imports_granularity: Crate
+// rustfmt-reorder_imports: false
+
+use a::b::c::d::e;
+
+use a::b::c::d::e;
+
+use a::b::{d, c};
+
+use a::b::w::{d, c};
+
+use a::b::{
+    z, x, y,
+    u::{b, a},
+    w::{d, c},
+};
+
+use z123::{foo, baz};
+
+use z123::{baz, foo};

--- a/tests/target/imports_granularity_and_reorder/crate_reorder.rs
+++ b/tests/target/imports_granularity_and_reorder/crate_reorder.rs
@@ -1,0 +1,20 @@
+// rustfmt-imports_granularity: Crate
+// rustfmt-reorder_imports: true
+
+use a::b::c::d::e;
+
+use a::b::c::d::e;
+
+use a::b::{c, d};
+
+use a::b::w::{c, d};
+
+use a::b::{
+    u::{a, b},
+    w::{c, d},
+    x, y, z,
+};
+
+use z123::{baz, foo};
+
+use z123::{baz, foo};

--- a/tests/target/imports_granularity_and_reorder/preserve_no_reorder.rs
+++ b/tests/target/imports_granularity_and_reorder/preserve_no_reorder.rs
@@ -1,0 +1,24 @@
+// rustfmt-imports_granularity: Preserve
+// rustfmt-reorder_imports: false
+
+use a::b::c::d::e;
+
+use a::b::c::{d::e};
+
+use a::b::{d, c};
+
+use a::b::{
+    w::{d, c},
+};
+
+use a::b::{
+    z, x, y,
+    u::{b, a},
+    w::{d, c},
+};
+
+use z123::foo;
+use z123::baz;
+
+use z123::baz;
+use z123::foo;

--- a/tests/target/imports_granularity_and_reorder/preserve_reorder.rs
+++ b/tests/target/imports_granularity_and_reorder/preserve_reorder.rs
@@ -1,0 +1,20 @@
+// rustfmt-imports_granularity: Preserve
+// rustfmt-reorder_imports: true
+
+use a::b::c::d::e;
+
+use a::b::{c, d};
+
+use a::b::w::{c, d};
+
+use a::b::{
+    u::{a, b},
+    w::{c, d},
+    x, y, z,
+};
+
+use z123::baz;
+use z123::foo;
+
+use z123::baz;
+use z123::foo;


### PR DESCRIPTION
While evaluating enhancements to PR #5612, I found that **merging** use-trees does not take into account the `imports_reorder` setting and it is considered to set as `true`.  Assuming this is an issue, this PR is an attempt to fix it.  This is done by adding the `imports_reorder` config value as a parameter to the use-trees merge related functions.

Note that because of the added parameter, many internal test cases in `imports.rs` were changed.  For the existing tests I added `true` as the `imports_reorder` value, and I added a version of the tests with `false` value.

One case that is **not** handled by this PR, and that was raised in a [PR #5612 comment](https://github.com/rust-lang/rustfmt/pull/5612#issuecomment-1328084247) is the formatting of the following code, when `imports_granularity=Preserve` and `reorder_imports=true`:
```rust
use a::b::c::{
d::e
};
```
In this case, because of the `Preserve`, it is expected that the output will be `use a::b::c::{d::e}`, but it is `use a::b::c::d::e`.

For the record, following is a possible fix for this issue (if it is an issue). I didn't add this fix because it affects some existing test cases.  The possible fix is to `UseTree::normalize()`:
1. Add `imports_granularity` argument to the function (usually the passed value is `context.config.imports_granularity()`).
2. Change
```rust
        // Normalise foo::{bar} -> foo::bar
        if let UseSegmentKind::List(ref list) = last.kind {
            if list.len() == 1 && list[0].to_string() != "self" {
                normalize_sole_list = true;
            }
        }
```
To:
```rust
        // Normalise foo::{bar} -> foo::bar
        if let UseSegmentKind::List(ref list) = last.kind {
            if list.len() == 1 && list[0].to_string() != "self" && imports_granularity != ImportGranularity::Preserve {
                normalize_sole_list = true;
            }
        }
```