### PR TITLE
adjust span derivation for const generics

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -3244,7 +3244,7 @@ fn format_generics(
                     if brace_pos == BracePos::None {
                         span.hi()
                     } else {
-                        context.snippet_provider.span_before(span, "{")
+                        context.snippet_provider.span_before_last(span, "{")
                     },
                 ),
                 shape,

--- a/tests/source/issue-5935.rs
+++ b/tests/source/issue-5935.rs
@@ -1,0 +1,9 @@
+struct Regs<
+    const BEGIN: u64,
+    const END: u64,
+    const DIM: usize,
+    const N: usize = { (END - BEGIN) as usize / (8 * DIM) + 1 },
+>
+{
+    _foo: u64,
+}

--- a/tests/target/issue-5935.rs
+++ b/tests/target/issue-5935.rs
@@ -1,0 +1,8 @@
+struct Regs<
+    const BEGIN: u64,
+    const END: u64,
+    const DIM: usize,
+    const N: usize = { (END - BEGIN) as usize / (8 * DIM) + 1 },
+> {
+    _foo: u64,
+}


### PR DESCRIPTION
Fixes #5935

r? @ytmimi if you have time, otherwise I may just pull this in for the release later given the trivial nature of the change