### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,6 @@ dependencies = [
  "getopts",
  "ignore",
  "itertools",
- "lazy_static",
  "regex",
  "rustfmt-config_proc_macro",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ dirs = "5.0"
 getopts = "0.2"
 ignore = "0.4"
 itertools = "0.12"
-lazy_static = "1.4"
 regex = "1.7"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -3,8 +3,6 @@
 use std::{borrow::Cow, iter};
 
 use itertools::{multipeek, MultiPeek};
-use lazy_static::lazy_static;
-use regex::Regex;
 use rustc_span::Span;
 
 use crate::config::Config;
@@ -16,17 +14,6 @@ use crate::utils::{
     trimmed_last_line_width, unicode_str_width,
 };
 use crate::{ErrorKind, FormattingError};
-
-lazy_static! {
-    /// A regex matching reference doc links.
-    ///
-    /// ```markdown
-    /// /// An [example].
-    /// ///
-    /// /// [example]: this::is::a::link
-    /// ```
-    static ref REFERENCE_LINK_URL: Regex = Regex::new(r"^\[.+\]\s?:").unwrap();
-}
 
 fn is_custom_comment(comment: &str) -> bool {
     if !comment.starts_with("//") {
@@ -976,12 +963,21 @@ fn trim_custom_comment_prefix(s: &str) -> String {
 
 /// Returns `true` if the given string MAY include URLs or alike.
 fn has_url(s: &str) -> bool {
+    // A regex matching reference doc links.
+    //
+    // ```markdown
+    // /// An [example].
+    // ///
+    // /// [example]: this::is::a::link
+    // ```
+    let reference_link_url = static_regex!(r"^\[.+\]\s?:");
+
     // This function may return false positive, but should get its job done in most cases.
     s.contains("https://")
         || s.contains("http://")
         || s.contains("ftp://")
         || s.contains("file://")
-        || REFERENCE_LINK_URL.is_match(s)
+        || reference_link_url.is_match(s)
 }
 
 /// Returns true if the given string may be part of a Markdown table.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,6 @@
 #![recursion_limit = "256"]
 #![allow(clippy::match_like_matches_macro)]
 
-#[cfg(test)]
-#[macro_use]
-extern crate lazy_static;
 #[macro_use]
 extern crate tracing;
 
@@ -60,6 +57,13 @@ pub use crate::rustfmt_diff::{ModifiedChunk, ModifiedLines};
 
 #[macro_use]
 mod utils;
+
+macro_rules! static_regex {
+    ($re:literal) => {{
+        static RE: ::std::sync::OnceLock<::regex::Regex> = ::std::sync::OnceLock::new();
+        RE.get_or_init(|| ::regex::Regex::new($re).unwrap())
+    }};
+}
 
 mod attr;
 mod chains;

--- a/src/test/configuration_snippet.rs
+++ b/src/test/configuration_snippet.rs
@@ -24,19 +24,13 @@ impl ConfigurationSection {
     fn get_section<I: Iterator<Item = String>>(
         file: &mut Enumerate<I>,
     ) -> Option<ConfigurationSection> {
-        lazy_static! {
-            static ref CONFIG_NAME_REGEX: regex::Regex =
-                regex::Regex::new(r"^## `([^`]+)`").expect("failed creating configuration pattern");
-            // Configuration values, which will be passed to `from_str`:
-            //
-            // - must be prefixed with `####`
-            // - must be wrapped in backticks
-            // - may by wrapped in double quotes (which will be stripped)
-            static ref CONFIG_VALUE_REGEX: regex::Regex =
-                regex::Regex::new(r#"^#### `"?([^`]+?)"?`"#)
-                    .expect("failed creating configuration value pattern");
-        }
-
+        let config_name_regex = static_regex!(r"^## `([^`]+)`");
+        // Configuration values, which will be passed to `from_str`:
+        //
+        // - must be prefixed with `####`
+        // - must be wrapped in backticks
+        // - may by wrapped in double quotes (which will be stripped)
+        let config_value_regex = static_regex!(r#"^#### `"?([^`]+?)"?`"#);
         loop {
             match file.next() {
                 Some((i, line)) => {
@@ -53,9 +47,9 @@ impl ConfigurationSection {
                         let start_line = (i + 2) as u32;
 
                         return Some(ConfigurationSection::CodeBlock((block, start_line)));
-                    } else if let Some(c) = CONFIG_NAME_REGEX.captures(&line) {
+                    } else if let Some(c) = config_name_regex.captures(&line) {
                         return Some(ConfigurationSection::ConfigName(String::from(&c[1])));
-                    } else if let Some(c) = CONFIG_VALUE_REGEX.captures(&line) {
+                    } else if let Some(c) = config_value_regex.captures(&line) {
                         return Some(ConfigurationSection::ConfigValue(String::from(&c[1])));
                     }
                 }


### PR DESCRIPTION
Split off from rust-lang/rust#124475. The functionality of the `lazy_static` crate is now available in the standard library as `OnceLock`. Rustfmt can now use this directly and drop the dependency.