### PR TITLE
fix clap deprecations

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -61,7 +61,7 @@ pub struct Opts {
 
     /// Options passed to rustfmt
     // 'raw = true' to make `--` explicit.
-    #[arg(name = "rustfmt_options", raw = true)]
+    #[arg(id = "rustfmt_options", raw = true)]
     rustfmt_options: Vec<String>,
 
     /// Format all packages, and also their local path-based dependencies
@@ -209,9 +209,8 @@ fn convert_message_format_to_rustfmt_args(
 fn print_usage_to_stderr(reason: &str) {
     eprintln!("{reason}");
     let app = Opts::command();
-    app.after_help("")
-        .write_help(&mut io::stderr())
-        .expect("failed to write to stderr");
+    let help = app.after_help("").render_help();
+    eprintln!("{help}");
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/format-diff/main.rs
+++ b/src/format-diff/main.rs
@@ -38,14 +38,14 @@ enum FormatDiffError {
 }
 
 #[derive(Parser, Debug)]
-#[clap(
+#[command(
     name = "rustfmt-format-diff",
     disable_version_flag = true,
     next_line_help = true
 )]
 pub struct Opts {
     /// Skip the smallest prefix containing NUMBER slashes
-    #[clap(
+    #[arg(
         short = 'p',
         long = "skip-prefix",
         value_name = "NUMBER",
@@ -54,7 +54,7 @@ pub struct Opts {
     skip_prefix: u32,
 
     /// Custom pattern selecting file paths to reformat
-    #[clap(
+    #[arg(
         short = 'f',
         long = "filter",
         value_name = "PATTERN",


### PR DESCRIPTION
Run `cargo check --features clap/deprecated` and fix all warnings