### PR TITLE
Fix diff check Job

### DIFF
--- a/.github/workflows/check_diff.yml
+++ b/.github/workflows/check_diff.yml
@@ -30,4 +30,4 @@ jobs:
         rustup target add x86_64-unknown-linux-gnu
 
     - name: check diff
-      run: bash ${GITHUB_WORKSPACE}/ci/check_diff.sh ${{ github.event.inputs.clone_url }} ${{ github.event.inputs.branch_name }} ${{ github.event.inputs.commit_hash }} ${{ github.event.inputs.rustfmt_configs }}
+      run: bash ${GITHUB_WORKSPACE}/ci/check_diff.sh ${{ github.event.inputs.clone_url }} ${{ github.event.inputs.branch_name }} ${{ github.event.inputs.commit_hash || github.event.inputs.branch_name }} ${{ github.event.inputs.rustfmt_configs }}

--- a/ci/check_diff.sh
+++ b/ci/check_diff.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# https://github.com/rust-lang/rustfmt/issues/5675
+export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
+
 function print_usage() {
     echo "usage check_diff REMOTE_REPO FEATURE_BRANCH [COMMIT_HASH] [OPTIONAL_RUSTFMT_CONFIGS]"
 }

--- a/ci/check_diff.sh
+++ b/ci/check_diff.sh
@@ -115,7 +115,7 @@ function compile_rustfmt() {
     git fetch feature $FEATURE_BRANCH
 
     cargo build --release --bin rustfmt && cp target/release/rustfmt $1/rustfmt
-    if [ -z "$OPTIONAL_COMMIT_HASH" ]; then
+    if [ -z "$OPTIONAL_COMMIT_HASH" ] || [ "$FEATURE_BRANCH" = "$OPTIONAL_COMMIT_HASH" ]; then
         git switch $FEATURE_BRANCH
     else
         git switch $OPTIONAL_COMMIT_HASH --detach

--- a/ci/check_diff.sh
+++ b/ci/check_diff.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # https://github.com/rust-lang/rustfmt/issues/5675
 export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
 
@@ -143,9 +145,15 @@ function check_repo() {
         init_submodules $SUBMODULES
     fi
 
+
+    # rustfmt --check returns 1 if a diff was found
+    # Also check_diff returns 1 if there was a diff between master rustfmt and the feature branch
+    # so we want to ignore the exit status check
+    set +e
     check_diff $REPO_NAME
     # append the status of running `check_diff` to the STATUSES array
     STATUSES+=($?)
+    set -e
 
     echo "removing tmp_dir $tmp_dir"
     rm -rf $tmp_dir


### PR DESCRIPTION
A few fixes for the diff-check job. The first bullet below is the most impactful, and to my knowledge the current job is broken without it. The other two are mostly quality of life improvements.

* Since we build rustfmt from source we also need to add the correct sysroot to `LD_LIBRARY_PATH`. See #5675
* `set -e` to propagate errors so we'll be alerted to issues more quickly in the future
* A minor bug fix for scenarios where you want to pass optional configs to the feature rustfmt binary, but don't specify a commit hash.

r? @calebcartwright 