### PR TITLE
Don't flatten blocks that have labels

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -246,8 +246,18 @@ fn rewrite_match_arm(
     };
 
     // Patterns
-    // 5 = ` => {`
-    let pat_shape = shape.sub_width(5)?.offset_left(pipe_offset)?;
+    let pat_shape = match &arm.body.kind {
+        ast::ExprKind::Block(_, Some(label)) => {
+            // Some block with a label ` => 'label: {`
+            // 7 = ` => : {`
+            let label_len = label.ident.as_str().len();
+            shape.sub_width(7 + label_len)?.offset_left(pipe_offset)?
+        }
+        _ => {
+            // 5 = ` => {`
+            shape.sub_width(5)?.offset_left(pipe_offset)?
+        }
+    };
     let pats_str = arm.pat.rewrite(context, pat_shape)?;
 
     // Guard

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -306,8 +306,9 @@ fn block_can_be_flattened<'a>(
     expr: &'a ast::Expr,
 ) -> Option<&'a ast::Block> {
     match expr.kind {
-        ast::ExprKind::Block(ref block, _)
-            if !is_unsafe_block(block)
+        ast::ExprKind::Block(ref block, label)
+            if label.is_none()
+                && !is_unsafe_block(block)
                 && !context.inside_macro()
                 && is_simple_block(context, block, Some(&expr.attrs))
                 && !stmt_is_expr_mac(&block.stmts[0]) =>

--- a/tests/target/issue_5676.rs
+++ b/tests/target/issue_5676.rs
@@ -1,0 +1,8 @@
+fn main() {
+    match true {
+        true => 'a: {
+            break 'a;
+        }
+        _ => (),
+    }
+}


### PR DESCRIPTION
Fixes #5676

This PR prevents rustfmt from flattening a match arm's body block if that block was labeled.

I wonder if it would be worth making this change a little smarter to allow flattening in cases where the label isn't used inside the block?

r? @calebcartwright 