### PR TITLE
Format diff line to be easily clickable

### DIFF
--- a/src/emitter/diff.rs
+++ b/src/emitter/diff.rs
@@ -32,7 +32,7 @@ impl Emitter for DiffEmitter {
             } else {
                 print_diff(
                     mismatch,
-                    |line_num| format!("Diff in {} at line {}:", filename, line_num),
+                    |line_num| format!("Diff in {}:{}:", filename, line_num),
                     &self.config,
                 );
             }


### PR DESCRIPTION
Instead of {filename} at {line}, use {filename}:{line} as this is a
format that many editors allow to be clicked to navigate directly to the
line.

---

This is a small papercut issue. I like being able to Cmd+Click a filename and navigate directly to the problematic code when I'm running `rustfmt check`.