### PR TITLE
refactor rewrite_literal & combine_strs_with_missing_comments

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -267,6 +267,7 @@ impl ChainItemKind {
 }
 
 impl Rewrite for ChainItem {
+    // TODO impl rewrite_result after rebase
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
         let shape = shape.sub_width(self.tries)?;
         let rewrite = match self.kind {
@@ -294,7 +295,7 @@ impl Rewrite for ChainItem {
             ),
             ChainItemKind::Await => ".await".to_owned(),
             ChainItemKind::Comment(ref comment, _) => {
-                rewrite_comment(comment, false, shape, context.config)?
+                rewrite_comment(comment, false, shape, context.config).ok()?
             }
         };
         Some(format!("{rewrite}{}", "?".repeat(self.tries)))

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -367,6 +367,7 @@ impl UseTree {
                     shape,
                     allow_extend,
                 )
+                .ok()
             }
             _ => Some(use_str),
         }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -8,7 +8,7 @@ use rustc_span::BytePos;
 use crate::comment::{find_comment_end, rewrite_comment, FindUncommented};
 use crate::config::lists::*;
 use crate::config::{Config, IndentStyle};
-use crate::rewrite::{RewriteContext, RewriteError, RewriteErrorExt, RewriteResult};
+use crate::rewrite::{RewriteContext, RewriteError, RewriteResult};
 use crate::shape::{Indent, Shape};
 use crate::utils::{
     count_newlines, first_line_width, last_line_width, mk_sp, starts_with_newline,
@@ -366,8 +366,8 @@ where
             // Block style in non-vertical mode.
             let block_mode = tactic == DefinitiveListTactic::Horizontal;
             // Width restriction is only relevant in vertical mode.
-            let comment = rewrite_comment(comment, block_mode, formatting.shape, formatting.config)
-                .unknown_error()?;
+            let comment =
+                rewrite_comment(comment, block_mode, formatting.shape, formatting.config)?;
             result.push_str(&comment);
 
             if !inner_item.is_empty() {
@@ -413,8 +413,7 @@ where
                 true,
                 Shape::legacy(formatting.shape.width, Indent::empty()),
                 formatting.config,
-            )
-            .unknown_error()?;
+            )?;
 
             result.push(' ');
             result.push_str(&formatted_comment);
@@ -465,8 +464,7 @@ where
                 )
             };
 
-            let mut formatted_comment =
-                rewrite_post_comment(&mut item_max_width).unknown_error()?;
+            let mut formatted_comment = rewrite_post_comment(&mut item_max_width)?;
 
             if !starts_with_newline(comment) {
                 if formatting.align_comments {
@@ -479,8 +477,7 @@ where
                         > formatting.config.max_width()
                     {
                         item_max_width = None;
-                        formatted_comment =
-                            rewrite_post_comment(&mut item_max_width).unknown_error()?;
+                        formatted_comment = rewrite_post_comment(&mut item_max_width)?;
                         comment_alignment =
                             post_comment_alignment(item_max_width, unicode_str_width(inner_item));
                     }

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -310,8 +310,7 @@ fn rewrite_match_arm(
         missing_span,
         shape,
         false,
-    )
-    .unknown_error()?;
+    )?;
 
     let arrow_span = mk_sp(
         arm.pat.span.hi(),
@@ -448,7 +447,7 @@ fn rewrite_match_body(
         if comment_str.is_empty() {
             String::new()
         } else {
-            rewrite_comment(comment_str, false, shape, context.config).unknown_error()?
+            rewrite_comment(comment_str, false, shape, context.config)?
         }
     };
 

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -284,13 +284,13 @@ impl<'a> FmtVisitor<'a> {
                     let other_lines = &subslice[offset + 1..];
                     let comment_str =
                         rewrite_comment(other_lines, false, comment_shape, self.config)
-                            .unwrap_or_else(|| String::from(other_lines));
+                            .unwrap_or_else(|_| String::from(other_lines));
                     self.push_str(&comment_str);
                 }
             }
         } else {
             let comment_str = rewrite_comment(subslice, false, comment_shape, self.config)
-                .unwrap_or_else(|| String::from(subslice));
+                .unwrap_or_else(|_| String::from(subslice));
             self.push_str(&comment_str);
         }
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -133,7 +133,8 @@ impl Rewrite for Pat {
                             mk_sp(lo, p.span.lo()),
                             shape,
                             true,
-                        )?
+                        )
+                        .ok()?
                     }
                     None => "".to_owned(),
                 };
@@ -152,7 +153,8 @@ impl Rewrite for Pat {
                                 mk_sp(lo, hi),
                                 shape,
                                 true,
-                            )?,
+                            )
+                            .ok()?,
                         )
                     }
                     (false, true) => (
@@ -181,7 +183,8 @@ impl Rewrite for Pat {
                                 mk_sp(lo, hi),
                                 shape,
                                 true,
-                            )?,
+                            )
+                            .ok()?,
                         )
                     }
                     (false, true) => (first_lo, first),
@@ -198,7 +201,8 @@ impl Rewrite for Pat {
                         mk_sp(ident.span.hi(), hi),
                         shape,
                         true,
-                    )?
+                    )
+                    .ok()?
                 } else {
                     id_str.to_owned()
                 };
@@ -211,6 +215,7 @@ impl Rewrite for Pat {
                     shape,
                     true,
                 )
+                .ok()
             }
             PatKind::Wild => {
                 if 1 <= shape.width {
@@ -408,6 +413,10 @@ fn rewrite_struct_pat(
 
 impl Rewrite for PatField {
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
+        self.rewrite_result(context, shape).ok()
+    }
+
+    fn rewrite_result(&self, context: &RewriteContext<'_>, shape: Shape) -> RewriteResult {
         let hi_pos = if let Some(last) = self.attrs.last() {
             last.span.hi()
         } else {
@@ -417,10 +426,10 @@ impl Rewrite for PatField {
         let attrs_str = if self.attrs.is_empty() {
             String::from("")
         } else {
-            self.attrs.rewrite(context, shape)?
+            self.attrs.rewrite_result(context, shape)?
         };
 
-        let pat_str = self.pat.rewrite(context, shape)?;
+        let pat_str = self.pat.rewrite_result(context, shape)?;
         if self.is_shorthand {
             combine_strs_with_missing_comments(
                 context,
@@ -441,7 +450,7 @@ impl Rewrite for PatField {
                     "{}:\n{}{}",
                     id_str,
                     nested_shape.indent.to_string(context.config),
-                    self.pat.rewrite(context, nested_shape)?
+                    self.pat.rewrite_result(context, nested_shape)?
                 )
             };
             combine_strs_with_missing_comments(

--- a/src/types.rs
+++ b/src/types.rs
@@ -713,8 +713,7 @@ impl Rewrite for ast::GenericParam {
                 mk_sp(last_attr.span.hi(), param_start),
                 shape,
                 !last_attr.is_doc_comment(),
-            )
-            .unknown_error()?;
+            )?;
         } else {
             // When rewriting generic params, an extra newline should be put
             // if the attributes end with a doc comment
@@ -831,8 +830,7 @@ impl Rewrite for ast::Ty {
                             before_lt_span,
                             shape,
                             true,
-                        )
-                        .unknown_error()?;
+                        )?;
                     } else {
                         result.push_str(&lt_str);
                     }
@@ -851,8 +849,7 @@ impl Rewrite for ast::Ty {
                             before_mut_span,
                             shape,
                             true,
-                        )
-                        .unknown_error()?;
+                        )?;
                     } else {
                         result.push_str(mut_str);
                     }
@@ -868,8 +865,7 @@ impl Rewrite for ast::Ty {
                         before_ty_span,
                         shape,
                         true,
-                    )
-                    .unknown_error()?;
+                    )?;
                 } else {
                     let used_width = last_line_width(&result);
                     let budget = shape
@@ -1182,8 +1178,7 @@ fn join_bounds_inner(
                         is_bound_extendable(bound_str, item),
                         combine_strs_with_missing_comments(
                             context, joiner, bound_str, ls, shape, true,
-                        )
-                        .unknown_error()?,
+                        )?,
                     ),
                     _ => (
                         is_bound_extendable(bound_str, item),
@@ -1200,7 +1195,6 @@ fn join_bounds_inner(
                     shape,
                     true,
                 )
-                .unknown_error()
                 .map(|v| (v, trailing_span, extendable)),
                 _ => Ok((strs + &trailing_str, trailing_span, extendable)),
             }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -312,8 +312,8 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                                 let comment_str =
                                     rewrite_comment(other_lines, false, comment_shape, config);
                                 match comment_str {
-                                    Some(ref s) => self.push_str(s),
-                                    None => self.push_str(other_lines),
+                                    Ok(ref s) => self.push_str(s),
+                                    Err(_) => self.push_str(other_lines),
                                 }
                             }
                         }
@@ -342,8 +342,8 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
 
                         let comment_str = rewrite_comment(&sub_slice, false, comment_shape, config);
                         match comment_str {
-                            Some(ref s) => self.push_str(s),
-                            None => self.push_str(&sub_slice),
+                            Ok(ref s) => self.push_str(s),
+                            Err(_) => self.push_str(&sub_slice),
                         }
                     }
                 }


### PR DESCRIPTION
Tracked by https://github.com/rust-lang/rustfmt/issues/6206

### Description
1. modify rewrite_literal to return RewriteResult
2. refactor `combine_strs_with_missing_comments` and its call sites