### PR TITLE
Prevent ICE when formatting braced vec! when...

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -296,20 +296,19 @@ fn rewrite_macro_inner(
                 // If we are rewriting `vec!` macro or other special macros,
                 // then we can rewrite this as a usual array literal.
                 // Otherwise, we must preserve the original existence of trailing comma.
-                let macro_name = &macro_name.as_str();
                 let mut force_trailing_comma = if trailing_comma {
                     Some(SeparatorTactic::Always)
                 } else {
                     Some(SeparatorTactic::Never)
                 };
-                if FORCED_BRACKET_MACROS.contains(macro_name) && !is_nested_macro {
+                if is_forced_bracket && !is_nested_macro {
                     context.leave_macro();
                     if context.use_block_indent() {
                         force_trailing_comma = Some(SeparatorTactic::Vertical);
                     };
                 }
                 let rewrite = rewrite_array(
-                    macro_name,
+                    &macro_name,
                     arg_vec.iter(),
                     mac.span(),
                     context,

--- a/tests/source/issue_5735.rs
+++ b/tests/source/issue_5735.rs
@@ -1,0 +1,6 @@
+fn find_errors(mut self) {
+	let errors: Vec<> = vec!{
+		#[debug_format = "A({})"]
+		struct A {}
+	};
+}

--- a/tests/target/issue_5735.rs
+++ b/tests/target/issue_5735.rs
@@ -1,0 +1,6 @@
+fn find_errors(mut self) {
+    let errors: Vec = vec![
+        #[debug_format = "A({})"]
+        struct A {}
+    ];
+}


### PR DESCRIPTION
Prevent ICE when formatting braced vec! when...

... it contains only items.

Fixes #5735

Attempting to format invocations of macros which are considered "forced
bracket macros" (currently only `vec!`), but are invoked with braces
instead of brackets, and contain only items in their token trees,
currently trigger an ICE in rustfmt. This is because the function that
handles formatting macro invocations containing only items,
`rewrite_macro_with_items`, assumes that the 'new' delimiter style of
the macro being formatted is the same as the delimiter style in the
source text when attempting to locate the span after the macro's opening
delimiter. This leads to the construction of an invalid span, triggering
the ICE.

The fix here is to pass the old delimiter style to
`rewrite_macro_with_items` as well, so that it can successfully locate
the span.

----

Hi rustfmt'ers! I'm back again with another ICE fix. Some notes for the reviewer:

- With how I've implemented this fix, the original reproducing case
```rust
fn find_errors(mut self) {
	let errors: Vec<> = vec!{
		#[debug_format = "A({})"]
		struct A {}
	};
}
```
will be formatted into
```rust
fn find_errors(mut self) {
    let errors: Vec = vec![
        #[debug_format = "A({})"]
        struct A {}
    ];
}
```
I understand that the team's stance is that braced macro invocations should generally be left unformatted. However, the current *behaviour* of `rustfmt` on braced macro invocations that contain a mix of items and non-items, including `vec!{...}`, is to format them. That is, before this PR, `rustfmt` will turn `vec!{1, struct X {} }` into `vec![1, struct X {}];`.
My PR doesn't change this behaviour. It just extends a similar behaviour to `vec!` invocations that contain only items. So with my PR, whereas formatting `vec!{ struct X {} }` would previously have triggered an ICE, it's now formatted into 
```rust
vec![
    struct X {}
];
```
I'm definitely not convinced that this is the 'right' direction to go in, but the alternative of leaving braced, item-only `vec!` invocations unformatted seemed about equally surprising to me from a user perspective. Any feedback here is appreciated, and I'm happy to tweak the implementation to whatever behaviour the team thinks is best.

- I've also included a small refactoring commit of some redundancy I noticed while working in `macros.rs`. I'm happy to split that off into a separate PR if that's what people prefer.

- Clippy isn't happy that I've added another parameter to `rewrite_macro_with_items`, pushing it over the threshold of 7 parameters. I didn't see a way to cleanly keep it below the threshold while still passing in the original delimiter style, but as usual any suggestions are appreciated.