### PR TITLE
Add a friend for lonely backtick

### DIFF
--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -18,7 +18,7 @@ pub enum NewlineStyle {
     Auto,
     /// Force CRLF (`\r\n`).
     Windows,
-    /// Force CR (`\n).
+    /// Force CR (`\n`).
     Unix,
     /// `\r\n` in Windows, `\n` on other platforms.
     Native,


### PR DESCRIPTION
This patch fixes the broken markdown that can be seen [here](https://doc.rust-lang.org/nightly/nightly-rustc/rustfmt_nightly/enum.NewlineStyle.html#variant.Unix).

It has been found by a [new rustdoc lint](https://github.com/rust-lang/rust/pull/105848) and this patch will be required to deny the lint in the rust-lang/rust repository.