### PR TITLE
Issue #6044 

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1773,7 +1773,18 @@ fn changed_comment_content(orig: &str, new: &str) -> bool {
         code_comment_content(orig).collect::<String>(),
         code_comment_content(new).collect::<String>()
     );
+    if removing_empty_comments(orig, new) {
+        return true;
+    }
     res
+}
+
+fn removing_empty_comments(orig: &str, new: &str) -> bool {
+    if contains_comment(orig) && !contains_comment(new) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 /// Iterator over the 'payload' characters of a comment.

--- a/tests/source/issue_6044.rs
+++ b/tests/source/issue_6044.rs
@@ -16,20 +16,20 @@ fn main() {
         let (/*comment*/
         (
 
-        ) 
+        )
 
 
         |      (
 
         )
-    /*comment*/) = ();
+    /*comment*/) = (); //
             
     enum Foo {
         A,
         B,
         C,
         Bar,
-    } //FF
+    } //
     let x = Foo::A;
     match x {
         Foo::

--- a/tests/source/issue_6044.rs
+++ b/tests/source/issue_6044.rs
@@ -1,0 +1,54 @@
+// rustfmt-wrap_comments: true
+
+// Ensure comments preserved no matter what
+fn main() {
+    let (/*
+        */ () /*
+        */ | /**/ () /**/) = (); //
+    let (/*
+            */ () /*
+            */ | /**/ () /**/) = (); //
+    let (//
+        () //
+        | () //
+    ) = (); //
+
+        let (/*comment*/
+        (
+
+        ) 
+
+
+        |      (
+
+        )
+    /*comment*/) = ();
+            
+    enum Foo {
+        A,
+        B,
+        C,
+        Bar,
+    } //FF
+    let x = Foo::A;
+    match x {
+        Foo::
+        Bar => { () },
+        Foo::
+        A
+        // FIXME lol
+        | Foo::
+        B//
+        | Foo::
+        C => { () }//
+      }
+    let (/*aaa
+        aaaa*/ () /*
+        */ | /**/ () /**/) = (/* */);
+
+    let (/*aaa
+        aaaa*/ () /*
+        */ | /**/ () /**/) = (/* */); //
+
+    let (/**/ () /**/ | /**/ () /**/) = (); //
+}

--- a/tests/target/issue_6044.rs
+++ b/tests/target/issue_6044.rs
@@ -1,0 +1,54 @@
+// rustfmt-wrap_comments: true
+
+// Ensure comments preserved no matter what
+fn main() {
+    let (/*
+        */ () /*
+        */ | /**/ () /**/) = (); //
+    let (/*
+            */ () /*
+            */ | /**/ () /**/) = (); //
+    let (//
+        () //
+        | () //
+    ) = (); //
+
+    let (/*comment*/
+        (
+
+        ) 
+
+
+        |      (
+
+        )
+    /*comment*/) = (); //
+
+    enum Foo {
+        A,
+        B,
+        C,
+        Bar,
+    } //
+    let x = Foo::A;
+    match x {
+        Foo::
+        Bar => { () },
+        Foo::
+        A
+        // FIXME lol
+        | Foo::
+        B//
+        | Foo::
+        C => { () }//
+      }
+    let (/*aaa
+        aaaa*/ () /*
+        */ | /**/ () /**/) = (/* */);
+
+    let (/*aaa
+        aaaa*/ () /*
+        */ | /**/ () /**/) = (/* */); //
+
+    let (/**/ () /**/ | /**/ () /**/) = (); //
+}

--- a/tests/target/issue_6044.rs
+++ b/tests/target/issue_6044.rs
@@ -16,7 +16,7 @@ fn main() {
     let (/*comment*/
         (
 
-        ) 
+        )
 
 
         |      (


### PR DESCRIPTION
Adding a check to make sure comments are not being removed! by adding a simple check to see what it is being rewritten to.

This was done by simply adding a check if a previously existing comment has been erased after the rewrite. 