### PR TITLE
rustfmt --check: handle writing to a broken pipe gracefully

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -43,7 +43,13 @@ fn main() {
         }
     };
     // Make sure standard output is flushed before we exit.
-    std::io::stdout().flush().unwrap();
+    // Silently ignore broken pipe errors, but any other errors are unexpected.
+    match std::io::stdout().flush() {
+        Err(e) if e.kind() != io::ErrorKind::BrokenPipe => {
+            panic!("flushing stdout failed: unexpected error: {:?}", e)
+        }
+        _ => {}
+    };
 
     // Exit with given exit code.
     //


### PR DESCRIPTION
this addresses a panic when `rustfmt --check` makes a `write()` call that fails. There have been a few issues that already discussed this: 

https://github.com/rust-lang/rustfmt/issues/5114
https://github.com/rust-lang/rustfmt/issues/2926

On one of the issues it was noted that it would be difficult to hit this outside of contrived situations like piping to "false", but I think it really is pretty easy to hit -- I got this panic by accidentally making a typo in "less", and piping to "les":

```
rustfmt --check prog.rs | les
```

With this patch I opted to leave the panic behavior in place for any write errors other than EPIPE, so that the tool's behavior is unchanged except in this specific situation. However, it could be preferable to take the opportunity to remove the panics entirely and handle all write errors gracefully. I can update the patch to not panic at all on write errors, if others agree.