### PR TITLE
Implement rewrite_result for AST nodes 

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -374,6 +374,14 @@ macro_rules! skip_out_of_file_lines_range {
     };
 }
 
+macro_rules! skip_out_of_file_lines_range_err {
+    ($self:ident, $span:expr) => {
+        if out_of_file_lines_range!($self, $span) {
+            return Err(RewriteError::SkipFormatting);
+        }
+    };
+}
+
 macro_rules! skip_out_of_file_lines_range_visitor {
     ($self:ident, $span:expr) => {
         if out_of_file_lines_range!($self, $span) {


### PR DESCRIPTION
## Background
Since current `rewrite` method cannot track the context , this pr plans to implement `rewrite_result` method that returns Result. I will replace `rewrite` with `rewrite_result` in further pr. 

## Detail 
Added a default implementation of the `rewrite_result` method, which calls the existing rewrite method and transforms the `Option` into a `Result` with a default error kind. Additionally, I implemented the `rewrite_result` method for the `Chain` and `ast::Local` types by copying the body of their respective rewrite functions and replacing some of the `Option` handling logic with appropriate error handling.

## TODO & Question 
