### PR TITLE
Add formatting for int literal suffixes

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -180,6 +180,14 @@ fn bar() {
 
 See also: [`blank_lines_lower_bound`](#blank_lines_lower_bound)
 
+## `literal_suffix_style`
+
+Determines how integer literal suffixes are written
+
+- **Default value**: `"Preserve"`
+- **Possible values**: `"Preserve"`, `"Separate"`, `"Join"`
+- **Stable**: No (tracking issue: TBD)
+
 ## `brace_style`
 
 Brace style for items

--- a/Configurations.md
+++ b/Configurations.md
@@ -182,7 +182,7 @@ See also: [`blank_lines_lower_bound`](#blank_lines_lower_bound)
 
 ## `literal_suffix_style`
 
-Determines how integer literal suffixes are written
+Control whether integer literal suffixes have a leading `_`
 
 - **Default value**: `"Preserve"`
 - **Possible values**: `"Preserve"`, `"Separate"`, `"Join"`

--- a/Configurations.md
+++ b/Configurations.md
@@ -188,6 +188,37 @@ Determines how integer literal suffixes are written
 - **Possible values**: `"Preserve"`, `"Separate"`, `"Join"`
 - **Stable**: No (tracking issue: TBD)
 
+### Example
+Original Code:
+
+```rust
+#![rustfmt::skip]
+
+const X: i32 = 0i32;
+const Y: i32 = 1_i32;
+```
+
+#### `"Preserve"` (default):
+
+```rust
+const X: i32 = 0i32;
+const Y: i32 = 1_i32;
+```
+
+#### `"Separate"`:
+
+```rust
+const X: i32 = 0_i32;
+const Y: i32 = 1_i32;
+```
+
+#### `"Join"`:
+
+```rust
+const X: i32 = 0i32;
+const Y: i32 = 1i32;
+```
+
 ## `brace_style`
 
 Brace style for items

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -146,7 +146,7 @@ create_config! {
     blank_lines_lower_bound: usize, 0, false,
         "Minimum number of blank lines which must be put between items";
     literal_suffix_style: LiteralSuffixStyle, LiteralSuffixStyle::Preserve, false,
-        "Control";
+        "Control whether integer literal suffixes have a leading `_`";
     edition: Edition, Edition::Edition2015, true, "The edition of the parser (RFC 2052)";
     version: Version, Version::One, false, "Version of formatting rules";
     inline_attribute_width: usize, 0, false,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -145,6 +145,8 @@ create_config! {
         "Maximum number of blank lines which can be put between items";
     blank_lines_lower_bound: usize, 0, false,
         "Minimum number of blank lines which must be put between items";
+    literal_suffix_style: LiteralSuffixStyle, LiteralSuffixStyle::Preserve, false,
+        "Control";
     edition: Edition, Edition::Edition2015, true, "The edition of the parser (RFC 2052)";
     version: Version, Version::One, false, "Version of formatting rules";
     inline_attribute_width: usize, 0, false,
@@ -678,6 +680,7 @@ trailing_comma = "Vertical"
 match_block_trailing_comma = false
 blank_lines_upper_bound = 1
 blank_lines_lower_bound = 0
+literal_suffix_style = "Preserve"
 edition = "2015"
 version = "One"
 inline_attribute_width = 0

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -81,6 +81,17 @@ pub enum TypeDensity {
 }
 
 #[config_type]
+/// Control for whether to separate or join integer literal suffixes.
+pub enum LiteralSuffixStyle {
+    /// Preserve the literal as-is
+    Preserve,
+    /// Separate the integer component and the suffix (e.g "u8") with an `_`
+    Separate,
+    /// Join the integer component and the suffix (e.g "u8") together
+    Join,
+}
+
+#[config_type]
 /// Heuristic settings that can be used to simply
 /// the configuration of the granular width configurations
 /// like `struct_lit_width`, `array_width`, etc.

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -183,7 +183,7 @@ fn dont_emit_ICE() {
         "tests/target/issue_6069.rs",
         "tests/target/issue-6105.rs",
     ];
-    
+
     for file in files {
         let args = [file];
         let (_stdout, stderr) = rustfmt(&args);

--- a/tests/target/literal_suffix_style_join.rs
+++ b/tests/target/literal_suffix_style_join.rs
@@ -1,6 +1,6 @@
 // rustfmt-literal_suffix_style: Join
-// rustfmt-hex_literal_case: Upper
+
 fn main() {
     let h1 = 1337i32;
-    let h2 = 2015i32;
+    let h2 = 0xFACEi32;
 }

--- a/tests/target/literal_suffix_style_join.rs
+++ b/tests/target/literal_suffix_style_join.rs
@@ -1,0 +1,6 @@
+// rustfmt-literal_suffix_style: Join
+// rustfmt-hex_literal_case: Upper
+fn main() {
+    let h1 = 1337i32;
+    let h2 = 2015i32;
+}

--- a/tests/target/literal_suffix_style_preserve.rs
+++ b/tests/target/literal_suffix_style_preserve.rs
@@ -1,0 +1,5 @@
+// rustfmt-literal_suffix_style: Preserve
+fn main() {
+    let h1 = 1337i32;
+    let h2 = 2015_i32;
+}

--- a/tests/target/literal_suffix_style_preserve.rs
+++ b/tests/target/literal_suffix_style_preserve.rs
@@ -1,5 +1,6 @@
 // rustfmt-literal_suffix_style: Preserve
+
 fn main() {
     let h1 = 1337i32;
-    let h2 = 2015_i32;
+    let h2 = 0xFACE_i32;
 }

--- a/tests/target/literal_suffix_style_separate.rs
+++ b/tests/target/literal_suffix_style_separate.rs
@@ -1,0 +1,6 @@
+// rustfmt-literal_suffix_style: Separate
+
+fn main() {
+    let h1 = 1337_i32;
+    let h2 = 2015_i32;
+}

--- a/tests/target/literal_suffix_style_separate.rs
+++ b/tests/target/literal_suffix_style_separate.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     let h1 = 1337_i32;
-    let h2 = 2015_i32;
+    let h2 = 0xFACE_i32;
 }


### PR DESCRIPTION
Adds rewrite rules and configuration options for suffixed int literals:
```rust
// literal_suffix_style: Join
let x = 0i32;
let y = 0xFFi32;

// literal_suffix_style: Separate
let x = 0_i32;
let y = 0xFF_i32;

// literal_suffix_style: Preserve
let x = 0i32;
let y = 0xFF_i32;
```