### PR TITLE
Update dependencies `cargo_metadata`, `env_logger` and `toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,15 +68,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "autocfg"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -122,15 +117,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -267,12 +263,12 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -339,19 +335,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -384,12 +377,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -400,7 +403,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",
@@ -645,6 +648,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,11 +724,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -928,6 +965,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ generic-simd = ["bytecount/generic-simd"]
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0"
 bytecount = "0.6"
-cargo_metadata = "0.14"
+cargo_metadata = "0.15.4"
 clap = { version = "4.2.1", features = ["derive"] }
 diff = "0.1"
 dirs = "4.0"
-env_logger = "0.9"
+env_logger = "0.10.0"
 getopts = "0.2"
 ignore = "0.4"
 itertools = "0.10"
@@ -51,7 +51,7 @@ serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"
 term = "0.7"
 thiserror = "1.0.40"
-toml = "0.5"
+toml = "0.7.4"
 unicode-segmentation = "1.9"
 unicode-width = "0.1"
 unicode_categories = "0.1"

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 
+use cargo_metadata::Edition;
 use clap::{CommandFactory, Parser};
 
 #[path = "test/mod.rs"]
@@ -270,7 +271,7 @@ pub struct Target {
     /// A kind of target (e.g., lib, bin, example, ...).
     kind: String,
     /// Rust edition for this target.
-    edition: String,
+    edition: Edition,
 }
 
 impl Target {
@@ -281,7 +282,7 @@ impl Target {
         Target {
             path: canonicalized,
             kind: target.kind[0].clone(),
-            edition: target.edition.clone(),
+            edition: target.edition,
         }
     }
 }
@@ -506,7 +507,7 @@ fn run_rustfmt(
         let mut command = rustfmt_command()
             .stdout(stdout)
             .args(files)
-            .args(&["--edition", edition])
+            .args(&["--edition", edition.as_str()])
             .args(fmt_args)
             .spawn()
             .map_err(|e| match e.kind() {

--- a/src/cargo-fmt/test/targets.rs
+++ b/src/cargo-fmt/test/targets.rs
@@ -2,7 +2,7 @@ use super::*;
 
 struct ExpTarget {
     path: &'static str,
-    edition: &'static str,
+    edition: Edition,
     kind: &'static str,
 }
 
@@ -26,7 +26,7 @@ mod all_targets {
         for target in exp_targets {
             assert!(targets.contains(&Target {
                 path: get_path(target.path),
-                edition: target.edition.to_owned(),
+                edition: target.edition,
                 kind: target.kind.to_owned(),
             }));
         }
@@ -39,17 +39,17 @@ mod all_targets {
             let exp_targets = vec![
                 ExpTarget {
                     path: "dependency-dir-name/subdep-dir-name/src/lib.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "lib",
                 },
                 ExpTarget {
                     path: "dependency-dir-name/src/lib.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "lib",
                 },
                 ExpTarget {
                     path: "src/main.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "main",
                 },
             ];
@@ -79,32 +79,32 @@ mod all_targets {
             let exp_targets = vec![
                 ExpTarget {
                     path: "ws/a/src/main.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "bin",
                 },
                 ExpTarget {
                     path: "ws/b/src/main.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "bin",
                 },
                 ExpTarget {
                     path: "ws/c/src/lib.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "lib",
                 },
                 ExpTarget {
                     path: "ws/a/d/src/lib.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "lib",
                 },
                 ExpTarget {
                     path: "e/src/main.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "main",
                 },
                 ExpTarget {
                     path: "ws/a/d/f/src/lib.rs",
-                    edition: "2018",
+                    edition: Edition::E2018,
                     kind: "lib",
                 },
             ];


### PR DESCRIPTION
Allows removing some duplicate dependencies in rust-lang/rust's Cargo.lock (except for `dirs`, that crate isn't depended upon anywhere else).