### PR TITLE
Group imports by their visibilities

### DIFF
--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -114,6 +114,15 @@ pub enum GroupImportsTactic {
     StdExternalCrate,
     /// Discard existing groups, and create a single group for everything
     One,
+    /// Discard existing groups, and create new groups for each visibility modifiers
+    /// from the least visible to the most visible, i.e.:
+    /// 1. unexported imports
+    /// 2. `pub (self)`
+    /// 3. `pub (super)` imports
+    /// 4. `pub (crate)` imports
+    /// 5. `pub (in path)` imports
+    /// 6. `pub` imports
+    Visibility,
 }
 
 #[config_type]

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -115,7 +115,7 @@ pub(crate) struct UseTree {
     pub(crate) list_item: Option<ListItem>,
     // Additional fields for top level use items.
     // Should we have another struct for top-level use items rather than reusing this?
-    visibility: Option<ast::Visibility>,
+    pub(crate) visibility: Option<ast::Visibility>,
     attrs: Option<ast::AttrVec>,
 }
 

--- a/tests/source/configs/group_imports/One.rs
+++ b/tests/source/configs/group_imports/One.rs
@@ -2,7 +2,7 @@
 use chrono::Utc;
 use super::update::convert_publish_payload;
 
-use juniper::{FieldError, FieldResult};
+pub use juniper::{FieldError, FieldResult};
 use uuid::Uuid;
 use alloc::alloc::Layout;
 

--- a/tests/source/configs/group_imports/Visibility.rs
+++ b/tests/source/configs/group_imports/Visibility.rs
@@ -1,0 +1,15 @@
+// rustfmt-group_imports: Visibility
+pub(super) use chrono::Utc;
+pub use super::update::convert_publish_payload;
+
+pub(crate) use juniper::{FieldError, FieldResult};
+pub(in crate::models) use uuid::Uuid;
+use alloc::alloc::Layout;
+
+use std::sync::Arc;
+
+pub(self) use broker::database::PooledConnection;
+
+use super::schema::{Context, Payload};
+use core::f32;
+pub use crate::models::Event;

--- a/tests/target/configs/group_imports/One.rs
+++ b/tests/target/configs/group_imports/One.rs
@@ -6,6 +6,6 @@ use alloc::alloc::Layout;
 use broker::database::PooledConnection;
 use chrono::Utc;
 use core::f32;
-use juniper::{FieldError, FieldResult};
+pub use juniper::{FieldError, FieldResult};
 use std::sync::Arc;
 use uuid::Uuid;

--- a/tests/target/configs/group_imports/Visibility.rs
+++ b/tests/target/configs/group_imports/Visibility.rs
@@ -1,0 +1,16 @@
+// rustfmt-group_imports: Visibility
+use super::schema::{Context, Payload};
+use alloc::alloc::Layout;
+use core::f32;
+use std::sync::Arc;
+
+pub(self) use broker::database::PooledConnection;
+
+pub(super) use chrono::Utc;
+
+pub(crate) use juniper::{FieldError, FieldResult};
+
+pub(in crate::models) use uuid::Uuid;
+
+pub use super::update::convert_publish_payload;
+pub use crate::models::Event;


### PR DESCRIPTION
Hi. This is a patch for feature request #5696 and #4070.

This patch adds another variant, `Visiblity` to `group_imports` that turn

Unordered:
```rust
pub(super) use chrono::Utc;
pub use super::update::convert_publish_payload;

pub(crate) use juniper::{FieldError, FieldResult};
pub(in crate::models) use uuid::Uuid;
use alloc::alloc::Layout;

use std::sync::Arc;

pub(self) use broker::database::PooledConnection;

use super::schema::{Context, Payload};
use core::f32;
pub use crate::models::Event;
```

into

Ordered:
```rust
use super::schema::{Context, Payload};
use alloc::alloc::Layout;
use core::f32;
use std::sync::Arc;

pub(self) use broker::database::PooledConnection;

pub(super) use chrono::Utc;

pub(crate) use juniper::{FieldError, FieldResult};

pub(in crate::models) use uuid::Uuid;

pub use super::update::convert_publish_payload;
pub use crate::models::Event;
```

I opt to order the imports from the least visible to the most to make exporting imported declaration look more natural, for example:

```rust
use proto::*;

pub use proto::Response;

pub fn send_request() -> Response { ... }
```
