### PR TITLE
Issue 6052

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -775,7 +775,7 @@ where
             ListItem {
                 pre_comment,
                 pre_comment_style,
-                item: if self.inner.peek().is_none() && self.leave_last {
+                item: if is_last && self.leave_last {
                     None
                 } else {
                     (self.get_item_string)(&item)

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -613,7 +613,7 @@ impl<'a> Context<'a> {
             |item| item.rewrite(self.context, self.nested_shape),
             span.lo(),
             span.hi(),
-            true,
+            self.items.len() > 1,
         );
         let mut list_items: Vec<_> = items.collect();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -613,7 +613,11 @@ impl Rewrite for ast::GenericParam {
                 TypeDensity::Wide => " = ",
             };
             param.push_str(eq_str);
-            let budget = shape.width.checked_sub(param.len())?;
+            // Need to allow the space required for the rewrite instead of bailing
+            // in that case a line that's too long will be produced, rather than an ICE.
+            // Another way to solve this, is to implement splitting into two lines for the case
+            // where the rhs of the `=` causes an overflow.
+            let budget = usize::MAX;
             let rewrite =
                 def.rewrite(context, Shape::legacy(budget, shape.indent + param.len()))?;
             param.push_str(&rewrite);

--- a/src/types.rs
+++ b/src/types.rs
@@ -612,14 +612,45 @@ impl Rewrite for ast::GenericParam {
                 TypeDensity::Compressed => "=",
                 TypeDensity::Wide => " = ",
             };
-            param.push_str(eq_str);
             // Need to allow the space required for the rewrite instead of bailing
-            // in that case a line that's too long will be produced, rather than an ICE.
-            // Another way to solve this, is to implement splitting into two lines for the case
-            // where the rhs of the `=` causes an overflow.
-            let budget = usize::MAX;
-            let rewrite =
-                def.rewrite(context, Shape::legacy(budget, shape.indent + param.len()))?;
+            // regardless of if the line overflows, if it doesn't it's split, if it still overflows,
+            // then the identifier is too long, which the user will have to deal with.
+            let rewrite = def.rewrite(
+                context,
+                Shape::legacy(usize::MAX, shape.indent + param.len()),
+            )?;
+            let can_fit_in_line = shape
+                .width
+                .saturating_sub(param.len())
+                .saturating_sub(eq_str.len())
+                .checked_sub(rewrite.len())
+                .is_some();
+            if can_fit_in_line {
+                param.push_str(eq_str);
+            } else {
+                // Begin a new line
+                param.push('\n');
+                for _ in 0..shape.indent.block_indent {
+                    param.push(' ');
+                }
+                let can_fit_in_line_with_eq_str = shape
+                    .width
+                    .saturating_sub(eq_str.len().min(2))
+                    .checked_sub(rewrite.len())
+                    .is_some();
+                if can_fit_in_line_with_eq_str {
+                    // Fits together with eq, remove leading whitespace
+                    param.push_str(eq_str.trim_start());
+                } else {
+                    // Split into three lines, might fit, might not, remove all whitespace,
+                    // eq goes on its own line
+                    param.push_str(eq_str.trim());
+                    param.push('\n');
+                    for _ in 0..shape.indent.block_indent {
+                        param.push(' ');
+                    }
+                }
+            }
             param.push_str(&rewrite);
         }
 

--- a/tests/target/issue_6052.rs
+++ b/tests/target/issue_6052.rs
@@ -1,4 +1,21 @@
 // Passing the max-line boundary seems to be, combined with the other stuff, causing the panic
 pub enum Dummy<
-    SomeVeryLongStructDeclarationAsItemMakingTheLineOverflowTheRightHandSideAssignmentIsImportant = MyDefault,
+    SomeVeryLongStructDeclarationAsItemMakingTheLineOverflowTheRightHandSideAssignmentIsImportant
+    = MyDefault,
+> {}
+
+pub enum Dummy2<
+    SomeVeryLongStructDeclarationAsItemMakingTheLineOverflowTheRightHandSideAssignmentIsImport
+    = MyDefault,
+> {}
+
+pub enum Dummy3<
+    SomeVeryLongStructDeclarationAsItemMakingTheLineOverflowTheRightHandSideAssignmentIsImport
+    =
+    MyDefaultThatIsAlsoTooLongToBeFitIntoTheNextLineCausingATripleSplitThisMayBeOverdoingItOrNotIdk,
+> {}
+
+pub enum Dummy4<
+    SomeVeryLongStructDeclarationAsItemMakingTheLineOverflowTheRightHandSideAssignmentIsImport
+    = MyDefaultThatIsAlsoTooLongToBeFitIntoTheNextLineCausingATripleSplitThisMayBeOverdoingItOrNot,
 > {}

--- a/tests/target/issue_6052.rs
+++ b/tests/target/issue_6052.rs
@@ -1,0 +1,4 @@
+// Passing the max-line boundary seems to be, combined with the other stuff, causing the panic
+pub enum Dummy<
+    SomeVeryLongStructDeclarationAsItemMakingTheLineOverflowTheRightHandSideAssignmentIsImportant = MyDefault,
+> {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rustfmt/issues/6052

The cause of the issue is when there's an ` = ` type assignment with the generics that overflows a line.

The budget given to `def.rewrite` is too low, this causes a cascading `Option::None` which eventually is unwrapped and causes the panic.

One more interaction caused another `Option::None`, the first was the formatting mentioned above, the second is that `overflow.rs` hardcodes to leave the last entry, which causes nothing to be written on a single entry, as was my test-case. I changed that logic to `leave_last` if greater than 1 length. I'm not familiar enough with the codebase to tell whether that could cause problems that aren't covered by tests.

I tried out two solutions to the formatting issue:

1. Just give a budget of `usize::MAX`, then the user gets a `line too long` instead of a panic.
2. Split the `eq_str` lhs and rhs into separate lines if it's too long, if it's still too long after that the user gets a `line too long`. Still usinge `usize::MAX` as budget.

Ending up going with the second one, since that seems nicer, it's very easy to change to the first one though.