### PR TITLE
fix: Add parenthesis around `..` closure if it's a method call receiver

### DIFF
--- a/tests/source/issue-4808.rs
+++ b/tests/source/issue-4808.rs
@@ -1,0 +1,13 @@
+trait Trait {
+    fn method(&self) {}
+}
+
+impl<F: Fn() -> T, T> Trait for F {}
+
+impl Trait for f32 {}
+
+fn main() {
+    || 10. .method();
+    || .. .method();
+    || 1.. .method();
+}

--- a/tests/target/issue-4808.rs
+++ b/tests/target/issue-4808.rs
@@ -1,0 +1,13 @@
+trait Trait {
+    fn method(&self) {}
+}
+
+impl<F: Fn() -> T, T> Trait for F {}
+
+impl Trait for f32 {}
+
+fn main() {
+    || (10.).method();
+    (|| ..).method();
+    (|| 1..).method();
+}


### PR DESCRIPTION
Fixes #4808

I think this is (perhaps?) okay without a version gate as the formatted code would be invalid before now, might be wrong though ^^