### PR TITLE
docs: pin a version of markedjs from cdnjs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,13 +3,33 @@
     <head>
       <meta name="viewport" content="width=device-width">
       <title>Rustfmt</title>
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.css" />
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/github-gist.min.css">
-      <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/vue@2.6.10/dist/vue.js"></script>
+      <link rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.min.css"
+            integrity="sha512-7e0rszTy0dKTIgYzCeBXpmycq0EOkwAvxZ0dv/LAtQfcXWCoaRhzs+v2Mn6of3jImxPazbYxiK0kpE/7wZ/UQA=="
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer" />
+      <link rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/github-gist.min.css"
+            integrity="sha512-od7JLoOTxM8w/HSKGzP9Kexc20K9p/M2zxSWsd7H1e4Ctf+8SQFtCWEZnW5u6ul5ehSECa5QmOk9ju2nQMmlVA=="
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer" />
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.2/marked.min.js"
+              integrity="sha512-xeUh+KxNyTufZOje++oQHstlMQ8/rpyzPuM+gjMFYK3z5ILJGE7l2NvYL+XfliKURMpBIKKp1XoPN/qswlSMFA=="
+              crossorigin="anonymous" 
+              referrerpolicy="no-referrer"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.10/vue.min.js"
+              integrity="sha512-PwQ5+jgXxxprNGc80ycHE3spgj6TuDieHe/yTkbEJ+U5aol7dTupi/4VbwHHzlQVW77Vb0GLOIsiYigHgC5vcg=="
+              crossorigin="anonymous"
+              referrerpolicy="no-referrer"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/highlight.min.js"
+              integrity="sha512-av6ZR84Ldk6j29DMhf6v0cssEhow1VROFLoKbX7wrvzZB++/nV8m0jXbYeWcHPEzSNONImx6zwBskCUT9AQidA=="
+              crossorigin="anonymous"
+              referrerpolicy="no-referrer"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"
+              integrity="sha512-3BBFWr73Xrf8GRjO+0pl0cbVwESBvg3ovnuCXpoqOkC/mkt/hTkFtutUPrwRz8eLySYvy5v1daulkyUZYvH8jw=="
+              crossorigin="anonymous"
+              referrerpolicy="no-referrer"></script>
       <script src="https://unpkg.com/vue-async-computed@3.8.1"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/highlight.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"></script>
       <style>
         @media (max-width: 767px) {
           .markdown-body {


### PR DESCRIPTION
Hi! It seems like [the docs site](https://rust-lang.github.io/rustfmt/) is currently broken. Previous to this commit, the cdn markedjs url was not versioned, so when [markedjs v13](https://github.com/markedjs/marked/releases/tag/v13.0.0) introduced breaking changes on 2024-06-12, the rustfmt docs site automatically pulled them in.

In addition to fixing that problem by pinning to v12, this PR:

* Expands the cdnjs links and script tags to reflect their recommendations, including an `integrity` hash so the browser can check that the retrieved executable content is in fact as-expected.
* Switches markedjs and vue from jsdelivr to cdnjs, which should be slightly faster as the browser already will have a reusable http/tls connection to cdnjs from other resources.
* Uses the minified vue file, silencing a warning that vue was being used in development mode.

However, this PR does not change the versions of any dependencies, many of which are significantly out of date.

Thanks!