### PR TITLE
modify ListItem to hold RewriteResult as the item field 

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -147,7 +147,7 @@ fn format_derive(
         .tactic(tactic)
         .trailing_separator(trailing_separator)
         .ends_with_newline(false);
-    let item_str = write_list(&all_items, &fmt)?;
+    let item_str = write_list(&all_items, &fmt).ok()?;
 
     debug!("item_str: '{}'", item_str);
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -99,7 +99,7 @@ fn format_derive(
                 ",",
                 |span| span.lo(),
                 |span| span.hi(),
-                |span| Some(context.snippet(*span).to_owned()),
+                |span| Ok(context.snippet(*span).to_owned()),
                 // We update derive attribute spans to start after the opening '('
                 // This helps us focus parsing to just what's inside #[derive(...)]
                 context.snippet_provider.span_after(attr.span, "("),

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -312,7 +312,7 @@ fn rewrite_closure_fn_decl(
         ",",
         |param| span_lo_for_param(param),
         |param| span_hi_for_param(context, param),
-        |param| param.rewrite(context, param_shape),
+        |param| param.rewrite_result(context, param_shape),
         context.snippet_provider.span_after(span, "|"),
         body.span.lo(),
         false,

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -336,7 +336,7 @@ fn rewrite_closure_fn_decl(
     let fmt = ListFormatting::new(param_shape, context.config)
         .tactic(tactic)
         .preserve_newline(true);
-    let list_str = write_list(&item_vec, &fmt).unknown_error()?;
+    let list_str = write_list(&item_vec, &fmt)?;
     let mut prefix = format!("{binder}{const_}{immovable}{coro}{mover}|{list_str}|");
 
     if !ret_str.is_empty() {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1677,7 +1677,6 @@ fn rewrite_struct_lit<'a>(
                     v_shape.sub_width(1).max_width_error(v_shape.width, span)?,
                     0,
                 )
-                .unknown_error()
             }
             StructLitField::Base(expr) => {
                 // 2 = ..
@@ -1719,7 +1718,7 @@ fn rewrite_struct_lit<'a>(
             force_no_trailing_comma || has_base_or_rest || !context.use_block_indent(),
         );
 
-        write_list(&item_vec, &fmt).unknown_error()?
+        write_list(&item_vec, &fmt)?
     };
 
     let fields_str =
@@ -1868,7 +1867,7 @@ fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + IntoOverflowableItem<'a>>(
     let fmt = ListFormatting::new(nested_shape, context.config)
         .tactic(tactic)
         .ends_with_newline(false);
-    let list_str = write_list(&item_vec, &fmt)?;
+    let list_str = write_list(&item_vec, &fmt).ok()?;
 
     Some(format!("({list_str})"))
 }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -470,7 +470,7 @@ impl UseTree {
                     ",",
                     |tree| tree.span.lo(),
                     |tree| tree.span.hi(),
-                    |_| Some("".to_owned()), // We only need comments for now.
+                    |_| Ok("".to_owned()), // We only need comments for now.
                     context.snippet_provider.span_after(a.span, "{"),
                     a.span.hi(),
                     false,

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -993,7 +993,7 @@ fn rewrite_nested_use_tree(
     };
     for use_tree in use_tree_list {
         if let Some(mut list_item) = use_tree.list_item.clone() {
-            list_item.item = use_tree.rewrite(context, nested_shape);
+            list_item.item = use_tree.rewrite_result(context, nested_shape);
             list_items.push(list_item);
         } else {
             list_items.push(ListItem::from_str(use_tree.rewrite(context, nested_shape)?));
@@ -1032,7 +1032,7 @@ fn rewrite_nested_use_tree(
         .preserve_newline(true)
         .nested(has_nested_list);
 
-    let list_str = write_list(&list_items, &fmt)?;
+    let list_str = write_list(&list_items, &fmt).ok()?;
 
     let result = if (list_str.contains('\n')
         || list_str.len() > remaining_width

--- a/src/items.rs
+++ b/src/items.rs
@@ -653,7 +653,7 @@ impl<'a> FmtVisitor<'a> {
             .trailing_separator(self.config.trailing_comma())
             .preserve_newline(true);
 
-        let list = write_list(&items, &fmt)?;
+        let list = write_list(&items, &fmt).ok()?;
         result.push_str(&list);
         result.push_str(&original_offset.to_string_with_newline(self.config));
         result.push('}');
@@ -2819,7 +2819,7 @@ fn rewrite_params(
         .trailing_separator(trailing_separator)
         .ends_with_newline(tactic.ends_with_newline(context.config.indent_style()))
         .preserve_newline(true);
-    write_list(&param_items, &fmt)
+    write_list(&param_items, &fmt).ok()
 }
 
 fn compute_budgets_for_params(
@@ -3076,7 +3076,7 @@ fn rewrite_bounds_on_where_clause(
         .tactic(shape_tactic)
         .trailing_separator(comma_tactic)
         .preserve_newline(preserve_newline);
-    write_list(&items.collect::<Vec<_>>(), &fmt)
+    write_list(&items.collect::<Vec<_>>(), &fmt).ok()
 }
 
 fn rewrite_where_clause(
@@ -3152,7 +3152,7 @@ fn rewrite_where_clause(
         .trailing_separator(comma_tactic)
         .ends_with_newline(tactic.ends_with_newline(context.config.indent_style()))
         .preserve_newline(true);
-    let preds_str = write_list(&item_vec, &fmt)?;
+    let preds_str = write_list(&item_vec, &fmt).ok()?;
 
     let end_length = if terminator == "{" {
         // If the brace is on the next line we don't need to count it otherwise it needs two

--- a/src/items.rs
+++ b/src/items.rs
@@ -629,7 +629,10 @@ impl<'a> FmtVisitor<'a> {
                     }
                 },
                 |f| f.span.hi(),
-                |f| self.format_variant(f, one_line_width, pad_discrim_ident_to),
+                |f| {
+                    self.format_variant(f, one_line_width, pad_discrim_ident_to)
+                        .unknown_error()
+                },
                 body_lo,
                 body_hi,
                 false,
@@ -2777,8 +2780,8 @@ fn rewrite_params(
         |param| param.ty.span.hi(),
         |param| {
             param
-                .rewrite(context, Shape::legacy(multi_line_budget, param_indent))
-                .or_else(|| Some(context.snippet(param.span()).to_owned()))
+                .rewrite_result(context, Shape::legacy(multi_line_budget, param_indent))
+                .or_else(|_| Ok(context.snippet(param.span()).to_owned()))
         },
         span.lo(),
         span.hi(),
@@ -3048,7 +3051,7 @@ fn rewrite_bounds_on_where_clause(
         ",",
         |pred| pred.span().lo(),
         |pred| pred.span().hi(),
-        |pred| pred.rewrite(context, shape),
+        |pred| pred.rewrite_result(context, shape),
         span_start,
         span_end,
         false,
@@ -3129,7 +3132,7 @@ fn rewrite_where_clause(
         ",",
         |pred| pred.span().lo(),
         |pred| pred.span().hi(),
-        |pred| pred.rewrite(context, Shape::legacy(budget, offset)),
+        |pred| pred.rewrite_result(context, Shape::legacy(budget, offset)),
         span_start,
         span_end,
         false,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -8,7 +8,7 @@ use rustc_span::BytePos;
 use crate::comment::{find_comment_end, rewrite_comment, FindUncommented};
 use crate::config::lists::*;
 use crate::config::{Config, IndentStyle};
-use crate::rewrite::RewriteContext;
+use crate::rewrite::{RewriteContext, RewriteResult};
 use crate::shape::{Indent, Shape};
 use crate::utils::{
     count_newlines, first_line_width, last_line_width, mk_sp, starts_with_newline,
@@ -281,6 +281,7 @@ where
     let indent_str = &formatting.shape.indent.to_string(formatting.config);
     while let Some((i, item)) = iter.next() {
         let item = item.as_ref();
+        // TODO here Is it possible to 실제로 list item이 없으면..
         let inner_item = item.item.as_ref()?;
         let first = i == 0;
         let last = iter.peek().is_none();
@@ -741,7 +742,7 @@ where
     I: Iterator<Item = T>,
     F1: Fn(&T) -> BytePos,
     F2: Fn(&T) -> BytePos,
-    F3: Fn(&T) -> Option<String>,
+    F3: Fn(&T) -> RewriteResult,
 {
     type Item = ListItem;
 
@@ -778,7 +779,7 @@ where
                 item: if self.inner.peek().is_none() && self.leave_last {
                     None
                 } else {
-                    (self.get_item_string)(&item)
+                    (self.get_item_string)(&item).ok()
                 },
                 post_comment,
                 new_lines,
@@ -805,7 +806,7 @@ where
     I: Iterator<Item = T>,
     F1: Fn(&T) -> BytePos,
     F2: Fn(&T) -> BytePos,
-    F3: Fn(&T) -> Option<String>,
+    F3: Fn(&T) -> RewriteResult,
 {
     ListItems {
         snippet_provider,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -477,8 +477,8 @@ pub(crate) fn rewrite_macro_def(
     }
 
     match write_list(&branch_items, &fmt) {
-        Some(ref s) => result += s,
-        None => return snippet,
+        Ok(ref s) => result += s,
+        Err(_) => return snippet,
     }
 
     if multi_branch_style {

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -236,7 +236,7 @@ fn rewrite_match_arms(
         .separator("")
         .preserve_newline(true);
 
-    write_list(&arms_vec, &fmt).unknown_error()
+    write_list(&arms_vec, &fmt)
 }
 
 fn rewrite_match_arm(

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -225,7 +225,7 @@ fn rewrite_match_arms(
         "|",
         |arm| arm.span().lo(),
         |arm| arm.span().hi(),
-        |arm| arm.rewrite(context, arm_shape),
+        |arm| arm.rewrite_result(context, arm_shape),
         open_brace_pos,
         span.hi(),
         false,

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -623,7 +623,7 @@ impl<'a> Context<'a> {
             ",",
             |item| item.span().lo(),
             |item| item.span().hi(),
-            |item| item.rewrite(self.context, self.nested_shape),
+            |item| item.rewrite_result(self.context, self.nested_shape),
             span.lo(),
             span.hi(),
             true,

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -343,7 +343,7 @@ fn rewrite_struct_pat(
             }
         },
         |f| f.span.hi(),
-        |f| f.rewrite(context, v_shape),
+        |f| f.rewrite_result(context, v_shape),
         context.snippet_provider.span_after(span, "{"),
         span.hi(),
         false,
@@ -551,7 +551,7 @@ fn count_wildcard_suffix_len(
         ",",
         |item| item.span().lo(),
         |item| item.span().hi(),
-        |item| item.rewrite(context, shape),
+        |item| item.rewrite_result(context, shape),
         context.snippet_provider.span_after(span, "("),
         span.hi() - BytePos(1),
         false,

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -101,7 +101,7 @@ impl Rewrite for Pat {
                     .separator(" |")
                     .separator_place(context.config.binop_separator())
                     .ends_with_newline(false);
-                write_list(&items, &fmt)
+                write_list(&items, &fmt).ok()
             }
             PatKind::Box(ref pat) => rewrite_unary_prefix(context, "box ", &**pat, shape),
             PatKind::Ident(BindingMode(by_ref, mutability), ident, ref sub_pat) => {
@@ -354,7 +354,7 @@ fn rewrite_struct_pat(
     let nested_shape = shape_for_tactic(tactic, h_shape, v_shape);
     let fmt = struct_lit_formatting(nested_shape, tactic, context, false);
 
-    let mut fields_str = write_list(&item_vec, &fmt).unknown_error()?;
+    let mut fields_str = write_list(&item_vec, &fmt)?;
     let one_line_width = h_shape.map_or(0, |shape| shape.width);
 
     let has_trailing_comma = fmt.needs_trailing_separator();
@@ -561,7 +561,7 @@ fn count_wildcard_suffix_len(
     for item in items
         .iter()
         .rev()
-        .take_while(|i| matches!(i.item, Some(ref internal_string) if internal_string == "_"))
+        .take_while(|i| matches!(i.item, Ok(ref internal_string) if internal_string == "_"))
     {
         suffix_len += 1;
 

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -15,7 +15,7 @@ use crate::config::{Config, GroupImportsTactic};
 use crate::imports::{normalize_use_trees_with_granularity, UseSegmentKind, UseTree};
 use crate::items::{is_mod_decl, rewrite_extern_crate, rewrite_mod};
 use crate::lists::{itemize_list, write_list, ListFormatting, ListItem};
-use crate::rewrite::RewriteContext;
+use crate::rewrite::{RewriteContext, RewriteErrorExt};
 use crate::shape::Shape;
 use crate::source_map::LineRangeUtils;
 use crate::spanned::Spanned;
@@ -99,7 +99,7 @@ fn rewrite_reorderable_or_regroupable_items(
                 ";",
                 |item| item.span().lo(),
                 |item| item.span().hi(),
-                |_item| Some("".to_owned()),
+                |_item| Ok("".to_owned()),
                 span.lo(),
                 span.hi(),
                 false,
@@ -151,7 +151,7 @@ fn rewrite_reorderable_or_regroupable_items(
                 ";",
                 |item| item.span().lo(),
                 |item| item.span().hi(),
-                |item| rewrite_reorderable_item(context, item, shape),
+                |item| rewrite_reorderable_item(context, item, shape).unknown_error(),
                 span.lo(),
                 span.hi(),
                 false,

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -30,7 +30,7 @@ impl<T: Rewrite> Rewrite for ptr::P<T> {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug)]
 pub(crate) enum RewriteError {
     #[error("Formatting was skipped due to skip attribute or out of file range.")]
     SkipFormatting,

--- a/src/types.rs
+++ b/src/types.rs
@@ -388,7 +388,7 @@ where
             ",",
             |arg| arg.span().lo(),
             |arg| arg.span().hi(),
-            |arg| arg.rewrite(context, list_shape),
+            |arg| arg.rewrite_result(context, list_shape),
             list_lo,
             span.hi(),
             false,

--- a/src/types.rs
+++ b/src/types.rs
@@ -407,7 +407,7 @@ where
             .trailing_separator(trailing_separator)
             .ends_with_newline(tactic.ends_with_newline(context.config.indent_style()))
             .preserve_newline(true);
-        (write_list(&item_vec, &fmt).unknown_error()?, tactic)
+        (write_list(&item_vec, &fmt)?, tactic)
     };
 
     let args = if tactic == DefinitiveListTactic::Horizontal

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -228,10 +228,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
         ",",
         |field| field.get_span().lo(),
         |field| field.get_span().hi(),
-        |field| {
-            field
-                .rewrite_aligned_item(context, item_shape, field_prefix_max_width)
-        },
+        |field| field.rewrite_aligned_item(context, item_shape, field_prefix_max_width),
         span.lo(),
         span.hi(),
         false,
@@ -247,14 +244,13 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
 
     if tactic == DefinitiveListTactic::Horizontal {
         // since the items fits on a line, there is no need to align them
-        let do_rewrite = |field: &T| -> Option<String> {
-            field.rewrite_aligned_item(context, item_shape, 0).ok()
-        };
+        let do_rewrite =
+            |field: &T| -> RewriteResult { field.rewrite_aligned_item(context, item_shape, 0) };
         fields
             .iter()
             .zip(items.iter_mut())
             .for_each(|(field, list_item): (&T, &mut ListItem)| {
-                if list_item.item.is_some() {
+                if list_item.item.is_ok() {
                     list_item.item = do_rewrite(field);
                 }
             });
@@ -270,7 +266,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
         .tactic(tactic)
         .trailing_separator(separator_tactic)
         .preserve_newline(true);
-    write_list(&items, &fmt)
+    write_list(&items, &fmt).ok()
 }
 
 /// Returns the index in `fields` up to which a field belongs to the current group.

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -231,7 +231,6 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
         |field| {
             field
                 .rewrite_aligned_item(context, item_shape, field_prefix_max_width)
-                .ok()
         },
         span.lo(),
         span.hi(),


### PR DESCRIPTION
Tracked by #6206 

### Description
We often use `itemize_list` & `write_list` to format list-like expressions. Since `ListItem` holds `Option<String>` as the item field, we cannot propagate `RewriteError` from these functions. This pr replaces the type for the item field with `RewriteResult`, while modifying bound for `itemize_list` and `write_list`.  