### PR TITLE
Suppress warning if max_width reduced below other settings in macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1329,14 +1329,14 @@ impl MacroBranch {
             shape.indent.block_indent(&config)
         };
         let new_width = config.max_width() - body_indent.width();
-        config.set().max_width(new_width);
+        config.set_no_warn().max_width(new_width);
 
         // First try to format as items, then as statements.
         let new_body_snippet = match crate::format_snippet(&body_str, &config, true) {
             Some(new_body) => new_body,
             None => {
                 let new_width = new_width + config.tab_spaces();
-                config.set().max_width(new_width);
+                config.set_no_warn().max_width(new_width);
                 match crate::format_code_block(&body_str, &config, true) {
                     Some(new_body) => new_body,
                     None => {


### PR DESCRIPTION
The warning makes sense at the top level because it indicates a user misconfiguration, but the warning can also fire when a macro reduces max_width within its scope, which is confusing.  We can plumb a flag through saying whether to warn or not and have the macro-related twiddling disable the warning, which will still be on at the top level.

---

This change allows setting, e.g., struct_lit_width to the same value as max_width without getting incorrect warnings within macro scopes.  The bug related to macros has been previously acknowledged, and a previous fix was attempted.  I attempt to fix the same problem, but my patch takes an approach different from deleting the warning.

Related:

* [Cannot set granular width configuration settings to 100% if `max_width = 100` (issue #5404)](https://github.com/rust-lang/rustfmt/issues/5404)
* [Remove confusing warning message when granular width configs are saturated in nested scopes (PR #6075)](https://github.com/rust-lang/rustfmt/pull/6075)
