### PR TITLE
Prevent ICE when calling parse_attribute in parse_cfg_if_inner

### DIFF
--- a/src/parse/macros/cfg_if.rs
+++ b/src/parse/macros/cfg_if.rs
@@ -44,7 +44,10 @@ fn parse_cfg_if_inner<'a>(
             // See also https://github.com/rust-lang/rust/pull/79433
             parser
                 .parse_attribute(rustc_parse::parser::attr::InnerAttrPolicy::Permitted)
-                .map_err(|_| "Failed to parse attributes")?;
+                .map_err(|e| {
+                    e.cancel();
+                    "Failed to parse attributes"
+                })?;
         }
 
         if !parser.eat(&TokenKind::OpenDelim(Delimiter::Brace)) {

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -174,3 +174,15 @@ fn rustfmt_emits_error_on_line_overflow_true() {
         "line formatted, but exceeded maximum width (maximum: 100 (see `max_width` option)"
     ))
 }
+
+#[test]
+#[allow(non_snake_case)]
+fn dont_emit_ICE() {
+    let files = ["tests/target/issue_5728.rs"];
+
+    for file in files {
+        let args = [file];
+        let (_stdout, stderr) = rustfmt(&args);
+        assert!(!stderr.contains("thread 'main' panicked"));
+    }
+}

--- a/tests/target/issue_5728.rs
+++ b/tests/target/issue_5728.rs
@@ -1,0 +1,5 @@
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+    } else if #(&cpus) {
+    } else [libc::CTL_HW, libc::HW_NCPU, 0, 0]
+}


### PR DESCRIPTION
Fixes #5728

Previously we were ignoring the diagnostic error, which lead to the ICE. Now we properly cancel the error.