### PR TITLE
track configs set from cli flags

### DIFF
--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -201,7 +201,7 @@ impl FileLines {
     }
 
     /// Returns `true` if this `FileLines` contains all lines in all files.
-    pub(crate) fn is_all(&self) -> bool {
+    pub fn is_all(&self) -> bool {
         self.0.is_none()
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -741,6 +741,20 @@ make_backup = false
         assert_eq!(config.unstable_features(), true);
     }
 
+    #[test]
+    fn test_set_cli() {
+        let mut config = Config::default();
+        assert_eq!(config.was_set().edition(), false);
+        assert_eq!(config.was_set_cli().edition(), false);
+        config.set().edition(Edition::Edition2021);
+        assert_eq!(config.was_set().edition(), false);
+        assert_eq!(config.was_set_cli().edition(), false);
+        config.set_cli().edition(Edition::Edition2021);
+        assert_eq!(config.was_set().edition(), false);
+        assert_eq!(config.was_set_cli().edition(), true);
+        assert_eq!(config.was_set_cli().emit_mode(), false);
+    }
+
     #[cfg(test)]
     mod deprecated_option_merge_imports {
         use super::*;


### PR DESCRIPTION
resolves #6252

There's more detail in that linked issue, but rustfmt internally needs to know whether the user explicitly specified a configuration value via a top level cli flag, e.g. `--edition` or `--style-edition`. This PR adds a separate boolean flag on configuration options that indicates whether the user specified it via a top level cli flag.

Notably, this intentionally does not make any changes to the `config.set().*` calls, nor the `config.was_set().*` behavior. That's because I'm unclear on the historical reasons why those ignored the CLI flag method, at this time I'm unclear on the potential side effects of changing that behavior, and we don't need to resolve nor risk any of that for the purposes of the 2024 work (i left an inline FIXME to revisit)
