### PR TITLE
Implement `let-else` formatting

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -609,6 +609,16 @@ fn rewrite_block_inner(
     result
 }
 
+/// Rewrite the divergent block of a `let-else` statement.
+pub(crate) fn rewrite_let_else_block(
+    block: &ast::Block,
+    allow_single_line: bool,
+    context: &RewriteContext<'_>,
+    shape: Shape,
+) -> Option<String> {
+    rewrite_block_inner(block, None, None, allow_single_line, context, shape)
+}
+
 // Rewrite condition if the given expression has one.
 pub(crate) fn rewrite_cond(
     context: &RewriteContext<'_>,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1027,12 +1027,14 @@ impl<'a> ControlFlow<'a> {
 
 /// Rewrite the `else` keyword with surrounding comments.
 ///
+/// force_newline_else: whether or not to rewrite the `else` keyword on a newline.
 /// is_last: true if this is an `else` and `false` if this is an `else if` block.
 /// context: rewrite context
 /// span: Span between the end of the last expression and the start of the else block,
 ///       which contains the `else` keyword
 /// shape: Shape
 pub(crate) fn rewrite_else_kw_with_comments(
+    force_newline_else: bool,
     is_last: bool,
     context: &RewriteContext<'_>,
     span: Span,
@@ -1048,6 +1050,7 @@ pub(crate) fn rewrite_else_kw_with_comments(
 
     let newline_sep = &shape.indent.to_string_with_newline(context.config);
     let before_sep = match context.config.control_brace_style() {
+        _ if force_newline_else => newline_sep.as_ref(),
         ControlBraceStyle::AlwaysNextLine | ControlBraceStyle::ClosingNextLine => {
             newline_sep.as_ref()
         }
@@ -1132,6 +1135,7 @@ impl<'a> Rewrite for ControlFlow<'a> {
             };
 
             let else_kw = rewrite_else_kw_with_comments(
+                false,
                 last_in_chain,
                 context,
                 self.block.span.between(else_block.span),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -576,6 +576,17 @@ fn rewrite_block(
     context: &RewriteContext<'_>,
     shape: Shape,
 ) -> Option<String> {
+    rewrite_block_inner(block, attrs, label, true, context, shape)
+}
+
+fn rewrite_block_inner(
+    block: &ast::Block,
+    attrs: Option<&[ast::Attribute]>,
+    label: Option<ast::Label>,
+    allow_single_line: bool,
+    context: &RewriteContext<'_>,
+    shape: Shape,
+) -> Option<String> {
     let prefix = block_prefix(context, block, shape)?;
 
     // shape.width is used only for the single line case: either the empty block `{}`,
@@ -586,7 +597,7 @@ fn rewrite_block(
 
     let result = rewrite_block_with_visitor(context, &prefix, block, attrs, label, shape, true);
     if let Some(ref result_str) = result {
-        if result_str.lines().count() <= 3 {
+        if allow_single_line && result_str.lines().count() <= 3 {
             if let rw @ Some(_) =
                 rewrite_single_line_block(context, &prefix, block, attrs, label, shape)
             {

--- a/src/items.rs
+++ b/src/items.rs
@@ -18,7 +18,8 @@ use crate::config::lists::*;
 use crate::config::{BraceStyle, Config, IndentStyle, Version};
 use crate::expr::{
     is_empty_block, is_simple_block_stmt, rewrite_assign_rhs, rewrite_assign_rhs_with,
-    rewrite_assign_rhs_with_comments, rewrite_else_kw_with_comments, RhsAssignKind, RhsTactics,
+    rewrite_assign_rhs_with_comments, rewrite_else_kw_with_comments, rewrite_let_else_block,
+    RhsAssignKind, RhsTactics,
 };
 use crate::lists::{definitive_tactic, itemize_list, write_list, ListFormatting, Separator};
 use crate::macros::{rewrite_macro, MacroPosition};
@@ -132,7 +133,13 @@ impl Rewrite for ast::Local {
                     shape,
                 );
                 result.push_str(&else_kw);
-                result.push_str(&block.rewrite(context, shape)?);
+                let allow_single_line = !result.contains('\n');
+                result.push_str(&rewrite_let_else_block(
+                    block,
+                    allow_single_line,
+                    context,
+                    shape,
+                )?);
             };
         }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -175,8 +175,10 @@ fn same_line_else_kw_and_brace(
     init_shape: Shape,
 ) -> bool {
     if !init_str.contains('\n') {
-        // initializer expression is single lined so the "else {" should be placed on the same line
-        return true;
+        // initializer expression is single lined. The "else {" can only be placed on the same line
+        // as the initializer expression if there is enough room for it.
+        // 7 = ` else {`
+        return init_shape.width.saturating_sub(init_str.len()) >= 7;
     }
 
     // 1. The initializer expression ends with one or more `)`, `]`, `}`.

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -1,3 +1,0 @@
-fn main() {
-    let Some(1) = Some(1) else { return };
-}

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -79,18 +79,18 @@ fn unbreakable_initializer_expr_pre_formatting_let_else_length_near_max_width() 
 
 fn unbreakable_initializer_expr_pre_formatting_length_up_to_opening_brace_near_max_width() {
     // Pre Formatting:
-    // The length of `(indent)let pat = init else {` is 100 (max_width)
+    // The length of `(indent)let pat = init else {` is 99 (< max_width)
     // Post Formatting:
     // The else keyword and opening brace remain on the same line as the initializer expr,
     // and the else block is formatted over multiple lines because we can't fit the
     // else block on the same line as the initializer expr.
-    let Some(x) = some_really_really_really_really_really_really_really_really_long_name____E else {return};
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name___E else {return};
 
     // Pre Formatting:
     // The length of `(indent)let pat = init else {` is 101 (> max_width)
     // Post Formatting:
-    // The else keyword and opening brace remain on the same line as the initializer expr,
-    // which leads to the `{` exceeding the max width
+    // The else keyword and opening brace cannot fit on the same line as the initializer expr.
+    // They are formatted on the next line.
     let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F else {return};
 }
 
@@ -98,8 +98,8 @@ fn unbreakable_initializer_expr_pre_formatting_length_through_initializer_expr_n
     // Pre Formatting:
     // The length of `(indent)let pat = init` is 99 (< max_width)
     // Post Formatting:
-    // The else keyword and opening brace remain on the same line as the initializer expr,
-    // which leads to the `else {` exceeding the max width
+    // The else keyword and opening brace cannot fit on the same line as the initializer expr.
+    // They are formatted on the next line.
     let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G else {return};
 
     // Pre Formatting:

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -7,4 +7,8 @@ fn main() {
         // nope
         return;
     };
+
+    let Some(x) = y.foo("abc", fairly_long_identifier, "def", "123456", "string", "cheese") else { bar() };
+
+    let Some(x) = abcdef().foo("abc", some_really_really_really_long_ident, "ident", "123456").bar().baz().qux("fffffffffffffffff") else { foo_bar() };
 }

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let Some(x) = opt else { return };
+
+    let Some(x) = opt else { return; };
+
+    let Some(x) = opt else {
+        // nope
+        return;
+    };
+}

--- a/tests/source/let_else.rs
+++ b/tests/source/let_else.rs
@@ -1,5 +1,14 @@
 fn main() {
+    // Although this won't compile it still parses so make sure we can format empty else blocks
+    let Some(x) = opt else {};
+
+    // let-else may be formatted on a single line if they are "short"
+    // and only contain a single expression
     let Some(x) = opt else { return };
+
+    let Some(x) = opt else {
+        return
+    };
 
     let Some(x) = opt else { return; };
 
@@ -8,7 +17,135 @@ fn main() {
         return;
     };
 
+    let Some(x) = opt else { let y = 1; return y };
+
     let Some(x) = y.foo("abc", fairly_long_identifier, "def", "123456", "string", "cheese") else { bar() };
 
     let Some(x) = abcdef().foo("abc", some_really_really_really_long_ident, "ident", "123456").bar().baz().qux("fffffffffffffffff") else { foo_bar() };
+}
+
+fn with_comments_around_else_keyword() {
+    let Some(x) = opt /* pre else keyword block-comment */ else { return };
+
+    let Some(x) = opt else /* post else keyword block-comment */ { return };
+
+    let Some(x) = opt /* pre else keyword block-comment */ else /* post else keyword block-comment */ { return };
+
+    let Some(x) = opt // pre else keyword line-comment
+    else { return };
+
+    let Some(x) = opt else
+     // post else keyword line-comment
+    { return };
+
+    let Some(x) = opt // pre else keyword line-comment
+    else
+    // post else keyword line-comment
+    { return };
+
+}
+
+fn unbreakable_initializer_expr_pre_formatting_let_else_length_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The formatting is left unchanged!
+    let Some(x) = some_really_really_really_really_really_really_really_long_name_A else { return };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_long_name___B else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_long_name_____C else {some_divergent_function()};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 101 (> max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_long_name__D else { return };
+}
+
+fn unbreakable_initializer_expr_pre_formatting_length_up_to_opening_brace_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else {` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name____E else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else {` is 101 (> max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // which leads to the `{` exceeding the max width
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F else {return};
+}
+
+fn unbreakable_initializer_expr_pre_formatting_length_through_initializer_expr_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 99 (< max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // which leads to the `else {` exceeding the max width
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 100 (max_width)
+    // Post Formatting:
+    // Break after the `=` and put the initializer expr on it's own line.
+    // Because the initializer expr is multi-lined the else is placed on it's own line.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name____H else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 109 (> max_width)
+    // Post Formatting:
+    // Break after the `=` and put the initializer expr on it's own line.
+    // Because the initializer expr is multi-lined the else is placed on it's own line.
+    // The initializer expr has a length of 91, which when indented on the next line
+    // The `(indent)init` line has a lengh of 99. This is the max length that the `init` can be
+    // before we start running into max_width issues. I suspect this is becuase the shape is
+    // accounting for the `;` at the end of the `let-else` statement.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_really_long_name______I else {return};
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 110 (> max_width)
+    // Post Formatting:
+    // Max length issues prevent us from formatting.
+    // The initializer expr has a length of 92, which if it would be indented on the next line
+    // the `(indent)init` line has a lengh of 100 which == max_width of 100.
+    // One might expect formatting to succeed, but I suspect the reason we hit max_width issues is
+    // because the Shape is accounting for the `;` at the end of the `let-else` statement.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_really_really_long_nameJ else {return};
+}
+
+fn long_patterns() {
+    let Foo {x: Bar(..), y: FooBar(..), z: Baz(..)} = opt else {
+        return;
+    };
+
+    // with version=One we don't wrap long array patterns
+    let [aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbb, cccccccccccccccccc, dddddddddddddddddd] = opt else {
+        return;
+    };
+
+    let ("aaaaaaaaaaaaaaaaaaa" | "bbbbbbbbbbbbbbbbb" | "cccccccccccccccccccccccc" | "dddddddddddddddd" | "eeeeeeeeeeeeeeee") = opt else {
+        return;
+    };
+
+    let Some(Ok((Message::ChangeColor(super::color::Color::Rgb(r, g, b)), Point { x, y, z }))) = opt else {
+        return;
+    };
 }

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -1,3 +1,0 @@
-fn main() {
-    let Some(1) = Some(1) else { return };
-}

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -130,21 +130,22 @@ fn unbreakable_initializer_expr_pre_formatting_let_else_length_near_max_width() 
 
 fn unbreakable_initializer_expr_pre_formatting_length_up_to_opening_brace_near_max_width() {
     // Pre Formatting:
-    // The length of `(indent)let pat = init else {` is 100 (max_width)
+    // The length of `(indent)let pat = init else {` is 99 (< max_width)
     // Post Formatting:
     // The else keyword and opening brace remain on the same line as the initializer expr,
     // and the else block is formatted over multiple lines because we can't fit the
     // else block on the same line as the initializer expr.
-    let Some(x) = some_really_really_really_really_really_really_really_really_long_name____E else {
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name___E else {
         return;
     };
 
     // Pre Formatting:
     // The length of `(indent)let pat = init else {` is 101 (> max_width)
     // Post Formatting:
-    // The else keyword and opening brace remain on the same line as the initializer expr,
-    // which leads to the `{` exceeding the max width
-    let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F else {
+    // The else keyword and opening brace cannot fit on the same line as the initializer expr.
+    // They are formatted on the next line.
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F
+    else {
         return;
     };
 }
@@ -153,9 +154,10 @@ fn unbreakable_initializer_expr_pre_formatting_length_through_initializer_expr_n
     // Pre Formatting:
     // The length of `(indent)let pat = init` is 99 (< max_width)
     // Post Formatting:
-    // The else keyword and opening brace remain on the same line as the initializer expr,
-    // which leads to the `else {` exceeding the max width
-    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G else {
+    // The else keyword and opening brace cannot fit on the same line as the initializer expr.
+    // They are formatted on the next line.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G
+    else {
         return;
     };
 

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -1,4 +1,11 @@
 fn main() {
+    // Although this won't compile it still parses so make sure we can format empty else blocks
+    let Some(x) = opt else {};
+
+    // let-else may be formatted on a single line if they are "short"
+    // and only contain a single expression
+    let Some(x) = opt else { return };
+
     let Some(x) = opt else { return };
 
     let Some(x) = opt else {
@@ -8,6 +15,11 @@ fn main() {
     let Some(x) = opt else {
         // nope
         return;
+    };
+
+    let Some(x) = opt else {
+        let y = 1;
+        return y;
     };
 
     let Some(x) = y.foo(
@@ -33,5 +45,184 @@ fn main() {
         .qux("fffffffffffffffff")
     else {
         foo_bar()
+    };
+}
+
+fn with_comments_around_else_keyword() {
+    let Some(x) = opt
+    /* pre else keyword block-comment */
+    else {
+        return;
+    };
+
+    let Some(x) = opt else
+    /* post else keyword block-comment */
+    {
+        return;
+    };
+
+    let Some(x) = opt
+    /* pre else keyword block-comment */
+    else
+    /* post else keyword block-comment */
+    {
+        return;
+    };
+
+    let Some(x) = opt
+    // pre else keyword line-comment
+    else {
+        return;
+    };
+
+    let Some(x) = opt else
+    // post else keyword line-comment
+    {
+        return;
+    };
+
+    let Some(x) = opt
+    // pre else keyword line-comment
+    else
+    // post else keyword line-comment
+    {
+        return;
+    };
+}
+
+fn unbreakable_initializer_expr_pre_formatting_let_else_length_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The formatting is left unchanged!
+    let Some(x) = some_really_really_really_really_really_really_really_long_name_A else { return };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_long_name___B else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_long_name_____C else {
+        some_divergent_function()
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else block;` is 101 (> max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_long_name__D else {
+        return;
+    };
+}
+
+fn unbreakable_initializer_expr_pre_formatting_length_up_to_opening_brace_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else {` is 100 (max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // and the else block is formatted over multiple lines because we can't fit the
+    // else block on the same line as the initializer expr.
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name____E else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init else {` is 101 (> max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // which leads to the `{` exceeding the max width
+    let Some(x) = some_really_really_really_really_really_really_really_really_long_name_____F else {
+        return;
+    };
+}
+
+fn unbreakable_initializer_expr_pre_formatting_length_through_initializer_expr_near_max_width() {
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 99 (< max_width)
+    // Post Formatting:
+    // The else keyword and opening brace remain on the same line as the initializer expr,
+    // which leads to the `else {` exceeding the max width
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_long_name___G else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 100 (max_width)
+    // Post Formatting:
+    // Break after the `=` and put the initializer expr on it's own line.
+    // Because the initializer expr is multi-lined the else is placed on it's own line.
+    let Some(x) =
+        some_really_really_really_really_really_really_really_really_really_long_name____H
+    else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 109 (> max_width)
+    // Post Formatting:
+    // Break after the `=` and put the initializer expr on it's own line.
+    // Because the initializer expr is multi-lined the else is placed on it's own line.
+    // The initializer expr has a length of 91, which when indented on the next line
+    // The `(indent)init` line has a lengh of 99. This is the max length that the `init` can be
+    // before we start running into max_width issues. I suspect this is becuase the shape is
+    // accounting for the `;` at the end of the `let-else` statement.
+    let Some(x) =
+        some_really_really_really_really_really_really_really_really_really_really_long_name______I
+    else {
+        return;
+    };
+
+    // Pre Formatting:
+    // The length of `(indent)let pat = init` is 110 (> max_width)
+    // Post Formatting:
+    // Max length issues prevent us from formatting.
+    // The initializer expr has a length of 92, which if it would be indented on the next line
+    // the `(indent)init` line has a lengh of 100 which == max_width of 100.
+    // One might expect formatting to succeed, but I suspect the reason we hit max_width issues is
+    // because the Shape is accounting for the `;` at the end of the `let-else` statement.
+    let Some(x) = some_really_really_really_really_really_really_really_really_really_really_really_long_nameJ else {return};
+}
+
+fn long_patterns() {
+    let Foo {
+        x: Bar(..),
+        y: FooBar(..),
+        z: Baz(..),
+    } = opt
+    else {
+        return;
+    };
+
+    // with version=One we don't wrap long array patterns
+    let [aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbb, cccccccccccccccccc, dddddddddddddddddd] = opt else {
+        return;
+    };
+
+    let ("aaaaaaaaaaaaaaaaaaa"
+    | "bbbbbbbbbbbbbbbbb"
+    | "cccccccccccccccccccccccc"
+    | "dddddddddddddddd"
+    | "eeeeeeeeeeeeeeee") = opt
+    else {
+        return;
+    };
+
+    let Some(Ok((Message::ChangeColor(super::color::Color::Rgb(r, g, b)), Point { x, y, z }))) =
+        opt
+    else {
+        return;
     };
 }

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -9,4 +9,29 @@ fn main() {
         // nope
         return;
     };
+
+    let Some(x) = y.foo(
+        "abc",
+        fairly_long_identifier,
+        "def",
+        "123456",
+        "string",
+        "cheese",
+    ) else {
+        bar()
+    };
+
+    let Some(x) = abcdef()
+        .foo(
+            "abc",
+            some_really_really_really_long_ident,
+            "ident",
+            "123456",
+        )
+        .bar()
+        .baz()
+        .qux("fffffffffffffffff")
+    else {
+        foo_bar()
+    };
 }

--- a/tests/target/let_else.rs
+++ b/tests/target/let_else.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let Some(x) = opt else { return };
+
+    let Some(x) = opt else {
+        return;
+    };
+
+    let Some(x) = opt else {
+        // nope
+        return;
+    };
+}


### PR DESCRIPTION
ref #4914

r? @calebcartwright 

Implements `let-else` formatting based on the rules outlined in https://github.com/rust-lang/rust/pull/107312. The examples listed in the style guide are included as simple test cases to validate `let-else` formatting.

**Note** This PR does not implement a ["short" config for `let-else`](https://github.com/rust-lang/rustfmt/issues/5684).