### PR TITLE
Extend `inline_attribute_width` to more AST types

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -416,7 +416,23 @@ pub(crate) fn format_expr(
                 attrs.last().map_or(expr.span.lo(), |attr| attr.span.hi()),
                 expr.span.lo(),
             );
-            combine_strs_with_missing_comments(context, &attrs_str, &expr_str, span, shape, false)
+
+            let allow_extend = if attrs.len() == 1 {
+                let line_len = attrs_str.len() + 1 + expr_str.len();
+                !attrs.first().unwrap().is_doc_comment()
+                    && context.config.inline_attribute_width() >= line_len
+            } else {
+                false
+            };
+
+            combine_strs_with_missing_comments(
+                context,
+                &attrs_str,
+                &expr_str,
+                span,
+                shape,
+                allow_extend,
+            )
         })
 }
 

--- a/tests/source/issue-3343.rs
+++ b/tests/source/issue-3343.rs
@@ -15,6 +15,31 @@ extern crate len_is_50_;
 #[cfg(feature = "alloc")]
 extern crate len_is_51__;
 
+// https://github.com/rust-lang/rustfmt/issues/3343#issuecomment-589945611
+extern "C" {
+    #[no_mangle]
+    fn foo();
+}
+
+fn main() {
+    #[cfg(feature = "alloc")]
+    foo();
+    #[cfg(feature = "alloc")]
+    {
+        foo();
+    }
+    {
+        #[cfg(feature = "alloc")]
+        foo();
+    }
+}
+
+// https://github.com/rust-lang/rustfmt/pull/5538#issuecomment-1272367684
+struct EventConfigWidget {
+    #[widget]
+    menu_delay: Spinner<u32>,
+}
+
 /// this is a comment to test is_sugared_doc property
 use core::convert;
 

--- a/tests/target/issue-3343.rs
+++ b/tests/target/issue-3343.rs
@@ -12,6 +12,26 @@ use total_len_is::_51___;
 #[cfg(feature = "alloc")]
 extern crate len_is_51__;
 
+// https://github.com/rust-lang/rustfmt/issues/3343#issuecomment-589945611
+extern "C" {
+    #[no_mangle] fn foo();
+}
+
+fn main() {
+    #[cfg(feature = "alloc")] foo();
+    #[cfg(feature = "alloc")] {
+        foo();
+    }
+    {
+        #[cfg(feature = "alloc")] foo();
+    }
+}
+
+// https://github.com/rust-lang/rustfmt/pull/5538#issuecomment-1272367684
+struct EventConfigWidget {
+    #[widget] menu_delay: Spinner<u32>,
+}
+
 /// this is a comment to test is_sugared_doc property
 use core::convert;
 


### PR DESCRIPTION
Specifically: expressions, struct fields, and foreign ("extern") items.

Closes #3343

See also https://github.com/rust-lang/rustfmt/pull/5538#issuecomment-1272367684