### PR TITLE
Return Result from Shape methods

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -56,23 +56,22 @@ fn argument_shape(
     shape: Shape,
     context: &RewriteContext<'_>,
 ) -> Option<Shape> {
-    match context.config.indent_style() {
+    let shape = match context.config.indent_style() {
         IndentStyle::Block => {
             if combine {
-                shape.offset_left(left)
+                shape.offset_left_opt(left)?
             } else {
-                Some(
-                    shape
-                        .block_indent(context.config.tab_spaces())
-                        .with_max_width(context.config),
-                )
+                shape
+                    .block_indent(context.config.tab_spaces())
+                    .with_max_width(context.config)
             }
         }
         IndentStyle::Visual => shape
             .visual_indent(0)
-            .shrink_left(left)
-            .and_then(|s| s.sub_width(right)),
-    }
+            .shrink_left_opt(left)?
+            .sub_width_opt(right)?,
+    };
+    Some(shape)
 }
 
 fn format_derive(
@@ -127,8 +126,8 @@ fn format_derive(
         context,
     )?;
     let one_line_shape = shape
-        .offset_left("[derive()]".len() + prefix.len())?
-        .sub_width("()]".len())?;
+        .offset_left_opt("[derive()]".len() + prefix.len())?
+        .sub_width_opt("()]".len())?;
     let one_line_budget = one_line_shape.width;
 
     let tactic = definitive_tactic(
@@ -297,7 +296,7 @@ impl Rewrite for ast::MetaItem {
                     &path,
                     list.iter(),
                     // 1 = "]"
-                    shape.sub_width(1).max_width_error(shape.width, self.span)?,
+                    shape.sub_width(1, self.span)?,
                     self.span,
                     context.config.attr_fn_like_width(),
                     Some(if has_trailing_comma {
@@ -310,9 +309,7 @@ impl Rewrite for ast::MetaItem {
             ast::MetaItemKind::NameValue(ref lit) => {
                 let path = rewrite_path(context, PathContext::Type, &None, &self.path, shape)?;
                 // 3 = ` = `
-                let lit_shape = shape
-                    .shrink_left(path.len() + 3)
-                    .max_width_error(shape.width, self.span)?;
+                let lit_shape = shape.shrink_left(path.len() + 3, self.span)?;
                 // `rewrite_literal` returns `None` when `lit` exceeds max
                 // width. Since a literal is basically unformattable unless it
                 // is a string literal (and only if `format_strings` is set),
@@ -369,9 +366,7 @@ impl Rewrite for ast::Attribute {
                 }
 
                 // 1 = `[`
-                let shape = shape
-                    .offset_left(prefix.len() + 1)
-                    .max_width_error(shape.width, self.span)?;
+                let shape = shape.offset_left(prefix.len() + 1, self.span)?;
                 Ok(meta.rewrite_result(context, shape).map_or_else(
                     |_| snippet.to_owned(),
                     |rw| match &self.kind {

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -67,7 +67,9 @@ use crate::config::{IndentStyle, StyleEdition};
 use crate::expr::rewrite_call;
 use crate::lists::extract_pre_comment;
 use crate::macros::convert_try_mac;
-use crate::rewrite::{Rewrite, RewriteContext, RewriteError, RewriteErrorExt, RewriteResult};
+use crate::rewrite::{
+    ExceedsMaxWidthError, Rewrite, RewriteContext, RewriteError, RewriteErrorExt, RewriteResult,
+};
 use crate::shape::Shape;
 use crate::source_map::SpanUtils;
 use crate::utils::{
@@ -127,14 +129,15 @@ fn get_visual_style_child_shape(
     shape: Shape,
     offset: usize,
     parent_overflowing: bool,
-) -> Option<Shape> {
+    span: Span,
+) -> Result<Shape, ExceedsMaxWidthError> {
     if !parent_overflowing {
         shape
             .with_max_width(context.config)
-            .offset_left(offset)
+            .offset_left(offset, span)
             .map(|s| s.visual_indent(0))
     } else {
-        Some(shape.visual_indent(offset))
+        Ok(shape.visual_indent(offset))
     }
 }
 
@@ -280,9 +283,7 @@ impl Rewrite for ChainItem {
     }
 
     fn rewrite_result(&self, context: &RewriteContext<'_>, shape: Shape) -> RewriteResult {
-        let shape = shape
-            .sub_width(self.tries)
-            .max_width_error(shape.width, self.span)?;
+        let shape = shape.sub_width(self.tries, self.span)?;
         let rewrite = match self.kind {
             ChainItemKind::Parent {
                 ref expr,
@@ -559,9 +560,7 @@ impl Rewrite for Chain {
         let full_span = self.parent.span.with_hi(children_span.hi());
 
         // Decide how to layout the rest of the chain.
-        let child_shape = formatter
-            .child_shape(context, shape)
-            .max_width_error(shape.width, children_span)?;
+        let child_shape = formatter.child_shape(context, shape, children_span)?;
 
         formatter.format_children(context, child_shape)?;
         formatter.format_last_child(context, shape, child_shape)?;
@@ -590,7 +589,12 @@ trait ChainFormatter {
         context: &RewriteContext<'_>,
         shape: Shape,
     ) -> Result<(), RewriteError>;
-    fn child_shape(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<Shape>;
+    fn child_shape(
+        &self,
+        context: &RewriteContext<'_>,
+        shape: Shape,
+        span: Span,
+    ) -> Result<Shape, ExceedsMaxWidthError>;
     fn format_children(
         &mut self,
         context: &RewriteContext<'_>,
@@ -720,17 +724,11 @@ impl<'a> ChainFormatterShared<'a> {
             && self.rewrites.iter().all(|s| !s.contains('\n'))
             && one_line_budget > 0;
         let last_shape = if all_in_one_line {
-            shape
-                .sub_width(last.tries)
-                .max_width_error(shape.width, last.span)?
+            shape.sub_width(last.tries, last.span)?
         } else if extendable {
-            child_shape
-                .sub_width(last.tries)
-                .max_width_error(child_shape.width, last.span)?
+            child_shape.sub_width(last.tries, last.span)?
         } else {
-            child_shape
-                .sub_width(shape.rhs_overhead(context.config) + last.tries)
-                .max_width_error(child_shape.width, last.span)?
+            child_shape.sub_width(shape.rhs_overhead(context.config) + last.tries, last.span)?
         };
 
         let mut last_subexpr_str = None;
@@ -738,11 +736,11 @@ impl<'a> ChainFormatterShared<'a> {
             // First we try to 'overflow' the last child and see if it looks better than using
             // vertical layout.
             let one_line_shape = if context.use_block_indent() {
-                last_shape.offset_left(almost_total)
+                last_shape.offset_left_opt(almost_total)
             } else {
                 last_shape
                     .visual_indent(almost_total)
-                    .sub_width(almost_total)
+                    .sub_width_opt(almost_total)
             };
 
             if let Some(one_line_shape) = one_line_shape {
@@ -760,9 +758,10 @@ impl<'a> ChainFormatterShared<'a> {
                         // layout, just by looking at the overflowed rewrite. Now we rewrite the
                         // last child on its own line, and compare two rewrites to choose which is
                         // better.
-                        let last_shape = child_shape
-                            .sub_width(shape.rhs_overhead(context.config) + last.tries)
-                            .max_width_error(child_shape.width, last.span)?;
+                        let last_shape = child_shape.sub_width(
+                            shape.rhs_overhead(context.config) + last.tries,
+                            last.span,
+                        )?;
                         match last.rewrite_result(context, last_shape) {
                             Ok(ref new_rw) if !could_fit_single_line => {
                                 last_subexpr_str = Some(new_rw.clone());
@@ -787,9 +786,7 @@ impl<'a> ChainFormatterShared<'a> {
         let last_shape = if context.use_block_indent() {
             last_shape
         } else {
-            child_shape
-                .sub_width(shape.rhs_overhead(context.config) + last.tries)
-                .max_width_error(child_shape.width, last.span)?
+            child_shape.sub_width(shape.rhs_overhead(context.config) + last.tries, last.span)?
         };
 
         let last_subexpr_str =
@@ -863,9 +860,7 @@ impl<'a> ChainFormatter for ChainFormatterBlock<'a> {
             if let ChainItemKind::Comment(..) = item.kind {
                 break;
             }
-            let shape = shape
-                .offset_left(root_rewrite.len())
-                .max_width_error(shape.width, item.span)?;
+            let shape = shape.offset_left(root_rewrite.len(), item.span)?;
             match &item.rewrite_result(context, shape) {
                 Ok(rewrite) => root_rewrite.push_str(rewrite),
                 Err(_) => break,
@@ -883,9 +878,14 @@ impl<'a> ChainFormatter for ChainFormatterBlock<'a> {
         Ok(())
     }
 
-    fn child_shape(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<Shape> {
+    fn child_shape(
+        &self,
+        context: &RewriteContext<'_>,
+        shape: Shape,
+        _span: Span,
+    ) -> Result<Shape, ExceedsMaxWidthError> {
         let block_end = self.root_ends_with_block;
-        Some(get_block_child_shape(block_end, context, shape))
+        Ok(get_block_child_shape(block_end, context, shape))
     }
 
     fn format_children(
@@ -955,8 +955,7 @@ impl<'a> ChainFormatter for ChainFormatterVisual<'a> {
             }
             let child_shape = parent_shape
                 .visual_indent(self.offset)
-                .sub_width(self.offset)
-                .max_width_error(parent_shape.width, item.span)?;
+                .sub_width(self.offset, item.span)?;
             let rewrite = item.rewrite_result(context, child_shape)?;
             if filtered_str_fits(&rewrite, context.config.max_width(), shape) {
                 root_rewrite.push_str(&rewrite);
@@ -975,13 +974,19 @@ impl<'a> ChainFormatter for ChainFormatterVisual<'a> {
         Ok(())
     }
 
-    fn child_shape(&self, context: &RewriteContext<'_>, shape: Shape) -> Option<Shape> {
+    fn child_shape(
+        &self,
+        context: &RewriteContext<'_>,
+        shape: Shape,
+        span: Span,
+    ) -> Result<Shape, ExceedsMaxWidthError> {
         get_visual_style_child_shape(
             context,
             shape,
             self.offset,
             // TODO(calebcartwright): self.shared.permissibly_overflowing_parent,
             false,
+            span,
         )
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -70,7 +70,7 @@ pub(crate) fn format_expr(
         return Ok(context.snippet(expr.span()).to_owned());
     }
     let shape = if expr_type == ExprType::Statement && semicolon_for_expr(context, expr) {
-        shape.sub_width(1).max_width_error(shape.width, expr.span)?
+        shape.sub_width(1, expr.span)?
     } else {
         shape
     };
@@ -534,9 +534,7 @@ fn rewrite_single_line_block(
     shape: Shape,
 ) -> RewriteResult {
     if let Some(block_expr) = stmt::Stmt::from_simple_block(context, block, attrs) {
-        let expr_shape = shape
-            .offset_left(last_line_width(prefix))
-            .max_width_error(shape.width, block_expr.span())?;
+        let expr_shape = shape.offset_left(last_line_width(prefix), block_expr.span())?;
         let expr_str = block_expr.rewrite_result(context, expr_shape)?;
         let label_str = rewrite_label(context, label);
         let result = format!("{prefix}{label_str}{{ {expr_str} }}");
@@ -650,8 +648,8 @@ pub(crate) fn rewrite_cond(
         ast::ExprKind::Match(ref cond, _, MatchKind::Prefix) => {
             // `match `cond` {`
             let cond_shape = match context.config.indent_style() {
-                IndentStyle::Visual => shape.shrink_left(6).and_then(|s| s.sub_width(2))?,
-                IndentStyle::Block => shape.offset_left(8)?,
+                IndentStyle::Visual => shape.shrink_left_opt(6).and_then(|s| s.sub_width_opt(2))?,
+                IndentStyle::Block => shape.offset_left_opt(8)?,
             };
             cond.rewrite(context, cond_shape)
         }
@@ -888,9 +886,7 @@ impl<'a> ControlFlow<'a> {
     ) -> RewriteResult {
         debug!("rewrite_pat_expr {:?} {:?} {:?}", shape, self.pat, expr);
 
-        let cond_shape = shape
-            .offset_left(offset)
-            .max_width_error(shape.width, expr.span)?;
+        let cond_shape = shape.offset_left(offset, expr.span)?;
         if let Some(pat) = self.pat {
             let matcher = if self.matcher.is_empty() {
                 self.matcher.to_owned()
@@ -898,9 +894,8 @@ impl<'a> ControlFlow<'a> {
                 format!("{} ", self.matcher)
             };
             let pat_shape = cond_shape
-                .offset_left(matcher.len())
-                .and_then(|s| s.sub_width(self.connector.len()))
-                .max_width_error(cond_shape.width, pat.span)?;
+                .offset_left(matcher.len(), pat.span)?
+                .sub_width(self.connector.len(), pat.span)?;
             let pat_string = pat.rewrite_result(context, pat_shape)?;
             let comments_lo = context
                 .snippet_provider
@@ -950,9 +945,7 @@ impl<'a> ControlFlow<'a> {
         let constr_shape = if self.nested_if {
             // We are part of an if-elseif-else chain. Our constraints are tightened.
             // 7 = "} else " .len()
-            fresh_shape
-                .offset_left(7)
-                .max_width_error(fresh_shape.width, self.span)?
+            fresh_shape.offset_left(7, self.span)?
         } else {
             fresh_shape
         };
@@ -1514,10 +1507,7 @@ pub(crate) fn rewrite_paren(
     }
 
     // 1 = `(` and `)`
-    let sub_shape = shape
-        .offset_left(1)
-        .and_then(|s| s.sub_width(1))
-        .max_width_error(shape.width, span)?;
+    let sub_shape = shape.offset_left(1, span)?.sub_width(1, span)?;
     let subexpr_str = subexpr.rewrite_result(context, sub_shape)?;
     let fits_single_line = !pre_comment.contains("//") && !post_comment.contains("//");
     if fits_single_line {
@@ -1570,18 +1560,21 @@ fn rewrite_index(
     let rhs_overhead = shape.rhs_overhead(context.config);
     let index_shape = if expr_str.contains('\n') {
         Shape::legacy(context.config.max_width(), shape.indent)
-            .offset_left(offset)
-            .and_then(|shape| shape.sub_width(1 + rhs_overhead))
+            .offset_left(offset, index.span())
+            .and_then(|shape| shape.sub_width(1 + rhs_overhead, index.span()))
     } else {
         match context.config.indent_style() {
             IndentStyle::Block => shape
-                .offset_left(offset)
-                .and_then(|shape| shape.sub_width(1)),
-            IndentStyle::Visual => shape.visual_indent(offset).sub_width(offset + 1),
+                .offset_left(offset, index.span())
+                .and_then(|shape| shape.sub_width(1, index.span())),
+            IndentStyle::Visual => shape
+                .visual_indent(offset)
+                .sub_width(offset + 1, index.span()),
         }
-    }
-    .max_width_error(shape.width, index.span());
-    let orig_index_rw = index_shape.and_then(|s| index.rewrite_result(context, s));
+    };
+    let orig_index_rw = index_shape
+        .map_err(RewriteError::from)
+        .and_then(|s| index.rewrite_result(context, s));
 
     // Return if index fits in a single line.
     match orig_index_rw {
@@ -1594,11 +1587,8 @@ fn rewrite_index(
     // Try putting index on the next line and see if it fits in a single line.
     let indent = shape.indent.block_indent(context.config);
     let index_shape = Shape::indented(indent, context.config)
-        .offset_left(1)
-        .max_width_error(shape.width, index.span())?;
-    let index_shape = index_shape
-        .sub_width(1 + rhs_overhead)
-        .max_width_error(index_shape.width, index.span())?;
+        .offset_left(1, index.span())?
+        .sub_width(1 + rhs_overhead, index.span())?;
     let new_index_rw = index.rewrite_result(context, index_shape);
     match (orig_index_rw, new_index_rw) {
         (_, Ok(ref new_index_str)) if !new_index_str.contains('\n') => Ok(format!(
@@ -1644,7 +1634,7 @@ fn rewrite_struct_lit<'a>(
     }
 
     // 2 = " {".len()
-    let path_shape = shape.sub_width(2).max_width_error(shape.width, span)?;
+    let path_shape = shape.sub_width(2, span)?;
     let path_str = rewrite_path(context, PathContext::Expr, qself, path, path_shape)?;
 
     let has_base_or_rest = match struct_rest {
@@ -1657,8 +1647,7 @@ fn rewrite_struct_lit<'a>(
     };
 
     // Foo { a: Foo } - indent is +3, width is -5.
-    let (h_shape, v_shape) = struct_lit_shape(shape, context, path_str.len() + 3, 2)
-        .max_width_error(shape.width, span)?;
+    let (h_shape, v_shape) = struct_lit_shape(shape, context, path_str.len() + 3, 2, span)?;
 
     let one_line_width = h_shape.map_or(0, |shape| shape.width);
     let body_lo = context.snippet_provider.span_after(span, "{");
@@ -1701,22 +1690,12 @@ fn rewrite_struct_lit<'a>(
         let rewrite = |item: &StructLitField<'_>| match *item {
             StructLitField::Regular(field) => {
                 // The 1 taken from the v_budget is for the comma.
-                rewrite_field(
-                    context,
-                    field,
-                    v_shape.sub_width(1).max_width_error(v_shape.width, span)?,
-                    0,
-                )
+                rewrite_field(context, field, v_shape.sub_width(1, span)?, 0)
             }
             StructLitField::Base(expr) => {
                 // 2 = ..
-                expr.rewrite_result(
-                    context,
-                    v_shape
-                        .offset_left(2)
-                        .max_width_error(v_shape.width, span)?,
-                )
-                .map(|s| format!("..{}", s))
+                expr.rewrite_result(context, v_shape.offset_left(2, span)?)
+                    .map(|s| format!("..{}", s))
             }
             StructLitField::Rest(_) => Ok("..".to_owned()),
         };
@@ -1823,9 +1802,7 @@ pub(crate) fn rewrite_field(
             separator.push(' ');
         }
         let overhead = name.len() + separator.len();
-        let expr_shape = shape
-            .offset_left(overhead)
-            .max_width_error(shape.width, field.span)?;
+        let expr_shape = shape.offset_left(overhead, field.span)?;
         let expr = field.expr.rewrite_result(context, expr_shape);
         let is_lit = matches!(field.expr.kind, ast::ExprKind::Lit(_));
         match expr {
@@ -1865,10 +1842,7 @@ fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + IntoOverflowableItem<'a>>(
     debug!("rewrite_tuple_in_visual_indent_style {:?}", shape);
     if is_singleton_tuple {
         // 3 = "(" + ",)"
-        let nested_shape = shape
-            .sub_width(3)
-            .max_width_error(shape.width, span)?
-            .visual_indent(1);
+        let nested_shape = shape.sub_width(3, span)?.visual_indent(1);
         return items
             .next()
             .unwrap()
@@ -1877,10 +1851,7 @@ fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + IntoOverflowableItem<'a>>(
     }
 
     let list_lo = context.snippet_provider.span_after(span, "(");
-    let nested_shape = shape
-        .sub_width(2)
-        .max_width_error(shape.width, span)?
-        .visual_indent(1);
+    let nested_shape = shape.sub_width(2, span)?.visual_indent(1);
     let items = itemize_list(
         context.snippet_provider,
         items,
@@ -1919,9 +1890,7 @@ fn rewrite_let(
     // TODO(ytmimi) comments could appear between `let` and the `pat`
 
     // 4 = "let ".len()
-    let pat_shape = shape
-        .offset_left(4)
-        .max_width_error(shape.width, pat.span)?;
+    let pat_shape = shape.offset_left(4, pat.span)?;
     let pat_str = pat.rewrite_result(context, pat_shape)?;
     result.push_str(&pat_str);
 
@@ -1985,9 +1954,7 @@ pub(crate) fn rewrite_unary_prefix<R: Rewrite + Spanned>(
     rewrite: &R,
     shape: Shape,
 ) -> RewriteResult {
-    let shape = shape
-        .offset_left(prefix.len())
-        .max_width_error(shape.width, rewrite.span())?;
+    let shape = shape.offset_left(prefix.len(), rewrite.span())?;
     rewrite
         .rewrite_result(context, shape)
         .map(|r| format!("{}{}", prefix, r))
@@ -2001,9 +1968,7 @@ pub(crate) fn rewrite_unary_suffix<R: Rewrite + Spanned>(
     rewrite: &R,
     shape: Shape,
 ) -> RewriteResult {
-    let shape = shape
-        .sub_width(suffix.len())
-        .max_width_error(shape.width, rewrite.span())?;
+    let shape = shape.sub_width(suffix.len(), rewrite.span())?;
     rewrite.rewrite_result(context, shape).map(|mut r| {
         r.push_str(suffix);
         r
@@ -2061,9 +2026,7 @@ fn rewrite_assignment(
     };
 
     // 1 = space between lhs and operator.
-    let lhs_shape = shape
-        .sub_width(operator_str.len() + 1)
-        .max_width_error(shape.width, lhs.span())?;
+    let lhs_shape = shape.sub_width(operator_str.len() + 1, lhs.span())?;
     let lhs_str = format!(
         "{} {}",
         lhs.rewrite_result(context, lhs_shape)?,
@@ -2117,7 +2080,7 @@ pub(crate) fn rewrite_assign_rhs_expr<R: Rewrite>(
         0
     });
     // 1 = space between operator and rhs.
-    let orig_shape = shape.offset_left(last_line_width + 1).unwrap_or(Shape {
+    let orig_shape = shape.offset_left_opt(last_line_width + 1).unwrap_or(Shape {
         width: 0,
         offset: shape.offset + last_line_width + 1,
         ..shape
@@ -2165,9 +2128,10 @@ pub(crate) fn rewrite_assign_rhs_with_comments<S: Into<String>, R: Rewrite + Spa
     let lhs = lhs.into();
     let contains_comment = contains_comment(context.snippet(between_span));
     let shape = if contains_comment {
-        shape
-            .block_left(context.config.tab_spaces())
-            .max_width_error(shape.width, between_span.with_hi(ex.span().hi()))?
+        shape.block_left(
+            context.config.tab_spaces(),
+            between_span.with_hi(ex.span().hi()),
+        )?
     } else {
         shape
     };
@@ -2244,10 +2208,10 @@ fn shape_from_rhs_tactic(
     match rhs_tactic {
         RhsTactics::ForceNextLineWithoutIndent => shape
             .with_max_width(context.config)
-            .sub_width(shape.indent.width()),
+            .sub_width_opt(shape.indent.width()),
         RhsTactics::Default | RhsTactics::AllowOverflow => {
             Shape::indented(shape.indent.block_indent(context.config), context.config)
-                .sub_width(shape.rhs_overhead(context.config))
+                .sub_width_opt(shape.rhs_overhead(context.config))
         }
     }
 }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -338,12 +338,7 @@ impl UseTree {
             crate::utils::format_visibility(context, vis)
         });
         let use_str = self
-            .rewrite_result(
-                context,
-                shape
-                    .offset_left(vis.len())
-                    .max_width_error(shape.width, self.span())?,
-            )
+            .rewrite_result(context, shape.offset_left(vis.len(), self.span())?)
             .map(|s| {
                 if s.is_empty() {
                     s
@@ -1024,7 +1019,7 @@ fn rewrite_nested_use_tree(
         IndentStyle::Block => shape
             .block_indent(context.config.tab_spaces())
             .with_max_width(context.config)
-            .sub_width(1)
+            .sub_width_opt(1)
             .unknown_error()?,
         IndentStyle::Visual => shape.visual_indent(0),
     };
@@ -1115,8 +1110,8 @@ impl Rewrite for UseSegment {
                     use_tree_list,
                     // 1 = "{" and "}"
                     shape
-                        .offset_left(1)
-                        .and_then(|s| s.sub_width(1))
+                        .offset_left_opt(1)
+                        .and_then(|s| s.sub_width_opt(1))
                         .unknown_error()?,
                 )?
             }
@@ -1139,9 +1134,7 @@ impl Rewrite for UseTree {
             if iter.peek().is_some() {
                 result.push_str("::");
                 // 2 = "::"
-                shape = shape
-                    .offset_left(2 + segment_str.len())
-                    .max_width_error(shape.width, self.span())?;
+                shape = shape.offset_left(2 + segment_str.len(), self.span())?;
             }
         }
         Ok(result)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -381,9 +381,7 @@ fn handle_vec_semi(
     };
 
     // Should we return MaxWidthError, Or Macro failure
-    let mac_shape = shape
-        .offset_left(macro_name.len())
-        .max_width_error(shape.width, span)?;
+    let mac_shape = shape.offset_left(macro_name.len(), span)?;
     // 8 = `vec![]` + `; ` or `vec!()` + `; `
     let total_overhead = 8;
     let nested_shape = mac_shape.block_indent(context.config.tab_spaces());
@@ -1294,9 +1292,7 @@ impl MacroBranch {
         let mut result = format_macro_args(
             context,
             self.args.clone(),
-            shape
-                .sub_width(prefix_width)
-                .max_width_error(shape.width, self.span)?,
+            shape.sub_width(prefix_width, self.span)?,
         )?;
 
         if multi_branch_style {
@@ -1445,9 +1441,7 @@ fn format_lazy_static(
             stmt,
             &*expr,
             &RhsAssignKind::Expr(&expr.kind, expr.span),
-            nested_shape
-                .sub_width(1)
-                .max_width_error(nested_shape.width, expr.span)?,
+            nested_shape.sub_width(1, expr.span)?,
         )?);
         result.push(';');
         if i != last {

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -387,8 +387,8 @@ impl<'a> Context<'a> {
 
         // 1 = "(" or ")"
         let one_line_shape = shape
-            .offset_left(last_line_width(ident) + 1)
-            .and_then(|shape| shape.sub_width(1))
+            .offset_left_opt(last_line_width(ident) + 1)
+            .and_then(|shape| shape.sub_width_opt(1))
             .unwrap_or(Shape { width: 0, ..shape });
         let nested_shape = shape_from_indent_style(context, shape, used_width + 2, used_width + 1);
         Context {
@@ -774,7 +774,7 @@ fn last_item_shape(
         width: min(args_max_width, shape.width),
         ..shape
     }
-    .offset_left(offset)
+    .offset_left_opt(offset)
 }
 
 fn shape_from_indent_style(

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -86,7 +86,7 @@ fn rewrite_pairs_one_line<T: Rewrite>(
 
     let prefix_len = result.len();
     let last = list.list.last()?.0;
-    let cur_shape = base_shape.offset_left(last_line_width(&result))?;
+    let cur_shape = base_shape.offset_left_opt(last_line_width(&result))?;
     let last_rewrite = last.rewrite(context, cur_shape)?;
     result.push_str(&last_rewrite);
 
@@ -116,8 +116,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
         IndentStyle::Block => shape.block_indent(context.config.tab_spaces()),
     })
     .with_max_width(context.config)
-    .sub_width(rhs_offset)
-    .max_width_error(shape.width, list.span)?;
+    .sub_width(rhs_offset, list.span)?;
 
     let indent_str = nested_shape.indent.to_string_with_newline(context.config);
     let mut result = String::new();
@@ -136,7 +135,7 @@ fn rewrite_pairs_multiline<T: Rewrite>(
         if last_line_width(&result) + offset <= nested_shape.used_width() {
             // We must snuggle the next line onto the previous line to avoid an orphan.
             if let Some(line_shape) =
-                shape.offset_left(s.len() + 2 + trimmed_last_line_width(&result))
+                shape.offset_left_opt(s.len() + 2 + trimmed_last_line_width(&result))
             {
                 if let Ok(rewrite) = e.rewrite_result(context, line_shape) {
                     result.push(' ');
@@ -194,12 +193,11 @@ where
 
     // Try to put both lhs and rhs on the same line.
     let rhs_orig_result = shape
-        .offset_left(last_line_width(&lhs_result) + pp.infix.len())
-        .and_then(|s| s.sub_width(pp.suffix.len()))
-        .max_width_error(shape.width, rhs.span())
-        .and_then(|rhs_shape| rhs.rewrite_result(context, rhs_shape));
+        .offset_left_opt(last_line_width(&lhs_result) + pp.infix.len())
+        .and_then(|s| s.sub_width_opt(pp.suffix.len()))
+        .and_then(|rhs_shape| rhs.rewrite_result(context, rhs_shape).ok());
 
-    if let Ok(ref rhs_result) = rhs_orig_result {
+    if let Some(ref rhs_result) = rhs_orig_result {
         // If the length of the lhs is equal to or shorter than the tab width or
         // the rhs looks like block expression, we put the rhs on the same
         // line with the lhs even if the rhs is multi-lined.
@@ -227,15 +225,13 @@ where
     // Re-evaluate the rhs because we have more space now:
     let mut rhs_shape = match context.config.indent_style() {
         IndentStyle::Visual => shape
-            .sub_width(pp.suffix.len() + pp.prefix.len())
-            .max_width_error(shape.width, rhs.span())?
+            .sub_width(pp.suffix.len() + pp.prefix.len(), rhs.span())?
             .visual_indent(pp.prefix.len()),
         IndentStyle::Block => {
             // Try to calculate the initial constraint on the right hand side.
             let rhs_overhead = shape.rhs_overhead(context.config);
             Shape::indented(shape.indent.block_indent(context.config), context.config)
-                .sub_width(rhs_overhead)
-                .max_width_error(shape.width, rhs.span())?
+                .sub_width(rhs_overhead, rhs.span())?
         }
     };
     let infix = match separator_place {
@@ -243,9 +239,7 @@ where
         SeparatorPlace::Front => pp.infix.trim_start(),
     };
     if separator_place == SeparatorPlace::Front {
-        rhs_shape = rhs_shape
-            .offset_left(infix.len())
-            .max_width_error(rhs_shape.width, rhs.span())?;
+        rhs_shape = rhs_shape.offset_left(infix.len(), rhs.span())?;
     }
     let rhs_result = rhs.rewrite_result(context, rhs_shape)?;
     let indent_str = rhs_shape.indent.to_string_with_newline(context.config);
@@ -325,15 +319,10 @@ impl FlattenPair for ast::Expr {
                 IndentStyle::Block => shape.block_indent(context.config.tab_spaces()),
             })
             .with_max_width(context.config)
-            .sub_width(rhs_offset)
-            .max_width_error(shape.width, node.span)?;
+            .sub_width(rhs_offset, node.span)?;
             let default_shape = match context.config.binop_separator() {
-                SeparatorPlace::Back => nested_shape
-                    .sub_width(nested_overhead)
-                    .max_width_error(nested_shape.width, node.span)?,
-                SeparatorPlace::Front => nested_shape
-                    .offset_left(nested_overhead)
-                    .max_width_error(nested_shape.width, node.span)?,
+                SeparatorPlace::Back => nested_shape.sub_width(nested_overhead, node.span)?,
+                SeparatorPlace::Front => nested_shape.offset_left(nested_overhead, node.span)?,
             };
             node.rewrite_result(context, default_shape)
         };

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -332,10 +332,7 @@ impl Rewrite for Pat {
             PatKind::Paren(ref pat) => pat
                 .rewrite_result(
                     context,
-                    shape
-                        .offset_left(1)
-                        .and_then(|s| s.sub_width(1))
-                        .max_width_error(shape.width, self.span)?,
+                    shape.offset_left(1, self.span)?.sub_width(1, self.span)?,
                 )
                 .map(|inner_pat| format!("({})", inner_pat)),
             PatKind::Err(_) => Err(RewriteError::Unknown),
@@ -354,7 +351,7 @@ fn rewrite_struct_pat(
     shape: Shape,
 ) -> RewriteResult {
     // 2 =  ` {`
-    let path_shape = shape.sub_width(2).max_width_error(shape.width, span)?;
+    let path_shape = shape.sub_width(2, span)?;
     let path_str = rewrite_path(context, PathContext::Expr, qself, path, path_shape)?;
 
     if fields.is_empty() && !ellipsis {
@@ -364,9 +361,13 @@ fn rewrite_struct_pat(
     let (ellipsis_str, terminator) = if ellipsis { (", ..", "..") } else { ("", "}") };
 
     // 3 = ` { `, 2 = ` }`.
-    let (h_shape, v_shape) =
-        struct_lit_shape(shape, context, path_str.len() + 3, ellipsis_str.len() + 2)
-            .max_width_error(shape.width, span)?;
+    let (h_shape, v_shape) = struct_lit_shape(
+        shape,
+        context,
+        path_str.len() + 3,
+        ellipsis_str.len() + 2,
+        span,
+    )?;
 
     let items = itemize_list(
         context.snippet_provider,

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -138,7 +138,7 @@ fn rewrite_reorderable_or_regroupable_items(
             }
 
             // 4 = "use ", 1 = ";"
-            let nested_shape = shape.offset_left(4)?.sub_width(1)?;
+            let nested_shape = shape.offset_left_opt(4)?.sub_width_opt(1)?;
             let item_vec: Vec<_> = regrouped_items
                 .into_iter()
                 .filter(|use_group| !use_group.is_empty())

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -63,6 +63,20 @@ pub(crate) enum RewriteError {
     Unknown,
 }
 
+pub(crate) struct ExceedsMaxWidthError {
+    pub configured_width: usize,
+    pub span: Span,
+}
+
+impl From<ExceedsMaxWidthError> for RewriteError {
+    fn from(error: ExceedsMaxWidthError) -> Self {
+        RewriteError::ExceedsMaxWidth {
+            configured_width: error.configured_width,
+            span: error.span,
+        }
+    }
+}
+
 /// Extension trait used to conveniently convert to RewriteError
 pub(crate) trait RewriteErrorExt<T> {
     fn max_width_error(self, width: usize, span: Span) -> Result<T, RewriteError>;

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -188,8 +188,8 @@ impl Shape {
         }
     }
 
-    pub(crate) fn visual_indent(&self, extra_width: usize) -> Shape {
-        let alignment = self.offset + extra_width;
+    pub(crate) fn visual_indent(&self, delta: usize) -> Shape {
+        let alignment = self.offset + delta;
         Shape {
             width: self.width,
             indent: Indent::new(self.indent.block_indent, alignment),
@@ -197,29 +197,29 @@ impl Shape {
         }
     }
 
-    pub(crate) fn block_indent(&self, extra_width: usize) -> Shape {
+    pub(crate) fn block_indent(&self, delta: usize) -> Shape {
         if self.indent.alignment == 0 {
             Shape {
                 width: self.width,
-                indent: Indent::new(self.indent.block_indent + extra_width, 0),
+                indent: Indent::new(self.indent.block_indent + delta, 0),
                 offset: 0,
             }
         } else {
             Shape {
                 width: self.width,
-                indent: self.indent + extra_width,
-                offset: self.indent.alignment + extra_width,
+                indent: self.indent + delta,
+                offset: self.indent.alignment + delta,
             }
         }
     }
 
-    pub(crate) fn block_left(&self, width: usize) -> Option<Shape> {
-        self.block_indent(width).sub_width(width)
+    pub(crate) fn block_left(&self, delta: usize) -> Option<Shape> {
+        self.block_indent(delta).sub_width(delta)
     }
 
-    pub(crate) fn add_offset(&self, extra_width: usize) -> Shape {
+    pub(crate) fn add_offset(&self, delta: usize) -> Shape {
         Shape {
-            offset: self.offset + extra_width,
+            offset: self.offset + delta,
             ..*self
         }
     }
@@ -231,27 +231,27 @@ impl Shape {
         }
     }
 
-    pub(crate) fn saturating_sub_width(&self, width: usize) -> Shape {
-        self.sub_width(width).unwrap_or(Shape { width: 0, ..*self })
+    pub(crate) fn saturating_sub_width(&self, delta: usize) -> Shape {
+        self.sub_width(delta).unwrap_or(Shape { width: 0, ..*self })
     }
 
-    pub(crate) fn sub_width(&self, width: usize) -> Option<Shape> {
+    pub(crate) fn sub_width(&self, n: usize) -> Option<Shape> {
         Some(Shape {
-            width: self.width.checked_sub(width)?,
+            width: self.width.checked_sub(n)?,
             ..*self
         })
     }
 
-    pub(crate) fn shrink_left(&self, width: usize) -> Option<Shape> {
+    pub(crate) fn shrink_left(&self, delta: usize) -> Option<Shape> {
         Some(Shape {
-            width: self.width.checked_sub(width)?,
-            indent: self.indent + width,
-            offset: self.offset + width,
+            width: self.width.checked_sub(delta)?,
+            indent: self.indent + delta,
+            offset: self.offset + delta,
         })
     }
 
-    pub(crate) fn offset_left(&self, width: usize) -> Option<Shape> {
-        self.add_offset(width).sub_width(width)
+    pub(crate) fn offset_left(&self, delta: usize) -> Option<Shape> {
+        self.add_offset(delta).sub_width(delta)
     }
 
     pub(crate) fn used_width(&self) -> usize {

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -4,7 +4,7 @@ use rustc_span::Span;
 use crate::comment::recover_comment_removed;
 use crate::config::StyleEdition;
 use crate::expr::{ExprType, format_expr, is_simple_block};
-use crate::rewrite::{Rewrite, RewriteContext, RewriteError, RewriteErrorExt, RewriteResult};
+use crate::rewrite::{Rewrite, RewriteContext, RewriteError, RewriteResult};
 use crate::shape::Shape;
 use crate::source_map::LineRangeUtils;
 use crate::spanned::Spanned;
@@ -132,9 +132,7 @@ fn format_stmt(
                 ""
             };
 
-            let shape = shape
-                .sub_width(suffix.len())
-                .max_width_error(shape.width, ex.span())?;
+            let shape = shape.sub_width(suffix.len(), ex.span())?;
             format_expr(ex, expr_type, context, shape).map(|s| s + suffix)
         }
         ast::StmtKind::MacCall(..) | ast::StmtKind::Item(..) | ast::StmtKind::Empty => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,7 +67,7 @@ pub(crate) fn rewrite_path(
             }
 
             // 3 = ">::".len()
-            let shape = shape.sub_width(3).max_width_error(shape.width, path.span)?;
+            let shape = shape.sub_width(3, path.span)?;
 
             result = rewrite_path_segments(
                 PathContext::Type,
@@ -122,9 +122,7 @@ where
         }
 
         let extra_offset = extra_offset(&buffer, shape);
-        let new_shape = shape
-            .shrink_left(extra_offset)
-            .max_width_error(shape.width, mk_sp(span_lo, span_hi))?;
+        let new_shape = shape.shrink_left(extra_offset, mk_sp(span_lo, span_hi))?;
         let segment_string = rewrite_segment(
             path_context,
             segment,
@@ -277,12 +275,12 @@ fn rewrite_segment(
     result.push_str(rewrite_ident(context, segment.ident));
 
     let ident_len = result.len();
+    let span = mk_sp(*span_lo, span_hi);
     let shape = if context.use_block_indent() {
-        shape.offset_left(ident_len)
+        shape.offset_left(ident_len, span)?
     } else {
-        shape.shrink_left(ident_len)
-    }
-    .max_width_error(shape.width, mk_sp(*span_lo, span_hi))?;
+        shape.shrink_left(ident_len, span)?
+    };
 
     if let Some(ref args) = segment.args {
         let generics_str = rewrite_generic_args(args, context, shape, mk_sp(*span_lo, span_hi))?;
@@ -333,8 +331,8 @@ where
 
     let ty_shape = match context.config.indent_style() {
         // 4 = " -> "
-        IndentStyle::Block => shape.offset_left(4).max_width_error(shape.width, span)?,
-        IndentStyle::Visual => shape.block_left(4).max_width_error(shape.width, span)?,
+        IndentStyle::Block => shape.offset_left(4, span)?,
+        IndentStyle::Visual => shape.block_left(4, span)?,
     };
     let output = match *output {
         FnRetTy::Ty(ref ty) => {
@@ -570,9 +568,7 @@ fn rewrite_bounded_lifetime(
     } else {
         let colon = type_bound_colon(context);
         let overhead = last_line_width(&result) + colon.len();
-        let shape = shape
-            .sub_width(overhead)
-            .max_width_error(shape.width, span)?;
+        let shape = shape.sub_width(overhead, span)?;
         let result = format!(
             "{}{}{}",
             result,
@@ -629,9 +625,7 @@ impl Rewrite for ast::GenericBound {
                     asyncness.push(' ');
                 }
                 let polarity = polarity.as_str();
-                let shape = shape
-                    .offset_left(constness.len() + polarity.len())
-                    .max_width_error(shape.width, self.span())?;
+                let shape = shape.offset_left(constness.len() + polarity.len(), self.span())?;
                 poly_trait_ref
                     .rewrite_result(context, shape)
                     .map(|s| format!("{constness}{asyncness}{polarity}{s}"))
@@ -762,9 +756,7 @@ impl Rewrite for ast::PolyTraitRef {
         {
             // 6 is "for<> ".len()
             let extra_offset = lifetime_str.len() + 6;
-            let shape = shape
-                .offset_left(extra_offset)
-                .max_width_error(shape.width, self.span)?;
+            let shape = shape.offset_left(extra_offset, self.span)?;
             let path_str = self.trait_ref.rewrite_result(context, shape)?;
 
             Ok(format!("for<{lifetime_str}> {path_str}"))
@@ -795,15 +787,11 @@ impl Rewrite for ast::Ty {
                 // we have to consider 'dyn' keyword is used or not!!!
                 let (shape, prefix) = match tobj_syntax {
                     ast::TraitObjectSyntax::Dyn => {
-                        let shape = shape
-                            .offset_left(4)
-                            .max_width_error(shape.width, self.span())?;
+                        let shape = shape.offset_left(4, self.span())?;
                         (shape, "dyn ")
                     }
                     ast::TraitObjectSyntax::DynStar => {
-                        let shape = shape
-                            .offset_left(5)
-                            .max_width_error(shape.width, self.span())?;
+                        let shape = shape.offset_left(5, self.span())?;
                         (shape, "dyn* ")
                     }
                     ast::TraitObjectSyntax::None => (shape, ""),
@@ -920,7 +908,7 @@ impl Rewrite for ast::Ty {
                 }
 
                 // 2 = ()
-                if let Some(sh) = shape.sub_width(2) {
+                if let Some(sh) = shape.sub_width_opt(2) {
                     if let Ok(ref s) = ty.rewrite_result(context, sh) {
                         if !s.contains('\n') {
                             return Ok(format!("({s})"));
@@ -1042,14 +1030,11 @@ fn rewrite_bare_fn(
     result.push_str("fn");
 
     let func_ty_shape = if context.use_block_indent() {
-        shape
-            .offset_left(result.len())
-            .max_width_error(shape.width, span)?
+        shape.offset_left(result.len(), span)?
     } else {
         shape
             .visual_indent(result.len())
-            .sub_width(result.len())
-            .max_width_error(shape.width, span)?
+            .sub_width(result.len(), span)?
     };
 
     let rewrite = format_function_type(

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -213,7 +213,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
     force_trailing_separator: bool,
 ) -> Option<String> {
     // 1 = ","
-    let item_shape = Shape::indented(offset, context.config).sub_width(1)?;
+    let item_shape = Shape::indented(offset, context.config).sub_width_opt(1)?;
     let (mut field_prefix_max_width, field_prefix_min_width) =
         struct_field_prefix_max_min_width(context, fields, item_shape);
     let max_diff = field_prefix_max_width.saturating_sub(field_prefix_min_width);

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -325,7 +325,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                                 .saturating_sub(self.block_indent.width());
                             match comment_shape
                                 .visual_indent(offset_len)
-                                .sub_width(offset_len)
+                                .sub_width_opt(offset_len)
                             {
                                 Some(shp) => comment_shape = shp,
                                 None => comment_on_same_line = false,


### PR DESCRIPTION
* The `Shape` modifier methods now return `Result<Shape, ExeedsMaxWidthError>`
* There are `_opt` variants of the methods for when an Option is still needed
  * I believe this will remain useful in the long term, since sometimes we want to fallback and never error out
* There is a minor change in behavior for when multiple methods are chained together - the width used in the error will be the last successfully modified width. I think this is okay?