### PR TITLE
Check exit status of git commands spawned by build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,15 +43,16 @@ fn commit_hash() -> Option<String> {
         .args(["rev-parse", "HEAD"])
         .output()
         .ok()?;
-    let mut stdout = String::from_utf8(output.stdout).ok()?;
+    let mut stdout = output.status.success().then_some(output.stdout)?;
     stdout.truncate(10);
-    Some(stdout)
+    String::from_utf8(stdout).ok()
 }
 
 fn commit_date() -> Option<String> {
-    Command::new("git")
+    let output = Command::new("git")
         .args(["log", "-1", "--date=short", "--pretty=format:%cd"])
         .output()
-        .ok()
-        .and_then(|r| String::from_utf8(r.stdout).ok())
+        .ok()?;
+    let stdout = output.status.success().then_some(output.stdout)?;
+    String::from_utf8(stdout).ok()
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -450,13 +450,14 @@ are included as out of line modules from `src/lib.rs`."
 }
 
 fn print_version() {
-    let version_info = format!(
-        "{}-{}",
-        option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"),
-        include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
-    );
+    let version_number = option_env!("CARGO_PKG_VERSION").unwrap_or("unknown");
+    let commit_info = include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"));
 
-    println!("rustfmt {version_info}");
+    if commit_info.is_empty() {
+        println!("rustfmt {version_number}");
+    } else {
+        println!("rustfmt {version_number}-{commit_info}");
+    }
 }
 
 fn determine_operation(matches: &Matches) -> Result<Operation, OperationError> {


### PR DESCRIPTION
The git commands `git rev-parse HEAD` and `git log -1 --date=short --pretty=format:%cd` in rustfmt's build script might fail with **"fatal: not a git repository (or any of the parent directories): .git"** if rustfmt is being built from a source tarball rather than a git repository. That message is written by git to stderr, and nothing is written to stdout.

Previously, rustfmt's build script would take that empty stdout and treat it like valid commit info, unlike what it does when `git` cannot be spawned in the first place, and contradicting this comment about the build script's intended behavior in the case of there not being a git repository:

https://github.com/rust-lang/rustfmt/blob/17c5869dffc21356559f223770cbfa0648692808/build.rs#L24-L25

```console
$ curl -L https://github.com/rust-lang/rustfmt/archive/refs/heads/master.tar.gz | tar xz
$ cd rustfmt-master/
$ cargo run --bin rustfmt -- --version
```

Before this PR: `rustfmt 1.7.1-nightly ( )`
After first commit: `rustfmt 1.7.1-`
After second commit: `rustfmt 1.7.1`