### PR TITLE
Format trailing where clauses in type aliases

### DIFF
--- a/tests/source/type-alias-where-clauses-with-comments.rs
+++ b/tests/source/type-alias-where-clauses-with-comments.rs
@@ -1,0 +1,31 @@
+type Foo // comment1
+    // interlinear1
+where // comment2
+    // interlinear2
+A: B, // comment3
+C: D, // comment4
+    // interlinear3
+= E; // comment5
+
+type Foo // comment6
+    // interlinear4
+where// comment7
+    // interlinear5
+A: B, // comment8
+C: D, // comment9
+    // interlinear6
+= E // comment10
+    // interlinear7
+where // comment11
+    // interlinear8
+F: G, // comment12
+H: I; // comment13
+
+type Foo // comment14
+    // interlinear9
+= E // comment15
+    // interlinear10
+where // comment16
+    // interlinear11
+F: G,// comment17
+H: I;// comment18

--- a/tests/source/type-alias-where-clauses.rs
+++ b/tests/source/type-alias-where-clauses.rs
@@ -1,0 +1,20 @@
+    type Foo
+    where
+    A: B,
+    C: D,
+    = E;
+
+    type Foo
+    where
+    A: B,
+    C: D,
+    = E
+    where
+    F: G,
+    H: I;
+
+    type Foo
+    = E
+    where
+    F: G,
+    H: I;

--- a/tests/target/type-alias-where-clauses-with-comments.rs
+++ b/tests/target/type-alias-where-clauses-with-comments.rs
@@ -1,0 +1,39 @@
+type Foo
+// comment1
+// interlinear1
+where
+    // comment2
+    // interlinear2
+    A: B, // comment3
+    C: D, // comment4
+// interlinear3
+= E; // comment5
+
+type Foo
+// comment6
+// interlinear4
+where
+    // comment7
+    // interlinear5
+    A: B, // comment8
+    C: D, // comment9
+// interlinear6
+= E
+// comment10
+// interlinear7
+where
+    // comment11
+    // interlinear8
+    F: G, // comment12
+    H: I; // comment13
+
+type Foo // comment14
+    // interlinear9
+    = E
+// comment15
+// interlinear10
+where
+    // comment16
+    // interlinear11
+    F: G, // comment17
+    H: I; // comment18

--- a/tests/target/type-alias-where-clauses.rs
+++ b/tests/target/type-alias-where-clauses.rs
@@ -1,0 +1,20 @@
+type Foo
+where
+    A: B,
+    C: D,
+= E;
+
+type Foo
+where
+    A: B,
+    C: D,
+= E
+where
+    F: G,
+    H: I;
+
+type Foo
+    = E
+where
+    F: G,
+    H: I;


### PR DESCRIPTION
Self-explanatory. cc rust-lang/rust#114901

This implementation is probably super busted. I have no idea what most of these options in rustfmt mean, lol.