### PR TITLE
fix panic on failure to format generics in enum

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -524,21 +524,22 @@ impl<'a> FmtVisitor<'a> {
         self.push_rewrite(struct_parts.span, rewrite);
     }
 
-    pub(crate) fn visit_enum(
+    // TODO(ding-young) do I need to make it a separate function instead of a method of FmtVisitor?
+    fn format_enum(
         &mut self,
         ident: symbol::Ident,
         vis: &ast::Visibility,
         enum_def: &ast::EnumDef,
         generics: &ast::Generics,
         span: Span,
-    ) {
+    ) -> Option<String> {
         let enum_header =
             format_header(&self.get_context(), "enum ", ident, vis, self.block_indent);
-        self.push_str(&enum_header);
 
         let enum_snippet = self.snippet(span);
         let brace_pos = enum_snippet.find_uncommented("{").unwrap();
         let body_start = span.lo() + BytePos(brace_pos as u32 + 1);
+        // TODO(ding-young) what if there is no generic?
         let generics_str = format_generics(
             &self.get_context(),
             generics,
@@ -552,23 +553,34 @@ impl<'a> FmtVisitor<'a> {
             // make a span that starts right after `enum Foo`
             mk_sp(ident.span.hi(), body_start),
             last_line_width(&enum_header),
-        );
-
-        if let Some(generics_str) = generics_str {
-            self.push_str(&generics_str);
-        } else {
-            self.push_str(self.snippet(mk_sp(ident.span.hi(), body_start)));
-        }
-
-        self.last_pos = body_start;
+        )?;
 
         match self.format_variant_list(enum_def, body_start, span.hi()) {
-            Some(ref s) if enum_def.variants.is_empty() => self.push_str(s),
-            rw => {
-                self.push_rewrite(mk_sp(body_start, span.hi()), rw);
+            Some(ref s) if enum_def.variants.is_empty() => {
+                Some(format!("{enum_header}{generics_str}{s}"))
+            }
+            Some(rw) => {
+                let indent = self.block_indent.to_string(self.config);
                 self.block_indent = self.block_indent.block_unindent(self.config);
+                Some(format!("{enum_header}{generics_str}\n{indent}{rw}"))
+            }
+            None => {
+                self.block_indent = self.block_indent.block_unindent(self.config);
+                None
             }
         }
+    }
+
+    pub(crate) fn visit_enum(
+        &mut self,
+        ident: symbol::Ident,
+        vis: &ast::Visibility,
+        enum_def: &ast::EnumDef,
+        generics: &ast::Generics,
+        span: Span,
+    ) {
+        let rewrite = self.format_enum(ident, vis, enum_def, generics, span);
+        self.push_rewrite(span, rewrite);
     }
 
     // Format the body of an enum definition

--- a/src/items.rs
+++ b/src/items.rs
@@ -552,9 +552,13 @@ impl<'a> FmtVisitor<'a> {
             // make a span that starts right after `enum Foo`
             mk_sp(ident.span.hi(), body_start),
             last_line_width(&enum_header),
-        )
-        .unwrap();
-        self.push_str(&generics_str);
+        );
+
+        if let Some(generics_str) = generics_str {
+            self.push_str(&generics_str);
+        } else {
+            self.push_str(self.snippet(mk_sp(ident.span.hi(), body_start)));
+        }
 
         self.last_pos = body_start;
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -523,9 +523,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     self.visit_struct(&StructParts::from_item(item));
                 }
                 ast::ItemKind::Enum(ident, ref def, ref generics) => {
-                    self.format_missing_with_indent(source!(self, item.span).lo());
                     self.visit_enum(ident, &item.vis, def, generics, item.span);
-                    self.last_pos = source!(self, item.span).hi();
                 }
                 ast::ItemKind::Mod(safety, ident, ref mod_kind) => {
                     self.format_missing_with_indent(source!(self, item.span).lo());

--- a/tests/source/crash-on-enum-generics/issue_5738.rs
+++ b/tests/source/crash-on-enum-generics/issue_5738.rs
@@ -1,0 +1,13 @@
+enum Node where P::<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S>>>>>>>>>>>>>>>>>>>>>>>>:  {
+    Cons,
+}
+
+enum En6
+where
+    T: Tr1<En2<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S>>>>>>>>>>>>>>>>>>>>>>>>,
+{
+    V0,
+    V1,
+        V2,
+    V3,
+}

--- a/tests/source/crash-on-enum-generics/issue_5738.rs
+++ b/tests/source/crash-on-enum-generics/issue_5738.rs
@@ -8,6 +8,6 @@ where
 {
     V0,
     V1,
-        V2,
+        V2, // left unformatted since formatting where clause fails
     V3,
 }

--- a/tests/source/crash-on-enum-generics/issue_6137.rs
+++ b/tests/source/crash-on-enum-generics/issue_6137.rs
@@ -1,0 +1,3 @@
+enum MZReaderType<
+    D: DeconvolutedCentroidLike + Default + From<DeconvolutedPeak> + BuildFromArrayMap=DeconvolutedPeak
+> {}

--- a/tests/source/crash-on-enum-generics/issue_6318.rs
+++ b/tests/source/crash-on-enum-generics/issue_6318.rs
@@ -8,6 +8,7 @@ fn my_fn() {
                 Option<[u8; 4]>,
             >>::Archived,
         >,
+    // left unformatted since formatting where clause fails 
     {
     }
 }

--- a/tests/source/crash-on-enum-generics/issue_6318.rs
+++ b/tests/source/crash-on-enum-generics/issue_6318.rs
@@ -1,0 +1,13 @@
+// rustfmt-max_width: 80
+fn my_fn() {
+    enum MyEnum
+    where
+    SomeTypeA___: SomeTrait__<
+            _A,
+            Archived = <SomeTypeB____ as SomeTrait__<
+                Option<[u8; 4]>,
+            >>::Archived,
+        >,
+    {
+    }
+}

--- a/tests/source/crash-on-enum-generics/issue_6571.rs
+++ b/tests/source/crash-on-enum-generics/issue_6571.rs
@@ -1,0 +1,14 @@
+pub enum TestEnum<
+    T: std::collections::HashMap<String, Vec<Box<dyn std::fmt::Debug + Send + Sync + 'static>>> + Clone + Default + PartialEq + Eq + std::fmt::Debug + serde::Serialize + serde::Deserialize<'static> + Send + Sync + 'static = std::collections::HashMap<String, Vec<Box<dyn std::fmt::Debug + Send + Sync + 'static>>>,
+> {
+    Variant1(T),
+    Variant2 { field: T },
+}
+
+// More realistic example from real codebase
+pub enum ElementInit<
+    P: wrt_foundation::MemoryProvider + Clone + Default + PartialEq + Eq = wrt_foundation::NoStdProvider<1024>,
+> {
+    FuncIndices(crate::WasmVec<u32, P>),
+    Expressions(crate::WasmVec<crate::WasmVec<u8, P>, P>),
+}

--- a/tests/target/crash-on-enum-generics/issue_5738.rs
+++ b/tests/target/crash-on-enum-generics/issue_5738.rs
@@ -8,6 +8,6 @@ where
 {
     V0,
     V1,
-    V2,
+        V2, // left unformatted since formatting where clause fails
     V3,
 }

--- a/tests/target/crash-on-enum-generics/issue_5738.rs
+++ b/tests/target/crash-on-enum-generics/issue_5738.rs
@@ -1,0 +1,13 @@
+enum Node where P::<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S>>>>>>>>>>>>>>>>>>>>>>>>:  {
+    Cons,
+}
+
+enum En6
+where
+    T: Tr1<En2<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S>>>>>>>>>>>>>>>>>>>>>>>>,
+{
+    V0,
+    V1,
+    V2,
+    V3,
+}

--- a/tests/target/crash-on-enum-generics/issue_6137.rs
+++ b/tests/target/crash-on-enum-generics/issue_6137.rs
@@ -1,0 +1,3 @@
+enum MZReaderType<
+    D: DeconvolutedCentroidLike + Default + From<DeconvolutedPeak> + BuildFromArrayMap=DeconvolutedPeak
+> {}

--- a/tests/target/crash-on-enum-generics/issue_6318.rs
+++ b/tests/target/crash-on-enum-generics/issue_6318.rs
@@ -1,0 +1,12 @@
+// rustfmt-max_width: 80
+fn my_fn() {
+    enum MyEnum
+    where
+    SomeTypeA___: SomeTrait__<
+            _A,
+            Archived = <SomeTypeB____ as SomeTrait__<
+                Option<[u8; 4]>,
+            >>::Archived,
+        >,
+    {}
+}

--- a/tests/target/crash-on-enum-generics/issue_6318.rs
+++ b/tests/target/crash-on-enum-generics/issue_6318.rs
@@ -8,5 +8,7 @@ fn my_fn() {
                 Option<[u8; 4]>,
             >>::Archived,
         >,
-    {}
+    // left unformatted since formatting where clause fails 
+    {
+    }
 }

--- a/tests/target/crash-on-enum-generics/issue_6571.rs
+++ b/tests/target/crash-on-enum-generics/issue_6571.rs
@@ -1,0 +1,14 @@
+pub enum TestEnum<
+    T: std::collections::HashMap<String, Vec<Box<dyn std::fmt::Debug + Send + Sync + 'static>>> + Clone + Default + PartialEq + Eq + std::fmt::Debug + serde::Serialize + serde::Deserialize<'static> + Send + Sync + 'static = std::collections::HashMap<String, Vec<Box<dyn std::fmt::Debug + Send + Sync + 'static>>>,
+> {
+    Variant1(T),
+    Variant2 { field: T },
+}
+
+// More realistic example from real codebase
+pub enum ElementInit<
+    P: wrt_foundation::MemoryProvider + Clone + Default + PartialEq + Eq = wrt_foundation::NoStdProvider<1024>,
+> {
+    FuncIndices(crate::WasmVec<u32, P>),
+    Expressions(crate::WasmVec<crate::WasmVec<u8, P>, P>),
+}


### PR DESCRIPTION
fixes #5738 

## Description
Above issue reports panic when formatting complex enum with generic parameters.
This is because rustfmt simply calls `unwrap()` on `Rewrite` (`RewriteResult` in future), the return value from `format_generics`.
It is better not to panic on this sort of rewrite failure. 
~Therefore, this pr restores original snippet when we fail to format `generics` in enum instead of calling `unwrap()`.~

- This pr returns `None` early and then leave entire enum unformatted instead of calling `unwrap()`. 
- `visit_enum` is refactored with `format_enum` that returns `Rewrite`. Later pr will replace this rewrite with `RewriteResult` 


## TODO
- [x] Revisit test case
- Any other solutions ? Calling existing functions provided in `visitor.rs`?
- check whether version gate is required (originally it would've panic, so I'm not sure if this is a formatting change) 
- [x] check other related issues like #6378