### PR TITLE
Clarify `format_macro_bodies` description

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1098,7 +1098,7 @@ See also [`format_macro_bodies`](#format_macro_bodies).
 
 ## `format_macro_bodies`
 
-Format the bodies of macros.
+Format the bodies of declarative macro definitions.
 
 - **Default value**: `true`
 - **Possible values**: `true`, `false`

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -74,7 +74,7 @@ create_config! {
     format_strings: bool, false, false, "Format string literals where necessary";
     format_macro_matchers: bool, false, false,
         "Format the metavariable matching patterns in macros";
-    format_macro_bodies: bool, true, false, "Format the bodies of macros";
+    format_macro_bodies: bool, true, false, "Format the bodies of declarative macro definitions";
     skip_macro_invocations: MacroSelectors, MacroSelectors::default(), false,
         "Skip formatting the bodies of macros invoked with the following names.";
     hex_literal_case: HexLiteralCase, HexLiteralCase::Preserve, false,


### PR DESCRIPTION
The `format_macro_bodies` option was added prior to the addition of procedural macros, and the existing description can be a little unclear in describing what this option actually does.