### PR TITLE
remove unused tracing-attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,19 +710,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = "1.0"
 term = "0.7"
 thiserror = "1.0.40"
 toml = "0.7.4"
-tracing = "0.1.37"
+tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 unicode-segmentation = "1.9"
 unicode-width = "0.1"


### PR DESCRIPTION
This removed unused `tracing-attributes` dep (https://github.com/tokio-rs/tracing/blob/tracing-0.1.37/tracing/Cargo.toml) which provides `#[instrument]` macro.