### PR TITLE
Enable rustfmt to compile when using the `generic-simd` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 dependencies = [
  "packed_simd_2",
 ]
@@ -477,9 +477,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ generic-simd = ["bytecount/generic-simd"]
 [dependencies]
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0"
-bytecount = "0.6"
+bytecount = "0.6.3"
 cargo_metadata = "0.15.4"
 clap = { version = "4.2.1", features = ["derive"] }
 diff = "0.1"

--- a/ci/build_and_test.bat
+++ b/ci/build_and_test.bat
@@ -6,7 +6,11 @@ rustc -Vv || exit /b 1
 cargo -V || exit /b 1
 
 :: Build and test main crate
-cargo build --locked || exit /b 1
+if "%CFG_RELEASE_CHANNEL%"=="nightly" (
+    cargo build --locked --all-features || exit /b 1
+) else (
+    cargo build --locked || exit /b 1
+)
 cargo test || exit /b 1
 
 :: Build and test other crates

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -10,7 +10,11 @@ rustc -Vv
 cargo -V
 
 # Build and test main crate
-cargo build --locked
+if [ "$CFG_RELEASE_CHANNEL" == "nightly" ]; then
+    cargo build --locked --all-features
+else
+    cargo build --locked
+fi
 cargo test
 
 # Build and test other crates


### PR DESCRIPTION
Fixes #5859

In addition to the fix, CI is updated to hopefully avoid this issue moving forward.

r? @calebcartwright 