### PR TITLE
5801 enum variant doc comments are wrapped before `comment_width`

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -656,9 +656,16 @@ impl<'a> FmtVisitor<'a> {
         }
 
         let context = self.get_context();
-        // 1 = ','
-        let shape = self.shape().sub_width(1)?;
-        let attrs_str = field.attrs.rewrite(&context, shape)?;
+        let shape = self.shape();
+        let attrs_str = if context.config.version() == Version::Two {
+            field.attrs.rewrite(&context, shape)?
+        } else {
+            // Version::One formatting that was off by 1. See issue #5801
+            field.attrs.rewrite(&context, shape.sub_width(1)?)?
+        };
+        // sub_width(1) to take the trailing comma into account
+        let shape = shape.sub_width(1)?;
+
         let lo = field
             .attrs
             .last()

--- a/tests/config/issue-5801-v1.toml
+++ b/tests/config/issue-5801-v1.toml
@@ -1,0 +1,3 @@
+max_width = 120
+version = "One"
+attr_fn_like_width = 120

--- a/tests/config/issue-5801-v2.toml
+++ b/tests/config/issue-5801-v2.toml
@@ -1,0 +1,3 @@
+max_width = 120
+version = "Two"
+attr_fn_like_width = 120

--- a/tests/source/issue-5801/attribute_unexpectedly_wraps_before_max_width.rs
+++ b/tests/source/issue-5801/attribute_unexpectedly_wraps_before_max_width.rs
@@ -1,0 +1,8 @@
+// rustfmt-config: issue-5801-v1.toml
+
+pub enum Severity {
+    #[something(AAAAAAAAAAAAA, BBBBBBBBBBBBBB, CCCCCCCCCCCCCCCC, DDDDDDDDDDDDD, EEEEEEEEEEEE, FFFFFFFFFFF, GGGGGGGGGGG)]
+    AttrsWillWrap,
+    #[something_else(hhhhhhhhhhhhhhhh, iiiiiiiiiiiiiiii, jjjjjjjjjjjjjjj, kkkkkkkkkkkkk, llllllllllll, mmmmmmmmmmmmmm)]
+    AttrsWontWrap,
+}

--- a/tests/source/issue-5801/comment_unexpectedly_wraps_before_max_width.rs
+++ b/tests/source/issue-5801/comment_unexpectedly_wraps_before_max_width.rs
@@ -1,0 +1,17 @@
+// rustfmt-comment_width: 120
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 120
+// rustfmt-version: One
+
+/// This function is 120 columns wide and is left alone. This comment is 120 columns wide and the formatter is also fine
+fn my_super_cool_function_name(my_very_cool_argument_name: String, my_other_very_cool_argument_name: String) -> String {
+    unimplemented!()
+}
+
+pub enum Severity {
+    /// In version one, the below line got wrapped prematurely as we subtracted 1 to account for `,`. See issue #5801.
+    /// But here, this comment is 120 columns wide and the formatter wants to split it up onto two separate lines still.
+    Error,
+    /// This comment is 119 columns wide and works perfectly. Lorem ipsum. lorem ipsum. lorem ipsum. lorem ipsum lorem.
+    Warning,
+}

--- a/tests/target/issue-5801/attribute_does_not_wrap_within_max_width.rs
+++ b/tests/target/issue-5801/attribute_does_not_wrap_within_max_width.rs
@@ -1,0 +1,8 @@
+// rustfmt-config: issue-5801-v2.toml
+
+pub enum Severity {
+    #[something(AAAAAAAAAAAAA, BBBBBBBBBBBBBB, CCCCCCCCCCCCCCCC, DDDDDDDDDDDDD, EEEEEEEEEEEE, FFFFFFFFFFF, GGGGGGGGGGG)]
+    AttrsWillWrap,
+    #[something_else(hhhhhhhhhhhhhhhh, iiiiiiiiiiiiiiii, jjjjjjjjjjjjjjj, kkkkkkkkkkkkk, llllllllllll, mmmmmmmmmmmmmm)]
+    AttrsWontWrap,
+}

--- a/tests/target/issue-5801/attribute_unexpectedly_wraps_before_max_width.rs
+++ b/tests/target/issue-5801/attribute_unexpectedly_wraps_before_max_width.rs
@@ -1,0 +1,16 @@
+// rustfmt-config: issue-5801-v1.toml
+
+pub enum Severity {
+    #[something(
+        AAAAAAAAAAAAA,
+        BBBBBBBBBBBBBB,
+        CCCCCCCCCCCCCCCC,
+        DDDDDDDDDDDDD,
+        EEEEEEEEEEEE,
+        FFFFFFFFFFF,
+        GGGGGGGGGGG
+    )]
+    AttrsWillWrap,
+    #[something_else(hhhhhhhhhhhhhhhh, iiiiiiiiiiiiiiii, jjjjjjjjjjjjjjj, kkkkkkkkkkkkk, llllllllllll, mmmmmmmmmmmmmm)]
+    AttrsWontWrap,
+}

--- a/tests/target/issue-5801/comment_does_not_wrap_within_max_width.rs
+++ b/tests/target/issue-5801/comment_does_not_wrap_within_max_width.rs
@@ -1,0 +1,16 @@
+// rustfmt-comment_width: 120
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 120
+// rustfmt-version: Two
+
+/// This function is 120 columns wide and is left alone. This comment is 120 columns wide and the formatter is also fine
+fn my_super_cool_function_name(my_very_cool_argument_name: String, my_other_very_cool_argument_name: String) -> String {
+    unimplemented!()
+}
+
+pub enum Severity {
+    /// But here, this comment is 120 columns wide and the formatter wants to split it up onto two separate lines still.
+    Error,
+    /// This comment is 119 columns wide and works perfectly. Lorem ipsum. lorem ipsum. lorem ipsum. lorem ipsum lorem.
+    Warning,
+}

--- a/tests/target/issue-5801/comment_unexpectedly_wraps_before_max_width.rs
+++ b/tests/target/issue-5801/comment_unexpectedly_wraps_before_max_width.rs
@@ -1,0 +1,18 @@
+// rustfmt-comment_width: 120
+// rustfmt-wrap_comments: true
+// rustfmt-max_width: 120
+// rustfmt-version: One
+
+/// This function is 120 columns wide and is left alone. This comment is 120 columns wide and the formatter is also fine
+fn my_super_cool_function_name(my_very_cool_argument_name: String, my_other_very_cool_argument_name: String) -> String {
+    unimplemented!()
+}
+
+pub enum Severity {
+    /// In version one, the below line got wrapped prematurely as we subtracted 1 to account for `,`. See issue #5801.
+    /// But here, this comment is 120 columns wide and the formatter wants to split it up onto two separate lines
+    /// still.
+    Error,
+    /// This comment is 119 columns wide and works perfectly. Lorem ipsum. lorem ipsum. lorem ipsum. lorem ipsum lorem.
+    Warning,
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rustfmt/issues/5801
