### PR TITLE
Actually use `tracing` for logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 // N.B. these crates are loaded from the sysroot, so they need extern crate.
 extern crate rustc_ast;


### PR DESCRIPTION
tested:

```
> echo "fn main() {}" | RUSTFMT_LOG=rustfmt=debug cargo run --bin rustfmt --
   Compiling rustfmt-nightly v1.6.0 (/home/beef/rustfmt)
    Finished dev [unoptimized + debuginfo] target(s) in 5.05s
     Running `target/debug/rustfmt`
2023-07-06T05:22:03.430286Z DEBUG rustfmt_nightly::items: compute_budgets_for_params 7 Indent { block_indent: 0, alignment: 0 }, 0, SameLine
2023-07-06T05:22:03.430340Z DEBUG rustfmt_nightly::items: rewrite_fn_base: one_line_budget: 89, multi_line_budget: 95, param_indent: Indent { block_indent: 4, alignment: 0 }
2023-07-06T05:22:03.430420Z DEBUG rustfmt_nightly::formatting: track truncate: 14 2
fn main() {}
```

cc @ytmimi @calebcartwright 