### PR TITLE
leverage `itemize_list` and `write_list` to recover trait bound comments

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -206,6 +206,8 @@ impl ListItem {
 pub(crate) enum Separator {
     Comma,
     VerticalBar,
+    // Used to format trait bounds
+    Plus,
 }
 
 impl Separator {
@@ -215,6 +217,8 @@ impl Separator {
             Separator::Comma => 2,
             // 3 = ` | `
             Separator::VerticalBar => 3,
+            // 3 = ` + `
+            Separator::Plus => 3,
         }
     }
 }

--- a/tests/source/issue_2055.rs
+++ b/tests/source/issue_2055.rs
@@ -1,0 +1,12 @@
+// rustfmt-version: Two
+
+pub trait A {}
+pub trait B {}
+pub trait C {}
+
+pub trait Foo:
+// A and C
+A + C
+// and B
+    + B
+{}

--- a/tests/source/issue_6127.rs
+++ b/tests/source/issue_6127.rs
@@ -1,0 +1,32 @@
+// rustfmt-version: Two
+
+trait Foo:
+    Fn(
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+) -> ReallyLongTypeName
+{
+}
+
+
+trait Bar:
+    Fn(
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+) -> ReallyLongTypeName + Debug + Clone
+{
+}
+
+trait FooBar:
+    Clone + Debug + Fn(
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+) -> ReallyLongTypeName
+{
+}

--- a/tests/target/issue-4689/two.rs
+++ b/tests/target/issue-4689/two.rs
@@ -23,7 +23,8 @@ pub trait PrettyPrinter<'tcx>:
         Type = Self,
         DynExistential = Self,
         Const = Self,
-    > + fmt::Write
+    >
+    + fmt::Write
 {
     //
 }
@@ -36,7 +37,8 @@ pub trait PrettyPrinter<'tcx>:
         Type = Self,
         DynExistential = Self,
         Const = Self,
-    > + fmt::Write1
+    >
+    + fmt::Write1
     + fmt::Write2
 {
     //
@@ -65,7 +67,8 @@ pub trait PrettyPrinter<'tcx>:
         Type = Self,
         DynExistential = Self,
         Const = Self,
-    > + Printer2<
+    >
+    + Printer2<
         'tcx,
         Error = fmt::Error,
         Path = Self,

--- a/tests/target/issue_2055.rs
+++ b/tests/target/issue_2055.rs
@@ -1,0 +1,13 @@
+// rustfmt-version: Two
+
+pub trait A {}
+pub trait B {}
+pub trait C {}
+
+pub trait Foo:
+    // A and C
+    A
+    + C // and B
+    + B
+{
+}

--- a/tests/target/issue_6127.rs
+++ b/tests/target/issue_6127.rs
@@ -1,0 +1,35 @@
+// rustfmt-version: Two
+
+trait Foo:
+    Fn(
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+    ) -> ReallyLongTypeName
+{
+}
+
+trait Bar:
+    Fn(
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+    ) -> ReallyLongTypeName
+    + Debug
+    + Clone
+{
+}
+
+trait FooBar:
+    Clone
+    + Debug
+    + Fn(
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+    ) -> ReallyLongTypeName
+{
+}


### PR DESCRIPTION
Fixes #2055

Now when using `version::Two`, rustfmt will permit comments within trait bounds and actually reformat them instead of refusing to rewrite the entire trait definition because there are comments in the bounds.

This follows the approach hinted at in https://github.com/rust-lang/rustfmt/issues/2055#issuecomment-343150579.

Edit -- Other issues fixed by this change:
Fixes #6127