### PR TITLE
Fixed error caused by combination of match_arm_blocks and control_brace_style

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -451,8 +451,8 @@ fn rewrite_match_body(
             };
 
         let block_sep = match context.config.control_brace_style() {
-            ControlBraceStyle::AlwaysNextLine => format!("{}{}", alt_block_sep, body_prefix),
             _ if body_prefix.is_empty() => "".to_owned(),
+            ControlBraceStyle::AlwaysNextLine => format!("{}{}", alt_block_sep, body_prefix),
             _ if forbid_same_line || !arrow_comment.is_empty() => {
                 format!("{}{}", alt_block_sep, body_prefix)
             }

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -186,7 +186,7 @@ fn dont_emit_ICE() {
 }
 
 #[test]
-fn rustfmt_emits_error_when_control_bace_style_is_always_next_line() {
+fn rustfmt_emits_error_when_control_brace_style_is_always_next_line() {
     // See also https://github.com/rust-lang/rustfmt/issues/5912
     let args = [
         "--config=color=Never",

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -184,3 +184,19 @@ fn dont_emit_ICE() {
         assert!(!stderr.contains("thread 'main' panicked"));
     }
 }
+
+#[test]
+fn rustfmt_emits_error_when_control_bace_style_is_always_next_line() {
+    // See also https://github.com/rust-lang/rustfmt/issues/5912
+    let args = [
+        "--config=color=Never",
+        "--config",
+        "control_brace_style=AlwaysNextLine",
+        "--config",
+        "match_arm_blocks=false",
+        "tests/target/issue_5912.rs",
+    ];
+
+    let (_stdout, stderr) = rustfmt(&args);
+    assert!(!stderr.contains("error[internal]: left behind trailing whitespace"))
+}

--- a/tests/source/issue_5912.rs
+++ b/tests/source/issue_5912.rs
@@ -1,0 +1,15 @@
+// rustfmt-match_arm_blocks: false
+// rustfmt-control_brace_style: AlwaysNextLine
+
+fn foo() {
+    match 0 {
+        0 => {
+            aaaaaaaaaaaaaaaaaaaaaaaa
+                + bbbbbbbbbbbbbbbbbbbbbbbbb
+                + bbbbbbbbbbbbbbbbbbbbbbbbb
+                + bbbbbbbbbbbbbbbbbbbbbbbbb
+                + bbbbbbbbbbbbbbbbbbbbbbbbb
+        }
+        _ => 2,
+    }
+}

--- a/tests/target/issue_5912.rs
+++ b/tests/target/issue_5912.rs
@@ -1,0 +1,15 @@
+// rustfmt-match_arm_blocks: false
+// rustfmt-control_brace_style: AlwaysNextLine
+
+fn foo() {
+    match 0
+    {
+        0 =>
+            aaaaaaaaaaaaaaaaaaaaaaaa
+                + bbbbbbbbbbbbbbbbbbbbbbbbb
+                + bbbbbbbbbbbbbbbbbbbbbbbbb
+                + bbbbbbbbbbbbbbbbbbbbbbbbb
+                + bbbbbbbbbbbbbbbbbbbbbbbbb,
+        _ => 2,
+    }
+}


### PR DESCRIPTION
Fixes #5912 

When `control_brace_style = "AlwaysNextLine"`, the code seems to always assume that `body_prefix` is `{`. This is however not the case when `match_arm_blocks = false`. This causes [`block_sep`](https://github.com/rust-lang/rustfmt/blob/a1fabbf3865c1044c7e96e8ac337131ebdf411b6/src/matches.rs#L453C1-L460C32) to introduce extra white space that causes the error.

The fix was to check if `body_prefix` is empty before matching on `ControlBraceStyle::AlwaysNextLine`. If you prefer however, I can add a match guard instead of changing the ordering of the match arms.