### PR TITLE
Add `let_chain_style` configuration option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1128,6 +1128,72 @@ macro_rules! foo {
 
 See also [`format_macro_matchers`](#format_macro_matchers).
 
+## `let_chain_style`
+
+Controls how rustfmt treats let-chains
+
+- **Default value**: `LegibleBindings`
+- **Possible values**: `LegibleBindings`, `Tall`
+- **Stability**: No (tracking issue: N/A)
+
+#### `LegibleBindings` (default):
+
+let-chain items are formatted on their own line to disambiguate the new bindings.
+The let-chain may be arranged horizontally when the chain:
+1. Only contains two items
+2. The first item is an identifier
+3. The second item is a let expressions.
+
+```rust
+fn main() {
+    if let Some(x) = y
+        && a
+    {}
+
+    if let Some(x) = y
+        && let Some(a) = b
+    {}
+
+    if let Ok(name) = str::from_utf8(name)
+        && is_dyn_sym(name)
+    {}
+
+    if condition()
+        && let Some(binding) = expr
+        && condition2(binding)
+        && condition3()
+        && let Some(binding2) = expr2
+        && condition4(binding, binding2)
+    {
+        body();
+    }
+}
+```
+
+#### `Tall`:
+
+let-chain items are placed horizontally when there is sufficient space, otherwise the chain is formatted vertically.
+
+```rust
+fn main() {
+    if let Some(x) = y && a {}
+
+    if let Some(x) = y && let Some(a) = b {}
+
+    if let Ok(name) = str::from_utf8(name) && is_dyn_sym(name) {}
+
+    if condition()
+        && let Some(binding) = expr
+        && condition2(binding)
+        && condition3()
+        && let Some(binding2) = expr2
+        && condition4(binding, binding2)
+    {
+        body();
+    }
+}
+```
+
 ## `skip_macro_invocations`
 
 Skip formatting the bodies of macro invocations with the following names.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -151,6 +151,8 @@ create_config! {
         "Write an item and its attribute on the same line \
         if their combined width is below a threshold";
     format_generated_files: bool, true, false, "Format generated files";
+    let_chain_style: LetChainStyle, LetChainStyle::LegibleBindings, false, "Controls how rustfmt \
+        lays out let-chains";
 
     // Options that can change the source code beyond whitespace/blocks (somewhat linty things)
     merge_derives: bool, true, true, "Merge multiple `#[derive(...)]` into a single one";
@@ -680,6 +682,7 @@ edition = "2015"
 version = "One"
 inline_attribute_width = 0
 format_generated_files = true
+let_chain_style = "LegibleBindings"
 merge_derives = true
 use_try_shorthand = false
 use_field_init_shorthand = false

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -494,3 +494,17 @@ pub enum StyleEdition {
     /// [Edition 2024]().
     Edition2024,
 }
+
+/// Controls how rustfmt treats let-chains
+#[config_type]
+pub enum LetChainStyle {
+    /// let-chain items are formatted on their own line to disambiguate the new bindings.
+    /// The let-chain may be arranged horizontally when the chain:
+    /// 1. Only contains two items
+    /// 2. The first item is an identifier
+    /// 3. The second item is a let expressions.
+    LegibleBindings,
+    /// let-chain items are placed horizontally when there is sufficient space, otherwise the chain
+    /// is formatted vertically.
+    Tall,
+}

--- a/tests/source/configs/let_chain_style/legible_bindings.rs
+++ b/tests/source/configs/let_chain_style/legible_bindings.rs
@@ -1,3 +1,5 @@
+// rustfmt-let_chain_style: LegibleBindings
+
 fn main() {
     if let x = x && x {}
 

--- a/tests/source/configs/let_chain_style/tall.rs
+++ b/tests/source/configs/let_chain_style/tall.rs
@@ -1,0 +1,123 @@
+// rustfmt-let_chain_style: Tall
+
+fn main() {
+    if let x = x && x {}
+
+    if xxx && let x = x {}
+
+    if aaaaaaaaaaaaaaaaaaaaa &&  aaaaaaaaaaaaaaa && aaaaaaaaa && let Some(x) = xxxxxxxxxxxx && aaaaaaa && let None = aaaaaaaaaa {}
+
+    if aaaaaaaaaaaaaaaaaaaaa &&  aaaaaaaaaaaaaaa && aaaaaaaaa && let Some(x) = xxxxxxxxxxxx && aaaaaaa && let None = aaaaaaaaaa {}
+
+    if let Some(Struct { x:TS(1,2) }) = path::to::<_>(hehe)
+        && let [Simple, people] = /* get ready */ create_universe(/* hi */  GreatPowers).initialize_badminton().populate_swamps() &&
+        let    everybody    =    (Loops { hi /*hi*/  , ..loopy() }) && summons::triumphantly() { todo!() }
+
+    if let XXXXXXXXX { xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyy, zzzzzzzzzzzzz} = xxxxxxx()
+    && let Foo = bar() { todo!() }
+}
+
+fn test_single_line_let_chain() {
+    // first item in let-chain is an ident
+    if a && let Some(b) = foo() {
+    }
+
+    // first item in let-chain is a unary ! with an ident
+    let unary_not = if !from_hir_call
+        && let Some(p) = parent
+    {
+    };
+
+    // first item in let-chain is a unary * with an ident
+    let unary_deref = if *some_deref
+        && let Some(p) = parent
+    {
+    };
+
+    // first item in let-chain is a unary - (neg) with an ident
+    let unary_neg = if -some_ident
+        && let Some(p) = parent
+    {
+    };
+
+    // first item in let-chain is a try (?) with an ident
+    let try_ = if some_try?
+        && let Some(p) = parent
+    {
+    };
+
+    // first item in let-chain is an ident wrapped in parens
+    let in_parens = if (some_ident)
+        && let Some(p) = parent
+    {
+    };
+
+    // first item in let-chain is a ref & with an ident
+    let _ref = if &some_ref
+        && let Some(p) = parent
+    {
+    };
+
+    // first item in let-chain is a ref &mut with an ident
+    let mut_ref = if &mut some_ref
+        && let Some(p) = parent
+    {
+    };
+
+    // chain unary ref and try
+    let chain_of_unary_ref_and_try = if !&*some_ref?
+        && let Some(p) = parent {
+    };
+}
+
+fn test_multi_line_let_chain() {
+    // Can only single line the let-chain if the first item is an ident
+    if let Some(x) = y && a {
+
+    }
+
+    // More than one let-chain must be formatted on multiple lines
+    if let Some(x) = y && let Some(a) = b {
+
+    }
+
+    // The ident isn't long enough so we don't wrap the first let-chain
+    if a && let Some(x) = y && let Some(a) = b {
+
+    }
+
+    // The ident is long enough so both let-chains are wrapped
+    if aaa && let Some(x) = y && let Some(a) = b {
+
+    }
+
+    // function call
+    if a() && let Some(x) = y {
+
+    }
+
+    // bool literal
+    if true && let Some(x) = y {
+
+    }
+
+    // cast to a bool
+    if 1 as bool && let Some(x) = y {
+
+    }
+
+    // matches! macro call
+    if matches!(a, some_type) && let Some(x) = y {
+
+    }
+
+    // block expression returning bool
+    if { true } && let Some(x) = y {
+
+    }
+
+    // field access
+    if a.x && let Some(x) = y {
+
+    }
+}

--- a/tests/target/configs/let_chain_style/legible_bindings.rs
+++ b/tests/target/configs/let_chain_style/legible_bindings.rs
@@ -1,3 +1,5 @@
+// rustfmt-let_chain_style: LegibleBindings
+
 fn main() {
     if let x = x
         && x

--- a/tests/target/configs/let_chain_style/tall.rs
+++ b/tests/target/configs/let_chain_style/tall.rs
@@ -1,0 +1,108 @@
+// rustfmt-let_chain_style: Tall
+
+fn main() {
+    if let x = x && x {}
+
+    if xxx && let x = x {}
+
+    if aaaaaaaaaaaaaaaaaaaaa
+        && aaaaaaaaaaaaaaa
+        && aaaaaaaaa
+        && let Some(x) = xxxxxxxxxxxx
+        && aaaaaaa
+        && let None = aaaaaaaaaa
+    {}
+
+    if aaaaaaaaaaaaaaaaaaaaa
+        && aaaaaaaaaaaaaaa
+        && aaaaaaaaa
+        && let Some(x) = xxxxxxxxxxxx
+        && aaaaaaa
+        && let None = aaaaaaaaaa
+    {}
+
+    if let Some(Struct { x: TS(1, 2) }) = path::to::<_>(hehe)
+        && let [Simple, people] = /* get ready */
+            create_universe(/* hi */ GreatPowers)
+                .initialize_badminton()
+                .populate_swamps()
+        && let everybody = (Loops {
+            hi, /*hi*/
+            ..loopy()
+        })
+        && summons::triumphantly()
+    {
+        todo!()
+    }
+
+    if let XXXXXXXXX {
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+        yyyyyyyyyyyyy,
+        zzzzzzzzzzzzz,
+    } = xxxxxxx()
+        && let Foo = bar()
+    {
+        todo!()
+    }
+}
+
+fn test_single_line_let_chain() {
+    // first item in let-chain is an ident
+    if a && let Some(b) = foo() {}
+
+    // first item in let-chain is a unary ! with an ident
+    let unary_not = if !from_hir_call && let Some(p) = parent {};
+
+    // first item in let-chain is a unary * with an ident
+    let unary_deref = if *some_deref && let Some(p) = parent {};
+
+    // first item in let-chain is a unary - (neg) with an ident
+    let unary_neg = if -some_ident && let Some(p) = parent {};
+
+    // first item in let-chain is a try (?) with an ident
+    let try_ = if some_try? && let Some(p) = parent {};
+
+    // first item in let-chain is an ident wrapped in parens
+    let in_parens = if (some_ident) && let Some(p) = parent {};
+
+    // first item in let-chain is a ref & with an ident
+    let _ref = if &some_ref && let Some(p) = parent {};
+
+    // first item in let-chain is a ref &mut with an ident
+    let mut_ref = if &mut some_ref && let Some(p) = parent {};
+
+    // chain unary ref and try
+    let chain_of_unary_ref_and_try = if !&*some_ref? && let Some(p) = parent {};
+}
+
+fn test_multi_line_let_chain() {
+    // Can only single line the let-chain if the first item is an ident
+    if let Some(x) = y && a {}
+
+    // More than one let-chain must be formatted on multiple lines
+    if let Some(x) = y && let Some(a) = b {}
+
+    // The ident isn't long enough so we don't wrap the first let-chain
+    if a && let Some(x) = y && let Some(a) = b {}
+
+    // The ident is long enough so both let-chains are wrapped
+    if aaa && let Some(x) = y && let Some(a) = b {}
+
+    // function call
+    if a() && let Some(x) = y {}
+
+    // bool literal
+    if true && let Some(x) = y {}
+
+    // cast to a bool
+    if 1 as bool && let Some(x) = y {}
+
+    // matches! macro call
+    if matches!(a, some_type) && let Some(x) = y {}
+
+    // block expression returning bool
+    if { true } && let Some(x) = y {}
+
+    // field access
+    if a.x && let Some(x) = y {}
+}


### PR DESCRIPTION
This is a follow up to #5910, which added support for `let-chains`.

Now users have some control over how `let-chains` are formatted. The default value of `LegibleBindings` follows the style guide prescription defined in [r-l/rust#110568](https://github.com/rust-lang/rust/pull/110568). The `Tall` variant provides users an option to format all chain items on a single line if they fit.

Happy to bike shed on the variant names, but I wanted to get the ball rolling on the new configuration.

r? @calebcartwright