### PR TITLE
Fix match enum OR comment indentation

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -11,8 +11,8 @@ use crate::config::{Config, IndentStyle};
 use crate::rewrite::{ExceedsMaxWidthError, RewriteContext, RewriteError, RewriteResult};
 use crate::shape::{Indent, Shape};
 use crate::utils::{
-    count_newlines, first_line_width, last_line_width, mk_sp, starts_with_newline,
-    unicode_str_width,
+    count_newlines, first_line_width, last_line_unindented_width, last_line_width, mk_sp,
+    starts_with_newline, unicode_str_width,
 };
 use crate::visitor::SnippetProvider;
 
@@ -468,8 +468,13 @@ where
 
             if !starts_with_newline(comment) {
                 if formatting.align_comments {
+                    // If it's a multiline inner item, the length of indentation shouldn't
+                    // be counted when evaluating line length with respect to comments.
+                    let inner_item_width = last_line_unindented_width(&inner_item)
+                        .unwrap_or_else(|| unicode_str_width(inner_item));
+
                     let mut comment_alignment =
-                        post_comment_alignment(item_max_width, unicode_str_width(inner_item));
+                        post_comment_alignment(item_max_width, inner_item_width);
                     if first_line_width(&formatted_comment)
                         + last_line_width(&result)
                         + comment_alignment

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -208,6 +208,14 @@ pub(crate) fn last_line_width(s: &str) -> usize {
     unicode_str_width(s.rsplitn(2, '\n').next().unwrap_or(""))
 }
 
+#[inline]
+pub(crate) fn last_line_unindented_width(s: &str) -> Option<usize> {
+    s.rsplitn(2, '\n').next().map(|s| {
+        let trimmed = s.trim_start();
+        unicode_str_width(trimmed)
+    })
+}
+
 /// The total used width of the last line.
 #[inline]
 pub(crate) fn last_line_used_width(s: &str, offset: usize) -> usize {

--- a/tests/source/issue-6060/line_split.rs
+++ b/tests/source/issue-6060/line_split.rs
@@ -1,0 +1,9 @@
+fn dummy() {
+    let error_code = match err {
+        msgs::DecodeError::UnknownVersion => 0x4000 | 1, // unknown realm byte
+        msgs::DecodeError::UnknownRequiredFeature
+        | msgs::DecodeError::InvalidValue
+        | msgs::DecodeError::ShortReadNowExceedesMaxLineWidthAndTriggersAnotherBranch => 0x4000 | 22,   // invalid_onion
+        _ => 0x2000 | 2,                                 // Should never happen
+    };
+}

--- a/tests/target/issue-6060/line_split.rs
+++ b/tests/target/issue-6060/line_split.rs
@@ -1,0 +1,11 @@
+fn dummy() {
+    let error_code = match err {
+        msgs::DecodeError::UnknownVersion => 0x4000 | 1, // unknown realm byte
+        msgs::DecodeError::UnknownRequiredFeature
+        | msgs::DecodeError::InvalidValue
+        | msgs::DecodeError::ShortReadNowExceedesMaxLineWidthAndTriggersAnotherBranch => {
+            0x4000 | 22
+        }                                                // invalid_onion
+        _ => 0x2000 | 2,                                 // Should never happen
+    };
+}

--- a/tests/target/issue-6060/no_line_split.rs
+++ b/tests/target/issue-6060/no_line_split.rs
@@ -1,0 +1,9 @@
+fn dummy() {
+    let error_code = match err {
+        msgs::DecodeError::UnknownVersion => 0x4000 | 1, // unknown realm byte
+        msgs::DecodeError::UnknownRequiredFeature
+        | msgs::DecodeError::InvalidValue
+        | msgs::DecodeError::ShortRead => 0x4000 | 22,   // invalid_onion
+        _ => 0x2000 | 2,                                 // Should never happen
+    };
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rustfmt/issues/6060

This was a bit tricky.

When the inner item is multiline, identation-count before the actual inner item start throws off the line count.

In the usual case, the inner item doesn't contain indentation, example:
```Rust
fn simple(
    // pre-comment on a function!?
    i: i32,          // yes, it's possible!
    response: NoWay, // hose
)
```
in the above case, the inner item is `i: i32`, no comma, no indentation.

So when calculating whether the inner item is too long to add more spaces already, indentation needs to be 
removed beforehand, but only for inner items that have newlines in them. In the below case, the inner item is the entire: 
```Rust
msgs::DecodeError::UnknownRequiredFeature
        | msgs::DecodeError::InvalidValue
        | msgs::DecodeError::ShortRead => 0x4000 | 22
```
Newlines and indentation all.

If the line does become too long by the comment, it will be split and use the old logic in a branch, I added a test for that as well.