### PR TITLE
Fix Fn supertraits indentation

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2110,7 +2110,7 @@ fn choose_rhs<R: Rewrite>(
     expr: &R,
     shape: Shape,
     orig_rhs: Option<String>,
-    _rhs_kind: &RhsAssignKind<'_>,
+    rhs_kind: &RhsAssignKind<'_>,
     rhs_tactics: RhsTactics,
     has_rhs_comment: bool,
 ) -> Option<String> {
@@ -2141,6 +2141,16 @@ fn choose_rhs<R: Rewrite>(
                 (Some(ref orig_rhs), Some(ref new_rhs))
                     if prefer_next_line(orig_rhs, new_rhs, rhs_tactics) =>
                 {
+                    if let RhsAssignKind::Bounds = rhs_kind {
+                        if new_rhs.contains("->") {
+                            return Some(
+                                new_rhs
+                                    .lines()
+                                    .map(|l| format!("{new_indent_str}{l}"))
+                                    .join(""),
+                            );
+                        }
+                    }
                     Some(format!("{new_indent_str}{new_rhs}"))
                 }
                 (None, Some(ref new_rhs)) => Some(format!("{new_indent_str}{new_rhs}")),

--- a/tests/source/issue-6127.rs
+++ b/tests/source/issue-6127.rs
@@ -1,0 +1,9 @@
+trait Foo:
+    Fn(
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+    ReallyLongTypeName,
+) -> ReallyLongTypeName
+{
+}

--- a/tests/target/issue-6127.rs
+++ b/tests/target/issue-6127.rs
@@ -1,0 +1,9 @@
+trait Foo:
+    Fn(
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+        ReallyLongTypeName,
+    ) -> ReallyLongTypeName
+{
+}


### PR DESCRIPTION
Fixes #6127

In my opinion, the `choose_rhs` function wrongly presume that the `orig_rhs` is a single line and so indent only the beginning of the string instead of the whole block.
The changes have made fix the issues for #6127 but l’m really not convinced I've done it the right way 😓 