### PR TITLE
handle skip_macro_invocations from config file

### DIFF
--- a/src/config/macro_names.rs
+++ b/src/config/macro_names.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 use std::{fmt, str};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json as json;
 use thiserror::Error;
 
@@ -30,10 +30,20 @@ impl From<MacroName> for String {
 }
 
 /// Defines a selector to match against a macro.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
 pub enum MacroSelector {
     Name(MacroName),
     All,
+}
+
+impl<'de> Deserialize<'de> for MacroSelector {
+    fn deserialize<D>(de: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(de)?;
+        std::str::FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
 }
 
 impl fmt::Display for MacroSelector {

--- a/tests/config/issue-5816.toml
+++ b/tests/config/issue-5816.toml
@@ -1,0 +1,1 @@
+skip_macro_invocations=["*", "println"]

--- a/tests/source/skip_macro_invocations/config_file.rs
+++ b/tests/source/skip_macro_invocations/config_file.rs
@@ -1,0 +1,9 @@
+// rustfmt-unstable: true
+// rustfmt-config: issue-5816.toml
+
+fn main() {
+    println!(             "Hello, world!");
+    let     x    =    
+7
+;
+}

--- a/tests/target/skip_macro_invocations/config_file.rs
+++ b/tests/target/skip_macro_invocations/config_file.rs
@@ -1,0 +1,7 @@
+// rustfmt-unstable: true
+// rustfmt-config: issue-5816.toml
+
+fn main() {
+    println!(             "Hello, world!");
+    let x = 7;
+}


### PR DESCRIPTION
fixes #5816

We need to keep the `FromStr` impl for `MacroSelector` (e.g. to support command line config args), so seems reasonable to just have the serde deserializer use that impl too.

I'm not sure whether there's a better/simpler approach to achieve that (e.g. an item-level serde attribute), but adding our own `Deserialize` impl seems trivial enough