### PR TITLE
fix additional semicolon during changing parentheses style

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -228,6 +228,9 @@ fn rewrite_macro_inner(
     // Format well-known macros which cannot be parsed as a valid AST.
     if macro_name == "lazy_static!" && !has_comment {
         if let success @ Some(..) = format_lazy_static(context, shape, ts.clone()) {
+            if original_style == Delimiter::Parenthesis {
+                context.lazy_static_success.replace(true);
+            }
             return success;
         }
     }

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -50,6 +50,15 @@ impl<'a> FmtVisitor<'a> {
         self.format_missing_inner(end, |this, last_snippet, _| this.push_str(last_snippet))
     }
 
+    pub(crate) fn format_missing_ignore_semicolon(&mut self, end: BytePos) {
+        let missing_snippet = self.snippet(mk_sp(self.last_pos, end));
+        if missing_snippet.trim() == ";" {
+            self.last_pos = end;
+            return;
+        }
+        self.format_missing_inner(end, |this, last_snippet, _| this.push_str(last_snippet))
+    }
+
     pub(crate) fn format_missing_with_indent(&mut self, end: BytePos) {
         self.format_missing_indent(end, true)
     }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -43,6 +43,7 @@ pub(crate) struct RewriteContext<'a> {
     pub(crate) report: FormatReport,
     pub(crate) skip_context: SkipContext,
     pub(crate) skipped_range: Rc<RefCell<Vec<(usize, usize)>>>,
+    pub(crate) lazy_static_success: Cell<bool>,
 }
 
 pub(crate) struct InsideMacroGuard {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -87,6 +87,7 @@ pub(crate) struct FmtVisitor<'a> {
     pub(crate) report: FormatReport,
     pub(crate) skip_context: SkipContext,
     pub(crate) is_macro_def: bool,
+    pub(crate) lazy_static_success: bool,
 }
 
 impl<'a> Drop for FmtVisitor<'a> {
@@ -174,10 +175,15 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         stmt.span(),
                         get_span_without_attrs(stmt.as_ast_node()),
                     );
+                    self.format_missing(stmt.span().hi());
                 } else {
                     self.visit_mac(&mac_stmt.mac, None, MacroPosition::Statement);
+                    if self.lazy_static_success {
+                        self.format_missing_ignore_semicolon(stmt.span().hi());
+                    } else {
+                        self.format_missing(stmt.span().hi());
+                    }
                 }
-                self.format_missing(stmt.span().hi());
             }
             ast::StmtKind::Empty => (),
         }
@@ -792,6 +798,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             skipped_range: Rc::new(RefCell::new(vec![])),
             is_macro_def: false,
             macro_rewrite_failure: false,
+            lazy_static_success: false,
             report,
             skip_context,
         }
@@ -995,8 +1002,9 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     {
         let context = self.get_context();
         let result = f(&context);
-
+        let buf = context.lazy_static_success.get();
         self.macro_rewrite_failure |= context.macro_rewrite_failure.get();
+        self.lazy_static_success = buf;
         result
     }
 
@@ -1014,6 +1022,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             report: self.report.clone(),
             skip_context: self.skip_context.clone(),
             skipped_range: self.skipped_range.clone(),
+            lazy_static_success: Cell::new(false),
         }
     }
 }

--- a/tests/source/issue-6013/main.rs
+++ b/tests/source/issue-6013/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+lazy_static!(
+        static ref DYNAMODB_CLIENT: Option<aws_sdk_dynamodb::Client> = None;
+            static ref CASCADE_IP: String = std::env::var("CASCADE_IP").unwrap_or("127.0.0.1".to_string());
+                static ref CASCADE_PORT: String = std::env::var("CASCADE_PORT").unwrap_or("4000".to_string());
+)     ;
+}

--- a/tests/target/issue-6013/main.rs
+++ b/tests/target/issue-6013/main.rs
@@ -1,0 +1,9 @@
+fn main() {
+    lazy_static! {
+        static ref DYNAMODB_CLIENT: Option<aws_sdk_dynamodb::Client> = None;
+        static ref CASCADE_IP: String =
+            std::env::var("CASCADE_IP").unwrap_or("127.0.0.1".to_string());
+        static ref CASCADE_PORT: String =
+            std::env::var("CASCADE_PORT").unwrap_or("4000".to_string());
+    }
+}


### PR DESCRIPTION
#6013 

Prevent add semicolon when changing parentheses style when using lazy_static. If we see that previous parentheses is round and we use the rule for lazy_static then we set flag about it and after it we simple skip insert semicolon during postprocessing spaces and semicolon.
