### PR TITLE
Don't remove round brackets inside macro calls

### DIFF
--- a/tests/source/issue-5959/test.rs
+++ b/tests/source/issue-5959/test.rs
@@ -1,0 +1,3 @@
+fn main() {
+    mymacro!(  (  for<'a> Fn() ) + Send + Sync);
+}

--- a/tests/target/issue-5959/test.rs
+++ b/tests/target/issue-5959/test.rs
@@ -1,0 +1,3 @@
+fn main() {
+    mymacro!((for<'a> Fn()) + Send + Sync);
+}


### PR DESCRIPTION
#5959 

If arguments in macro call is parsed as types so round brackets restored around generic types.
