### PR TITLE
itertools bump to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ diff = "0.1"
 dirs = "5.0"
 getopts = "0.2"
 ignore = "0.4"
-itertools = "0.11"
+itertools = "0.12"
 lazy_static = "1.4"
 regex = "1.7"
 serde = { version = "1.0.160", features = ["derive"] }


### PR DESCRIPTION
changelog: https://github.com/rust-itertools/itertools/blob/v0.12.1/CHANGELOG.md