### PR TITLE
Impl rewrite_result for ast nodes in items.rs

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -375,6 +375,14 @@ macro_rules! skip_out_of_file_lines_range {
     };
 }
 
+macro_rules! skip_out_of_file_lines_range_err {
+    ($self:ident, $span:expr) => {
+        if out_of_file_lines_range!($self, $span) {
+            return Err(RewriteError::SkipFormatting);
+        }
+    };
+}
+
 macro_rules! skip_out_of_file_lines_range_visitor {
     ($self:ident, $span:expr) => {
         if out_of_file_lines_range!($self, $span) {

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -50,16 +50,15 @@ impl AlignedItem for ast::FieldDef {
             mk_sp(self.attrs.last().unwrap().span.hi(), self.span.lo())
         };
         let attrs_extendable = self.ident.is_none() && is_attributes_extendable(&attrs_str);
-        rewrite_struct_field_prefix(context, self).and_then(|field_str| {
-            combine_strs_with_missing_comments(
-                context,
-                &attrs_str,
-                &field_str,
-                missing_span,
-                shape,
-                attrs_extendable,
-            )
-        })
+        let field_str = rewrite_struct_field_prefix(context, self).ok()?;
+        combine_strs_with_missing_comments(
+            context,
+            &attrs_str,
+            &field_str,
+            missing_span,
+            shape,
+            attrs_extendable,
+        )
     }
 
     fn rewrite_aligned_item(
@@ -68,7 +67,7 @@ impl AlignedItem for ast::FieldDef {
         shape: Shape,
         prefix_max_width: usize,
     ) -> Option<String> {
-        rewrite_struct_field(context, self, shape, prefix_max_width)
+        rewrite_struct_field(context, self, shape, prefix_max_width).ok()
     }
 }
 


### PR DESCRIPTION
Tracked by #6206 

## Description 
- added `RewriteError` and blanket implementation for `rewrite_result` 
- above 6 ast nodes that implements rewrite, replaced rewrite function body with `rewrite_result` for 4 nodes; 
**ast::Local, ast::FieldDef, ast::Param, ast::FnRetTy**