### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/check_diff.yml
+++ b/.github/workflows/check_diff.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: install rustup
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
       # Run build
     - name: install rustup

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
       # Run build
     - name: install rustup

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
       # Run build
     - name: install rustup

--- a/.github/workflows/rustdoc_check.yml
+++ b/.github/workflows/rustdoc_check.yml
@@ -11,7 +11,7 @@ jobs:
     name: rustdoc check
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: install rustup
       run: |

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -31,7 +31,7 @@ jobs:
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
         # Run build
       - name: install rustup

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,7 +33,7 @@ jobs:
     - name: disable git eol translation
       run: git config --global core.autocrlf false
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
       # Run build
     - name: Install Rustup using win.rustup.rs


### PR DESCRIPTION
Required for using Node.js 20.x in CI
* Changelog for actions/checkout@v4 https://github.com/actions/checkout/blob/main/CHANGELOG.md?rgh-link-date=2024-09-04T18%3A38%3A10Z#v400
* GitHub Blog post https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Refs: https://github.com/rust-lang/rust/pull/130124#issuecomment-2336871149