### PR TITLE
impl rewrite_result for ast::Expr

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -135,9 +135,7 @@ fn format_stmt(
             let shape = shape
                 .sub_width(suffix.len())
                 .max_width_error(shape.width, ex.span())?;
-            format_expr(ex, expr_type, context, shape)
-                .map(|s| s + suffix)
-                .unknown_error()
+            format_expr(ex, expr_type, context, shape).map(|s| s + suffix)
         }
         ast::StmtKind::MacCall(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => {
             Err(RewriteError::Unknown)

--- a/src/types.rs
+++ b/src/types.rs
@@ -584,6 +584,10 @@ fn rewrite_bounded_lifetime(
 
 impl Rewrite for ast::AnonConst {
     fn rewrite(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<String> {
+        self.rewrite_result(context, shape).ok()
+    }
+
+    fn rewrite_result(&self, context: &RewriteContext<'_>, shape: Shape) -> RewriteResult {
         format_expr(&self.value, ExprType::SubExpression, context, shape)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -367,14 +367,6 @@ macro_rules! out_of_file_lines_range {
     };
 }
 
-macro_rules! skip_out_of_file_lines_range {
-    ($self:ident, $span:expr) => {
-        if out_of_file_lines_range!($self, $span) {
-            return None;
-        }
-    };
-}
-
 macro_rules! skip_out_of_file_lines_range_err {
     ($self:ident, $span:expr) => {
         if out_of_file_lines_range!($self, $span) {


### PR DESCRIPTION
tracked by #6206 

## Description
This pr impl `rewrite_result` for `Expr` by updating `format_expr` to return `RewriteResult`. 
Now we don't call `.ok()` after calling `rewrite_***` functions in `format_expr` :) 