### PR TITLE
Rename `IntoOverflowableItem` to satisfy clippy

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -21,7 +21,7 @@ use crate::lists::{
 };
 use crate::macros::{MacroPosition, rewrite_macro};
 use crate::matches::rewrite_match;
-use crate::overflow::{self, IntoOverflowableItem, OverflowableItem};
+use crate::overflow::{self, OverflowableItem, ToOverflowableItem};
 use crate::pairs::{PairParts, rewrite_all_pairs, rewrite_pair};
 use crate::rewrite::{Rewrite, RewriteContext, RewriteError, RewriteErrorExt, RewriteResult};
 use crate::shape::{Indent, Shape};
@@ -499,7 +499,7 @@ pub(crate) fn format_expr(
         })
 }
 
-pub(crate) fn rewrite_array<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_array<'a, T: 'a + ToOverflowableItem<'a>>(
     name: &'a str,
     exprs: impl Iterator<Item = &'a T>,
     span: Span,
@@ -1973,7 +1973,7 @@ pub(crate) fn rewrite_field(
     }
 }
 
-fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + IntoOverflowableItem<'a>>(
+fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + ToOverflowableItem<'a>>(
     context: &RewriteContext<'_>,
     mut items: impl Iterator<Item = &'a T>,
     span: Span,
@@ -2059,7 +2059,7 @@ fn rewrite_let(
     )
 }
 
-pub(crate) fn rewrite_tuple<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_tuple<'a, T: 'a + ToOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     items: impl Iterator<Item = &'a T>,
     span: Span,

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -117,7 +117,7 @@ impl<'a> OverflowableItem<'a> {
 
     pub(crate) fn map<F, T>(&self, f: F) -> T
     where
-        F: Fn(&dyn IntoOverflowableItem<'a>) -> T,
+        F: Fn(&dyn ToOverflowableItem<'a>) -> T,
     {
         match self {
             OverflowableItem::Expr(expr) => f(*expr),
@@ -215,21 +215,21 @@ impl<'a> OverflowableItem<'a> {
     }
 }
 
-pub(crate) trait IntoOverflowableItem<'a>: Rewrite + Spanned {
-    fn into_overflowable_item(&'a self) -> OverflowableItem<'a>;
+pub(crate) trait ToOverflowableItem<'a>: Rewrite + Spanned {
+    fn to_overflowable_item(&'a self) -> OverflowableItem<'a>;
 }
 
-impl<'a, T: 'a + IntoOverflowableItem<'a>> IntoOverflowableItem<'a> for Box<T> {
-    fn into_overflowable_item(&'a self) -> OverflowableItem<'a> {
-        (**self).into_overflowable_item()
+impl<'a, T: 'a + ToOverflowableItem<'a>> ToOverflowableItem<'a> for Box<T> {
+    fn to_overflowable_item(&'a self) -> OverflowableItem<'a> {
+        (**self).to_overflowable_item()
     }
 }
 
-macro_rules! impl_into_overflowable_item_for_ast_node {
+macro_rules! impl_to_overflowable_item_for_ast_node {
     ($($ast_node:ident),*) => {
         $(
-            impl<'a> IntoOverflowableItem<'a> for ast::$ast_node {
-                fn into_overflowable_item(&'a self) -> OverflowableItem<'a> {
+            impl<'a> ToOverflowableItem<'a> for ast::$ast_node {
+                fn to_overflowable_item(&'a self) -> OverflowableItem<'a> {
                     OverflowableItem::$ast_node(self)
                 }
             }
@@ -237,18 +237,18 @@ macro_rules! impl_into_overflowable_item_for_ast_node {
     }
 }
 
-macro_rules! impl_into_overflowable_item_for_rustfmt_types {
+macro_rules! impl_to_overflowable_item_for_rustfmt_types {
     ([$($ty:ident),*], [$($ty_with_lifetime:ident),*]) => {
         $(
-            impl<'a> IntoOverflowableItem<'a> for $ty {
-                fn into_overflowable_item(&'a self) -> OverflowableItem<'a> {
+            impl<'a> ToOverflowableItem<'a> for $ty {
+                fn to_overflowable_item(&'a self) -> OverflowableItem<'a> {
                     OverflowableItem::$ty(self)
                 }
             }
         )*
         $(
-            impl<'a> IntoOverflowableItem<'a> for $ty_with_lifetime<'a> {
-                fn into_overflowable_item(&'a self) -> OverflowableItem<'a> {
+            impl<'a> ToOverflowableItem<'a> for $ty_with_lifetime<'a> {
+                fn to_overflowable_item(&'a self) -> OverflowableItem<'a> {
                     OverflowableItem::$ty_with_lifetime(self)
                 }
             }
@@ -256,7 +256,7 @@ macro_rules! impl_into_overflowable_item_for_rustfmt_types {
     }
 }
 
-impl_into_overflowable_item_for_ast_node!(
+impl_to_overflowable_item_for_ast_node!(
     Expr,
     GenericParam,
     MetaItemInner,
@@ -265,18 +265,18 @@ impl_into_overflowable_item_for_ast_node!(
     Pat,
     PreciseCapturingArg
 );
-impl_into_overflowable_item_for_rustfmt_types!([MacroArg], [SegmentParam, TuplePatField]);
+impl_to_overflowable_item_for_rustfmt_types!([MacroArg], [SegmentParam, TuplePatField]);
 
 pub(crate) fn into_overflowable_list<'a, T>(
     iter: impl Iterator<Item = &'a T>,
 ) -> impl Iterator<Item = OverflowableItem<'a>>
 where
-    T: 'a + IntoOverflowableItem<'a>,
+    T: 'a + ToOverflowableItem<'a>,
 {
-    iter.map(|x| IntoOverflowableItem::into_overflowable_item(x))
+    iter.map(|x| ToOverflowableItem::to_overflowable_item(x))
 }
 
-pub(crate) fn rewrite_with_parens<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_with_parens<'a, T: 'a + ToOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     ident: &'a str,
     items: impl Iterator<Item = &'a T>,
@@ -300,7 +300,7 @@ pub(crate) fn rewrite_with_parens<'a, T: 'a + IntoOverflowableItem<'a>>(
     .rewrite(shape)
 }
 
-pub(crate) fn rewrite_with_angle_brackets<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_with_angle_brackets<'a, T: 'a + ToOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     ident: &'a str,
     items: impl Iterator<Item = &'a T>,
@@ -322,7 +322,7 @@ pub(crate) fn rewrite_with_angle_brackets<'a, T: 'a + IntoOverflowableItem<'a>>(
     .rewrite(shape)
 }
 
-pub(crate) fn rewrite_with_square_brackets<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_with_square_brackets<'a, T: 'a + ToOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     name: &'a str,
     items: impl Iterator<Item = &'a T>,
@@ -367,7 +367,7 @@ struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
-    fn new<T: 'a + IntoOverflowableItem<'a>>(
+    fn new<T: 'a + ToOverflowableItem<'a>>(
         context: &'a RewriteContext<'_>,
         items: impl Iterator<Item = &'a T>,
         ident: &'a str,


### PR DESCRIPTION
#5400 isn't making progress, so here's one of the commits split out.

`into_…` is supposed to be used by functions that consume `self`, however `into_overflowable_item` borrows `self`.