### PR TITLE
Fix incorrect separator for match arms (#6373)

### DIFF
--- a/src/matches.rs
+++ b/src/matches.rs
@@ -224,7 +224,7 @@ fn rewrite_match_arms(
             .zip(beginning_verts.into_iter())
             .map(|((arm, is_last), beginning_vert)| ArmWrapper::new(arm, is_last, beginning_vert)),
         "}",
-        "|",
+        ",",
         |arm| arm.span().lo(),
         |arm| arm.span().hi(),
         |arm| arm.rewrite_result(context, arm_shape),

--- a/tests/source/issue-6373.rs
+++ b/tests/source/issue-6373.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let x: Option<i32> = Some(10);
+    let value = match x {
+        Some(i) => i /* comment */,
+        None => 0,
+    };
+    println!("{}", value);
+}

--- a/tests/target/issue-6373.rs
+++ b/tests/target/issue-6373.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let x: Option<i32> = Some(10);
+    let value = match x {
+        Some(i) => i, /* comment */
+        None => 0,
+    };
+    println!("{}", value);
+}


### PR DESCRIPTION
Fixes #6373 

The `post_comment` member of the `ListItem` corresponding to the first match arm in the test contained the trailing comma, even though it should have been trimmed.
The reason it wasn't trimmed is that the separator for the match arms list was pipe `|` rather than comma `,`.