### PR TITLE
Custom import reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Added
 
 - Add new configuration option, `doc_comment_code_block_width`, which allows for setting a shorter width limit to use for formatting code snippets in doc comments [#5384](https://github.com/rust-lang/rustfmt/issues/5384)
+- Supported custom wildcarded groups for [group_imports](https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#group_imports).
 
 ### Install/Download Options
 - **rustup (nightly)** - nightly-2022-06-24

--- a/Configurations.md
+++ b/Configurations.md
@@ -2229,7 +2229,7 @@ Controls the strategy for how consecutive imports are grouped together.
 Controls the strategy for grouping sets of consecutive imports. Imports may contain newlines between imports and still be grouped together as a single set, but other statements between imports will result in different grouping sets.
 
 - **Default value**: `Preserve`
-- **Possible values**: `Preserve`, `StdExternalCrate`, `One`
+- **Possible values**: `Preserve`, `StdExternalCrate`, `One`, custom wildcard groups
 - **Stable**: No (tracking issue: [#5083](https://github.com/rust-lang/rustfmt/issues/5083))
 
 Each set of imports (one or more `use` statements, optionally separated by newlines) will be formatted independently. Other statements such as `mod ...` or `extern crate ...` will cause imports to not be grouped together.
@@ -2292,6 +2292,39 @@ use core::f32;
 use juniper::{FieldError, FieldResult};
 use std::sync::Arc;
 use uuid::Uuid;
+```
+
+#### Example for custom groups:
+
+Discard existing import groups, and create groups as specified by the wildcarded list.
+Handy aliases are supported:
+
+- `$std` prefix is an alias for standard library (i.e `std`, `core`, `alloc`);
+- `$crate` prefix is an alias for crate-local modules (i.e `self`, `crate`, `super`).
+
+For a given config:
+
+```toml
+group_imports = [
+    ["$std::*", "proc_macro::*"],
+    ["my_crate::*", "crate::*::xyz"],
+    ["$crate::*"],
+]
+```
+
+The following order would be set:
+
+```rust
+use proc_macro::Span;
+use std::rc::Rc;
+
+use crate::abc::xyz;
+use my_crate::a::B;
+use my_crate::A;
+
+use self::X;
+use super::Y;
+use crate::Z;
 ```
 
 ## `reorder_modules`

--- a/config_proc_macro/src/args.rs
+++ b/config_proc_macro/src/args.rs
@@ -1,0 +1,46 @@
+use syn::{
+    parenthesized,
+    parse::{Error as ParserError, Parse, ParseStream},
+    Ident, Token,
+};
+
+#[derive(Debug, Default)]
+pub struct Args {
+    pub skip_derive: Option<Vec<String>>,
+}
+
+impl Args {
+    pub fn skip_derives(&self) -> impl Iterator<Item = &str> + '_ {
+        self.skip_derive
+            .as_ref()
+            .into_iter()
+            .flatten()
+            .map(|s| s.as_ref())
+    }
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream<'_>) -> Result<Self, ParserError> {
+        let mut args = Self::default();
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            match ident.to_string().as_str() {
+                "skip_derive" => {
+                    let content;
+                    parenthesized!(content in input);
+                    args.skip_derive = Some(
+                        content
+                            .parse_terminated::<_, Token![,]>(Ident::parse)?
+                            .into_iter()
+                            .map(|i| i.to_string())
+                            .collect(),
+                    );
+                }
+                a => panic!("unknown attribute: {}", a),
+            }
+        }
+
+        Ok(args)
+    }
+}

--- a/config_proc_macro/src/attrs.rs
+++ b/config_proc_macro/src/attrs.rs
@@ -40,11 +40,6 @@ pub fn config_value(attr: &syn::Attribute) -> Option<String> {
     get_name_value_str_lit(attr, "value")
 }
 
-/// Returns `true` if the given attribute is a `value` attribute.
-pub fn is_config_value(attr: &syn::Attribute) -> bool {
-    is_attr_name_value(attr, "value")
-}
-
 /// Returns `true` if the given attribute is an `unstable` attribute.
 pub fn is_unstable_variant(attr: &syn::Attribute) -> bool {
     is_attr_path(attr, "unstable_variant")

--- a/config_proc_macro/src/config_type.rs
+++ b/config_proc_macro/src/config_type.rs
@@ -1,14 +1,15 @@
 use proc_macro2::TokenStream;
 
+use crate::args::Args;
 use crate::item_enum::define_config_type_on_enum;
 use crate::item_struct::define_config_type_on_struct;
 
 /// Defines `config_type` on enum or struct.
 // FIXME: Implement this on struct.
-pub fn define_config_type(input: &syn::Item) -> TokenStream {
+pub fn define_config_type(args: &Args, input: &syn::Item) -> TokenStream {
     match input {
-        syn::Item::Struct(st) => define_config_type_on_struct(st),
-        syn::Item::Enum(en) => define_config_type_on_enum(en),
+        syn::Item::Struct(st) => define_config_type_on_struct(args, st),
+        syn::Item::Enum(en) => define_config_type_on_enum(args, en),
         _ => panic!("Expected enum or struct"),
     }
     .unwrap()

--- a/config_proc_macro/src/item_struct.rs
+++ b/config_proc_macro/src/item_struct.rs
@@ -1,5 +1,10 @@
 use proc_macro2::TokenStream;
 
-pub fn define_config_type_on_struct(_st: &syn::ItemStruct) -> syn::Result<TokenStream> {
+use crate::args::Args;
+
+pub fn define_config_type_on_struct(
+    _args: &Args,
+    _st: &syn::ItemStruct,
+) -> syn::Result<TokenStream> {
     unimplemented!()
 }

--- a/config_proc_macro/src/lib.rs
+++ b/config_proc_macro/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![recursion_limit = "256"]
 
+mod args;
 mod attrs;
 mod config_type;
 mod item_enum;
@@ -14,9 +15,10 @@ use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 #[proc_macro_attribute]
-pub fn config_type(_args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn config_type(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as args::Args);
     let input = parse_macro_input!(input as syn::Item);
-    let output = config_type::define_config_type(&input);
+    let output = config_type::define_config_type(&args, &input);
 
     #[cfg(feature = "debug-with-rustfmt")]
     {

--- a/config_proc_macro/src/utils.rs
+++ b/config_proc_macro/src/utils.rs
@@ -1,12 +1,12 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
-pub fn fold_quote<F, I, T>(input: impl Iterator<Item = I>, f: F) -> TokenStream
+pub fn fold_quote<F, I, T>(input: impl IntoIterator<Item = I>, f: F) -> TokenStream
 where
     F: Fn(I) -> T,
     T: ToTokens,
 {
-    input.fold(quote! {}, |acc, x| {
+    input.into_iter().fold(quote! {}, |acc, x| {
         let y = f(x);
         quote! { #acc #y }
     })

--- a/config_proc_macro/tests/smoke.rs
+++ b/config_proc_macro/tests/smoke.rs
@@ -18,4 +18,9 @@ mod tests {
         FooBar,
         FooFoo(i32),
     }
+
+    #[config_type(skip_derive(Copy, Serialize))]
+    enum X {
+        Abc(String),
+    }
 }

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -11,7 +11,7 @@ use std::cmp::{Ord, Ordering};
 use rustc_ast::ast;
 use rustc_span::{symbol::sym, Span};
 
-use crate::config::{Config, GroupImportsTactic};
+use crate::config::{Config, GroupImportsTactic, WildcardGroups};
 use crate::imports::{normalize_use_trees_with_granularity, UseSegmentKind, UseTree};
 use crate::items::{is_mod_decl, rewrite_extern_crate, rewrite_mod};
 use crate::lists::{itemize_list, write_list, ListFormatting, ListItem};
@@ -117,6 +117,7 @@ fn rewrite_reorderable_or_regroupable_items(
                     vec![normalized_items]
                 }
                 GroupImportsTactic::StdExternalCrate => group_imports(normalized_items),
+                GroupImportsTactic::Wildcards(w) => group_imports_custom(w, normalized_items),
             };
 
             if context.config.reorder_imports() {
@@ -168,6 +169,28 @@ fn rewrite_reorderable_or_regroupable_items(
 
 fn contains_macro_use_attr(item: &ast::Item) -> bool {
     crate::attr::contains_name(&item.attrs, sym::macro_use)
+}
+
+fn group_imports_custom(wildcards: WildcardGroups, uts: Vec<UseTree>) -> Vec<Vec<UseTree>> {
+    let mut groups = vec![vec![]; wildcards.len() + 1];
+    let fallback_group = groups.len() - 1;
+
+    for ut in uts.into_iter() {
+        let ut_path_str = ut.to_string();
+        if ut.path.is_empty() {
+            groups[fallback_group].push(ut);
+            continue;
+        }
+
+        if let Some(idx) = wildcards.iter().position(|w| w.matches(&ut_path_str)) {
+            groups[idx].push(ut);
+            continue;
+        }
+
+        groups[fallback_group].push(ut);
+    }
+
+    groups
 }
 
 /// Divides imports into three groups, corresponding to standard, external

--- a/tests/config/wildcard-base.toml
+++ b/tests/config/wildcard-base.toml
@@ -1,0 +1,7 @@
+group_imports = [
+    ["a", "b::c"],
+    ["$crate::x::*"],
+    ["$std::sync"],
+    ["*::ipsum::*"],
+    ["xyz::abc::dez"],
+]

--- a/tests/config/wildcard-example.rs
+++ b/tests/config/wildcard-example.rs
@@ -1,0 +1,5 @@
+group_imports = [
+    ["$std::*", "proc_macro::*"],
+    ["my_crate::*", "crate::*::xyz"],
+    ["$crate::*"],
+]

--- a/tests/source/wildcard-group-import/config-example.rs
+++ b/tests/source/wildcard-group-import/config-example.rs
@@ -1,0 +1,9 @@
+// rustfmt-config: wildcard-example.rs
+use self::X;
+use super::Y;
+use crate::abc::xyz;
+use crate::Z;
+use my_crate::a::B;
+use my_crate::A;
+use proc_macro::Span;
+use std::rc::Rc;

--- a/tests/source/wildcard-group-import/import.rs
+++ b/tests/source/wildcard-group-import/import.rs
@@ -1,0 +1,13 @@
+// rustfmt-config: wildcard-base.toml
+use self::x;
+use crate::x::y;
+use crate::y;
+use a;
+use a::ipsum::b;
+use b::c;
+use b::c::d;
+use c::d::ipsum::b;
+use core::sync;
+use core::sync::A;
+use std::sync;
+use xyz::abc::dez;

--- a/tests/target/wildcard-group-import/config-example.rs
+++ b/tests/target/wildcard-group-import/config-example.rs
@@ -1,0 +1,11 @@
+// rustfmt-config: wildcard-example.rs
+use proc_macro::Span;
+use std::rc::Rc;
+
+use crate::abc::xyz;
+use my_crate::a::B;
+use my_crate::A;
+
+use self::X;
+use super::Y;
+use crate::Z;

--- a/tests/target/wildcard-group-import/import.rs
+++ b/tests/target/wildcard-group-import/import.rs
@@ -1,0 +1,18 @@
+// rustfmt-config: wildcard-base.toml
+use a;
+use b::c;
+
+use crate::x::y;
+
+use core::sync;
+use std::sync;
+
+use a::ipsum::b;
+use c::d::ipsum::b;
+
+use xyz::abc::dez;
+
+use self::x;
+use crate::y;
+use b::c::d;
+use core::sync::A;


### PR DESCRIPTION
TLDR, for a given config:

```toml
group_imports = [
    ["$std::*", "proc_macro::*"],
    ["my_crate::*", "crate::*::xyz"],
    ["$crate::*"],
]
```

The following order would be set:

```rust
use proc_macro::Span;
use std::rc::Rc;

use crate::abc::xyz;
use my_crate::a::B;
use my_crate::A;

use self::X;
use super::Y;
use crate::Z;
```

This PR also contains three auxiliary patches for proc-macro `#[config_type]`:

- 0a462a0 allows one to use `#[config_type(skip_derive(Debug, ...))]`, also `impl Copy` removed from most of types where unneeded;
- 1d3e43e is for deriving `serde::{Serialize, Deserialize}`;
- b195129 `impl Display` for singled-fielded enums.

These are not really mandatory but simplify the final commit itself. Probably the proc macro could be refactored further but I think it shall be enough for now.

Implementation notes:

- toml does not support fielded enums at all, that's why manual `impl Deserialize for GroupImportsTactic` is required (https://github.com/toml-rs/toml-rs/issues/302 https://github.com/toml-rs/toml/issues/364);
- don't really want to introduce an additional crate for wildcards so regex is basically used with a hack: `escape(user_pattern).replace("\\*", ".*")`, performance should not be concern here anyway;
- `group_imports` function (i.e for `StdExternalCrate`) could be re-implemented with `group_imports_custom` but I would rather prefer leaving it separate;
- `FromStr` is not implemented for `GroupImportsTactic::Wildcards`;
- `$crate` alias doesn't mean usage of macro-specific `$crate` import.

Resolves #4693 #4788 #5550