### PR TITLE
Don't remove const generic when using `#[feature(generic_const_items)]`

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1924,6 +1924,7 @@ pub(crate) struct StaticParts<'a> {
     prefix: &'a str,
     vis: &'a ast::Visibility,
     ident: symbol::Ident,
+    generics: Option<&'a ast::Generics>,
     ty: &'a ast::Ty,
     mutability: ast::Mutability,
     expr_opt: Option<&'a ptr::P<ast::Expr>>,
@@ -1933,14 +1934,15 @@ pub(crate) struct StaticParts<'a> {
 
 impl<'a> StaticParts<'a> {
     pub(crate) fn from_item(item: &'a ast::Item) -> Self {
-        let (defaultness, prefix, ty, mutability, expr) = match &item.kind {
-            ast::ItemKind::Static(s) => (None, "static", &s.ty, s.mutability, &s.expr),
+        let (defaultness, prefix, ty, mutability, expr, generics) = match &item.kind {
+            ast::ItemKind::Static(s) => (None, "static", &s.ty, s.mutability, &s.expr, None),
             ast::ItemKind::Const(c) => (
                 Some(c.defaultness),
                 "const",
                 &c.ty,
                 ast::Mutability::Not,
                 &c.expr,
+                Some(&c.generics),
             ),
             _ => unreachable!(),
         };
@@ -1948,6 +1950,7 @@ impl<'a> StaticParts<'a> {
             prefix,
             vis: &item.vis,
             ident: item.ident,
+            generics,
             ty,
             mutability,
             expr_opt: expr.as_ref(),
@@ -1957,14 +1960,15 @@ impl<'a> StaticParts<'a> {
     }
 
     pub(crate) fn from_trait_item(ti: &'a ast::AssocItem) -> Self {
-        let (defaultness, ty, expr_opt) = match &ti.kind {
-            ast::AssocItemKind::Const(c) => (c.defaultness, &c.ty, &c.expr),
+        let (defaultness, ty, expr_opt, generics) = match &ti.kind {
+            ast::AssocItemKind::Const(c) => (c.defaultness, &c.ty, &c.expr, &c.generics),
             _ => unreachable!(),
         };
         StaticParts {
             prefix: "const",
             vis: &ti.vis,
             ident: ti.ident,
+            generics: Some(generics),
             ty,
             mutability: ast::Mutability::Not,
             expr_opt: expr_opt.as_ref(),
@@ -1974,14 +1978,15 @@ impl<'a> StaticParts<'a> {
     }
 
     pub(crate) fn from_impl_item(ii: &'a ast::AssocItem) -> Self {
-        let (defaultness, ty, expr) = match &ii.kind {
-            ast::AssocItemKind::Const(c) => (c.defaultness, &c.ty, &c.expr),
+        let (defaultness, ty, expr, generics) = match &ii.kind {
+            ast::AssocItemKind::Const(c) => (c.defaultness, &c.ty, &c.expr, &c.generics),
             _ => unreachable!(),
         };
         StaticParts {
             prefix: "const",
             vis: &ii.vis,
             ident: ii.ident,
+            generics: Some(generics),
             ty,
             mutability: ast::Mutability::Not,
             expr_opt: expr.as_ref(),
@@ -1997,13 +2002,19 @@ fn rewrite_static(
     offset: Indent,
 ) -> Option<String> {
     let colon = colon_spaces(context.config);
+    let ident = rewrite_ident(context, static_parts.ident);
+    let shape = Shape::indented(offset, context.config);
     let mut prefix = format!(
         "{}{}{} {}{}{}",
         format_visibility(context, static_parts.vis),
         static_parts.defaultness.map_or("", format_defaultness),
         static_parts.prefix,
         format_mutability(static_parts.mutability),
-        rewrite_ident(context, static_parts.ident),
+        if let Some(generics) = static_parts.generics {
+            Cow::Owned(rewrite_generics(context, ident, generics, shape)?)
+        } else {
+            Cow::Borrowed(ident)
+        },
         colon,
     );
     // 2 = " =".len()

--- a/tests/target/issue_5995.rs
+++ b/tests/target/issue_5995.rs
@@ -1,0 +1,2 @@
+#![feature(generic_const_items)]
+const C<T>: Option<T> = None;


### PR DESCRIPTION
Fixes #5995

Added support for rewriting generics on const items.