### PR TITLE
Don't merge crates when `imports_granularity="Module"`

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -662,7 +662,12 @@ impl UseTree {
             match shared_prefix {
                 SharedPrefix::Crate => self.path[0] == other.path[0],
                 SharedPrefix::Module => {
-                    self.path[..self.path.len() - 1] == other.path[..other.path.len() - 1]
+                    if self.path.len() == 1 && other.path.len() == 1 {
+                        // When importing an entire crate, use the crate name for comparison.
+                        self.path[0] == other.path[0]
+                    } else {
+                        self.path[..self.path.len() - 1] == other.path[..other.path.len() - 1]
+                    }
                 }
                 SharedPrefix::One => true,
             }

--- a/tests/source/imports/imports_granularity_module.rs
+++ b/tests/source/imports/imports_granularity_module.rs
@@ -45,3 +45,7 @@ use b::v::{
 };
 use b::t::{/* Before b::t::self */ self};
 use b::c;
+
+// Issue #6191: grouping of top-level modules
+use library1;
+use {library2 as lib2, library3};

--- a/tests/source/issue-6191.rs
+++ b/tests/source/issue-6191.rs
@@ -1,0 +1,4 @@
+// rustfmt-imports_granularity: Module
+
+use library1;
+use {library2 as lib2, library3};

--- a/tests/target/imports/imports_granularity_module.rs
+++ b/tests/target/imports/imports_granularity_module.rs
@@ -53,3 +53,8 @@ use b::{
     /* Before b::l group */ l::{self, m, n::o, p::*},
     q,
 };
+
+// Issue #6191: grouping of top-level modules
+use library1;
+use library2 as lib2;
+use library3;

--- a/tests/target/issue-6191.rs
+++ b/tests/target/issue-6191.rs
@@ -1,0 +1,5 @@
+// rustfmt-imports_granularity: Module
+
+use library1;
+use library2 as lib2;
+use library3;


### PR DESCRIPTION
When merging imports using `imports_granularity="Module"`, individual crate imports should get their own `use` statement on a new line.

```
// Before this commit:
use {library1, library2 as lib2, library3};

// After this commit:
use library1;
use library2 as lib2;
use library3;
```

Fixes: #6191