### PR TITLE
 rust-lang/style-team#189: rhs-should-use-indent-of-last-line-of-lhs 

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3,32 +3,32 @@ use std::cmp::min;
 
 use itertools::Itertools;
 use rustc_ast::token::{Delimiter, Lit, LitKind};
-use rustc_ast::{ForLoopKind, MatchKind, ast, ptr, token};
+use rustc_ast::{ast, ptr, token, ForLoopKind, MatchKind};
 use rustc_span::{BytePos, Span};
 
 use crate::chains::rewrite_chain;
 use crate::closures;
 use crate::comment::{
-    CharClasses, FindUncommented, combine_strs_with_missing_comments, contains_comment,
-    recover_comment_removed, rewrite_comment, rewrite_missing_comment,
+    combine_strs_with_missing_comments, contains_comment, recover_comment_removed, rewrite_comment,
+    rewrite_missing_comment, CharClasses, FindUncommented,
 };
 use crate::config::lists::*;
 use crate::config::{Config, ControlBraceStyle, HexLiteralCase, IndentStyle, StyleEdition};
 use crate::lists::{
-    ListFormatting, Separator, definitive_tactic, itemize_list, shape_for_tactic,
-    struct_lit_formatting, struct_lit_shape, struct_lit_tactic, write_list,
+    definitive_tactic, itemize_list, shape_for_tactic, struct_lit_formatting, struct_lit_shape,
+    struct_lit_tactic, write_list, ListFormatting, Separator,
 };
-use crate::macros::{MacroPosition, rewrite_macro};
+use crate::macros::{rewrite_macro, MacroPosition};
 use crate::matches::rewrite_match;
 use crate::overflow::{self, IntoOverflowableItem, OverflowableItem};
-use crate::pairs::{PairParts, rewrite_all_pairs, rewrite_pair};
+use crate::pairs::{rewrite_all_pairs, rewrite_pair, PairParts};
 use crate::rewrite::{Rewrite, RewriteContext, RewriteError, RewriteErrorExt, RewriteResult};
 use crate::shape::{Indent, Shape};
 use crate::source_map::{LineRangeUtils, SpanUtils};
 use crate::spanned::Spanned;
 use crate::stmt;
-use crate::string::{StringFormat, rewrite_string};
-use crate::types::{PathContext, rewrite_path};
+use crate::string::{rewrite_string, StringFormat};
+use crate::types::{rewrite_path, PathContext};
 use crate::utils::{
     colon_spaces, contains_skip, count_newlines, filtered_str_fits, first_line_ends_with,
     inner_attributes, last_line_extendable, last_line_width, mk_sp, outer_attributes,
@@ -2124,6 +2124,25 @@ pub(crate) fn rewrite_assign_rhs_expr<R: Rewrite>(
     rhs_kind: &RhsAssignKind<'_>,
     rhs_tactics: RhsTactics,
 ) -> RewriteResult {
+    let get_lhs_last_line_shape = || {
+        let last_line = lhs.rsplitn(2, "\n").next().unwrap_or_default();
+        let tab_spaces = context.config.tab_spaces();
+        let new_shape = shape
+            .block_indent(tab_spaces)
+            .saturating_sub_width(tab_spaces);
+        let extra_indent_string = new_shape.to_string(&context.config).to_string();
+        if last_line.starts_with(&extra_indent_string) {
+            new_shape
+        } else {
+            shape
+        }
+    };
+    let shape = if context.config.style_edition() >= StyleEdition::Edition2024 {
+        get_lhs_last_line_shape()
+    } else {
+        shape
+    };
+
     let last_line_width = last_line_width(lhs).saturating_sub(if lhs.contains('\n') {
         shape.indent.width()
     } else {

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -278,6 +278,7 @@ impl Shape {
         offset_indent.to_string_inner(config, 0)
     }
 
+    /// similar to to_string_with_newline, except the result does not start with a new line
     pub(crate) fn to_string(&self, config: &Config) -> Cow<'static, str> {
         let mut offset_indent = self.indent;
         offset_indent.alignment = self.offset;

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -278,6 +278,12 @@ impl Shape {
         offset_indent.to_string_inner(config, 0)
     }
 
+    pub(crate) fn to_string(&self, config: &Config) -> Cow<'static, str> {
+        let mut offset_indent = self.indent;
+        offset_indent.alignment = self.offset;
+        offset_indent.to_string_inner(config, 1)
+    }
+
     /// Creates a `Shape` with a virtually infinite width.
     pub(crate) fn infinite_width(&self) -> Shape {
         Shape {

--- a/tests/source/rust-lang/style-team#189.rs
+++ b/tests/source/rust-lang/style-team#189.rs
@@ -1,0 +1,24 @@
+// rustfmt-style_edition: 2024
+
+impl SomeType {
+    fn method(&mut self) {
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info = Some(ExtraInfo {
+            parent,
+            count: count as u16,
+            children: children.into_boxed_slice(),
+        });
+    }
+}
+
+impl SomeType {
+    fn method(&mut self) {
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info =
+            long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
+    }
+}

--- a/tests/target/rust-lang/style-team#189.rs
+++ b/tests/target/rust-lang/style-team#189.rs
@@ -1,0 +1,24 @@
+// rustfmt-style_edition: 2024
+
+impl SomeType {
+    fn method(&mut self) {
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info = Some(ExtraInfo {
+                parent,
+                count: count as u16,
+                children: children.into_boxed_slice(),
+            });
+    }
+}
+
+impl SomeType {
+    fn method(&mut self) {
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info =
+                long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
+    }
+}


### PR DESCRIPTION
## Pull Request Template

### Checklist

- [x] Confirmed that `cargo test` passes

### Related Issues/PRs

https://github.com/rust-lang/style-team/issues/189

### Changes

Make sure that the rhs is formatted using the indentation of the last line of lhs, as opposed to the first line

### Testing

added a test case