### PR TITLE
Don't skip semicolon if expressions follow

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -80,13 +80,19 @@ impl<'a> Rewrite for Stmt<'a> {
         } else {
             ExprType::Statement
         };
-        format_stmt(context, shape, self.as_ast_node(), expr_type)
+        format_stmt(
+            context,
+            shape,
+            self.as_ast_node(),
+            expr_type,
+            Some(self.is_last_expr()),
+        )
     }
 }
 
 impl Rewrite for ast::Stmt {
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
-        format_stmt(context, shape, self, ExprType::Statement)
+        format_stmt(context, shape, self, ExprType::Statement, None)
     }
 }
 
@@ -95,13 +101,14 @@ fn format_stmt(
     shape: Shape,
     stmt: &ast::Stmt,
     expr_type: ExprType,
+    is_last_expr: Option<bool>,
 ) -> Option<String> {
     skip_out_of_file_lines_range!(context, stmt.span());
 
     let result = match stmt.kind {
         ast::StmtKind::Local(ref local) => local.rewrite(context, shape),
         ast::StmtKind::Expr(ref ex) | ast::StmtKind::Semi(ref ex) => {
-            let suffix = if semicolon_for_stmt(context, stmt) {
+            let suffix = if semicolon_for_stmt(context, stmt, is_last_expr) {
                 ";"
             } else {
                 ""

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -292,14 +292,20 @@ pub(crate) fn semicolon_for_expr(context: &RewriteContext<'_>, expr: &ast::Expr)
 }
 
 #[inline]
-pub(crate) fn semicolon_for_stmt(context: &RewriteContext<'_>, stmt: &ast::Stmt) -> bool {
+pub(crate) fn semicolon_for_stmt(
+    context: &RewriteContext<'_>,
+    stmt: &ast::Stmt,
+    is_last_expr: Option<bool>,
+) -> bool {
     match stmt.kind {
         ast::StmtKind::Semi(ref expr) => match expr.kind {
             ast::ExprKind::While(..) | ast::ExprKind::Loop(..) | ast::ExprKind::ForLoop(..) => {
                 false
             }
             ast::ExprKind::Break(..) | ast::ExprKind::Continue(..) | ast::ExprKind::Ret(..) => {
-                context.config.trailing_semicolon()
+                // The only time we can skip the semi-colon is if the config option is set to false
+                // **and** this is the last expr (even though any following exprs are unreachable)
+                context.config.trailing_semicolon() || !is_last_expr.unwrap_or(false)
             }
             _ => true,
         },

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -295,7 +295,7 @@ pub(crate) fn semicolon_for_expr(context: &RewriteContext<'_>, expr: &ast::Expr)
 pub(crate) fn semicolon_for_stmt(
     context: &RewriteContext<'_>,
     stmt: &ast::Stmt,
-    is_last_expr: Option<bool>,
+    is_last_expr: bool,
 ) -> bool {
     match stmt.kind {
         ast::StmtKind::Semi(ref expr) => match expr.kind {
@@ -305,7 +305,7 @@ pub(crate) fn semicolon_for_stmt(
             ast::ExprKind::Break(..) | ast::ExprKind::Continue(..) | ast::ExprKind::Ret(..) => {
                 // The only time we can skip the semi-colon is if the config option is set to false
                 // **and** this is the last expr (even though any following exprs are unreachable)
-                context.config.trailing_semicolon() || !is_last_expr.unwrap_or(false)
+                context.config.trailing_semicolon() || !is_last_expr
             }
             _ => true,
         },

--- a/tests/target/issue-5797/retain_trailing_semicolon.rs
+++ b/tests/target/issue-5797/retain_trailing_semicolon.rs
@@ -1,0 +1,7 @@
+// rustfmt-trailing_semicolon: false
+
+fn foo() {}
+fn main() {
+    return;
+    foo()
+}


### PR DESCRIPTION
Fixes #5797 

This changes the logic for `semicolon_for_stmt()` to only allow skipping the semicolon on the last expression

Lingering question: I'm not sure when`ast::Stmt` gets used and I don't know of a way to check the docs for `rustc_ast` (doesn't seem to be included in the docs for `cargo doc --open`?), so I just skipped the last statement logic for that