### PR TITLE
Adjust enum variant spans to exclude any explicit discriminant

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -560,7 +560,7 @@ impl<'a> FmtVisitor<'a> {
         let variant_body = match field.data {
             ast::VariantData::Tuple(..) | ast::VariantData::Struct(..) => format_struct(
                 &context,
-                &StructParts::from_variant(field),
+                &StructParts::from_variant(field, &context),
                 self.block_indent,
                 Some(one_line_width),
             )?,
@@ -951,14 +951,14 @@ impl<'a> StructParts<'a> {
         format_header(context, self.prefix, self.ident, self.vis, offset)
     }
 
-    fn from_variant(variant: &'a ast::Variant) -> Self {
+    fn from_variant(variant: &'a ast::Variant, context: &RewriteContext<'_>) -> Self {
         StructParts {
             prefix: "",
             ident: variant.ident,
             vis: &DEFAULT_VISIBILITY,
             def: &variant.data,
             generics: None,
-            span: variant.span,
+            span: enum_variant_span(variant, context),
         }
     }
 
@@ -976,6 +976,25 @@ impl<'a> StructParts<'a> {
             generics: Some(generics),
             span: item.span,
         }
+    }
+}
+
+fn enum_variant_span(variant: &ast::Variant, context: &RewriteContext<'_>) -> Span {
+    use ast::VariantData::*;
+    if let Some(ref anon_const) = variant.disr_expr {
+        let span_before_consts = variant.span.until(anon_const.value.span);
+        let hi = match &variant.data {
+            Struct(..) => context
+                .snippet_provider
+                .span_after_last(span_before_consts, "}"),
+            Tuple(..) => context
+                .snippet_provider
+                .span_after_last(span_before_consts, ")"),
+            Unit(..) => variant.ident.span.hi(),
+        };
+        mk_sp(span_before_consts.lo(), hi)
+    } else {
+        variant.span
     }
 }
 

--- a/tests/source/issue_5686.rs
+++ b/tests/source/issue_5686.rs
@@ -1,0 +1,40 @@
+#[repr(u8)]
+enum MyEnum {
+    UnitWithExplicitDiscriminant = 0,
+    EmptyStructSingleLineBlockComment {
+        /* Comment */
+    } = 1,
+    EmptyStructMultiLineBlockComment {
+        /*
+         * Comment
+         */
+    } = 2,
+    EmptyStructLineComment {
+        // comment
+    } = 3,
+    EmptyTupleSingleLineBlockComment(
+        /* Comment */
+    ) = 4,
+    EmptyTupleMultiLineBlockComment(
+        /*
+         * Comment
+         */
+    ) = 5,
+    EmptyTupleLineComment(
+        // comment
+    ) = 6,
+}
+
+enum Animal {
+    Dog(/* tuple variant closer in comment -> ) */) = 1,
+    #[hello(world)]
+    Cat(/* tuple variant close in leading attribute */) = 2,
+    Bee(/* tuple variant closer on associated field attribute */ #[hello(world)] usize) = 3,
+    Fox(/* tuple variant closer on const fn call */) = some_const_fn(),
+    Ant(/* tuple variant closer on macro call */) = some_macro!(),
+    Snake {/* stuct variant closer in comment -> } */} = 6,
+    #[hell{world}]
+    Cobra {/* struct variant close in leading attribute */} = 6,
+    Eagle {/* struct variant closer on associated field attribute */ #[hell{world}]value: Sting} = 7,
+    Koala {/* struct variant closer on macro call */} = some_macro!{}
+}

--- a/tests/target/issue_5686.rs
+++ b/tests/target/issue_5686.rs
@@ -1,0 +1,42 @@
+#[repr(u8)]
+enum MyEnum {
+    UnitWithExplicitDiscriminant = 0,
+    EmptyStructSingleLineBlockComment {/* Comment */} = 1,
+    EmptyStructMultiLineBlockComment {
+        /*
+         * Comment
+         */
+    } = 2,
+    EmptyStructLineComment {
+        // comment
+    } = 3,
+    EmptyTupleSingleLineBlockComment(/* Comment */) = 4,
+    EmptyTupleMultiLineBlockComment(
+        /*
+         * Comment
+         */
+    ) = 5,
+    EmptyTupleLineComment(
+        // comment
+    ) = 6,
+}
+
+enum Animal {
+    Dog(/* tuple variant closer in comment -> ) */) = 1,
+    #[hello(world)]
+    Cat(/* tuple variant close in leading attribute */) = 2,
+    Bee(
+        /* tuple variant closer on associated field attribute */ #[hello(world)] usize,
+    ) = 3,
+    Fox(/* tuple variant closer on const fn call */) = some_const_fn(),
+    Ant(/* tuple variant closer on macro call */) = some_macro!(),
+    Snake {/* stuct variant closer in comment -> } */} = 6,
+    #[hell{world}]
+    Cobra {/* struct variant close in leading attribute */} = 6,
+    Eagle {
+        /* struct variant closer on associated field attribute */
+        #[hell{world}]
+        value: Sting,
+    } = 7,
+    Koala {/* struct variant closer on macro call */} = some_macro! {},
+}


### PR DESCRIPTION
Fixes #5686

For reference, explicit discriminants were proposed in [RFC-2363], and I believe the feature is stabilized. 

`ast::Variant` spans extend to include explicit discriminants when they are present.

Now we'll adjust the span of enum variants to exclude any explicit discriminant.

[RFC-2363]: https://rust-lang.github.io/rfcs/2363-arbitrary-enum-discriminant.html
