### PR TITLE
do not remove brackets around statement arg in macro

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -316,6 +316,9 @@ fn flatten_arm_body<'a>(
     body: &'a ast::Expr,
     opt_shape: Option<Shape>,
 ) -> (bool, &'a ast::Expr) {
+    if context.is_macro_def {
+        return (false, body);
+    }
     let can_extend =
         |expr| !context.config.force_multiline_blocks() && can_flatten_block_around_this(expr);
 

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -587,3 +587,13 @@ unsafe {}
 }
 }
 }
+
+// #5680
+macro_rules! foo {
+    ($v:expr, $s:stmt) => {
+        match $v {
+            Some(v) => v,
+            None => { $s },
+        }
+    };
+}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -627,3 +627,15 @@ fn issue_4109() {
         }
     }
 }
+
+// #5680
+macro_rules! foo {
+    ($v:expr, $s:stmt) => {
+        match $v {
+            Some(v) => v,
+            None => {
+                $s
+            }
+        }
+    };
+}


### PR DESCRIPTION
Fixes #5680