### PR TITLE
fix: respect trailing semicolon setting for last statements

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -100,7 +100,7 @@ impl<'a> Rewrite for Stmt<'a> {
             shape,
             self.as_ast_node(),
             expr_type,
-            self.is_last_expr(),
+            self.is_last,
         )
     }
 }
@@ -110,14 +110,14 @@ fn format_stmt(
     shape: Shape,
     stmt: &ast::Stmt,
     expr_type: ExprType,
-    is_last_expr: bool,
+    is_last: bool,
 ) -> Option<String> {
     skip_out_of_file_lines_range!(context, stmt.span());
 
     let result = match stmt.kind {
         ast::StmtKind::Local(ref local) => local.rewrite(context, shape),
         ast::StmtKind::Expr(ref ex) | ast::StmtKind::Semi(ref ex) => {
-            let suffix = if semicolon_for_stmt(context, stmt, is_last_expr) {
+            let suffix = if semicolon_for_stmt(context, stmt, is_last) {
                 ";"
             } else {
                 ""


### PR DESCRIPTION
## Problem

https://github.com/rust-lang/rustfmt/issues/5797 fixed the [trailing_semicolon](https://rust-lang.github.io/rustfmt/?version=v1.4.30&search=#trailing_semicolon) rule, allowing it only for the last expression in the block. The side-effect of this change is that such snippet

```rust
fn main() {
    println!("{}", greet());
}

fn greet() -> String {
    return "Hello, b!".to_string();
}
```

will not get formatted into
```rust
fn main() {
    println!("{}", greet());
}

fn greet() -> String {
    return "Hello, b!".to_string()
}
```

(notice the `;` in the `greet` function), even though `return` is the last expression here. It's happening because the implementation of `is_last_expr()` additionally checks for the type of expression for some reason unknown to me https://github.com/rust-lang/rustfmt/blob/46e5f14ae2300967d57ab8d032f446c07e0ed415/src/stmt.rs#L74-L88

## Solution

This PR fixes that by checking only the `is_last` field of the `Stmt` struct when deciding whether to emit the semicolon.

```rust    
fn main() {
    println!("{}", greet());
}

fn greet() -> String {
    return "Hello, b!".to_string();
}

fn foo() {}
fn main() {
    return;
    foo()
}
```

```console
➜  rustfmt git:(trailing-semicolon-last-stmt) cargo run --bin rustfmt -- --check -- ~/Projects/semicolon/src/main.rs
   Compiling rustfmt-nightly v1.7.0 (/Users/shekhirin/Projects/rustfmt)
    Finished dev [unoptimized + debuginfo] target(s) in 0.61s
     Running `target/debug/rustfmt --check -- /Users/shekhirin/Projects/semicolon/src/main.rs`
Diff in /Users/shekhirin/Projects/semicolon/src/main.rs:3:
 }
 
 fn greet() -> String {
-    return "Hello, b!".to_string();
+    return "Hello, b!".to_string()
 }
 
 fn foo() {}
```

As you can see, the example from the original PR is still not getting formatted, while the trailing comma for the last `return` statement gets removed.