### PR TITLE
Test do nothing with doc comment with code

### DIFF
--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -5,7 +5,7 @@ use std::fs::remove_file;
 use std::path::Path;
 use std::process::Command;
 
-use rustfmt_config_proc_macro::rustfmt_only_ci_test;
+use rustfmt_config_proc_macro::{nightly_only_test, rustfmt_only_ci_test};
 
 /// Run the rustfmt executable and return its output.
 fn rustfmt(args: &[&str]) -> (String, String) {
@@ -208,6 +208,7 @@ fn rustfmt_emits_error_when_control_brace_style_is_always_next_line() {
     assert!(!stderr.contains("error[internal]: left behind trailing whitespace"))
 }
 
+#[nightly_only_test]
 #[test]
 fn rustfmt_generates_no_error() {
     // See also https://github.com/rust-lang/rustfmt/issues/6109

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -210,7 +210,7 @@ fn rustfmt_emits_error_when_control_brace_style_is_always_next_line() {
 
 #[nightly_only_test]
 #[test]
-fn rustfmt_generates_no_error() {
+fn rustfmt_generates_no_error_if_failed_format_code_in_doc_comments() {
     // See also https://github.com/rust-lang/rustfmt/issues/6109
 
     let file = "tests/target/issue-6109.rs";

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -207,3 +207,14 @@ fn rustfmt_emits_error_when_control_brace_style_is_always_next_line() {
     let (_stdout, stderr) = rustfmt(&args);
     assert!(!stderr.contains("error[internal]: left behind trailing whitespace"))
 }
+
+#[test]
+fn rustfmt_generates_no_error() {
+    // See also https://github.com/rust-lang/rustfmt/issues/6109
+
+    let file = "tests/target/issue-6109.rs";
+    let args = ["--config", "format_code_in_doc_comments=true", file];
+    let (stdout, stderr) = rustfmt(&args);
+    assert!(stderr.is_empty());
+    assert!(stdout.is_empty());
+}

--- a/tests/target/issue-6109.rs
+++ b/tests/target/issue-6109.rs
@@ -1,0 +1,7 @@
+/// Some doc comment with code snippet:
+///```
+/// '\u{1F}
+/// ```
+pub struct Code {}
+
+fn main() {}


### PR DESCRIPTION
Adding a test to prevent regression with regards to code snippet in doc comments as mentioned in this issue: https://github.com/rust-lang/rustfmt/issues/6109 The expected behavior is that the test shouldn't fai.