### PR TITLE
5796 derive attribute is not wrapped if it's exactly max length

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -150,6 +150,18 @@ fn format_derive(
     let item_str = write_list(&all_items, &fmt)?;
 
     debug!("item_str: '{}'", item_str);
+    let item_str = if item_str.len() > argument_shape.width {
+        // Due to write_list subtracting 1 from the separator count sometimes we can get back
+        // a line that exceeds the max_width. So format the line again but with a Vertical tactic.
+        let fmt = ListFormatting::new(argument_shape, context.config)
+            .tactic(DefinitiveListTactic::Vertical)
+            .trailing_separator(trailing_separator)
+            .ends_with_newline(false);
+
+        write_list(&all_items, &fmt)?
+    } else {
+        item_str
+    };
 
     // Determine if the result will be nested, i.e. if we're using the block
     // indent style and either the items are on multiple lines or we've exceeded

--- a/tests/source/issue-5796/false.rs
+++ b/tests/source/issue-5796/false.rs
@@ -1,0 +1,12 @@
+// rustfmt-error_on_line_overflow: false
+
+#[derive(
+    Serialize, Deserialize, Debug, Clone, EnumString, EnumIter, strum_macros::Display, PartialEq, Eq,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Create,
+    Update,
+    Delete,
+    Undefined,
+}

--- a/tests/source/issue-5796/true.rs
+++ b/tests/source/issue-5796/true.rs
@@ -1,0 +1,12 @@
+// rustfmt-error_on_line_overflow: true
+
+#[derive(
+    Serialize, Deserialize, Debug, Clone, EnumString, EnumIter, strum_macros::Display, PartialEq, Eq,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Create,
+    Update,
+    Delete,
+    Undefined,
+}

--- a/tests/target/issue-5796/false.rs
+++ b/tests/target/issue-5796/false.rs
@@ -1,0 +1,20 @@
+// rustfmt-error_on_line_overflow: false
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    EnumString,
+    EnumIter,
+    strum_macros::Display,
+    PartialEq,
+    Eq,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Create,
+    Update,
+    Delete,
+    Undefined,
+}

--- a/tests/target/issue-5796/true.rs
+++ b/tests/target/issue-5796/true.rs
@@ -1,0 +1,20 @@
+// rustfmt-error_on_line_overflow: true
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    EnumString,
+    EnumIter,
+    strum_macros::Display,
+    PartialEq,
+    Eq,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Create,
+    Update,
+    Delete,
+    Undefined,
+}


### PR DESCRIPTION
https://github.com/rust-lang/rustfmt/issues/5796

This is not the prettiest solution but there is a assumption that once we enter `write_list` for `list.rs` we always subtract the separator from the width. This is causing the bug to occur here. As the line exceeds that max width by 1 and this subtraction makes the formatter think it is equal.

So the `item_str` we get back is actually greater than the width so I do a check for this and format it again but this time vertically.

I don't think this is pretty or a optimal fix (as we've to format twice) but I wanted to open a PR to generate a conversation about it. Maybe we can discuss a better solution to the problem now it has been identified a little more.