### PR TITLE
fn_width config option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -768,6 +768,20 @@ By default this option is set as a percentage of [`max_width`](#max_width) provi
 
 See also [`max_width`](#max_width) and [`use_small_heuristics`](#use_small_heuristics)
 
+
+## `fn_width`
+
+Maximum width of the declaration of a function signature before falling back to formatting chosen with `fn_param_layout`.
+
+- **Default value**: `100`
+- **Possible values**: any positive integer that is less than or equal to the value specified for [`max_width`](#max_width)
+- **Stable**: Yes
+
+By default this option is set as a percentage of [`max_width`](#max_width) provided by [`use_small_heuristics`](#use_small_heuristics), but a value set directly for `fn_width` will take precedence.
+
+See also [`max_width`](#max_width) and [`use_small_heuristics`](#use_small_heuristics)
+
+
 ## `fn_params_layout`
 
 Control the layout of parameters in function signatures.

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -122,6 +122,7 @@ macro_rules! create_config {
                     | "fn_call_width"
                     | "single_line_if_else_max_width"
                     | "single_line_let_else_max_width"
+                    | "fn_width"
                     | "attr_fn_like_width"
                     | "struct_lit_width"
                     | "struct_variant_width"
@@ -273,6 +274,7 @@ macro_rules! create_config {
                     | "fn_call_width"
                     | "single_line_if_else_max_width"
                     | "single_line_let_else_max_width"
+                    | "fn_width"
                     | "attr_fn_like_width"
                     | "struct_lit_width"
                     | "struct_variant_width"
@@ -421,6 +423,14 @@ macro_rules! create_config {
                     "single_line_let_else_max_width",
                 );
                 self.single_line_let_else_max_width.2 = single_line_let_else_max_width;
+
+                let fn_width = get_width_value(
+                    self.was_set().fn_width(),
+                    self.fn_width.2,
+                    heuristics.fn_width,
+                    "fn_width",
+                );
+                self.fn_width.2 = fn_width;
             }
 
             fn set_heuristics(&mut self) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,6 +61,7 @@ create_config! {
     single_line_let_else_max_width: usize, 50, true, "Maximum line length for single line \
         let-else statements. A value of zero means always format the divergent `else` block \
         over multiple lines.";
+    fn_width: usize, 100, true, "Maximum line length for function declarations.";
 
     // Comments. macros, and strings
     wrap_comments: bool, false, false, "Break comments to fit on the line";
@@ -490,6 +491,7 @@ mod test {
             single_line_let_else_max_width: usize, 50, false, "Maximum line length for single \
                 line let-else statements. A value of zero means always format the divergent \
                 `else` block over multiple lines.";
+            fn_width: usize, 100, true, "Maximum line length for function declarations.";
 
             // Options that are used by the tests
             stable_option: bool, false, true, "A stable option";
@@ -634,6 +636,7 @@ array_width = 60
 chain_width = 60
 single_line_if_else_max_width = 50
 single_line_let_else_max_width = 50
+fn_width = 100
 wrap_comments = false
 format_code_in_doc_comments = false
 doc_comment_code_block_width = 100

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -241,6 +241,8 @@ pub struct WidthHeuristics {
     // Maximum line length for single line let-else statements. A value of zero means
     // always format the divergent `else` block over multiple lines.
     pub(crate) single_line_let_else_max_width: usize,
+    // Maximum line length for function declarations.
+    pub(crate) fn_width: usize,
 }
 
 impl fmt::Display for WidthHeuristics {
@@ -261,6 +263,7 @@ impl WidthHeuristics {
             chain_width: usize::max_value(),
             single_line_if_else_max_width: 0,
             single_line_let_else_max_width: 0,
+            fn_width: usize::max_value(),
         }
     }
 
@@ -274,6 +277,7 @@ impl WidthHeuristics {
             chain_width: max_width,
             single_line_if_else_max_width: max_width,
             single_line_let_else_max_width: max_width,
+            fn_width: max_width,
         }
     }
 
@@ -296,6 +300,7 @@ impl WidthHeuristics {
             chain_width: (60.0 * max_width_ratio).round() as usize,
             single_line_if_else_max_width: (50.0 * max_width_ratio).round() as usize,
             single_line_let_else_max_width: (50.0 * max_width_ratio).round() as usize,
+            fn_width: (100.0 * max_width_ratio).round() as usize,
         }
     }
 }

--- a/src/items.rs
+++ b/src/items.rs
@@ -2353,7 +2353,13 @@ fn rewrite_fn_base(
         2
     };
     let used_width = last_line_used_width(&result, indent.width());
-    let one_line_budget = context.budget(used_width + overhead);
+    let one_line_budget = std::cmp::min(
+        context.budget(used_width + overhead),
+        context
+            .config
+            .fn_width()
+            .saturating_sub(used_width + overhead),
+    );
     let shape = Shape {
         width: one_line_budget,
         indent,
@@ -2797,7 +2803,10 @@ fn compute_budgets_for_params(
             FnBraceStyle::SameLine => used_space += 2, // 2 = `{}`
             FnBraceStyle::NextLine => (),
         }
-        let one_line_budget = context.budget(used_space);
+        let one_line_budget = std::cmp::min(
+            context.budget(used_space),
+            context.config.fn_width().saturating_sub(used_space),
+        );
 
         if one_line_budget > 0 {
             // 4 = "() {".len()

--- a/tests/source/fn_width/100.rs
+++ b/tests/source/fn_width/100.rs
@@ -1,0 +1,18 @@
+// rustfmt-max_width: 100
+// rustfmt-fn_width: 100
+
+impl Trait {
+    fn lorem(first: First, second: Second);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter, fourth: FourthParameter);
+
+    fn lorem(first: First, second: Second) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter, fourth: FourthParameter) {
+        // block
+    }
+}

--- a/tests/source/fn_width/150.rs
+++ b/tests/source/fn_width/150.rs
@@ -1,0 +1,18 @@
+// rustfmt-max_width: 150
+// rustfmt-fn_width: 150
+
+impl Trait {
+    fn lorem(first: First, second: Second);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter, fourth: FourthParameter);
+
+    fn lorem(first: First, second: Second) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter, fourth: FourthParameter) {
+        // block
+    }
+}

--- a/tests/source/fn_width/50.rs
+++ b/tests/source/fn_width/50.rs
@@ -1,0 +1,18 @@
+// rustfmt-max_width: 100
+// rustfmt-fn_width: 50
+
+impl Trait {
+    fn lorem(first: First, second: Second);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter, fourth: FourthParameter);
+
+    fn lorem(first: First, second: Second) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter, fourth: FourthParameter) {
+        // block
+    }
+}

--- a/tests/target/fn_width/100.rs
+++ b/tests/target/fn_width/100.rs
@@ -1,0 +1,28 @@
+// rustfmt-max_width: 100
+// rustfmt-fn_width: 100
+
+impl Trait {
+    fn lorem(first: First, second: Second);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter);
+    fn lorem(
+        first: FirstParameter,
+        second: SecondParameter,
+        third: ThirdParameter,
+        fourth: FourthParameter,
+    );
+
+    fn lorem(first: First, second: Second) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter) {
+        // block
+    }
+    fn lorem(
+        first: FirstParameter,
+        second: SecondParameter,
+        third: ThirdParameter,
+        fourth: FourthParameter,
+    ) {
+        // block
+    }
+}

--- a/tests/target/fn_width/150.rs
+++ b/tests/target/fn_width/150.rs
@@ -1,0 +1,18 @@
+// rustfmt-max_width: 150
+// rustfmt-fn_width: 150
+
+impl Trait {
+    fn lorem(first: First, second: Second);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter);
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter, fourth: FourthParameter);
+
+    fn lorem(first: First, second: Second) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter) {
+        // block
+    }
+    fn lorem(first: FirstParameter, second: SecondParameter, third: ThirdParameter, fourth: FourthParameter) {
+        // block
+    }
+}

--- a/tests/target/fn_width/50.rs
+++ b/tests/target/fn_width/50.rs
@@ -1,0 +1,36 @@
+// rustfmt-max_width: 100
+// rustfmt-fn_width: 50
+
+impl Trait {
+    fn lorem(first: First, second: Second);
+    fn lorem(
+        first: FirstParameter,
+        second: SecondParameter,
+        third: ThirdParameter,
+    );
+    fn lorem(
+        first: FirstParameter,
+        second: SecondParameter,
+        third: ThirdParameter,
+        fourth: FourthParameter,
+    );
+
+    fn lorem(first: First, second: Second) {
+        // block
+    }
+    fn lorem(
+        first: FirstParameter,
+        second: SecondParameter,
+        third: ThirdParameter,
+    ) {
+        // block
+    }
+    fn lorem(
+        first: FirstParameter,
+        second: SecondParameter,
+        third: ThirdParameter,
+        fourth: FourthParameter,
+    ) {
+        // block
+    }
+}


### PR DESCRIPTION
Thought it'd be nice to be able to choose how long you want function declarations to be before going vertical. This is basically the gate before `fn_params_layout` kicks in. It used to just be `max_width`, but now it takes the `min` between `max_width` and `fn_width`.

The default is 100, which is what `max_width` defaults to so this should not break anything.