### PR TITLE
Handle Cargo.toml manifests that are symlinks

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -384,11 +384,10 @@ fn get_targets_root_only(
             .packages
             .into_iter()
             .filter(|p| {
+                let manifest_path = PathBuf::from(&p.manifest_path);
                 in_workspace_root
-                    || PathBuf::from(&p.manifest_path)
-                        .canonicalize()
-                        .unwrap_or_default()
-                        == current_dir_manifest
+                    || manifest_path == current_dir_manifest
+                    || manifest_path.canonicalize().unwrap_or_default() == current_dir_manifest
             })
             .flat_map(|p| p.targets)
             .collect(),


### PR DESCRIPTION
The canonicalize() function resolves symlinks, which would cause targets whose "Cargo.toml" is a symlink to be filtered out. This would cause `cargo-fmt` to print an error "Failed to find targets".

Resolves #6184