### PR TITLE
formatting empty where clauses when there are return types

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2690,29 +2690,38 @@ fn rewrite_fn_base(
         }
 
         // Comment between return type and the end of the decl.
-        let snippet_lo = fd.output.span().hi();
         if where_clause.predicates.is_empty() {
+            let snippet_lo = fd.output.span().hi();
             let snippet_hi = span.hi();
-            let snippet = context.snippet(mk_sp(snippet_lo, snippet_hi));
-            // Try to preserve the layout of the original snippet.
-            let original_starts_with_newline = snippet
-                .find(|c| c != ' ')
-                .map_or(false, |i| starts_with_newline(&snippet[i..]));
-            let original_ends_with_newline = snippet
-                .rfind(|c| c != ' ')
-                .map_or(false, |i| snippet[i..].ends_with('\n'));
-            let snippet = snippet.trim();
-            if !snippet.is_empty() {
-                result.push(if original_starts_with_newline {
-                    '\n'
-                } else {
-                    ' '
-                });
-                result.push_str(snippet);
-                if original_ends_with_newline {
-                    force_new_line_for_brace = true;
+
+            let mut deal_snippet = |snippet: &str| {
+                // Try to preserve the layout of the original snippet.
+                let original_starts_with_newline = snippet
+                    .find(|c| c != ' ')
+                    .map_or(false, |i| starts_with_newline(&snippet[i..]));
+                let original_ends_with_newline = snippet
+                    .rfind(|c| c != ' ')
+                    .map_or(false, |i| snippet[i..].ends_with('\n'));
+                let snippet = snippet.trim();
+                if !snippet.is_empty() {
+                    result.push(if original_starts_with_newline {
+                        '\n'
+                    } else {
+                        ' '
+                    });
+                    result.push_str(snippet);
+                    if original_ends_with_newline {
+                        force_new_line_for_brace = true;
+                    }
                 }
-            }
+            };
+
+            if context.config.version() == crate::Version::Two && where_clause.has_where_token {
+                deal_snippet(context.snippet(mk_sp(snippet_lo, where_clause.span.lo())));
+                deal_snippet(context.snippet(mk_sp(where_clause.span.hi(), snippet_hi)));
+            } else {
+                deal_snippet(context.snippet(mk_sp(snippet_lo, snippet_hi)));
+            };
         }
     }
 

--- a/tests/source/empty-where-clauses.rs
+++ b/tests/source/empty-where-clauses.rs
@@ -1,0 +1,6 @@
+// rustfmt-version: Two
+
+fn foo() -> () where {}
+fn bar() -> () /* comment */ where {}
+fn baz() -> () where /* comment */ {}
+fn qux() -> () /* comment */ where /* comment */ {}

--- a/tests/target/empty-where-clauses.rs
+++ b/tests/target/empty-where-clauses.rs
@@ -1,0 +1,6 @@
+// rustfmt-version: Two
+
+fn foo() -> () {}
+fn bar() -> () /* comment */ {}
+fn baz() -> () /* comment */ {}
+fn qux() -> () /* comment */ /* comment */ {}


### PR DESCRIPTION
Fixes the bug, see https://github.com/rust-lang/rust/issues/125242#issuecomment-2119377808