### PR TITLE
Don't remove inner attributes from `loop`, `for` and `while` expressions

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -678,6 +678,7 @@ pub(crate) fn rewrite_cond(
 // Abstraction over control flow expressions
 #[derive(Debug)]
 struct ControlFlow<'a> {
+    inner_attributes: Option<Vec<ast::Attribute>>,
     cond: Option<&'a ast::Expr>,
     block: &'a ast::Block,
     else_block: Option<&'a ast::Expr>,
@@ -702,6 +703,7 @@ fn extract_pats_and_cond(expr: &ast::Expr) -> (Option<&ast::Pat>, &ast::Expr) {
 
 // FIXME: Refactor this.
 fn to_control_flow(expr: &ast::Expr, expr_type: ExprType) -> Option<ControlFlow<'_>> {
+    let inner_attributes = inner_attributes(&expr.attrs);
     match expr.kind {
         ast::ExprKind::If(ref cond, ref if_block, ref else_block) => {
             let (pat, cond) = extract_pats_and_cond(cond);
@@ -716,14 +718,30 @@ fn to_control_flow(expr: &ast::Expr, expr_type: ExprType) -> Option<ControlFlow<
             ))
         }
         ast::ExprKind::ForLoop(ref f) => Some(ControlFlow::new_for(
-            &f.pat, &f.iter, &f.body, f.label, expr.span, f.kind,
+            inner_attributes,
+            &f.pat,
+            &f.iter,
+            &f.body,
+            f.label,
+            expr.span,
+            f.kind,
         )),
-        ast::ExprKind::Loop(ref block, label, _) => {
-            Some(ControlFlow::new_loop(block, label, expr.span))
-        }
+        ast::ExprKind::Loop(ref block, label, _) => Some(ControlFlow::new_loop(
+            inner_attributes,
+            block,
+            label,
+            expr.span,
+        )),
         ast::ExprKind::While(ref cond, ref block, label) => {
             let (pat, cond) = extract_pats_and_cond(cond);
-            Some(ControlFlow::new_while(pat, cond, block, label, expr.span))
+            Some(ControlFlow::new_while(
+                inner_attributes,
+                pat,
+                cond,
+                block,
+                label,
+                expr.span,
+            ))
         }
         _ => None,
     }
@@ -745,6 +763,7 @@ impl<'a> ControlFlow<'a> {
     ) -> ControlFlow<'a> {
         let matcher = choose_matcher(pat);
         ControlFlow {
+            inner_attributes: None,
             cond: Some(cond),
             block,
             else_block,
@@ -760,8 +779,14 @@ impl<'a> ControlFlow<'a> {
         }
     }
 
-    fn new_loop(block: &'a ast::Block, label: Option<ast::Label>, span: Span) -> ControlFlow<'a> {
+    fn new_loop(
+        inner_attributes: Vec<ast::Attribute>,
+        block: &'a ast::Block,
+        label: Option<ast::Label>,
+        span: Span,
+    ) -> ControlFlow<'a> {
         ControlFlow {
+            inner_attributes: Some(inner_attributes),
             cond: None,
             block,
             else_block: None,
@@ -778,6 +803,7 @@ impl<'a> ControlFlow<'a> {
     }
 
     fn new_while(
+        inner_attributes: Vec<ast::Attribute>,
         pat: Option<&'a ast::Pat>,
         cond: &'a ast::Expr,
         block: &'a ast::Block,
@@ -786,6 +812,7 @@ impl<'a> ControlFlow<'a> {
     ) -> ControlFlow<'a> {
         let matcher = choose_matcher(pat);
         ControlFlow {
+            inner_attributes: Some(inner_attributes),
             cond: Some(cond),
             block,
             else_block: None,
@@ -802,6 +829,7 @@ impl<'a> ControlFlow<'a> {
     }
 
     fn new_for(
+        inner_attributes: Vec<ast::Attribute>,
         pat: &'a ast::Pat,
         cond: &'a ast::Expr,
         block: &'a ast::Block,
@@ -810,6 +838,7 @@ impl<'a> ControlFlow<'a> {
         kind: ForLoopKind,
     ) -> ControlFlow<'a> {
         ControlFlow {
+            inner_attributes: Some(inner_attributes),
             cond: Some(cond),
             block,
             else_block: None,
@@ -1138,8 +1167,15 @@ impl<'a> Rewrite for ControlFlow<'a> {
         let block_str = {
             let old_val = context.is_if_else_block.replace(self.else_block.is_some());
             let old_is_loop = context.is_loop_block.replace(self.is_loop);
-            let result =
-                rewrite_block_with_visitor(context, "", self.block, None, None, block_shape, true);
+            let result = rewrite_block_with_visitor(
+                context,
+                "",
+                self.block,
+                self.inner_attributes.as_deref(),
+                None,
+                block_shape,
+                true,
+            );
             context.is_loop_block.replace(old_is_loop);
             context.is_if_else_block.replace(old_val);
             result?

--- a/tests/target/issue_5973.rs
+++ b/tests/target/issue_5973.rs
@@ -1,0 +1,19 @@
+fn main() {
+    while i < days.len() {
+        #![allow(clippy::indexing_slicing)]
+        w |= days[i].bit_value();
+        i += 1;
+    }
+
+    for i in 0..days.len() {
+        #![allow(clippy::indexing_slicing)]
+        w |= days[i].bit_value();
+        i += 1;
+    }
+
+    loop {
+        #![allow(clippy::indexing_slicing)]
+        w |= days[i].bit_value();
+        i += 1;
+    }
+}


### PR DESCRIPTION
Fixes #5973

The [attribute] docs in the rust reference explain that inner attributes are allowed in block expressions.

[attribute]: https://doc.rust-lang.org/reference/attributes.html