### PR TITLE
docs: Fix grammar in Configurations.md

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -3114,7 +3114,7 @@ Break comments to fit on the line
 
 Note that no wrapping will happen if:
 1. The comment is the start of a markdown header doc comment
-2. An URL was found in the comment
+2. A URL was found in the comment
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`


### PR DESCRIPTION
URL is pronounced by spelling out each letter, therefore, it doesn't start with a vowel sound.