### PR TITLE
Clamp width settings to max_width before warning about exceeding it

### DIFF
--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -431,18 +431,24 @@ macro_rules! create_config {
                     heuristic_value: usize,
                     config_key: &str,
                 | -> usize {
-                    if !was_set {
-                        return heuristic_value;
-                    }
-                    if override_value > max_width {
+                    let value = if !was_set {
+                        heuristic_value
+                    } else {
+                        override_value
+                    };
+
+                    let value = value.min(max_width);
+
+                    if value > max_width {
                         eprintln!(
                             "`{0}` cannot have a value that exceeds `max_width`. \
                             `{0}` will be set to the same value as `max_width`",
                             config_key,
                         );
-                        return max_width;
+                        max_width
+                    } else {
+                        value
                     }
-                    override_value
                 };
 
                 let fn_call_width = get_width_value(


### PR DESCRIPTION
Within a macro scope, max_width is reduced, which can trigger warnings if it is reduced below some other width setting (e.g. struct_lit_width.) Width settings were already being clamped to max_width, but only after the warning fired.  The order is now reversed.

---

This change allows setting, e.g., struct_lit_width to the same value as max_width without getting incorrect warnings within macro scopes.  The bug related to macros has been previously acknowledged, and a previous fix was attempted.  I attempt to fix the same problem, but my patch takes an approach different from deleting the warning.

Related:

* [Cannot set granular width configuration settings to 100% if `max_width = 100` (issue #5404)](https://github.com/rust-lang/rustfmt/issues/5404)
* [Remove confusing warning message when granular width configs are saturated in nested scopes (PR #6075)](https://github.com/rust-lang/rustfmt/pull/6075)
