### PR TITLE
Issue6246-Let statement should rewrite rhs with comments after equal sign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ tests/cargo-fmt/**/target
 .idea/
 .vscode/
 *~
+
+# Git
+.git/

--- a/src/items.rs
+++ b/src/items.rs
@@ -131,14 +131,23 @@ impl Rewrite for ast::Local {
                 .sub_width(1)
                 .max_width_error(shape.width, self.span())?;
 
-            result = rewrite_assign_rhs(
+            // should always find a comment span if init exists
+            let comment_span = context
+                .snippet_provider
+                .opt_span_after(self.span, "=")
+                .map(|op_lo| mk_sp(op_lo, init.span.lo()))
+                .unwrap();
+
+            result = rewrite_assign_rhs_with_comments(
                 context,
                 result,
                 init,
-                &RhsAssignKind::Expr(&init.kind, init.span),
                 nested_shape,
-            )
-            .max_width_error(shape.width, self.span())?;
+                &RhsAssignKind::Expr(&init.kind, init.span),
+                RhsTactics::Default,
+                comment_span,
+                true,
+            )?;
 
             if let Some(block) = else_block {
                 let else_kw_span = init.span.between(block.span);

--- a/tests/source/issue-6246.rs
+++ b/tests/source/issue-6246.rs
@@ -1,0 +1,20 @@
+fn main() {
+    let foo = 
+    // 114514
+    if true {
+        1919
+    } else {
+        810
+    };
+}
+
+// Test a let statement without equal sign
+fn main() {
+    let mut foo ;
+    // 114514
+    foo = if true {
+        1919
+    } else {
+        810
+    };
+}

--- a/tests/source/issue-6246.rs
+++ b/tests/source/issue-6246.rs
@@ -8,6 +8,28 @@ fn main() {
     };
 }
 
+fn main() {
+    let foo = 
+    // line 1
+    // line 2
+    if true {
+        1919
+    } else {
+        810
+    };
+}
+
+fn main() {
+    let foo = 
+    /* line 1
+       line 2 */
+    if true {
+        1919
+    } else {
+        810
+    };
+}
+
 // Test a let statement without equal sign
 fn main() {
     let mut foo ;

--- a/tests/target/issue-6246.rs
+++ b/tests/target/issue-6246.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let foo =
+        // 114514
+        if true { 1919 } else { 810 };
+}
+
+// Test a let statement without equal sign
+fn main() {
+    let mut foo;
+    // 114514
+    foo = if true { 1919 } else { 810 };
+}

--- a/tests/target/issue-6246.rs
+++ b/tests/target/issue-6246.rs
@@ -4,6 +4,20 @@ fn main() {
         if true { 1919 } else { 810 };
 }
 
+fn main() {
+    let foo =
+        // line 1
+        // line 2
+        if true { 1919 } else { 810 };
+}
+
+fn main() {
+    let foo =
+        /* line 1
+        line 2 */
+        if true { 1919 } else { 810 };
+}
+
 // Test a let statement without equal sign
 fn main() {
     let mut foo;


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo test` passes

### Related Issues/PRs

https://github.com/rust-lang/rustfmt/issues/6246

### Changes

The problem in 6246
```
fn main() {
    let foo = 
    // 114514
    if true {
        1919
    } else {
        810
    };
}
```

Rustfmt doesn't seem to account for comments between the `=` sign and the if expression. I solve it by checking the existence of a comment span and insert it back after rewrite. 

### Testing

added a test case `tests/source/issue-6246.rs`




