### PR TITLE
#3390: hide_parse_errors to show_parse_errors

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1248,11 +1248,19 @@ Control the case of the letters in hexadecimal literal values
 
 ## `hide_parse_errors`
 
-Do not show parse errors if the parser failed to parse files.
+This option is deprecated and has been renamed to `show_parse_errors` to avoid confusion around the double negative default of `hide_parse_errors=false`.
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
 - **Stable**: No (tracking issue: [#3390](https://github.com/rust-lang/rustfmt/issues/3390))
+
+## `show_parse_errors`
+
+Show parse errors if the parser failed to parse files.
+
+- **Default value**: `true`
+- **Possible values**: `true`, `false`
+- **Stable**: No (tracking issue: [#5977](https://github.com/rust-lang/rustfmt/issues/5977))
 
 ## `ignore`
 

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -129,6 +129,7 @@ macro_rules! create_config {
                     | "chain_width" => self.0.set_heuristics(),
                     "merge_imports" => self.0.set_merge_imports(),
                     "fn_args_layout" => self.0.set_fn_args_layout(),
+                    "hide_parse_errors" => self.0.set_hide_parse_errors(),
                     &_ => (),
                 }
             }
@@ -184,6 +185,7 @@ macro_rules! create_config {
                 self.set_ignore(dir);
                 self.set_merge_imports();
                 self.set_fn_args_layout();
+                self.set_hide_parse_errors();
                 self
             }
 
@@ -278,19 +280,21 @@ macro_rules! create_config {
                     | "chain_width" => self.set_heuristics(),
                     "merge_imports" => self.set_merge_imports(),
                     "fn_args_layout" => self.set_fn_args_layout(),
+                    "hide_parse_errors" => self.set_hide_parse_errors(),
                     &_ => (),
                 }
             }
 
             #[allow(unreachable_pub)]
             pub fn is_hidden_option(name: &str) -> bool {
-                const HIDE_OPTIONS: [&str; 6] = [
+                const HIDE_OPTIONS: [&str; 7] = [
                     "verbose",
                     "verbose_diff",
                     "file_lines",
                     "width_heuristics",
                     "merge_imports",
-                    "fn_args_layout"
+                    "fn_args_layout",
+                    "hide_parse_errors"
                 ];
                 HIDE_OPTIONS.contains(&name)
             }
@@ -457,6 +461,18 @@ macro_rules! create_config {
                     );
                     if !self.was_set().fn_params_layout() {
                         self.fn_params_layout.2 = self.fn_args_layout();
+                    }
+                }
+            }
+
+            fn set_hide_parse_errors(&mut self) {
+                if self.was_set().hide_parse_errors() {
+                    eprintln!(
+                        "Warning: the `hide_parse_errors` option is deprecated. \
+                        Use `show_parse_errors` instead"
+                    );
+                    if !self.was_set().show_parse_errors() {
+                        self.show_parse_errors.2 = self.hide_parse_errors();
                     }
                 }
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -169,7 +169,8 @@ create_config! {
             "Enables unstable features. Only available on nightly channel";
     disable_all_formatting: bool, false, true, "Don't reformat anything";
     skip_children: bool, false, false, "Don't reformat out of line modules";
-    hide_parse_errors: bool, false, false, "Hide errors from the parser";
+    hide_parse_errors: bool, false, false, "(deprecated: use show_parse_errors instead)";
+    show_parse_errors: bool, true, false, "Show errors from the parser (unstable)";
     error_on_line_overflow: bool, false, false, "Error if unable to get all lines within max_width";
     error_on_unformatted: bool, false, false,
         "Error if unable to get comments or string literals within max_width, \
@@ -204,6 +205,7 @@ impl PartialConfig {
         cloned.print_misformatted_file_names = None;
         cloned.merge_imports = None;
         cloned.fn_args_layout = None;
+        cloned.hide_parse_errors = None;
 
         ::toml::to_string(&cloned).map_err(ToTomlError)
     }
@@ -456,6 +458,13 @@ mod test {
             fn_params_layout: Density, Density::Tall, true,
                 "Control the layout of parameters in a function signatures.";
 
+            // hide_parse_errors renamed to show_parse_errors
+            hide_parse_errors: bool, false, false,
+                "(deprecated: use show_parse_errors instead)";
+            show_parse_errors: bool, true, false,
+                "Show errors from the parser (unstable)";
+
+
             // Width Heuristics
             use_small_heuristics: Heuristics, Heuristics::Default, true,
                 "Whether to use different formatting for items and \
@@ -681,7 +690,7 @@ required_version = "{}"
 unstable_features = false
 disable_all_formatting = false
 skip_children = false
-hide_parse_errors = false
+show_parse_errors = true
 error_on_line_overflow = false
 error_on_unformatted = false
 ignore = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ fn format_snippet(snippet: &str, config: &Config, is_macro_def: bool) -> Option<
         let mut out: Vec<u8> = Vec::with_capacity(snippet.len() * 2);
         config.set().emit_mode(config::EmitMode::Stdout);
         config.set().verbose(Verbosity::Quiet);
-        config.set().hide_parse_errors(true);
+        config.set().show_parse_errors(false);
         if is_macro_def {
             config.set().error_on_unformatted(true);
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1269,7 +1269,7 @@ impl MacroBranch {
         let has_block_body = old_body.starts_with('{');
 
         let mut config = context.config.clone();
-        config.set().hide_parse_errors(true);
+        config.set().show_parse_errors(false);
 
         result += " {";
 

--- a/src/parse/session.rs
+++ b/src/parse/session.rs
@@ -122,7 +122,7 @@ fn default_handler(
     source_map: Lrc<SourceMap>,
     ignore_path_set: Lrc<IgnorePathSet>,
     can_reset: Lrc<AtomicBool>,
-    hide_parse_errors: bool,
+    show_parse_errors: bool,
     color: Color,
 ) -> Handler {
     let supports_color = term::stderr().map_or(false, |term| term.supports_color());
@@ -132,7 +132,7 @@ fn default_handler(
         ColorConfig::Never
     };
 
-    let emitter = if hide_parse_errors {
+    let emitter = if !show_parse_errors {
         silent_emitter()
     } else {
         let fallback_bundle = rustc_errors::fallback_fluent_bundle(
@@ -163,7 +163,7 @@ impl ParseSess {
             Lrc::clone(&source_map),
             Lrc::clone(&ignore_path_set),
             Lrc::clone(&can_reset_errors),
-            config.hide_parse_errors(),
+            config.show_parse_errors(),
             config.color(),
         );
         let parse_sess = RawParseSess::with_span_handler(handler, source_map);


### PR DESCRIPTION
Fix of [3390 issue](https://github.com/rust-lang/rustfmt/issues/3390), changed `hide_parse_errors` to `show_parse_errors`