### PR TITLE
return RewriteResult for `rewrite_block` and `rewrite_closure`

### DIFF
--- a/src/closures.rs
+++ b/src/closures.rs
@@ -183,7 +183,8 @@ fn rewrite_closure_with_block(
         None,
         shape,
         false,
-    )?;
+    )
+    .ok()?;
     Some(format!("{prefix} {block}"))
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -230,7 +230,8 @@ pub(crate) fn format_expr(
             expr.span,
             context,
             shape,
-        ),
+        )
+        .ok(),
         ast::ExprKind::Try(..)
         | ast::ExprKind::Field(..)
         | ast::ExprKind::MethodCall(..)

--- a/src/items.rs
+++ b/src/items.rs
@@ -181,8 +181,7 @@ impl Rewrite for ast::Local {
                     && allow_single_line_let_else_block(assign_str_with_else_kw, block);
 
                 let mut rw_else_block =
-                    rewrite_let_else_block(block, allow_single_line, context, shape)
-                        .unknown_error()?;
+                    rewrite_let_else_block(block, allow_single_line, context, shape)?;
 
                 let single_line_else = !rw_else_block.contains('\n');
                 // +1 for the trailing `;`
@@ -191,8 +190,7 @@ impl Rewrite for ast::Local {
                 if allow_single_line && single_line_else && else_block_exceeds_width {
                     // writing this on one line would exceed the available width
                     // so rewrite the else block over multiple lines.
-                    rw_else_block =
-                        rewrite_let_else_block(block, false, context, shape).unknown_error()?;
+                    rw_else_block = rewrite_let_else_block(block, false, context, shape)?;
                 }
 
                 result.push_str(&rw_else_block);

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -427,7 +427,7 @@ impl<'a> Context<'a> {
                         if closures::args_have_many_closure(&self.items) {
                             None
                         } else {
-                            closures::rewrite_last_closure(self.context, expr, shape)
+                            closures::rewrite_last_closure(self.context, expr, shape).ok()
                         }
                     }
 


### PR DESCRIPTION
Tracked by #6206 

### Description
modify the signature of `rewrite_block` and `rewrite_closure` to return `RewriteResult`

### Side notes
- I did not change the return type of `rewrite_empty_block`(it returns None when given block is not empty) since every caller tries `rewrite_empty_block` first and then applies formatting logic for non empty block if it returns None. It seems that there's no need to propagate RewriteError upward from this function currently. 