### PR TITLE
impl rewrite_result for ArmWrapper

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -183,7 +183,7 @@ pub(crate) fn format_expr(
             }
         }
         ast::ExprKind::Match(ref cond, ref arms, kind) => {
-            rewrite_match(context, cond, arms, shape, expr.span, &expr.attrs, kind)
+            rewrite_match(context, cond, arms, shape, expr.span, &expr.attrs, kind).ok()
         }
         ast::ExprKind::Path(ref qself, ref path) => {
             rewrite_path(context, PathContext::Expr, qself, path, shape).ok()


### PR DESCRIPTION
Tracked by https://github.com/rust-lang/rustfmt/issues/6206
### Description
This pr implements `rewrite_result` for `ArmWrapper` (wrapper for ast `Arm`), while modifying functions used for formatting match expression like `rewrite_match`, `rewrite_match_arm` and so on. 
