### PR TITLE
5978 Trailing whitespaces are stripped in raw string literals in doc tests

### DIFF
--- a/tests/source/configs/format_code_in_doc_comments/false.rs
+++ b/tests/source/configs/format_code_in_doc_comments/false.rs
@@ -1,0 +1,14 @@
+// rustfmt-format_code_in_doc_comments: false
+/// Adds one to the number given.
+///
+/// # Examples
+///
+/// ```
+/// let five = 5;
+///
+/// assert_eq!(6, add_one(5))
+/// ;
+/// ```
+fn add_one(x: i32) -> i32 {
+    x + 1
+}

--- a/tests/source/configs/format_code_in_doc_comments/true.rs
+++ b/tests/source/configs/format_code_in_doc_comments/true.rs
@@ -1,0 +1,14 @@
+// rustfmt-format_code_in_doc_comments: true
+/// Adds one to the number given.
+///
+/// # Examples
+///
+/// ```
+/// let five = 5;
+///
+/// assert_eq!(6, add_one(5))
+/// ;
+/// ```
+fn add_one(x: i32) -> i32 {
+    x + 1
+}

--- a/tests/source/configs/format_code_in_doc_comments/true_ignore_string_literals.rs
+++ b/tests/source/configs/format_code_in_doc_comments/true_ignore_string_literals.rs
@@ -1,0 +1,10 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// String literal test
+/// ```rust
+/// let expected = "\nfoo \n";
+/// assert_eq!(expected, r#"
+/// foo
+/// "#);
+/// ```
+pub fn main() {}

--- a/tests/target/configs/format_code_in_doc_comments/false.rs
+++ b/tests/target/configs/format_code_in_doc_comments/false.rs
@@ -1,0 +1,14 @@
+// rustfmt-format_code_in_doc_comments: false
+/// Adds one to the number given.
+///
+/// # Examples
+///
+/// ```
+/// let five = 5;
+///
+/// assert_eq!(6, add_one(5))
+/// ;
+/// ```
+fn add_one(x: i32) -> i32 {
+    x + 1
+}

--- a/tests/target/configs/format_code_in_doc_comments/true.rs
+++ b/tests/target/configs/format_code_in_doc_comments/true.rs
@@ -1,0 +1,13 @@
+// rustfmt-format_code_in_doc_comments: true
+/// Adds one to the number given.
+///
+/// # Examples
+///
+/// ```
+/// let five = 5;
+///
+/// assert_eq!(6, add_one(5));
+/// ```
+fn add_one(x: i32) -> i32 {
+    x + 1
+}

--- a/tests/target/configs/format_code_in_doc_comments/true_ignore_string_literals.rs
+++ b/tests/target/configs/format_code_in_doc_comments/true_ignore_string_literals.rs
@@ -1,0 +1,13 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// String literal test
+/// ```rust
+/// let expected = "\nfoo \n";
+/// assert_eq!(
+///     expected,
+///     r#"
+/// foo 
+/// "#
+/// );
+/// ```
+pub fn main() {}


### PR DESCRIPTION
Fixes issue: https://github.com/rust-lang/rustfmt/issues/5978

WIP: Have created the test for this feature just need to implement the code.
