### PR TITLE
Prevent ICE when formatting item-only `vec!{}`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -296,20 +296,19 @@ fn rewrite_macro_inner(
                 // If we are rewriting `vec!` macro or other special macros,
                 // then we can rewrite this as a usual array literal.
                 // Otherwise, we must preserve the original existence of trailing comma.
-                let macro_name = &macro_name.as_str();
                 let mut force_trailing_comma = if trailing_comma {
                     Some(SeparatorTactic::Always)
                 } else {
                     Some(SeparatorTactic::Never)
                 };
-                if FORCED_BRACKET_MACROS.contains(macro_name) && !is_nested_macro {
+                if is_forced_bracket && !is_nested_macro {
                     context.leave_macro();
                     if context.use_block_indent() {
                         force_trailing_comma = Some(SeparatorTactic::Vertical);
                     };
                 }
                 let rewrite = rewrite_array(
-                    macro_name,
+                    &macro_name,
                     arg_vec.iter(),
                     mac.span(),
                     context,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -255,6 +255,7 @@ fn rewrite_macro_inner(
             &macro_name,
             shape,
             style,
+            original_style,
             position,
             mac.span(),
         );
@@ -1402,15 +1403,19 @@ fn rewrite_macro_with_items(
     macro_name: &str,
     shape: Shape,
     style: Delimiter,
+    original_style: Delimiter,
     position: MacroPosition,
     span: Span,
 ) -> Option<String> {
-    let (opener, closer) = match style {
-        Delimiter::Parenthesis => ("(", ")"),
-        Delimiter::Bracket => ("[", "]"),
-        Delimiter::Brace => (" {", "}"),
-        _ => return None,
+    let style_to_delims = |style| match style {
+        Delimiter::Parenthesis => Some(("(", ")")),
+        Delimiter::Bracket => Some(("[", "]")),
+        Delimiter::Brace => Some((" {", "}")),
+        _ => None,
     };
+
+    let (opener, closer) = style_to_delims(style)?;
+    let (original_opener, _) = style_to_delims(original_style)?;
     let trailing_semicolon = match style {
         Delimiter::Parenthesis | Delimiter::Bracket if position == MacroPosition::Item => ";",
         _ => "",
@@ -1418,7 +1423,13 @@ fn rewrite_macro_with_items(
 
     let mut visitor = FmtVisitor::from_context(context);
     visitor.block_indent = shape.indent.block_indent(context.config);
-    visitor.last_pos = context.snippet_provider.span_after(span, opener.trim());
+
+    // The current opener may be different from the original opener. This can happen
+    // if our macro is a forced bracket macro originally written with non-bracket
+    // delimiters. We need to use the original opener to locate the span after it.
+    visitor.last_pos = context
+        .snippet_provider
+        .span_after(span, original_opener.trim());
     for item in items {
         let item = match item {
             MacroArg::Item(item) => item,

--- a/tests/source/issue_5735.rs
+++ b/tests/source/issue_5735.rs
@@ -1,0 +1,6 @@
+fn find_errors(mut self) {
+	let errors: Vec<> = vec!{
+		#[debug_format = "A({})"]
+		struct A {}
+	};
+}

--- a/tests/target/issue_5735.rs
+++ b/tests/target/issue_5735.rs
@@ -1,0 +1,6 @@
+fn find_errors(mut self) {
+    let errors: Vec = vec![
+        #[debug_format = "A({})"]
+        struct A {}
+    ];
+}


### PR DESCRIPTION
Prevent ICE when formatting item-only `vec!{}`

Fixes #5735

Attempting to format invocations of macros which are considered "forced bracket macros" (currently only `vec!`), but are invoked with braces instead of brackets, and contain only items in their token trees, currently triggers an ICE in rustfmt. This is because the function that handles formatting macro invocations containing only items, `rewrite_macro_with_items`, assumes that the forced delimiter style of the macro being formatted is the same as the delimiter style in the macro's source text when attempting to locate the span after the macro's opening delimiter. This leads to the construction of an invalid span, triggering the ICE.

The fix here is to pass the old delimiter style to `rewrite_macro_with_items` as well, so that it can successfully locate the span.

----

Hi rustfmt'ers! I'm back again with another ICE fix. Some notes for the reviewer:

- With how I've implemented this fix, the original reproducing case
```rust
fn find_errors(mut self) {
	let errors: Vec<> = vec!{
		#[debug_format = "A({})"]
		struct A {}
	};
}
```
will be formatted into
```rust
fn find_errors(mut self) {
    let errors: Vec = vec![
        #[debug_format = "A({})"]
        struct A {}
    ];
}
```
I understand that the team's stance is that braced macro invocations should generally be left unformatted. However, the current behaviour of `rustfmt` on braced `vec!` invocations is to format them. That is, before this PR, `rustfmt` will turn `vec!{1, struct X {} }` into `vec![1, struct X {}];`.
My PR doesn't change this behaviour. It just extends a similar behaviour to `vec!` invocations that contain only items. So with my PR, whereas formatting `vec!{ struct X {} }` would previously have triggered an ICE, it's now formatted into 
```rust
vec![
    struct X {}
];
```
I'm not entirely sure that this is the 'right' direction to go in, but the alternative of leaving braced, item-only `vec!` invocations unformatted seemed about equally surprising to me from a user perspective. Any feedback here is appreciated, and I'm happy to tweak the implementation to whatever behaviour the team thinks is best.

- I've also included a small refactoring commit of some redundancy I noticed while working in `macros.rs`. I'm happy to split that off into a separate PR if that's what people prefer.

- Clippy isn't happy that I've added another parameter to `rewrite_macro_with_items`, pushing it over the threshold of 7 parameters. I didn't see a way to cleanly keep it below the threshold while still passing in the original delimiter style, but as usual any suggestions are appreciated.