### PR TITLE
reuse `rewrite_static` when formatting foreign static items

### DIFF
--- a/tests/target/issue_6267.rs
+++ b/tests/target/issue_6267.rs
@@ -1,0 +1,3 @@
+extern "C" {
+    static TEST: i32 = 42;
+}


### PR DESCRIPTION
fixes #6267

The `ForeignItemKind::Static(_)` match arm in the `ast::ForeignItem` `Rewrite` impl duplicated some of the logic already implemented in `rewrite_static`, so reusing it helps centralize the logic.

The other benefit to using `rewrite_static` is that it already supports rewriting the rhs of a static assignment.