### PR TITLE
Fix panic in annotated_snippet dependency (GitHub issue #4968).

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -582,12 +582,14 @@ impl<'a> FormatLines<'a> {
     fn char(&mut self, c: char, kind: FullCodeCharKind) {
         self.newline_count = 0;
         self.line_len += if c == '\t' {
+            self.line_buffer
+                .push_str(&" ".repeat(self.config.tab_spaces()));
             self.config.tab_spaces()
         } else {
-            1
+            self.line_buffer.push(c);
+            c.len_utf8()
         };
         self.last_was_space = c.is_whitespace();
-        self.line_buffer.push(c);
         if kind.is_string() {
             self.current_line_contains_string_literal = true;
         }

--- a/tests/parser/issue_4968.rs
+++ b/tests/parser/issue_4968.rs
@@ -1,0 +1,12 @@
+// rustfmt-hard_tabs: true
+// rustfmt-max_width: 40
+// rustfmt-error_on_unformatted: true
+// rustfmt-error_on_line_overflow: true
+
+fn foo(x: u32) {
+	if x > 10 {
+		if x > 20 {
+			println!("0123456789abcdefghijklmnopqrstuvwxyz");
+		}
+	}
+}


### PR DESCRIPTION
Ref #4968. Changes based on the code review suggestions in #5039. Tabs are counted as `config.tab_spaces` columns, but the `annotated_snippet` dependency counts tabs as 1 space. This difference may lead to a panic in `annotated_snippet`, which can be seen in the test-case added (with this PR's change, it should nolonger panic).

Note that #5039 is about changing tabs to "align to `config.tab_spaces` columns". But the code review suggestion by camsteffen also fixes the panic. This PR doesn't change the arithmetic (tabs are still always counted as a fixed number of spaces) - but just addresses the panic in the dependency.