### PR TITLE
Fix failure with line comment following `..` in a struct pattern

### DIFF
--- a/tests/source/issue_6040.rs
+++ b/tests/source/issue_6040.rs
@@ -1,0 +1,21 @@
+fn main() {
+    match e { // this line still gets formatted
+            MyStruct {
+                field_a,
+                .. // this comment here apparently causes trouble
+            } => (),
+    _ => (), // this line is no longer formatted
+        };
+}
+
+fn main() {
+    match e {                                           // this line still gets formatted
+        MyStruct {
+            field_a,
+                field_b, // this should be aligned with field_a
+                    field_c, // this should be aligned with field_a
+                        } => (),
+                        
+        _ => (), // this line is no longer formatted
+    };
+}

--- a/tests/target/issue_6040.rs
+++ b/tests/target/issue_6040.rs
@@ -1,0 +1,23 @@
+fn main() {
+    match e {
+        // this line still gets formatted
+        MyStruct {
+            field_a,
+            .. // this comment here apparently causes trouble
+        } => (),
+        _ => (), // this line is no longer formatted
+    };
+}
+
+fn main() {
+    match e {
+        // this line still gets formatted
+        MyStruct {
+            field_a,
+            field_b, // this should be aligned with field_a
+            field_c, // this should be aligned with field_a
+        } => (),
+
+        _ => (), // this line is no longer formatted
+    };
+}


### PR DESCRIPTION
Fixes #6040 

When a struct pattern that contained a `..` was formatted, it failed to consider the case when there is line comment following it. Instead it produced a formatting error because it realizes that if it went ahead with the rewirte it would remove the line comment.

Now, the following line comment is taken into consideration by adopting the approach to `rewrite_struct_lit`, which is a similar function, for rewriting structs, but doesn't seem to suffer from this trailing comment problem because `rewrite_struct_lit` considers the `..` as part of the struct fields that it needs to rewrite.
