### PR TITLE
Add documentation for negated ignored files and add a test for it as well

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1306,6 +1306,15 @@ If you want to ignore every file under the directory where you put your rustfmt.
 ignore = ["/"]
 ```
 
+If you want to allow specific paths that would otherwise be ignored, prefix those paths with a `!`:
+
+```toml
+ignore = ["bar_dir/*", "!bar_dir/*/what.rs"]
+```
+
+In this case, all files under `bar_dir` will be ignored, except files like `bar_dir/sub/what.rs`
+or `bar_dir/another/what.rs`.
+
 ## `imports_indent`
 
 Indent style of imports

--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -49,4 +49,22 @@ mod test {
         assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz.rs"))));
         assert!(!ignore_path_set.is_match(&FileName::Real(PathBuf::from("src/bar.rs"))));
     }
+
+    #[nightly_only_test]
+    #[test]
+    fn test_negated_ignore_path_set() {
+        use crate::config::{Config, FileName};
+        use crate::ignore_path::IgnorePathSet;
+        use std::path::{Path, PathBuf};
+
+        let config = Config::from_toml(
+            r#"ignore = ["foo.rs", "bar_dir/*", "!bar_dir/*/what.rs"]"#,
+            Path::new(""),
+        )
+        .unwrap();
+        let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
+        assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/what.rs"))));
+        assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz/a.rs"))));
+        assert!(!ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz/what.rs"))));
+    }
 }


### PR DESCRIPTION
I was looking into the source code to check how to add support for negated ignore because I didn't find any mention of it into the documentation until I went through the `ignore` crate source code, [here in particular](https://docs.rs/ignore/latest/src/ignore/gitignore.rs.html#463-466). Would have saved me a lot of time if such an example existed so here we are. :)