### PR TITLE
Fix #5624

### DIFF
--- a/src/closures.rs
+++ b/src/closures.rs
@@ -199,6 +199,10 @@ fn rewrite_closure_expr(
             | ast::ExprKind::Unary(_, ref expr)
             | ast::ExprKind::Cast(ref expr, _) => allow_multi_line(expr),
 
+            ast::ExprKind::Binary(_, ref expr1, ref expr2) => {
+                allow_multi_line(expr1) && allow_multi_line(expr2)
+            }
+
             _ => false,
         }
     }

--- a/tests/source/issue-5624.rs
+++ b/tests/source/issue-5624.rs
@@ -1,0 +1,13 @@
+fn func<F: Fn(usize) -> usize>(f: F) -> usize {
+    f(0)
+}
+
+fn main() {
+    let _result = func(|x| 
+        match x {
+            _ => 0,
+        } + match 1 {
+            _ => 1,
+        }
+    );
+}

--- a/tests/target/issue-5624.rs
+++ b/tests/target/issue-5624.rs
@@ -1,0 +1,11 @@
+fn func<F: Fn(usize) -> usize>(f: F) -> usize {
+    f(0)
+}
+
+fn main() {
+    let _result = func(|x| match x {
+        _ => 0,
+    } + match 1 {
+        _ => 1,
+    });
+}


### PR DESCRIPTION
Fixes #5624. The output seems to follow the [style guide for closures](https://doc.rust-lang.org/stable/style-guide/expressions.html#closures) without any additional effort.