### PR TITLE
add `keep_newline_in_where_clause` option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1059,6 +1059,35 @@ This option is currently ignored for stdin (`@generated` in stdin is ignored.)
 - **Possible values**: `true`, `false`
 - **Stable**: No (tracking issue: [#5080](https://github.com/rust-lang/rustfmt/issues/5080))
 
+## `keep_newline_in_where_clause`
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+- **Stable**: No (tracking issue: [#5655](https://github.com/rust-lang/rustfmt/issues/5655))
+
+#### `true` (default):
+
+```rust
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+
+    T: std::fmt::Display,
+{
+}
+```
+
+#### `false` 
+
+```rust
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+    T: std::fmt::Display,
+{
+}
+```
+
 ## `format_macro_matchers`
 
 Format the metavariable matching patterns in macros.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -148,6 +148,7 @@ create_config! {
         "Write an item and its attribute on the same line \
         if their combined width is below a threshold";
     format_generated_files: bool, true, false, "Format generated files";
+    keep_newline_in_where_clause: bool, true, false, "Keep newline in where clause";
 
     // Options that can change the source code beyond whitespace/blocks (somewhat linty things)
     merge_derives: bool, true, true, "Merge multiple `#[derive(...)]` into a single one";
@@ -667,6 +668,7 @@ edition = "2015"
 version = "One"
 inline_attribute_width = 0
 format_generated_files = true
+keep_newline_in_where_clause = true
 merge_derives = true
 use_try_shorthand = false
 use_field_init_shorthand = false

--- a/src/items.rs
+++ b/src/items.rs
@@ -2886,7 +2886,7 @@ fn rewrite_bounds_on_where_clause(
     let fmt = ListFormatting::new(shape, context.config)
         .tactic(shape_tactic)
         .trailing_separator(comma_tactic)
-        .preserve_newline(true);
+        .preserve_newline(context.config.keep_newline_in_where_clause());
     write_list(&items.collect::<Vec<_>>(), &fmt)
 }
 

--- a/tests/source/issue-5655/keep_newline_in_where_clause_false.rs
+++ b/tests/source/issue-5655/keep_newline_in_where_clause_false.rs
@@ -1,0 +1,7 @@
+// keep_newline_in_where_clause: false
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+    T: std::fmt::Display,
+{
+}

--- a/tests/source/issue-5655/keep_newline_in_where_clause_true.rs
+++ b/tests/source/issue-5655/keep_newline_in_where_clause_true.rs
@@ -1,0 +1,8 @@
+// keep_newline_in_where_clause: true
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+
+    T: std::fmt::Display,
+{
+}

--- a/tests/target/issue-5655/keep_newline_in_where_clause_false.rs
+++ b/tests/target/issue-5655/keep_newline_in_where_clause_false.rs
@@ -1,0 +1,7 @@
+// keep_newline_in_where_clause: false
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+    T: std::fmt::Display,
+{
+}

--- a/tests/target/issue-5655/keep_newline_in_where_clause_true.rs
+++ b/tests/target/issue-5655/keep_newline_in_where_clause_true.rs
@@ -1,0 +1,8 @@
+// keep_newline_in_where_clause: true
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+
+    T: std::fmt::Display,
+{
+}


### PR DESCRIPTION
To resolve #5655 , add new option `keep_newline_in_where_clause` 