### PR TITLE
doc: fix instruction about running Rustfmt from source code

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -95,10 +95,18 @@ wish there weren't. You can leave `FIXME`s, preferably with an issue number.
 
 You may want to run a version of rustfmt from source code as part of a test or
 hacking on the rustfmt codebase. It's strongly discouraged to install a version
-of rustfmt from source. Instead, run it using `cargo run`, and `--manifest-path`.
+of rustfmt from source.
+
+To run `rustfmt` on a file:
 
 ```
-RUSTFMT="./target/debug/rustfmt" cargo run --bin cargo-fmt -- --manifest-path path/to/project/you/want2test/Cargo.toml
+cargo run --bin rustfmt -- path/to/file.rs
+```
+
+If you want to test modified `cargo-fmt`, or run `rustfmt` on the whole project:
+
+```
+cargo build --bin rustfmt && RUSTFMT="./target/debug/rustfmt" cargo run --bin cargo-fmt -- --manifest-path path/to/project/you/want2test/Cargo.toml
 ```
 
 ### Version-gate formatting changes

--- a/Contributing.md
+++ b/Contributing.md
@@ -103,10 +103,10 @@ To run `rustfmt` on a file:
 cargo run --bin rustfmt -- path/to/file.rs
 ```
 
-If you want to test modified `cargo-fmt`, or run `rustfmt` on the whole project:
+If you want to test modified `cargo-fmt`, or run `rustfmt` on the whole project (You may need to build rustfmt first):
 
 ```
-cargo build --bin rustfmt && RUSTFMT="./target/debug/rustfmt" cargo run --bin cargo-fmt -- --manifest-path path/to/project/you/want2test/Cargo.toml
+RUSTFMT="./target/debug/rustfmt" cargo run --bin cargo-fmt -- --manifest-path path/to/project/you/want2test/Cargo.toml
 ```
 
 ### Version-gate formatting changes

--- a/Contributing.md
+++ b/Contributing.md
@@ -98,7 +98,7 @@ hacking on the rustfmt codebase. It's strongly discouraged to install a version
 of rustfmt from source. Instead, run it using `cargo run`, and `--manifest-path`.
 
 ```
-cargo run --bin cargo-fmt -- --manifest-path path/to/project/you/want2test/Cargo.toml
+RUSTFMT="./target/debug/rustfmt" cargo run --bin cargo-fmt -- --manifest-path path/to/project/you/want2test/Cargo.toml
 ```
 
 ### Version-gate formatting changes


### PR DESCRIPTION
`cargo-fmt` uses `rustfmt` from `PATH`, so `cargo run --bin cargo-fmt` still uses installed `rustfmt` instead of built one.