### PR TITLE
return RewriteResult for rewrite_path & rewrite_struct_***

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -276,10 +276,11 @@ impl Rewrite for ast::MetaItem {
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
         Some(match self.kind {
             ast::MetaItemKind::Word => {
-                rewrite_path(context, PathContext::Type, &None, &self.path, shape)?
+                rewrite_path(context, PathContext::Type, &None, &self.path, shape).ok()?
             }
             ast::MetaItemKind::List(ref list) => {
-                let path = rewrite_path(context, PathContext::Type, &None, &self.path, shape)?;
+                let path =
+                    rewrite_path(context, PathContext::Type, &None, &self.path, shape).ok()?;
                 let has_trailing_comma = crate::expr::span_ends_with_comma(context, self.span);
                 overflow::rewrite_with_parens(
                     context,
@@ -297,7 +298,8 @@ impl Rewrite for ast::MetaItem {
                 )?
             }
             ast::MetaItemKind::NameValue(ref lit) => {
-                let path = rewrite_path(context, PathContext::Type, &None, &self.path, shape)?;
+                let path =
+                    rewrite_path(context, PathContext::Type, &None, &self.path, shape).ok()?;
                 // 3 = ` = `
                 let lit_shape = shape.shrink_left(path.len() + 3)?;
                 // `rewrite_literal` returns `None` when `lit` exceeds max

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -185,7 +185,7 @@ pub(crate) fn format_expr(
             rewrite_match(context, cond, arms, shape, expr.span, &expr.attrs, kind)
         }
         ast::ExprKind::Path(ref qself, ref path) => {
-            rewrite_path(context, PathContext::Expr, qself, path, shape)
+            rewrite_path(context, PathContext::Expr, qself, path, shape).ok()
         }
         ast::ExprKind::Assign(ref lhs, ref rhs, _) => {
             rewrite_assignment(context, lhs, rhs, None, shape)
@@ -1614,7 +1614,7 @@ fn rewrite_struct_lit<'a>(
 
     // 2 = " {".len()
     let path_shape = shape.sub_width(2)?;
-    let path_str = rewrite_path(context, PathContext::Expr, qself, path, path_shape)?;
+    let path_str = rewrite_path(context, PathContext::Expr, qself, path, path_shape).ok()?;
 
     let has_base_or_rest = match struct_rest {
         ast::StructRest::None if fields.is_empty() => return Some(format!("{path_str} {{}}")),

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -254,10 +254,11 @@ impl Rewrite for Pat {
             }
             PatKind::Tuple(ref items) => rewrite_tuple_pat(items, None, self.span, context, shape),
             PatKind::Path(ref q_self, ref path) => {
-                rewrite_path(context, PathContext::Expr, q_self, path, shape)
+                rewrite_path(context, PathContext::Expr, q_self, path, shape).ok()
             }
             PatKind::TupleStruct(ref q_self, ref path, ref pat_vec) => {
-                let path_str = rewrite_path(context, PathContext::Expr, q_self, path, shape)?;
+                let path_str =
+                    rewrite_path(context, PathContext::Expr, q_self, path, shape).ok()?;
                 rewrite_tuple_pat(pat_vec, Some(path_str), self.span, context, shape)
             }
             PatKind::Lit(ref expr) => expr.rewrite(context, shape),
@@ -315,7 +316,7 @@ fn rewrite_struct_pat(
 ) -> Option<String> {
     // 2 =  ` {`
     let path_shape = shape.sub_width(2)?;
-    let path_str = rewrite_path(context, PathContext::Expr, qself, path, path_shape)?;
+    let path_str = rewrite_path(context, PathContext::Expr, qself, path, path_shape).ok()?;
 
     if fields.is_empty() && !ellipsis {
         return Some(format!("{path_str} {{}}"));


### PR DESCRIPTION
Tracked by https://github.com/rust-lang/rustfmt/issues/6206

### Description
Modify following functions to return `RewriteResult`
- rewrite_path and its caller (rewrite_struct_lit / pat)
- method rewrite_aligned_item of AlignedItem trait

Impl rewrite_result for `PreciseCapturingArg`, `AssocItemConstraint`, `PolyTraitRef`, `TraitRef` in types.rs
(These are the nodes that were waiting for certain rewrite_*** to return RewriteResult. see #6220) 

### Side notes
- rewrite_prefix, another method of the AlignedItem trait remains `Option<String>` since it is used for the possible range of width for struct prefix (see struct_field_prefix_max_min_width)
- Additionally, there are some messy `unknown_error()` calls since I haven't modified `write_list`, `itemize_list`, and similar functions. There's ongoing concern about modifying these functions and the iterator implementation for `ListItems`.