### PR TITLE
support aarch64 for linux and macos

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         target: [
           x86_64-unknown-linux-gnu,
+          aarch64-unknown-linux-gnu,
         ]
         cfg_release_channel: [nightly, stable]
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         target: [
           x86_64-apple-darwin,
+          aarch64-apple-darwin,
         ]
         cfg_release_channel: [nightly, stable]
 

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -11,13 +11,13 @@ jobs:
     name: build-release
     strategy:
       matrix:
-        build: [linux-x86_64, linux-arm64, macos-x86_64, windows-x86_64-gnu, windows-x86_64-msvc]
+        build: [linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64, windows-x86_64-gnu, windows-x86_64-msvc]
         include:
           - build: linux-x86_64
             os: ubuntu-latest
             rust: nightly
             target: x86_64-unknown-linux-gnu
-          - build: linux-arm64
+          - build: linux-aarch64
             os: ubuntu-latest
             rust: nightly
             target: aarch64-unknown-linux-gnu
@@ -25,6 +25,10 @@ jobs:
             os: macos-latest
             rust: nightly
             target: x86_64-apple-darwin
+          - build: macos-aarch64
+            os: macos-latest
+            rust: nightly
+            target: aarch64-apple-darwin
           - build: windows-x86_64-gnu
             os: windows-latest
             rust: nightly-x86_64-gnu

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -11,12 +11,16 @@ jobs:
     name: build-release
     strategy:
       matrix:
-        build: [linux-x86_64, macos-x86_64, windows-x86_64-gnu, windows-x86_64-msvc]
+        build: [linux-x86_64, linux-arm64, macos-x86_64, windows-x86_64-gnu, windows-x86_64-msvc]
         include:
           - build: linux-x86_64
             os: ubuntu-latest
             rust: nightly
             target: x86_64-unknown-linux-gnu
+          - build: linux-arm64
+            os: ubuntu-latest
+            rust: nightly
+            target: aarch64-unknown-linux-gnu
           - build: macos-x86_64
             os: macos-latest
             rust: nightly


### PR DESCRIPTION
The rustfmt (neo)vim plugins installed via mason fetches releases from github. However there are only x86_64 assets in the release. This means on linux aarch64, rustfmt vim plugin is not installable, and on macOS it's installing the x86_64 version so it runs in rosetta, this is not ideal. Note that if you run neovim inside a docker container on apple silicon macs, you also get this problem (it's running aarch64 linux inside). 

This PR adds support for aarch64 for linux and macos. The workflows pass, but no artifacts are generated in my fork.

Please let me know if there's anything else needed besides this PR. 