### PR TITLE
use correct span for struct generics

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1278,7 +1278,7 @@ pub(crate) fn format_struct_struct(
     let header_hi = struct_parts.ident.span.hi();
     let body_lo = if let Some(generics) = struct_parts.generics {
         // Adjust the span to start at the end of the generic arguments before searching for the '{'
-        let span = span.with_lo(generics.span.hi());
+        let span = span.with_lo(generics.where_clause.span.hi());
         context.snippet_provider.span_after(span, "{")
     } else {
         context.snippet_provider.span_after(span, "{")

--- a/tests/target/issue_5691.rs
+++ b/tests/target/issue_5691.rs
@@ -1,0 +1,16 @@
+struct S<const C: usize>
+where
+    [(); { num_slots!(C) }]:, {
+    /* An asterisk-based, or a double-slash-prefixed, comment here is
+       required to trigger the fmt bug.
+
+    A single-line triple-slash-prefixed comment (with a field following it) is not enough - it will not trigger the fmt bug.
+
+    Side note: If you have a combination of two, or all three of the
+    above mentioned types of comments here, some of them disappear
+    after `cargo fmt`.
+
+    The bug gets triggered even if a field definition following the
+    (asterisk-based, or a double-slash-prefixed) comment, too.
+    */
+}


### PR DESCRIPTION
Fixes #5691 