### PR TITLE
Preserve markdown's double-space line break syntax in block doc comment

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -364,7 +364,7 @@ fn identify_comment(
     let (first_group, rest) = orig.split_at(first_group_ending);
     let rewritten_first_group =
         if !config.normalize_comments() && has_bare_lines && style.is_block_comment() {
-            trim_left_preserve_layout(first_group, shape.indent, config)?
+            trim_left_preserve_layout(first_group, shape.indent, config, is_doc_comment)?
         } else if !config.normalize_comments()
             && !config.wrap_comments()
             && !config.format_code_in_doc_comments()
@@ -986,7 +986,7 @@ pub(crate) fn recover_missing_comment_in_span(
 }
 
 /// Trim trailing whitespaces unless they consist of two or more whitespaces.
-fn trim_end_unless_two_whitespaces(s: &str, is_doc_comment: bool) -> &str {
+pub(crate) fn trim_end_unless_two_whitespaces(s: &str, is_doc_comment: bool) -> &str {
     if is_doc_comment && s.ends_with("  ") {
         s
     } else {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -132,7 +132,7 @@ fn return_macro_parse_failure_fallback(
         })
         .unwrap_or(false);
     if is_like_block_indent_style {
-        return trim_left_preserve_layout(context.snippet(span), indent, context.config);
+        return trim_left_preserve_layout(context.snippet(span), indent, context.config, false);
     }
 
     context.skipped_range.borrow_mut().push((
@@ -329,7 +329,7 @@ fn rewrite_macro_inner(
             // the `macro_name!` and `{ /* macro_body */ }` but skip modifying
             // anything in between the braces (for now).
             let snippet = context.snippet(mac.span()).trim_start_matches(|c| c != '{');
-            match trim_left_preserve_layout(snippet, shape.indent, context.config) {
+            match trim_left_preserve_layout(snippet, shape.indent, context.config, false) {
                 Some(macro_body) => Some(format!("{} {}", macro_name, macro_body)),
                 None => Some(format!("{} {}", macro_name, snippet)),
             }

--- a/tests/target/issue_5639.rs
+++ b/tests/target/issue_5639.rs
@@ -1,0 +1,9 @@
+/*!
+This  
+has  
+breaks.
+*/
+
+//! This  
+//! has  
+//! breaks.


### PR DESCRIPTION
Fixes #5639

Now we'll preserve two blank lines at the end of block doc comments that contain bare lines (lines without a leading `*`).

For example, the newlines in the following block doc comment won't be removed.

```rust
/*!
This  
has  
breaks.
*/
```