### PR TITLE
In macro definitions new name can start from $ without spaces before it.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -519,6 +519,13 @@ fn replace_names(input: &str) -> Option<(String, HashMap<String, String>)> {
         if kind != FullCodeCharKind::Normal {
             result.push(c);
         } else if c == '$' {
+            // the name can end by starting new name with $
+            if !cur_name.is_empty() {
+                dbg!(&cur_name);
+                register_metavariable(&mut substs, &mut result, &cur_name, dollar_count);
+                dollar_count = 0;
+                cur_name.clear();
+            }
             dollar_count += 1;
         } else if dollar_count == 0 {
             result.push(c);

--- a/tests/source/issue-5905/test.rs
+++ b/tests/source/issue-5905/test.rs
@@ -1,0 +1,8 @@
+macro_rules! test_macro {
+    ($member:ident $($rest:tt)*) => {
+        paste::paste! {fn test(&self) {
+        (self.$member$($rest)* )
+        }}
+    };
+}
+

--- a/tests/target/issue-5905/test.rs
+++ b/tests/target/issue-5905/test.rs
@@ -1,0 +1,7 @@
+macro_rules! test_macro {
+    ($member:ident $($rest:tt)*) => {
+        paste::paste! {fn test(&self) {
+        (self.$member$($rest)* )
+        }}
+    };
+}


### PR DESCRIPTION
5905

