### PR TITLE
Remove `println!` in `rewrite_static()`

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1994,7 +1994,6 @@ fn rewrite_static(
     static_parts: &StaticParts<'_>,
     offset: Indent,
 ) -> Option<String> {
-    println!("rewriting static");
     let colon = colon_spaces(context.config);
     let mut prefix = format!(
         "{}{}{}{} {}{}{}",


### PR DESCRIPTION
There's an extraneous `println!()` in `rewrite_static` in `items.rs`:

https://github.com/rust-lang/rustfmt/blob/e4944185ae09c99f59b460e358909f329010ea9c/src/items.rs#L1992-L2000

This causes rustfmt to add "rewriting static" to the top of every file that triggers `rewrite_static()` when formatting:

![image](https://github.com/rust-lang/rustfmt/assets/104604363/4056fb3a-afea-4737-8656-250a8fa5bc8a)

This PR removes the `println!()`. Nothing fancy, I assume this was a mistake.