### PR TITLE
improve the --file-lines help

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -426,7 +426,7 @@ rustfmt --file-lines '[
     {{\"file\":\"src/lib.rs\",\"range\":[7,13]}},
     {{\"file\":\"src/lib.rs\",\"range\":[21,29]}},
     {{\"file\":\"src/foo.rs\",\"range\":[10,11]}},
-    {{\"file\":\"src/foo.rs\",\"range\":[15,15]}}]'
+    {{\"file\":\"src/foo.rs\",\"range\":[15,15]}}]' src/lib.rs src/foo.rs
 ```
 
 would format lines `7-13` and `21-29` of `src/lib.rs`, and lines `10-11`,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -422,11 +422,11 @@ are 1-based and inclusive of both end points. Specifying an empty array
 will result in no files being formatted. For example,
 
 ```
-rustfmt --file-lines '[
+rustfmt src/lib.rs src/foo.rs --file-lines '[
     {{\"file\":\"src/lib.rs\",\"range\":[7,13]}},
     {{\"file\":\"src/lib.rs\",\"range\":[21,29]}},
     {{\"file\":\"src/foo.rs\",\"range\":[10,11]}},
-    {{\"file\":\"src/foo.rs\",\"range\":[15,15]}}]' src/lib.rs src/foo.rs
+    {{\"file\":\"src/foo.rs\",\"range\":[15,15]}}]'
 ```
 
 would format lines `7-13` and `21-29` of `src/lib.rs`, and lines `10-11`,


### PR DESCRIPTION
This is something incredibly small but as someone new to using rustfmt I found the --file-lines example quite frustrating
```
rustfmt --file-lines '[
    {"file":"src/lib.rs","range":[7,13]},
    {"file":"src/lib.rs","range":[21,29]},
    {"file":"src/foo.rs","range":[10,11]},
    {"file":"src/foo.rs","range":[15,15]}]' 
```
This leads me to believe that the file is going to be taken based on the json I passed as an argument but that is not the case, it also need to the files that are going to be modified as extra parameters, so since this `--help=file-lines` represents a complete example the message should be something like this:
```
rustfmt --file-lines '[
    {"file":"src/lib.rs","range":[7,13]},
    {"file":"src/lib.rs","range":[21,29]},
    {"file":"src/foo.rs","range":[10,11]},
    {"file":"src/foo.rs","range":[15,15]}]' src/lib.rs src/foo.rs
```