### PR TITLE
Fix: rustfmt should not remove inner attributes from inline const blocks

### DIFF
--- a/tests/target/issue_6158.rs
+++ b/tests/target/issue_6158.rs
@@ -1,0 +1,7 @@
+fn main() {
+    const {
+        #![allow(clippy::assertions_on_constants)]
+
+        assert!(1 < 2);
+    }
+}


### PR DESCRIPTION
fixes #6158

`cargo test` 0 failed

first time contributed on this project🥳
