### PR TITLE
Print a deterministic length of commit hash in --version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,7 @@ fn main() {
 // (git not installed or if this is not a git repository) just return an empty string.
 fn commit_info() -> String {
     match (channel(), commit_hash(), commit_date()) {
-        (channel, Some(hash), Some(date)) => format!("{} ({} {})", channel, hash.trim_end(), date),
+        (channel, Some(hash), Some(date)) => format!("{} ({} {})", channel, hash, date),
         _ => String::new(),
     }
 }
@@ -39,11 +39,13 @@ fn channel() -> String {
 }
 
 fn commit_hash() -> Option<String> {
-    Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
         .output()
-        .ok()
-        .and_then(|r| String::from_utf8(r.stdout).ok())
+        .ok()?;
+    let mut stdout = String::from_utf8(output.stdout).ok()?;
+    stdout.truncate(10);
+    Some(stdout)
 }
 
 fn commit_date() -> Option<String> {


### PR DESCRIPTION
Previously, `rustfmt --version` would print nondeterministic output when built from the exact same source code and git commit. The number of hex digits printed in the commit hash would vary based on how many other branches and tags you had fetched so far, what other commits you had been working on in other branches, how recently you had run `git gc`, platform-specific variation in git's default configuration, and platform differences in the sequence of steps performed by the release pipeline.

You can see this in the official build of `rustfmt` that is part of the Rust 1.80.0 stable release.

The rustfmt for x86_64-unknown-linux-gnu prints:

```console
$ rustfmt +1.80.0 --version
rustfmt 1.7.0-stable (0514789 2024-07-21)
```

Whereas for aarch64-apple-darwin it prints:

```console
$ rustfmt +1.80.0 --version
rustfmt 1.7.0-stable (05147895 2024-07-21)
```