### PR TITLE
Remove outdated comment from `mac.yml`

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   test:
     # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources
-    # macOS Catalina 10.15
     runs-on: macos-latest
     name: (${{ matrix.target }}, ${{ matrix.cfg_release_channel }})
     env:


### PR DESCRIPTION
Per [the documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources), `macos-latest` now refers to macOS 14.