### PR TITLE
refactor ABI formatting

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -248,7 +248,6 @@ impl<'a> Item<'a> {
             abi: format_extern(
                 ast::Extern::from_abi(fm.abi, DUMMY_SP),
                 config.force_explicit_abi(),
-                true,
             ),
             vis: None,
             body: fm
@@ -336,7 +335,6 @@ impl<'a> FnSig<'a> {
         result.push_str(&format_extern(
             self.ext,
             context.config.force_explicit_abi(),
-            false,
         ));
         result
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -892,7 +892,6 @@ fn rewrite_bare_fn(
     result.push_str(&format_extern(
         bare_fn.ext,
         context.config.force_explicit_abi(),
-        false,
     ));
 
     result.push_str("fn");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -136,6 +136,10 @@ pub(crate) fn format_extern(ext: ast::Extern, explicit_abi: bool) -> Cow<'static
         ast::Extern::None => Cow::from(""),
         ast::Extern::Implicit(_) if explicit_abi => Cow::from("extern \"C\" "),
         ast::Extern::Implicit(_) => Cow::from("extern "),
+        // turn `extern "C"` into `extern` when `explicit_abi` is set to false
+        ast::Extern::Explicit(abi, _) if abi.symbol_unescaped == sym::C && !explicit_abi => {
+            Cow::from("extern ")
+        }
         ast::Extern::Explicit(abi, _) => {
             Cow::from(format!(r#"extern "{}" "#, abi.symbol_unescaped))
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -131,23 +131,14 @@ pub(crate) fn format_mutability(mutability: ast::Mutability) -> &'static str {
 }
 
 #[inline]
-pub(crate) fn format_extern(
-    ext: ast::Extern,
-    explicit_abi: bool,
-    is_mod: bool,
-) -> Cow<'static, str> {
-    let abi = match ext {
-        ast::Extern::None => "Rust".to_owned(),
-        ast::Extern::Implicit(_) => "C".to_owned(),
-        ast::Extern::Explicit(abi, _) => abi.symbol_unescaped.to_string(),
-    };
-
-    if abi == "Rust" && !is_mod {
-        Cow::from("")
-    } else if abi == "C" && !explicit_abi {
-        Cow::from("extern ")
-    } else {
-        Cow::from(format!(r#"extern "{abi}" "#))
+pub(crate) fn format_extern(ext: ast::Extern, explicit_abi: bool) -> Cow<'static, str> {
+    match ext {
+        ast::Extern::None => Cow::from(""),
+        ast::Extern::Implicit(_) if explicit_abi => Cow::from("extern \"C\" "),
+        ast::Extern::Implicit(_) => Cow::from("extern "),
+        ast::Extern::Explicit(abi, _) => {
+            Cow::from(format!(r#"extern "{}" "#, abi.symbol_unescaped))
+        }
     }
 }
 

--- a/tests/target/extern-rust.rs
+++ b/tests/target/extern-rust.rs
@@ -1,0 +1,1 @@
+extern "Rust" fn uwu() {}

--- a/tests/target/extern_not_explicit.rs
+++ b/tests/target/extern_not_explicit.rs
@@ -1,12 +1,12 @@
 // rustfmt-force_explicit_abi: false
 
-extern "C" {
+extern {
     fn some_fn() -> ();
 }
 
-extern "C" fn sup() {}
+extern fn sup() {}
 
-type funky_func = extern "C" fn(
+type funky_func = extern fn(
     unsafe extern "rust-call" fn(
         *const JSJitInfo,
         *mut JSContext,

--- a/tests/target/extern_not_explicit.rs
+++ b/tests/target/extern_not_explicit.rs
@@ -1,12 +1,12 @@
 // rustfmt-force_explicit_abi: false
 
-extern {
+extern "C" {
     fn some_fn() -> ();
 }
 
-extern fn sup() {}
+extern "C" fn sup() {}
 
-type funky_func = extern fn(
+type funky_func = extern "C" fn(
     unsafe extern "rust-call" fn(
         *const JSJitInfo,
         *mut JSContext,


### PR DESCRIPTION
whenever we see an `extern "Rust"` on a function, we don't strip it from the function (which fixes #5701)