### PR TITLE
Remove newlines in where clauses for v2

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2996,10 +2996,12 @@ fn rewrite_bounds_on_where_clause(
         DefinitiveListTactic::Vertical
     };
 
+    let preserve_newline = context.config.version() == Version::One;
+
     let fmt = ListFormatting::new(shape, context.config)
         .tactic(shape_tactic)
         .trailing_separator(comma_tactic)
-        .preserve_newline(true);
+        .preserve_newline(preserve_newline);
     write_list(&items.collect::<Vec<_>>(), &fmt)
 }
 

--- a/tests/source/issue-5655/one.rs
+++ b/tests/source/issue-5655/one.rs
@@ -1,0 +1,9 @@
+// rustfmt-version: One
+
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+
+    T: std::fmt::Display,
+{
+}

--- a/tests/source/issue-5655/two.rs
+++ b/tests/source/issue-5655/two.rs
@@ -1,0 +1,9 @@
+// rustfmt-version: Two
+
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+
+    T: std::fmt::Display,
+{
+}

--- a/tests/target/issue-5655/one.rs
+++ b/tests/target/issue-5655/one.rs
@@ -1,0 +1,9 @@
+// rustfmt-version: One
+
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+
+    T: std::fmt::Display,
+{
+}

--- a/tests/target/issue-5655/two.rs
+++ b/tests/target/issue-5655/two.rs
@@ -1,0 +1,8 @@
+// rustfmt-version: Two
+
+fn foo<T>(_: T)
+where
+    T: std::fmt::Debug,
+    T: std::fmt::Display,
+{
+}


### PR DESCRIPTION
Fixes #5655.

Closes #5679. This PR is an alternative that feature-gates the fix per the [comment in that PR](https://github.com/rust-lang/rustfmt/pull/5679#discussion_r1091116166).