### PR TITLE
fix #6164: Reduce format failure for non default `imports_granularity`

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1144,6 +1144,8 @@ impl Rewrite for UseTree {
                 if next_segment.is_some() {
                     rewritten_segment.push_str("::");
                 }
+                // If `next_segment` is a list, we should check overflow with `curr_segment` with
+                // open brace: `...::curr_segment{`. So, 1 will be added to a shape.
                 let reserved_room_for_brace = match next_segment.map(|s| &s.kind) {
                     Some(UseSegmentKind::List(_)) => "{".len(),
                     _ => 0,

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -19,7 +19,7 @@ use crate::config::{Edition, IndentStyle, StyleEdition};
 use crate::lists::{
     ListFormatting, ListItem, Separator, definitive_tactic, itemize_list, write_list,
 };
-use crate::rewrite::{Rewrite, RewriteContext, RewriteErrorExt, RewriteResult};
+use crate::rewrite::{Rewrite, RewriteContext, RewriteError, RewriteErrorExt, RewriteResult};
 use crate::shape::Shape;
 use crate::sort::version_sort;
 use crate::source_map::SpanUtils;
@@ -1115,9 +1115,9 @@ impl Rewrite for UseSegment {
                     use_tree_list,
                     // 1 = "{" and "}"
                     shape
-                        .offset_left_opt(1)
-                        .and_then(|s| s.sub_width_opt(1))
-                        .unknown_error()?,
+                        .offset_left(1)
+                        .unknown_error()?
+                        .saturating_sub_width(1),
                 )?
             }
         })
@@ -1131,18 +1131,107 @@ impl Rewrite for UseTree {
 
     // This does NOT format attributes and visibility or add a trailing `;`.
     fn rewrite_result(&self, context: &RewriteContext<'_>, mut shape: Shape) -> RewriteResult {
-        let mut result = String::with_capacity(256);
-        let mut iter = self.path.iter().peekable();
-        while let Some(segment) = iter.next() {
-            let segment_str = segment.rewrite_result(context, shape)?;
-            result.push_str(&segment_str);
-            if iter.peek().is_some() {
-                result.push_str("::");
-                // 2 = "::"
-                shape = shape.offset_left(2 + segment_str.len(), self.span())?;
+        if context.config.style_edition() >= StyleEdition::Edition2024 {
+            fn proceed(
+                context: &RewriteContext<'_>,
+                span: &Span,
+                shape: &Shape,
+                curr_segment: &UseSegment,
+                curr_segment_is_allow_overflow: bool,
+                next_segment: Option<&&UseSegment>,
+            ) -> Result<(String, Shape), RewriteError> {
+                let mut rewritten_segment = curr_segment.rewrite_result(context, shape.clone())?;
+                if next_segment.is_some() {
+                    rewritten_segment.push_str("::");
+                }
+                let reserved_room_for_brace = match next_segment.map(|s| &s.kind) {
+                    Some(UseSegmentKind::List(_)) => "{".len(),
+                    _ => 0,
+                };
+                let next_shape = if matches!(&curr_segment.kind, UseSegmentKind::List(_)) {
+                    // This is the last segment and we won't use `next_shape`. Return `shape`
+                    // unchanged.
+                    shape.clone()
+                } else if curr_segment_is_allow_overflow {
+                    // If the segment follows `use ` or newline, force to consume the segment with
+                    // overflow.
+
+                    let s = shape.offset_left_maybe_overflow(rewritten_segment.len());
+                    if s.width == 0 {
+                        // We have to to commit current segment in this line. Make a room for next
+                        // round.
+                        s.add_width(reserved_room_for_brace)
+                    } else {
+                        s.clone()
+                    }
+                } else {
+                    let Some(ret) = shape.offset_left(rewritten_segment.len()) else {
+                        return Err(RewriteError::ExceedsMaxWidth {
+                            configured_width: shape.width,
+                            span: span.clone(),
+                        });
+                    };
+                    // Check that there is a room for the next "{". If not, return an error for
+                    // retry with newline.
+                    if ret.offset_left(reserved_room_for_brace).is_none() {
+                        return Err(RewriteError::ExceedsMaxWidth {
+                            configured_width: shape.width,
+                            span: span.clone(),
+                        });
+                    }
+                    ret
+                };
+                Ok((rewritten_segment, next_shape))
             }
+
+            let shape_top_level = shape.clone();
+            let mut result = String::with_capacity(256);
+            let mut is_first = true;
+            let mut iter = self.path.iter().peekable();
+            let span = self.span();
+            while let Some(segment) = iter.next() {
+                let allow_overflow = is_first;
+                is_first = false;
+                match proceed(context, &span, &shape, segment, allow_overflow, iter.peek()) {
+                    Ok((rewritten_segment, next_shape)) => {
+                        result.push_str(&rewritten_segment);
+                        shape = next_shape;
+                        continue;
+                    }
+                    Err(RewriteError::ExceedsMaxWidth { .. }) => {
+                        // If the first `proceed()` failed with no room, retry with newline.
+                    }
+                    Err(e) => {
+                        // Abort otherwise.
+                        return Err(e);
+                    }
+                }
+                result.push_str("\n");
+                result.push_str(&" ".repeat(shape.indent.block_indent + 4));
+                shape = shape_top_level.clone();
+                let allow_overflow = true;
+                let (rewritten_segment, next_shape) =
+                    proceed(context, &span, &shape, segment, allow_overflow, iter.peek())?;
+                result.push_str(&rewritten_segment);
+                shape = next_shape;
+            }
+            Ok(result)
+        } else {
+            let mut result = String::with_capacity(256);
+            let mut iter = self.path.iter().peekable();
+            while let Some(segment) = iter.next() {
+                let segment_str = segment.rewrite_result(context, shape)?;
+                result.push_str(&segment_str);
+                if iter.peek().is_some() {
+                    result.push_str("::");
+                    // 2 = "::"
+                    shape = shape
+                        .offset_left(2 + segment_str.len())
+                        .max_width_error(shape.width, self.span())?;
+                }
+            }
+            Ok(result)
         }
-        Ok(result)
     }
 }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1115,7 +1115,7 @@ impl Rewrite for UseSegment {
                     use_tree_list,
                     // 1 = "{" and "}"
                     shape
-                        .offset_left(1)
+                        .offset_left_opt(1)
                         .unknown_error()?
                         .saturating_sub_width(1),
                 )?
@@ -1165,7 +1165,7 @@ impl Rewrite for UseTree {
                         s.clone()
                     }
                 } else {
-                    let Some(ret) = shape.offset_left(rewritten_segment.len()) else {
+                    let Some(ret) = shape.offset_left_opt(rewritten_segment.len()) else {
                         return Err(RewriteError::ExceedsMaxWidth {
                             configured_width: shape.width,
                             span: span.clone(),
@@ -1173,7 +1173,7 @@ impl Rewrite for UseTree {
                     };
                     // Check that there is a room for the next "{". If not, return an error for
                     // retry with newline.
-                    if ret.offset_left(reserved_room_for_brace).is_none() {
+                    if ret.offset_left_opt(reserved_room_for_brace).is_none() {
                         return Err(RewriteError::ExceedsMaxWidth {
                             configured_width: shape.width,
                             span: span.clone(),
@@ -1226,7 +1226,7 @@ impl Rewrite for UseTree {
                     result.push_str("::");
                     // 2 = "::"
                     shape = shape
-                        .offset_left(2 + segment_str.len())
+                        .offset_left_opt(2 + segment_str.len())
                         .max_width_error(shape.width, self.span())?;
                 }
             }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -293,14 +293,6 @@ impl Shape {
         }
     }
 
-    pub(crate) fn shrink_left(&self, width: usize) -> Option<Shape> {
-        Some(Shape {
-            width: self.width.checked_sub(width)?,
-            indent: self.indent + width,
-            offset: self.offset + width,
-        })
-    }
-
     pub(crate) fn offset_left_opt(&self, delta: usize) -> Option<Shape> {
         self.add_offset(delta).sub_width_opt(delta)
     }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -286,8 +286,27 @@ impl Shape {
             .ok_or_else(|| self.exceeds_max_width_error(span))
     }
 
+    pub(crate) fn add_width(&self, width: usize) -> Shape {
+        Shape {
+            width: self.width + width,
+            ..*self
+        }
+    }
+
+    pub(crate) fn shrink_left(&self, width: usize) -> Option<Shape> {
+        Some(Shape {
+            width: self.width.checked_sub(width)?,
+            indent: self.indent + width,
+            offset: self.offset + width,
+        })
+    }
+
     pub(crate) fn offset_left_opt(&self, delta: usize) -> Option<Shape> {
         self.add_offset(delta).sub_width_opt(delta)
+    }
+
+    pub(crate) fn offset_left_maybe_overflow(&self, width: usize) -> Shape {
+        self.add_offset(width).saturating_sub_width(width)
     }
 
     pub(crate) fn used_width(&self) -> usize {

--- a/tests/source/5131_crate.rs
+++ b/tests/source/5131_crate.rs
@@ -12,3 +12,153 @@ use foo::d::e;
 use qux::h;
 use qux::h as h2;
 use qux::i;
+
+mod indent4 {
+    use column_____________________________________________________________________________________102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use column_______________________________________________________________________________096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use column_________________________________________________________________________090::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::c102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+}
+
+use smithay::{
+    backend::renderer::element::{
+        default_primary_scanout_output_compare, utils::select_dmabuf_feedback, RenderElementStates,
+    },
+    delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
+    delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_layer_shell,
+    delegate_output, delegate_pointer_constraints, delegate_pointer_gestures,
+    delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_shm, delegate_tablet_manager, delegate_text_input_manager,
+    delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
+    delegate_xdg_decoration, delegate_xdg_shell,
+    desktop::{
+        space::SpaceElement,
+        utils::{
+            surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
+            update_surface_primary_scanout_output, OutputPresentationFeedback,
+        },
+        PopupKind, PopupManager, Space,
+    },
+    input::{
+        keyboard::{Keysym, LedState, XkbConfig},
+        pointer::{CursorImageStatus, PointerHandle},
+        Seat, SeatHandler, SeatState,
+    },
+    output::Output,
+    reexports::{
+        calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+        wayland_protocols::xdg::decoration::{
+            self as xdg_decoration,
+            zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
+        },
+        wayland_server::{
+            backend::{ClientData, ClientId, DisconnectReason},
+            protocol::{wl_data_source::WlDataSource, wl_surface::WlSurface},
+            Display, DisplayHandle, Resource,
+        },
+    },
+    utils::{Clock, Monotonic, Rectangle},
+    wayland::{
+        compositor::{get_parent, with_states, CompositorClientState, CompositorState},
+        dmabuf::DmabufFeedback,
+        fractional_scale::{
+            with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+        },
+        input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface},
+        keyboard_shortcuts_inhibit::{
+            KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState,
+            KeyboardShortcutsInhibitor,
+        },
+        output::{OutputHandler, OutputManagerState},
+        pointer_constraints::{
+            with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+        },
+        pointer_gestures::PointerGesturesState,
+        presentation::PresentationState,
+        relative_pointer::RelativePointerManagerState,
+        seat::WaylandFocus,
+        security_context::{
+            SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
+            SecurityContextState,
+        },
+        selection::data_device::{
+            set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+            ServerDndGrabHandler,
+        },
+        selection::{
+            primary_selection::{
+                set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+            },
+            wlr_data_control::{DataControlHandler, DataControlState},
+            SelectionHandler,
+        },
+        shell::{
+            wlr_layer::WlrLayerShellState,
+            xdg::{
+                decoration::{XdgDecorationHandler, XdgDecorationState},
+                ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+            },
+        },
+        shm::{ShmHandler, ShmState},
+        socket::ListeningSocketSource,
+        tablet_manager::{TabletManagerState, TabletSeatTrait},
+        text_input::TextInputManagerState,
+        viewporter::ViewporterState,
+        virtual_keyboard::VirtualKeyboardManagerState,
+        xdg_activation::{
+            XdgActivationHandler, XdgActivationState, XdgActivationToken, XdgActivationTokenData,
+        },
+        xdg_foreign::{XdgForeignHandler, XdgForeignState},
+    },
+};

--- a/tests/source/5131_crate_2024.rs
+++ b/tests/source/5131_crate_2024.rs
@@ -1,18 +1,19 @@
-// rustfmt-imports_granularity: One
+// rustfmt-imports_granularity: Crate
+// rustfmt-style_edition: 2024
 
-pub use foo::x;
-pub use foo::x as x2;
-pub use foo::y;
-use bar::a;
-use bar::b;
-use bar::b::f;
-use bar::b::f as f2;
-use bar::b::g;
-use bar::c;
-use bar::d::e;
-use bar::d::e as e2;
+use foo::a;
+use foo::a;
+use foo::b;
+use foo::b as b2;
+use foo::b::f;
+use foo::b::g;
+use foo::b::g as g2;
+use foo::c;
+use foo::d::e;
 use qux::h;
+use qux::h as h2;
 use qux::i;
+
 
 mod indent4 {
     use column_____________________________________________________________________________________102::{

--- a/tests/source/5131_module.rs
+++ b/tests/source/5131_module.rs
@@ -31,3 +31,188 @@ mod a {
         }
     }
 }
+
+mod indent4 {
+    use column_____________________________________________________________________________________102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use column_______________________________________________________________________________096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use column_________________________________________________________________________090::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::c102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    // Check that the behavior when "{" exceeds the max column.
+    //
+    // Note that `shape.offset_left(4)?.sub_width(1)?;` in
+    // `rewrite_reorderable_or_regroupable_items()` replaces the max column 100 by 99.
+
+    use x::column______________________________________________________________________________098::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use x::column__Only_the_last_one_wraps_due_to_brace_______________________________________097::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use x::column_____________________________________________________________________________096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    // Test for top-level `UseSegmentKind::List`.
+    use {
+        a,
+        column_____________________________________________________________________________________102,
+    };
+}
+
+use smithay::{
+    backend::renderer::element::{
+        default_primary_scanout_output_compare, utils::select_dmabuf_feedback, RenderElementStates,
+    },
+    delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
+    delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_layer_shell,
+    delegate_output, delegate_pointer_constraints, delegate_pointer_gestures,
+    delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_shm, delegate_tablet_manager, delegate_text_input_manager,
+    delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
+    delegate_xdg_decoration, delegate_xdg_shell,
+    desktop::{
+        space::SpaceElement,
+        utils::{
+            surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
+            update_surface_primary_scanout_output, OutputPresentationFeedback,
+        },
+        PopupKind, PopupManager, Space,
+    },
+    input::{
+        keyboard::{Keysym, LedState, XkbConfig},
+        pointer::{CursorImageStatus, PointerHandle},
+        Seat, SeatHandler, SeatState,
+    },
+    output::Output,
+    reexports::{
+        calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+        wayland_protocols::xdg::decoration::{
+            self as xdg_decoration,
+            zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
+        },
+        wayland_server::{
+            backend::{ClientData, ClientId, DisconnectReason},
+            protocol::{wl_data_source::WlDataSource, wl_surface::WlSurface},
+            Display, DisplayHandle, Resource,
+        },
+    },
+    utils::{Clock, Monotonic, Rectangle},
+    wayland::{
+        compositor::{get_parent, with_states, CompositorClientState, CompositorState},
+        dmabuf::DmabufFeedback,
+        fractional_scale::{
+            with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+        },
+        input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface},
+        keyboard_shortcuts_inhibit::{
+            KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState,
+            KeyboardShortcutsInhibitor,
+        },
+        output::{OutputHandler, OutputManagerState},
+        pointer_constraints::{
+            with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+        },
+        pointer_gestures::PointerGesturesState,
+        presentation::PresentationState,
+        relative_pointer::RelativePointerManagerState,
+        seat::WaylandFocus,
+        security_context::{
+            SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
+            SecurityContextState,
+        },
+        selection::data_device::{
+            set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+            ServerDndGrabHandler,
+        },
+        selection::{
+            primary_selection::{
+                set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+            },
+            wlr_data_control::{DataControlHandler, DataControlState},
+            SelectionHandler,
+        },
+        shell::{
+            wlr_layer::WlrLayerShellState,
+            xdg::{
+                decoration::{XdgDecorationHandler, XdgDecorationState},
+                ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+            },
+        },
+        shm::{ShmHandler, ShmState},
+        socket::ListeningSocketSource,
+        tablet_manager::{TabletManagerState, TabletSeatTrait},
+        text_input::TextInputManagerState,
+        viewporter::ViewporterState,
+        virtual_keyboard::VirtualKeyboardManagerState,
+        xdg_activation::{
+            XdgActivationHandler, XdgActivationState, XdgActivationToken, XdgActivationTokenData,
+        },
+        xdg_foreign::{XdgForeignHandler, XdgForeignState},
+    },
+};

--- a/tests/source/5131_module_2024.rs
+++ b/tests/source/5131_module_2024.rs
@@ -1,18 +1,37 @@
-// rustfmt-imports_granularity: One
+// rustfmt-imports_granularity: Module
+// rustfmt-style_edition: 2024
 
-pub use foo::x;
-pub use foo::x as x2;
-pub use foo::y;
-use bar::a;
-use bar::b;
-use bar::b::f;
-use bar::b::f as f2;
-use bar::b::g;
-use bar::c;
-use bar::d::e;
-use bar::d::e as e2;
-use qux::h;
-use qux::i;
+#![allow(dead_code)]
+
+mod a {
+    pub mod b {
+        pub struct Data {
+            pub a: i32,
+        }
+    }
+
+    use crate::a::b::Data;
+    use crate::a::b::Data as Data2;
+
+    pub fn data(a: i32) -> Data {
+        Data { a }
+    }
+
+    pub fn data2(a: i32) -> Data2 {
+        Data2 { a }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        pub fn test() {
+            data(1);
+            data2(1);
+        }
+    }
+}
 
 mod indent4 {
     use column_____________________________________________________________________________________102::{
@@ -69,6 +88,41 @@ mod indent4 {
         bar::baz::Baz,
         Foo2,
         bar::Bar2,
+    };
+
+    // Check that the behavior when "{" exceeds the max column.
+    //
+    // Note that `shape.offset_left(4)?.sub_width(1)?;` in
+    // `rewrite_reorderable_or_regroupable_items()` replaces the max column 100 by 99.
+
+    use x::column______________________________________________________________________________098::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use x::column__Only_the_last_one_wraps_due_to_brace_______________________________________097::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use x::column_____________________________________________________________________________096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    // Test for top-level `UseSegmentKind::List`.
+    use {
+        a,
+        column_____________________________________________________________________________________102,
     };
 }
 

--- a/tests/source/5131_one_2024.rs
+++ b/tests/source/5131_one_2024.rs
@@ -1,4 +1,5 @@
 // rustfmt-imports_granularity: One
+// rustfmt-style_edition: 2024
 
 pub use foo::x;
 pub use foo::x as x2;

--- a/tests/target/5131_crate.rs
+++ b/tests/target/5131_crate.rs
@@ -7,3 +7,138 @@ use foo::{
     d::e,
 };
 use qux::{h, h as h2, i};
+
+mod indent4 {
+    use column_____________________________________________________________________________________102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use column_______________________________________________________________________________096::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+
+    use column_________________________________________________________________________090::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::c102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+}
+
+use smithay::{
+    backend::renderer::element::{
+        default_primary_scanout_output_compare, utils::select_dmabuf_feedback, RenderElementStates,
+    },
+    delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
+    delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_layer_shell,
+    delegate_output, delegate_pointer_constraints, delegate_pointer_gestures,
+    delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_shm, delegate_tablet_manager, delegate_text_input_manager,
+    delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
+    delegate_xdg_decoration, delegate_xdg_shell,
+    desktop::{
+        space::SpaceElement,
+        utils::{
+            surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
+            update_surface_primary_scanout_output, OutputPresentationFeedback,
+        },
+        PopupKind, PopupManager, Space,
+    },
+    input::{
+        keyboard::{Keysym, LedState, XkbConfig},
+        pointer::{CursorImageStatus, PointerHandle},
+        Seat, SeatHandler, SeatState,
+    },
+    output::Output,
+    reexports::{
+        calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+        wayland_protocols::xdg::decoration::{
+            self as xdg_decoration,
+            zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
+        },
+        wayland_server::{
+            backend::{ClientData, ClientId, DisconnectReason},
+            protocol::{wl_data_source::WlDataSource, wl_surface::WlSurface},
+            Display, DisplayHandle, Resource,
+        },
+    },
+    utils::{Clock, Monotonic, Rectangle},
+    wayland::{
+        compositor::{get_parent, with_states, CompositorClientState, CompositorState},
+        dmabuf::DmabufFeedback,
+        fractional_scale::{
+            with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+        },
+        input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface},
+        keyboard_shortcuts_inhibit::{
+            KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState,
+            KeyboardShortcutsInhibitor,
+        },
+        output::{OutputHandler, OutputManagerState},
+        pointer_constraints::{
+            with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+        },
+        pointer_gestures::PointerGesturesState,
+        presentation::PresentationState,
+        relative_pointer::RelativePointerManagerState,
+        seat::WaylandFocus,
+        security_context::{
+            SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
+            SecurityContextState,
+        },
+        selection::{
+            data_device::{
+                set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+                ServerDndGrabHandler,
+            },
+            primary_selection::{
+                set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+            },
+            wlr_data_control::{DataControlHandler, DataControlState},
+            SelectionHandler,
+        },
+        shell::{
+            wlr_layer::WlrLayerShellState,
+            xdg::{
+                decoration::{XdgDecorationHandler, XdgDecorationState},
+                ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+            },
+        },
+        shm::{ShmHandler, ShmState},
+        socket::ListeningSocketSource,
+        tablet_manager::{TabletManagerState, TabletSeatTrait},
+        text_input::TextInputManagerState,
+        viewporter::ViewporterState,
+        virtual_keyboard::VirtualKeyboardManagerState,
+        xdg_activation::{
+            XdgActivationHandler, XdgActivationState, XdgActivationToken, XdgActivationTokenData,
+        },
+        xdg_foreign::{XdgForeignHandler, XdgForeignState},
+    },
+};

--- a/tests/target/5131_crate_2024.rs
+++ b/tests/target/5131_crate_2024.rs
@@ -1,74 +1,49 @@
-// rustfmt-imports_granularity: One
+// rustfmt-imports_granularity: Crate
+// rustfmt-style_edition: 2024
 
-pub use foo::x;
-pub use foo::x as x2;
-pub use foo::y;
-use bar::a;
-use bar::b;
-use bar::b::f;
-use bar::b::f as f2;
-use bar::b::g;
-use bar::c;
-use bar::d::e;
-use bar::d::e as e2;
-use qux::h;
-use qux::i;
+use foo::{
+    a, b, b as b2,
+    b::{f, g, g as g2},
+    c,
+    d::e,
+};
+use qux::{h, h as h2, i};
 
 mod indent4 {
     use column_____________________________________________________________________________________102::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use column_______________________________________________________________________________096::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use column_________________________________________________________________________090::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
-    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::c102::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        c102::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 }
 
@@ -133,11 +108,11 @@ use smithay::{
             SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
             SecurityContextState,
         },
-        selection::data_device::{
-            set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
-            ServerDndGrabHandler,
-        },
         selection::{
+            data_device::{
+                set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+                ServerDndGrabHandler,
+            },
             primary_selection::{
                 set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
             },

--- a/tests/target/5131_crate_2024.rs
+++ b/tests/target/5131_crate_2024.rs
@@ -11,45 +11,45 @@ use qux::{h, h as h2, i};
 
 mod indent4 {
     use column_____________________________________________________________________________________102::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use column_______________________________________________________________________________096::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use column_________________________________________________________________________090::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
         c102::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 }
 
 use smithay::{
     backend::renderer::element::{
-        default_primary_scanout_output_compare, utils::select_dmabuf_feedback, RenderElementStates,
+        RenderElementStates, default_primary_scanout_output_compare, utils::select_dmabuf_feedback,
     },
     delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
     delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_layer_shell,
@@ -59,37 +59,37 @@ use smithay::{
     delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
     delegate_xdg_decoration, delegate_xdg_shell,
     desktop::{
+        PopupKind, PopupManager, Space,
         space::SpaceElement,
         utils::{
-            surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
-            update_surface_primary_scanout_output, OutputPresentationFeedback,
+            OutputPresentationFeedback, surface_presentation_feedback_flags_from_states,
+            surface_primary_scanout_output, update_surface_primary_scanout_output,
         },
-        PopupKind, PopupManager, Space,
     },
     input::{
+        Seat, SeatHandler, SeatState,
         keyboard::{Keysym, LedState, XkbConfig},
         pointer::{CursorImageStatus, PointerHandle},
-        Seat, SeatHandler, SeatState,
     },
     output::Output,
     reexports::{
-        calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+        calloop::{Interest, LoopHandle, Mode, PostAction, generic::Generic},
         wayland_protocols::xdg::decoration::{
             self as xdg_decoration,
             zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
         },
         wayland_server::{
+            Display, DisplayHandle, Resource,
             backend::{ClientData, ClientId, DisconnectReason},
             protocol::{wl_data_source::WlDataSource, wl_surface::WlSurface},
-            Display, DisplayHandle, Resource,
         },
     },
     utils::{Clock, Monotonic, Rectangle},
     wayland::{
-        compositor::{get_parent, with_states, CompositorClientState, CompositorState},
+        compositor::{CompositorClientState, CompositorState, get_parent, with_states},
         dmabuf::DmabufFeedback,
         fractional_scale::{
-            with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+            FractionalScaleHandler, FractionalScaleManagerState, with_fractional_scale,
         },
         input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface},
         keyboard_shortcuts_inhibit::{
@@ -98,7 +98,7 @@ use smithay::{
         },
         output::{OutputHandler, OutputManagerState},
         pointer_constraints::{
-            with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+            PointerConstraintsHandler, PointerConstraintsState, with_pointer_constraint,
         },
         pointer_gestures::PointerGesturesState,
         presentation::PresentationState,
@@ -109,21 +109,21 @@ use smithay::{
             SecurityContextState,
         },
         selection::{
+            SelectionHandler,
             data_device::{
-                set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
-                ServerDndGrabHandler,
+                ClientDndGrabHandler, DataDeviceHandler, DataDeviceState, ServerDndGrabHandler,
+                set_data_device_focus,
             },
             primary_selection::{
-                set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+                PrimarySelectionHandler, PrimarySelectionState, set_primary_focus,
             },
             wlr_data_control::{DataControlHandler, DataControlState},
-            SelectionHandler,
         },
         shell::{
             wlr_layer::WlrLayerShellState,
             xdg::{
-                decoration::{XdgDecorationHandler, XdgDecorationState},
                 ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+                decoration::{XdgDecorationHandler, XdgDecorationState},
             },
         },
         shm::{ShmHandler, ShmState},

--- a/tests/target/5131_module.rs
+++ b/tests/target/5131_module.rs
@@ -30,3 +30,186 @@ mod a {
         }
     }
 }
+
+mod indent4 {
+    use column_____________________________________________________________________________________102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use column_______________________________________________________________________________096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use column_________________________________________________________________________090::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::c102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::bar::baz::Baz;
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::bar::{
+        Bar, Bar2,
+    };
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{Foo, Foo2};
+
+    // Check that the behavior when "{" exceeds the max column.
+    //
+    // Note that `shape.offset_left(4)?.sub_width(1)?;` in
+    // `rewrite_reorderable_or_regroupable_items()` replaces the max column 100 by 99.
+
+    use x::column______________________________________________________________________________098::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use x::column__Only_the_last_one_wraps_due_to_brace_______________________________________097::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use x::column_____________________________________________________________________________096::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    // Test for top-level `UseSegmentKind::List`.
+    use {
+        a,
+        column_____________________________________________________________________________________102,
+    };
+}
+
+use smithay::{
+    backend::renderer::element::{
+        default_primary_scanout_output_compare, utils::select_dmabuf_feedback, RenderElementStates,
+    },
+    delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
+    delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_layer_shell,
+    delegate_output, delegate_pointer_constraints, delegate_pointer_gestures,
+    delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_shm, delegate_tablet_manager, delegate_text_input_manager,
+    delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
+    delegate_xdg_decoration, delegate_xdg_shell,
+    desktop::{
+        space::SpaceElement,
+        utils::{
+            surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
+            update_surface_primary_scanout_output, OutputPresentationFeedback,
+        },
+        PopupKind, PopupManager, Space,
+    },
+    input::{
+        keyboard::{Keysym, LedState, XkbConfig},
+        pointer::{CursorImageStatus, PointerHandle},
+        Seat, SeatHandler, SeatState,
+    },
+    output::Output,
+    reexports::{
+        calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+        wayland_protocols::xdg::decoration::{
+            self as xdg_decoration,
+            zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
+        },
+        wayland_server::{
+            backend::{ClientData, ClientId, DisconnectReason},
+            protocol::{wl_data_source::WlDataSource, wl_surface::WlSurface},
+            Display, DisplayHandle, Resource,
+        },
+    },
+    utils::{Clock, Monotonic, Rectangle},
+    wayland::{
+        compositor::{get_parent, with_states, CompositorClientState, CompositorState},
+        dmabuf::DmabufFeedback,
+        fractional_scale::{
+            with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+        },
+        input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface},
+        keyboard_shortcuts_inhibit::{
+            KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState,
+            KeyboardShortcutsInhibitor,
+        },
+        output::{OutputHandler, OutputManagerState},
+        pointer_constraints::{
+            with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+        },
+        pointer_gestures::PointerGesturesState,
+        presentation::PresentationState,
+        relative_pointer::RelativePointerManagerState,
+        seat::WaylandFocus,
+        security_context::{
+            SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
+            SecurityContextState,
+        },
+        selection::data_device::{
+            set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+            ServerDndGrabHandler,
+        },
+        selection::{
+            primary_selection::{
+                set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+            },
+            wlr_data_control::{DataControlHandler, DataControlState},
+            SelectionHandler,
+        },
+        shell::{
+            wlr_layer::WlrLayerShellState,
+            xdg::{
+                decoration::{XdgDecorationHandler, XdgDecorationState},
+                ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+            },
+        },
+        shm::{ShmHandler, ShmState},
+        socket::ListeningSocketSource,
+        tablet_manager::{TabletManagerState, TabletSeatTrait},
+        text_input::TextInputManagerState,
+        viewporter::ViewporterState,
+        virtual_keyboard::VirtualKeyboardManagerState,
+        xdg_activation::{
+            XdgActivationHandler, XdgActivationState, XdgActivationToken, XdgActivationTokenData,
+        },
+        xdg_foreign::{XdgForeignHandler, XdgForeignState},
+    },
+};

--- a/tests/target/5131_module_2024.rs
+++ b/tests/target/5131_module_2024.rs
@@ -1,0 +1,208 @@
+// rustfmt-imports_granularity: Module
+// rustfmt-style_edition: 2024
+
+#![allow(dead_code)]
+
+mod a {
+    pub mod b {
+        pub struct Data {
+            pub a: i32,
+        }
+    }
+
+    use crate::a::b::{Data, Data as Data2};
+
+    pub fn data(a: i32) -> Data {
+        Data { a }
+    }
+
+    pub fn data2(a: i32) -> Data2 {
+        Data2 { a }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        pub fn test() {
+            data(1);
+            data2(1);
+        }
+    }
+}
+
+mod indent4 {
+    use column_____________________________________________________________________________________102::
+        bar::baz::Baz;
+    use column_____________________________________________________________________________________102::
+        bar::{Bar, Bar2};
+    use column_____________________________________________________________________________________102::{
+        Foo, Foo2,
+    };
+
+    use column_______________________________________________________________________________096::
+        bar::baz::Baz;
+    use column_______________________________________________________________________________096::
+        bar::{Bar, Bar2};
+    use column_______________________________________________________________________________096::{
+        Foo, Foo2,
+    };
+
+    use column_________________________________________________________________________090::bar::
+        baz::Baz;
+    use column_________________________________________________________________________090::bar::{
+        Bar, Bar2,
+    };
+    use column_________________________________________________________________________090::{
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        c102::bar::baz::Baz;
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        c102::bar::{Bar, Bar2};
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        c102::{Foo, Foo2};
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        bar::baz::Baz;
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        bar::{Bar, Bar2};
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::bar::
+        baz::Baz;
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::bar::{
+        Bar, Bar2,
+    };
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::bar::baz::Baz;
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::bar::{
+        Bar, Bar2,
+    };
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{Foo, Foo2};
+
+    // Check that the behavior when "{" exceeds the max column.
+    //
+    // Note that `shape.offset_left(4)?.sub_width(1)?;` in
+    // `rewrite_reorderable_or_regroupable_items()` replaces the max column 100 by 99.
+
+    use x::
+        column______________________________________________________________________________098::
+        bar::baz::Baz;
+    use x::
+        column______________________________________________________________________________098::
+        bar::{Bar, Bar2};
+    use x::
+        column______________________________________________________________________________098::{
+        Foo, Foo2,
+    };
+
+    use x::column__Only_the_last_one_wraps_due_to_brace_______________________________________097::
+        bar::baz::Baz;
+    use x::column__Only_the_last_one_wraps_due_to_brace_______________________________________097::
+        bar::{Bar, Bar2};
+    use x::
+        column__Only_the_last_one_wraps_due_to_brace_______________________________________097::{
+        Foo, Foo2,
+    };
+
+    use x::column_____________________________________________________________________________096::
+        bar::baz::Baz;
+    use x::column_____________________________________________________________________________096::
+        bar::{Bar, Bar2};
+    use x::
+        column_____________________________________________________________________________096::{
+        Foo, Foo2,
+    };
+
+    // Test for top-level `UseSegmentKind::List`.
+    use {
+        a,
+        column_____________________________________________________________________________________102,
+    };
+}
+
+use smithay::backend::renderer::element::utils::select_dmabuf_feedback;
+use smithay::backend::renderer::element::{
+    default_primary_scanout_output_compare, RenderElementStates,
+};
+use smithay::desktop::space::SpaceElement;
+use smithay::desktop::utils::{
+    surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
+    update_surface_primary_scanout_output, OutputPresentationFeedback,
+};
+use smithay::desktop::{PopupKind, PopupManager, Space};
+use smithay::input::keyboard::{Keysym, LedState, XkbConfig};
+use smithay::input::pointer::{CursorImageStatus, PointerHandle};
+use smithay::input::{Seat, SeatHandler, SeatState};
+use smithay::output::Output;
+use smithay::reexports::calloop::generic::Generic;
+use smithay::reexports::calloop::{Interest, LoopHandle, Mode, PostAction};
+use smithay::reexports::wayland_protocols::xdg::decoration::zv1::server::
+    zxdg_toplevel_decoration_v1::Mode as DecorationMode;
+use smithay::reexports::wayland_protocols::xdg::decoration::{self as xdg_decoration};
+use smithay::reexports::wayland_server::backend::{ClientData, ClientId, DisconnectReason};
+use smithay::reexports::wayland_server::protocol::wl_data_source::WlDataSource;
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::reexports::wayland_server::{Display, DisplayHandle, Resource};
+use smithay::utils::{Clock, Monotonic, Rectangle};
+use smithay::wayland::compositor::{
+    get_parent, with_states, CompositorClientState, CompositorState,
+};
+use smithay::wayland::dmabuf::DmabufFeedback;
+use smithay::wayland::fractional_scale::{
+    with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+};
+use smithay::wayland::input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface};
+use smithay::wayland::keyboard_shortcuts_inhibit::{
+    KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState, KeyboardShortcutsInhibitor,
+};
+use smithay::wayland::output::{OutputHandler, OutputManagerState};
+use smithay::wayland::pointer_constraints::{
+    with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+};
+use smithay::wayland::pointer_gestures::PointerGesturesState;
+use smithay::wayland::presentation::PresentationState;
+use smithay::wayland::relative_pointer::RelativePointerManagerState;
+use smithay::wayland::seat::WaylandFocus;
+use smithay::wayland::security_context::{
+    SecurityContext, SecurityContextHandler, SecurityContextListenerSource, SecurityContextState,
+};
+use smithay::wayland::selection::data_device::{
+    set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+    ServerDndGrabHandler,
+};
+use smithay::wayland::selection::primary_selection::{
+    set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+};
+use smithay::wayland::selection::wlr_data_control::{DataControlHandler, DataControlState};
+use smithay::wayland::selection::SelectionHandler;
+use smithay::wayland::shell::wlr_layer::WlrLayerShellState;
+use smithay::wayland::shell::xdg::decoration::{XdgDecorationHandler, XdgDecorationState};
+use smithay::wayland::shell::xdg::{ToplevelSurface, XdgShellState, XdgToplevelSurfaceData};
+use smithay::wayland::shm::{ShmHandler, ShmState};
+use smithay::wayland::socket::ListeningSocketSource;
+use smithay::wayland::tablet_manager::{TabletManagerState, TabletSeatTrait};
+use smithay::wayland::text_input::TextInputManagerState;
+use smithay::wayland::viewporter::ViewporterState;
+use smithay::wayland::virtual_keyboard::VirtualKeyboardManagerState;
+use smithay::wayland::xdg_activation::{
+    XdgActivationHandler, XdgActivationState, XdgActivationToken, XdgActivationTokenData,
+};
+use smithay::wayland::xdg_foreign::{XdgForeignHandler, XdgForeignState};
+use smithay::{
+    delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
+    delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_layer_shell,
+    delegate_output, delegate_pointer_constraints, delegate_pointer_gestures,
+    delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_shm, delegate_tablet_manager, delegate_text_input_manager,
+    delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
+    delegate_xdg_decoration, delegate_xdg_shell,
+};

--- a/tests/target/5131_module_2024.rs
+++ b/tests/target/5131_module_2024.rs
@@ -131,12 +131,12 @@ mod indent4 {
 
 use smithay::backend::renderer::element::utils::select_dmabuf_feedback;
 use smithay::backend::renderer::element::{
-    default_primary_scanout_output_compare, RenderElementStates,
+    RenderElementStates, default_primary_scanout_output_compare,
 };
 use smithay::desktop::space::SpaceElement;
 use smithay::desktop::utils::{
-    surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
-    update_surface_primary_scanout_output, OutputPresentationFeedback,
+    OutputPresentationFeedback, surface_presentation_feedback_flags_from_states,
+    surface_primary_scanout_output, update_surface_primary_scanout_output,
 };
 use smithay::desktop::{PopupKind, PopupManager, Space};
 use smithay::input::keyboard::{Keysym, LedState, XkbConfig};
@@ -154,11 +154,11 @@ use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::{Display, DisplayHandle, Resource};
 use smithay::utils::{Clock, Monotonic, Rectangle};
 use smithay::wayland::compositor::{
-    get_parent, with_states, CompositorClientState, CompositorState,
+    CompositorClientState, CompositorState, get_parent, with_states,
 };
 use smithay::wayland::dmabuf::DmabufFeedback;
 use smithay::wayland::fractional_scale::{
-    with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+    FractionalScaleHandler, FractionalScaleManagerState, with_fractional_scale,
 };
 use smithay::wayland::input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface};
 use smithay::wayland::keyboard_shortcuts_inhibit::{
@@ -166,7 +166,7 @@ use smithay::wayland::keyboard_shortcuts_inhibit::{
 };
 use smithay::wayland::output::{OutputHandler, OutputManagerState};
 use smithay::wayland::pointer_constraints::{
-    with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+    PointerConstraintsHandler, PointerConstraintsState, with_pointer_constraint,
 };
 use smithay::wayland::pointer_gestures::PointerGesturesState;
 use smithay::wayland::presentation::PresentationState;
@@ -175,15 +175,15 @@ use smithay::wayland::seat::WaylandFocus;
 use smithay::wayland::security_context::{
     SecurityContext, SecurityContextHandler, SecurityContextListenerSource, SecurityContextState,
 };
+use smithay::wayland::selection::SelectionHandler;
 use smithay::wayland::selection::data_device::{
-    set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
-    ServerDndGrabHandler,
+    ClientDndGrabHandler, DataDeviceHandler, DataDeviceState, ServerDndGrabHandler,
+    set_data_device_focus,
 };
 use smithay::wayland::selection::primary_selection::{
-    set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+    PrimarySelectionHandler, PrimarySelectionState, set_primary_focus,
 };
 use smithay::wayland::selection::wlr_data_control::{DataControlHandler, DataControlState};
-use smithay::wayland::selection::SelectionHandler;
 use smithay::wayland::shell::wlr_layer::WlrLayerShellState;
 use smithay::wayland::shell::xdg::decoration::{XdgDecorationHandler, XdgDecorationState};
 use smithay::wayland::shell::xdg::{ToplevelSurface, XdgShellState, XdgToplevelSurfaceData};

--- a/tests/target/5131_one.rs
+++ b/tests/target/5131_one.rs
@@ -10,3 +10,138 @@ use {
     },
     qux::{h, i},
 };
+
+mod indent4 {
+    use column_____________________________________________________________________________________102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use column_______________________________________________________________________________096::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+
+    use column_________________________________________________________________________090::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::c102::{
+        Foo,
+        bar::Bar,
+        bar::baz::Baz,
+        Foo2,
+        bar::Bar2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
+    };
+}
+
+use smithay::{
+    backend::renderer::element::{
+        default_primary_scanout_output_compare, utils::select_dmabuf_feedback, RenderElementStates,
+    },
+    delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
+    delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_layer_shell,
+    delegate_output, delegate_pointer_constraints, delegate_pointer_gestures,
+    delegate_presentation, delegate_primary_selection, delegate_relative_pointer, delegate_seat,
+    delegate_security_context, delegate_shm, delegate_tablet_manager, delegate_text_input_manager,
+    delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
+    delegate_xdg_decoration, delegate_xdg_shell,
+    desktop::{
+        space::SpaceElement,
+        utils::{
+            surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
+            update_surface_primary_scanout_output, OutputPresentationFeedback,
+        },
+        PopupKind, PopupManager, Space,
+    },
+    input::{
+        keyboard::{Keysym, LedState, XkbConfig},
+        pointer::{CursorImageStatus, PointerHandle},
+        Seat, SeatHandler, SeatState,
+    },
+    output::Output,
+    reexports::{
+        calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+        wayland_protocols::xdg::decoration::{
+            self as xdg_decoration,
+            zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
+        },
+        wayland_server::{
+            backend::{ClientData, ClientId, DisconnectReason},
+            protocol::{wl_data_source::WlDataSource, wl_surface::WlSurface},
+            Display, DisplayHandle, Resource,
+        },
+    },
+    utils::{Clock, Monotonic, Rectangle},
+    wayland::{
+        compositor::{get_parent, with_states, CompositorClientState, CompositorState},
+        dmabuf::DmabufFeedback,
+        fractional_scale::{
+            with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+        },
+        input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface},
+        keyboard_shortcuts_inhibit::{
+            KeyboardShortcutsInhibitHandler, KeyboardShortcutsInhibitState,
+            KeyboardShortcutsInhibitor,
+        },
+        output::{OutputHandler, OutputManagerState},
+        pointer_constraints::{
+            with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+        },
+        pointer_gestures::PointerGesturesState,
+        presentation::PresentationState,
+        relative_pointer::RelativePointerManagerState,
+        seat::WaylandFocus,
+        security_context::{
+            SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
+            SecurityContextState,
+        },
+        selection::{
+            data_device::{
+                set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+                ServerDndGrabHandler,
+            },
+            primary_selection::{
+                set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+            },
+            wlr_data_control::{DataControlHandler, DataControlState},
+            SelectionHandler,
+        },
+        shell::{
+            wlr_layer::WlrLayerShellState,
+            xdg::{
+                decoration::{XdgDecorationHandler, XdgDecorationState},
+                ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+            },
+        },
+        shm::{ShmHandler, ShmState},
+        socket::ListeningSocketSource,
+        tablet_manager::{TabletManagerState, TabletSeatTrait},
+        text_input::TextInputManagerState,
+        viewporter::ViewporterState,
+        virtual_keyboard::VirtualKeyboardManagerState,
+        xdg_activation::{
+            XdgActivationHandler, XdgActivationState, XdgActivationToken, XdgActivationTokenData,
+        },
+        xdg_foreign::{XdgForeignHandler, XdgForeignState},
+    },
+};

--- a/tests/target/5131_one_2024.rs
+++ b/tests/target/5131_one_2024.rs
@@ -1,74 +1,52 @@
 // rustfmt-imports_granularity: One
+// rustfmt-style_edition: 2024
 
-pub use foo::x;
-pub use foo::x as x2;
-pub use foo::y;
-use bar::a;
-use bar::b;
-use bar::b::f;
-use bar::b::f as f2;
-use bar::b::g;
-use bar::c;
-use bar::d::e;
-use bar::d::e as e2;
-use qux::h;
-use qux::i;
+pub use foo::{x, x as x2, y};
+use {
+    bar::{
+        a,
+        b::{self, f, g},
+        c,
+        d::{e, e as e2},
+    },
+    qux::{h, i},
+};
 
 mod indent4 {
     use column_____________________________________________________________________________________102::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use column_______________________________________________________________________________096::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use column_________________________________________________________________________090::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
-    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::c102::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+    use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        c102::{
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{
-        Foo,
-        bar::Bar,
-        bar::baz::Baz,
-        Foo2,
-        bar::Bar2,
+        bar::{baz::Baz, Bar, Bar2},
+        Foo, Foo2,
     };
 }
 
@@ -133,11 +111,11 @@ use smithay::{
             SecurityContext, SecurityContextHandler, SecurityContextListenerSource,
             SecurityContextState,
         },
-        selection::data_device::{
-            set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
-            ServerDndGrabHandler,
-        },
         selection::{
+            data_device::{
+                set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+                ServerDndGrabHandler,
+            },
             primary_selection::{
                 set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
             },

--- a/tests/target/5131_one_2024.rs
+++ b/tests/target/5131_one_2024.rs
@@ -14,45 +14,45 @@ use {
 
 mod indent4 {
     use column_____________________________________________________________________________________102::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use column_______________________________________________________________________________096::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use column_________________________________________________________________________090::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
         c102::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 
     use c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::{
-        bar::{baz::Baz, Bar, Bar2},
         Foo, Foo2,
+        bar::{Bar, Bar2, baz::Baz},
     };
 }
 
 use smithay::{
     backend::renderer::element::{
-        default_primary_scanout_output_compare, utils::select_dmabuf_feedback, RenderElementStates,
+        RenderElementStates, default_primary_scanout_output_compare, utils::select_dmabuf_feedback,
     },
     delegate_compositor, delegate_data_control, delegate_data_device, delegate_fractional_scale,
     delegate_input_method_manager, delegate_keyboard_shortcuts_inhibit, delegate_layer_shell,
@@ -62,37 +62,37 @@ use smithay::{
     delegate_viewporter, delegate_virtual_keyboard_manager, delegate_xdg_activation,
     delegate_xdg_decoration, delegate_xdg_shell,
     desktop::{
+        PopupKind, PopupManager, Space,
         space::SpaceElement,
         utils::{
-            surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
-            update_surface_primary_scanout_output, OutputPresentationFeedback,
+            OutputPresentationFeedback, surface_presentation_feedback_flags_from_states,
+            surface_primary_scanout_output, update_surface_primary_scanout_output,
         },
-        PopupKind, PopupManager, Space,
     },
     input::{
+        Seat, SeatHandler, SeatState,
         keyboard::{Keysym, LedState, XkbConfig},
         pointer::{CursorImageStatus, PointerHandle},
-        Seat, SeatHandler, SeatState,
     },
     output::Output,
     reexports::{
-        calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction},
+        calloop::{Interest, LoopHandle, Mode, PostAction, generic::Generic},
         wayland_protocols::xdg::decoration::{
             self as xdg_decoration,
             zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode,
         },
         wayland_server::{
+            Display, DisplayHandle, Resource,
             backend::{ClientData, ClientId, DisconnectReason},
             protocol::{wl_data_source::WlDataSource, wl_surface::WlSurface},
-            Display, DisplayHandle, Resource,
         },
     },
     utils::{Clock, Monotonic, Rectangle},
     wayland::{
-        compositor::{get_parent, with_states, CompositorClientState, CompositorState},
+        compositor::{CompositorClientState, CompositorState, get_parent, with_states},
         dmabuf::DmabufFeedback,
         fractional_scale::{
-            with_fractional_scale, FractionalScaleHandler, FractionalScaleManagerState,
+            FractionalScaleHandler, FractionalScaleManagerState, with_fractional_scale,
         },
         input_method::{InputMethodHandler, InputMethodManagerState, PopupSurface},
         keyboard_shortcuts_inhibit::{
@@ -101,7 +101,7 @@ use smithay::{
         },
         output::{OutputHandler, OutputManagerState},
         pointer_constraints::{
-            with_pointer_constraint, PointerConstraintsHandler, PointerConstraintsState,
+            PointerConstraintsHandler, PointerConstraintsState, with_pointer_constraint,
         },
         pointer_gestures::PointerGesturesState,
         presentation::PresentationState,
@@ -112,21 +112,21 @@ use smithay::{
             SecurityContextState,
         },
         selection::{
+            SelectionHandler,
             data_device::{
-                set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
-                ServerDndGrabHandler,
+                ClientDndGrabHandler, DataDeviceHandler, DataDeviceState, ServerDndGrabHandler,
+                set_data_device_focus,
             },
             primary_selection::{
-                set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
+                PrimarySelectionHandler, PrimarySelectionState, set_primary_focus,
             },
             wlr_data_control::{DataControlHandler, DataControlState},
-            SelectionHandler,
         },
         shell::{
             wlr_layer::WlrLayerShellState,
             xdg::{
-                decoration::{XdgDecorationHandler, XdgDecorationState},
                 ToplevelSurface, XdgShellState, XdgToplevelSurfaceData,
+                decoration::{XdgDecorationHandler, XdgDecorationState},
             },
         },
         shm::{ShmHandler, ShmState},

--- a/tests/target/issue_3033.rs
+++ b/tests/target/issue_3033.rs
@@ -1,2 +1,13 @@
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerBinding::
     BluetoothRemoteGATTServerMethods;
+
+mod indent4 {
+    use column__This_segment_overflows_because_it_follows_use______________________________________102::
+        column__This_segment_overflows_because_it_follows_newline__________________________________102::
+        c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        c012::
+        column__This_segment_wraps_because_it_exceeds_100_and_follows_the_previous_segment___102::
+        c012::c018::c024::c030::c036::c042::c048::c054::c060::c066::c072::c078::c084::c090::c096::
+        c012::column__This_segment_doesnt_wrap_because_it_doesnt_exceed_100__________________096::
+        Foo;
+}


### PR DESCRIPTION
Fixed: #6164

This patch reduces format failure for non default `imports_granularity` and correct the behavior around some edge cases.

- Supports too long line of `use ...` that contains `{}`.
- Fixes the width calculation of too long lines of `use ...`.
