### PR TITLE
init: macOS apple silicon runner

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -8,29 +8,28 @@ on:
 jobs:
   test:
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
-    # macOS Catalina 10.15
-    runs-on: macos-latest
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners
+    # macOS Ventura 13 Apple Silicon
+    runs-on: macos-latest-xlarge
     name: (${{ matrix.target }}, ${{ matrix.cfg_release_channel }})
     env:
       CFG_RELEASE_CHANNEL: ${{ matrix.cfg_release_channel }}
     strategy:
       fail-fast: false
       matrix:
-        target: [
-          x86_64-apple-darwin,
-        ]
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
         cfg_release_channel: [nightly, stable]
 
     steps:
-    - name: checkout
-      uses: actions/checkout@v3
+      - name: checkout
+        uses: actions/checkout@v3
 
-      # Run build
-    - name: install rustup
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
-        sh rustup-init.sh -y --default-toolchain none
-        rustup target add ${{ matrix.target }}
+        # Run build
+      - name: install rustup
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
+          sh rustup-init.sh -y --default-toolchain none
+          rustup target add ${{ matrix.target }}
 
-    - name: Build and Test
-      run: ./ci/build_and_test.sh
+      - name: Build and Test
+        run: ./ci/build_and_test.sh


### PR DESCRIPTION
I started the first steps to have aarch64-apple-darwin builds possible for rustfmt so that that people who use the aarch64-apple-darwin target can use the latest rustfmt builds.