### PR TITLE
Preallocate missmatches in `JsonEmitter::add_misformatted_file`

### DIFF
--- a/src/emitter/json.rs
+++ b/src/emitter/json.rs
@@ -57,7 +57,7 @@ impl JsonEmitter {
         filename: &FileName,
         diff: Vec<Mismatch>,
     ) -> Result<(), io::Error> {
-        let mut mismatches = vec![];
+        let mut mismatches = Vec::with_capacity(diff.len());
         for mismatch in diff {
             let original_begin_line = mismatch.line_number_orig;
             let expected_begin_line = mismatch.line_number;


### PR DESCRIPTION
The mismatches length is known to be equal to `diff.len()`.