### PR TITLE
Fix failure with `=>` in comment after match `=>`

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -402,7 +402,16 @@ fn rewrite_match_body(
         let arrow_snippet = context.snippet(arrow_span).trim();
         // search for the arrow starting from the end of the snippet since there may be a match
         // expression within the guard
-        let arrow_index = arrow_snippet.rfind("=>").unwrap();
+        let mut arrow_index = arrow_snippet.rfind("=>").unwrap();
+        // check whether `=>` is included in the comment
+        if arrow_index != 0 {
+            let prev_arrow = arrow_snippet[..arrow_index].trim();
+            let single_line_comment_index = prev_arrow.rfind("//").unwrap_or(0);
+            let new_line_index = prev_arrow.rfind("\n").unwrap_or(0);
+            if single_line_comment_index > new_line_index {
+                arrow_index = 0;
+            }
+        }
         // 2 = `=>`
         let comment_str = arrow_snippet[arrow_index + 2..].trim();
         if comment_str.is_empty() {

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -402,7 +402,11 @@ fn rewrite_match_body(
         let arrow_snippet = context.snippet(arrow_span).trim();
         // search for the arrow starting from the end of the snippet since there may be a match
         // expression within the guard
-        let arrow_index = arrow_snippet.find_last_uncommented("=>").unwrap();
+        let arrow_index = if context.config.version() == Version::One {
+            arrow_snippet.rfind("=>").unwrap()
+        } else {
+            arrow_snippet.find_last_uncommented("=>").unwrap()
+        };
         // 2 = `=>`
         let comment_str = arrow_snippet[arrow_index + 2..].trim();
         if comment_str.is_empty() {

--- a/tests/source/arrow_in_comments/arrow_in_single_comment.rs
+++ b/tests/source/arrow_in_comments/arrow_in_single_comment.rs
@@ -1,4 +1,4 @@
-// rustfmt-wrap_comments: true
+// rustfmt-version: Two
 fn main() {
     match a {
         _ =>

--- a/tests/source/arrow_in_comments/arrow_in_single_comment.rs
+++ b/tests/source/arrow_in_comments/arrow_in_single_comment.rs
@@ -1,0 +1,10 @@
+// rustfmt-wrap_comments: true
+fn main() {
+    match a {
+        _ =>
+        // comment with =>
+                {
+            println!("A")
+        }
+    }
+}

--- a/tests/source/arrow_in_comments/multiple_arrows.rs
+++ b/tests/source/arrow_in_comments/multiple_arrows.rs
@@ -1,0 +1,14 @@
+// rustfmt-wrap_comments: true
+fn main() {
+    match a {
+        _ => // comment with => 
+        match b {
+            // one goes to =>
+            one => {
+                println("1");
+            }
+            // two goes to =>
+            two => { println("2"); }
+        } 
+    }
+}

--- a/tests/source/arrow_in_comments/multiple_arrows.rs
+++ b/tests/source/arrow_in_comments/multiple_arrows.rs
@@ -1,4 +1,4 @@
-// rustfmt-wrap_comments: true
+// rustfmt-version: Two
 fn main() {
     match a {
         _ => // comment with => 

--- a/tests/target/arrow_in_comments/arrow_in_single_comment.rs
+++ b/tests/target/arrow_in_comments/arrow_in_single_comment.rs
@@ -1,4 +1,4 @@
-// rustfmt-wrap_comments: true
+// rustfmt-version: Two
 fn main() {
     match a {
         _ =>

--- a/tests/target/arrow_in_comments/arrow_in_single_comment.rs
+++ b/tests/target/arrow_in_comments/arrow_in_single_comment.rs
@@ -1,0 +1,10 @@
+// rustfmt-wrap_comments: true
+fn main() {
+    match a {
+        _ =>
+        // comment with =>
+        {
+            println!("A")
+        }
+    }
+}

--- a/tests/target/arrow_in_comments/multiple_arrows.rs
+++ b/tests/target/arrow_in_comments/multiple_arrows.rs
@@ -1,0 +1,19 @@
+// rustfmt-wrap_comments: true
+fn main() {
+    match a {
+        _ =>
+        // comment with =>
+        {
+            match b {
+                // one goes to =>
+                one => {
+                    println("1");
+                }
+                // two goes to =>
+                two => {
+                    println("2");
+                }
+            }
+        }
+    }
+}

--- a/tests/target/arrow_in_comments/multiple_arrows.rs
+++ b/tests/target/arrow_in_comments/multiple_arrows.rs
@@ -1,4 +1,4 @@
-// rustfmt-wrap_comments: true
+// rustfmt-version: Two
 fn main() {
     match a {
         _ =>


### PR DESCRIPTION
Fixes #5998 

## Background
(1) Comment without arrow `=>`
```rust
fn main() {
    match a {
        _ =>
        // comment with ==
                {
            println!("A")
        }
    }
}
```
(2) Comment without arrow `=>`
```rust
fn main() {
    match a {
        _ =>
        // comment with =>
                {
            println!("A")
        }
    }
}
```
Previously, second example fails to reformat unlike the first example. The cause was rustfmt returns original code snippet when comment is lost after rewrite. When `rewrite_match_body`, there's logic to check if comment exists between `=>` and match body, but it tries to find another `=>` in arrow_snippet considering the case with nested match. Since `=>` in comment was also caught with `rfind()`, the comment was lost, which led to silent failure. 

## Solution
Add extra check whether found `=>` was included in single line comment.

## TODO
- [ ] add more test case and verify
- [ ] think for any other alternative approach