### PR TITLE
tests/target: Add failing test for docstring in enum

### DIFF
--- a/tests/target/rust-doc-in-enum/with-doc.rs
+++ b/tests/target/rust-doc-in-enum/with-doc.rs
@@ -1,0 +1,13 @@
+enum A {
+    B {
+        a: usize,
+        b: usize,
+        c: usize,
+        d: usize,
+    },
+
+    /// C
+    C {
+        a: usize,
+    },
+}

--- a/tests/target/rust-doc-in-enum/without-doc.rs
+++ b/tests/target/rust-doc-in-enum/without-doc.rs
@@ -1,0 +1,12 @@
+enum A {
+    B {
+        a: usize,
+        b: usize,
+        c: usize,
+        d: usize,
+    },
+
+    C {
+        a: usize,
+    },
+}


### PR DESCRIPTION
For the time being, this PR only adds a failing test describing an unexpected behavior.

## Issue

`tests/target/rust-doc-in-enum/without-doc.rs` is being left unformatted (expected behavior), while ``tests/target/rust-doc-in-enum/with-doc.rs` is formatted to `C { a: usize }` (unexpected behavior).

The only different between the two samples is the `/// C` rustdoc added in `with-doc.rs`.
As far as I can tell, this reproducing example is minimal: for example, after removing `d: usize` we do not reproduce the reported behavior.

I found this issue while adding rustdocs to an existing project. I would expect that adding a line of documentation should not cause the formatting of the code to change.