### PR TITLE
Prevent ICE when calling parse_attribute without an attribute

### DIFF
--- a/src/parse/macros/cfg_if.rs
+++ b/src/parse/macros/cfg_if.rs
@@ -34,6 +34,11 @@ fn parse_cfg_if_inner<'a>(
             if !parser.eat_keyword(kw::If) {
                 return Err("Expected `if`");
             }
+
+            if !matches!(parser.token.kind, TokenKind::Pound) {
+                return Err("Failed to parse attributes");
+            }
+
             // Inner attributes are not actually syntactically permitted here, but we don't
             // care about inner vs outer attributes in this position. Our purpose with this
             // special case parsing of cfg_if macros is to ensure we can correctly resolve

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -178,7 +178,7 @@ fn rustfmt_emits_error_on_line_overflow_true() {
 #[test]
 #[allow(non_snake_case)]
 fn dont_emit_ICE() {
-    let files = ["tests/target/issue_5728.rs"];
+    let files = ["tests/target/issue_5728.rs", "tests/target/issue_5729.rs"];
 
     for file in files {
         let args = [file];

--- a/tests/target/issue_5729.rs
+++ b/tests/target/issue_5729.rs
@@ -1,0 +1,5 @@
+cfg_if::cfg_if! {
+    if {
+    } else if #(&cpus) {
+    } else [libc::CTL_HW, libc::HW_NCPU, 0, 0]
+}


### PR DESCRIPTION
Fixes #5729

[`parse_attribute` will panic if the first token is not a `#`](https://github.com/rust-lang/rust/blob/b869e84e581612f4a30a4bca63bd9e90e9a17003/compiler/rustc_parse/src/parser/attr.rs#L122). To prevent this we return early instead of trying to parse an invalid attribute.