### PR TITLE
chore: prep v1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.8.0] 2024-09-20
 
 ### Fixed
 - Fix issue where rustfmt would crash on Windows when using the `ignore` option [#6178](https://github.com/rust-lang/rustfmt/issues/6178)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rustfmt-nightly"
-version = "1.7.1"
+version = "1.8.0"
 description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang/rustfmt"
 readme = "README.md"


### PR DESCRIPTION
Most notably this release adds `style_edition` and soft deprecates `version`. `version` is superseded by `style_edition`. `style_edtion={2015|2018|2021}` are equivalent to `version=One`, and `style_edition=2024` is equivalent to `version=Two`. `style_edition=2024` is still marked as unstable.

r? @calebcartwright 