### PR TITLE
Refactor visit_struct, visit_enum to propagate RewriteResult

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1671,8 +1671,7 @@ fn rewrite_struct_lit<'a>(
             v_shape,
             mk_sp(body_lo, span.hi()),
             one_line_width,
-        )
-        .unknown_error()?
+        )?
     } else {
         let field_iter = fields.iter().map(StructLitField::Regular).chain(
             match struct_rest {


### PR DESCRIPTION
Tracked by #6206 

## Description
- refactor `visit_struct` and `visit_enum` 
- update related functions like `format_struct_struct`, `rewrite_with_alignment` to return `RewriteResult`