### PR TITLE
Bugfix/comment duplication

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1453,11 +1453,7 @@ pub(crate) fn rewrite_paren(
     let remove_nested_parens = context.config.remove_nested_parens();
     loop {
         // 1 = "(" or ")"
-        let expr_lo = subexpr
-            .attrs
-            .first()
-            .map_or(subexpr.span().lo(), |attr| attr.span.lo());
-        pre_span = mk_sp(span.lo() + BytePos(1), expr_lo);
+        pre_span = mk_sp(span.lo() + BytePos(1), subexpr.span().lo());
         post_span = mk_sp(subexpr.span.hi(), span.hi() - BytePos(1));
         pre_comment = rewrite_missing_comment(pre_span, shape, context)?;
         post_comment = rewrite_missing_comment(post_span, shape, context)?;

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1453,7 +1453,11 @@ pub(crate) fn rewrite_paren(
     let remove_nested_parens = context.config.remove_nested_parens();
     loop {
         // 1 = "(" or ")"
-        pre_span = mk_sp(span.lo() + BytePos(1), subexpr.span.lo());
+        let expr_lo = subexpr
+            .attrs
+            .first()
+            .map_or(subexpr.span().lo(), |attr| attr.span.lo());
+        pre_span = mk_sp(span.lo() + BytePos(1), expr_lo);
         post_span = mk_sp(subexpr.span.hi(), span.hi() - BytePos(1));
         pre_comment = rewrite_missing_comment(pre_span, shape, context)?;
         post_comment = rewrite_missing_comment(post_span, shape, context)?;

--- a/tests/source/issue-5871.rs
+++ b/tests/source/issue-5871.rs
@@ -1,0 +1,8 @@
+#![feature(stmt_expr_attributes)]
+fn okay() -> u32 {
+    (
+        // Comments in parentheses-expressions caused attributes to be duplicated.
+        #[allow(unused_variables)]
+        0
+    )
+}

--- a/tests/source/issue-5871.rs
+++ b/tests/source/issue-5871.rs
@@ -1,8 +1,0 @@
-#![feature(stmt_expr_attributes)]
-fn okay() -> u32 {
-    (
-        // Comments in parentheses-expressions caused attributes to be duplicated.
-        #[allow(unused_variables)]
-        0
-    )
-}

--- a/tests/target/issue-5871.rs
+++ b/tests/target/issue-5871.rs
@@ -1,0 +1,8 @@
+#![feature(stmt_expr_attributes)]
+fn okay() -> u32 {
+    (
+        // Comments in parentheses-expressions caused attributes to be duplicated.
+        #[allow(unused_variables)]
+        0
+    )
+}


### PR DESCRIPTION
Fixes #5871 

The issue  was in the `rewrite_paren` function.

Since the span on expressions doesn't include attributes and attributes comes before the expression, this caused the attribute to be included in `pre_comment` since the end of the comment span was `subexpr.span.lo()`.
I changed the logic to use the span of the first attribute, if there are any attributes present. If not, default to the expression span.