### PR TITLE
Properly handle unicode whitespace chars when rewriting missing spans

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -205,7 +205,8 @@ impl<'a> FmtVisitor<'a> {
                 // 2: blank lines.
                 self.push_vertical_spaces(newline_count);
                 status.cur_line += newline_count;
-                status.line_start = offset + lf_count + crlf_count * 2;
+                // To avoid any issues with whitespace unicode chars just add the len of the slice
+                status.line_start = offset + subslice.len()
             } else {
                 // 3: code which we failed to format or which is not within file-lines range.
                 self.process_missing_code(&mut status, snippet, subslice, offset, file_name);

--- a/tests/source/issue_5739.rs
+++ b/tests/source/issue_5739.rs
@@ -1,0 +1,6 @@
+// Note the input snippet is: `compile-flags: -Z dump-mir-spanview=block\n\n\n\u{2029}\n`
+// compile-flags: -Z dump-mir-spanview=block
+
+
+ 
+

--- a/tests/target/issue_5739.rs
+++ b/tests/target/issue_5739.rs
@@ -1,0 +1,2 @@
+// Note the input snippet is: `compile-flags: -Z dump-mir-spanview=block\n\n\n\u{2029}\n`
+// compile-flags: -Z dump-mir-spanview=block


### PR DESCRIPTION
Fixes #5739

This prevents rustfmt from incorrectly indexing into an invalid byte position for unicode characters.