### PR TITLE
use Span from `ast::WhereClause` when rewriting Structs

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1278,7 +1278,10 @@ pub(crate) fn format_struct_struct(
     let header_hi = struct_parts.ident.span.hi();
     let body_lo = if let Some(generics) = struct_parts.generics {
         // Adjust the span to start at the end of the generic arguments before searching for the '{'
-        let span = span.with_lo(generics.span.hi());
+        // Use generics.where_clause.span.hi() as it should be the same as generics.span.hi() when
+        // the struct is written without a where clause, and larger when the struct is written with
+        // a where clause.
+        let span = span.with_lo(generics.where_clause.span.hi());
         context.snippet_provider.span_after(span, "{")
     } else {
         context.snippet_provider.span_after(span, "{")

--- a/tests/source/issue_5691.rs
+++ b/tests/source/issue_5691.rs
@@ -1,0 +1,112 @@
+/* Empty Struct With Block Comments */
+struct Empty {/* comment */}
+
+struct EmptyWithGeneric<T> {/* comment */}
+
+// Note: `where` with no bounds are removed
+struct EmptyWithGenericAndWhereWithNoBounds<T>
+where
+{/* comment */}
+
+struct EmptyWithGenericAndWhereWithBounds<T>
+where T: Clone
+{/* comment */}
+
+// Note: `where` with no bounds are removed
+struct EmptyWithConstGenericAndWhereWithNoBounds<const C: usize>
+where
+{/* comment */}
+
+struct EmptyWithConstGenericAndWhereWithBounds<const C: usize>
+where [(); { num_slots!(C) }]:,
+{/* comment */}
+
+
+// Empty Structs With Line Comments
+struct Empty {// comment
+}
+
+struct EmptyWithGeneric<T> {// comment
+}
+
+// Note: `where` with no bounds are removed
+struct EmptyWithGenericAndWhereWithNoBounds<T>
+where
+{// comment
+}
+
+struct EmptyWithGenericAndWhereWithBounds<T>
+where T: Clone
+{// comment
+}
+
+// Note: `where` with no bounds are removed
+struct EmptyWithConstGenericAndWhereWithNoBounds<const C: usize>
+where
+{// comment
+}
+
+struct EmptyWithConstGenericAndWhereWithBounds<const C: usize>
+where [(); { num_slots!(C) }]:,
+{// comment
+}
+
+
+/* Struct With Fields and Block Comments */
+struct Fields {/* comment */ x: usize}
+
+struct FieldsWithGeneric<T> {/* comment */ x: usize}
+
+// Note: `where` with no bounds are removed
+struct FieldsWithGenericAndWhereWithNoBounds<T>
+where
+{/* comment */ x: usize}
+
+struct FieldsWithGenericAndWhereWithBounds<T>
+where T: Clone
+{/* comment */ x: usize}
+
+// Note: `where` with no bounds are removed
+struct FieldsWithConstGenericAndWhereWithNoBounds<const C: usize>
+where
+{/* comment */ x: usize}
+
+struct FieldsWithConstGenericAndWhereWithBounds<const C: usize>
+where [(); { num_slots!(C) }]:,
+{/* comment */ x: usize}
+
+
+// Struct With Fields and Line Comments
+struct Fields {// comment
+x: usize
+}
+
+struct FieldsWithGeneric<T> {// comment
+x: usize
+}
+
+// Note: `where` with no bounds are removed
+struct FieldsWithGenericAndWhereWithNoBounds<T>
+where
+{// comment
+x: usize
+}
+
+struct FieldsWithGenericAndWhereWithBounds<T>
+where T: Clone
+{// comment
+x: usize
+}
+
+// Note: `where` with no bounds are removed
+struct FieldsWithConstGenericAndWhereWithNoBounds<const C: usize>
+where
+{// comment
+x: usize
+}
+
+struct FieldsWithConstGenericAndWhereWithBounds<const C: usize>
+where [(); { num_slots!(C) }]:,
+{// comment
+x: usize
+}

--- a/tests/target/issue_5691.rs
+++ b/tests/target/issue_5691.rs
@@ -1,0 +1,121 @@
+/* Empty Struct With Block Comments */
+struct Empty {/* comment */}
+
+struct EmptyWithGeneric<T> {/* comment */}
+
+// Note: `where` with no bounds are removed
+struct EmptyWithGenericAndWhereWithNoBounds<T> {/* comment */}
+
+struct EmptyWithGenericAndWhereWithBounds<T>
+where
+    T: Clone, {/* comment */}
+
+// Note: `where` with no bounds are removed
+struct EmptyWithConstGenericAndWhereWithNoBounds<const C: usize> {/* comment */}
+
+struct EmptyWithConstGenericAndWhereWithBounds<const C: usize>
+where
+    [(); { num_slots!(C) }]:, {/* comment */}
+
+// Empty Structs With Line Comments
+struct Empty {
+    // comment
+}
+
+struct EmptyWithGeneric<T> {
+    // comment
+}
+
+// Note: `where` with no bounds are removed
+struct EmptyWithGenericAndWhereWithNoBounds<T> {
+    // comment
+}
+
+struct EmptyWithGenericAndWhereWithBounds<T>
+where
+    T: Clone, {
+    // comment
+}
+
+// Note: `where` with no bounds are removed
+struct EmptyWithConstGenericAndWhereWithNoBounds<const C: usize> {
+    // comment
+}
+
+struct EmptyWithConstGenericAndWhereWithBounds<const C: usize>
+where
+    [(); { num_slots!(C) }]:, {
+    // comment
+}
+
+/* Struct With Fields and Block Comments */
+struct Fields {
+    /* comment */ x: usize,
+}
+
+struct FieldsWithGeneric<T> {
+    /* comment */ x: usize,
+}
+
+// Note: `where` with no bounds are removed
+struct FieldsWithGenericAndWhereWithNoBounds<T> {
+    /* comment */ x: usize,
+}
+
+struct FieldsWithGenericAndWhereWithBounds<T>
+where
+    T: Clone,
+{
+    /* comment */ x: usize,
+}
+
+// Note: `where` with no bounds are removed
+struct FieldsWithConstGenericAndWhereWithNoBounds<const C: usize> {
+    /* comment */ x: usize,
+}
+
+struct FieldsWithConstGenericAndWhereWithBounds<const C: usize>
+where
+    [(); { num_slots!(C) }]:,
+{
+    /* comment */ x: usize,
+}
+
+// Struct With Fields and Line Comments
+struct Fields {
+    // comment
+    x: usize,
+}
+
+struct FieldsWithGeneric<T> {
+    // comment
+    x: usize,
+}
+
+// Note: `where` with no bounds are removed
+struct FieldsWithGenericAndWhereWithNoBounds<T> {
+    // comment
+    x: usize,
+}
+
+struct FieldsWithGenericAndWhereWithBounds<T>
+where
+    T: Clone,
+{
+    // comment
+    x: usize,
+}
+
+// Note: `where` with no bounds are removed
+struct FieldsWithConstGenericAndWhereWithNoBounds<const C: usize> {
+    // comment
+    x: usize,
+}
+
+struct FieldsWithConstGenericAndWhereWithBounds<const C: usize>
+where
+    [(); { num_slots!(C) }]:,
+{
+    // comment
+    x: usize,
+}


### PR DESCRIPTION
Fixes #5691

Through testing I observed that the `Span` from an `ast::WhereClause` was just as large as the span from `ast::Generics` when the struct was written without a where clause, and was larger when the struct was written with a where clause.

Hopefully the wide range of tests cases help to validate that as well!

r? @calebcartwright 