### PR TITLE
Slightly more correctly formatting multiline attributes

### DIFF
--- a/tests/source/issue-5974/test.rs
+++ b/tests/source/issue-5974/test.rs
@@ -1,0 +1,8 @@
+macro_rules! repro {
+() => {
+        #[doc = concat!("let var = ",
+        "false;")]
+        fn f() {}
+};
+}
+

--- a/tests/target/issue-5974/test.rs
+++ b/tests/target/issue-5974/test.rs
@@ -1,0 +1,7 @@
+macro_rules! repro {
+    () => {
+        #[doc = concat!("let var = ",
+        "false;")]
+        fn f() {}
+    };
+}


### PR DESCRIPTION
Solve #5974 

First and last line of multiline attributes will have equal indent, middle lines will have indent, which has 4 additional spaces.
