### PR TITLE
Replace wrap_str with validate_shape

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -74,7 +74,7 @@ use crate::shape::Shape;
 use crate::source_map::SpanUtils;
 use crate::utils::{
     self, filtered_str_fits, first_line_width, last_line_extendable, last_line_width, mk_sp,
-    rewrite_ident, trimmed_last_line_width, wrap_str,
+    rewrite_ident, trimmed_last_line_width, validate_shape,
 };
 
 use thin_vec::ThinVec;
@@ -550,8 +550,8 @@ impl Rewrite for Chain {
 
         formatter.format_root(&self.parent, context, shape)?;
         if let Some(result) = formatter.pure_root() {
-            return wrap_str(result, context.config.max_width(), shape)
-                .max_width_error(shape.width, self.parent.span);
+            validate_shape(&result, shape, context.config, self.parent.span)?;
+            return Ok(result);
         }
 
         let first = self.children.first().unwrap_or(&self.parent);
@@ -566,7 +566,8 @@ impl Rewrite for Chain {
         formatter.format_last_child(context, shape, child_shape)?;
 
         let result = formatter.join_rewrites(context, child_shape)?;
-        wrap_str(result, context.config.max_width(), shape).max_width_error(shape.width, full_span)
+        validate_shape(&result, shape, context.config, full_span)?;
+        Ok(result)
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -33,7 +33,7 @@ use crate::types::{PathContext, rewrite_path};
 use crate::utils::{
     colon_spaces, contains_skip, count_newlines, filtered_str_fits, first_line_ends_with,
     inner_attributes, last_line_extendable, last_line_width, mk_sp, outer_attributes,
-    semicolon_for_expr, unicode_str_width, wrap_str,
+    semicolon_for_expr, unicode_str_width, validate_shape,
 };
 use crate::vertical::rewrite_with_alignment;
 use crate::visitor::FmtVisitor;
@@ -242,12 +242,9 @@ pub(crate) fn format_expr(
         | ast::ExprKind::Await(_, _) => rewrite_chain(expr, context, shape),
         ast::ExprKind::MacCall(ref mac) => {
             rewrite_macro(mac, None, context, shape, MacroPosition::Expression).or_else(|_| {
-                wrap_str(
-                    context.snippet(expr.span).to_owned(),
-                    context.config.max_width(),
-                    shape,
-                )
-                .max_width_error(shape.width, expr.span)
+                let snippet = context.snippet(expr.span).to_owned();
+                validate_shape(&snippet, shape, context.config, expr.span)?;
+                Ok(snippet)
             })
         }
         ast::ExprKind::Ret(None) => Ok("return".to_owned()),
@@ -1267,12 +1264,11 @@ pub(crate) fn rewrite_literal(
     match token_lit.kind {
         token::LitKind::Str => rewrite_string_lit(context, span, shape),
         token::LitKind::Integer => rewrite_int_lit(context, token_lit, span, shape),
-        _ => wrap_str(
-            context.snippet(span).to_owned(),
-            context.config.max_width(),
-            shape,
-        )
-        .max_width_error(shape.width, span),
+        _ => {
+            let snippet = context.snippet(span).to_owned();
+            validate_shape(&snippet, shape, context.config, span)?;
+            Ok(snippet)
+        }
     }
 }
 
@@ -1288,8 +1284,9 @@ fn rewrite_string_lit(context: &RewriteContext<'_>, span: Span, shape: Shape) ->
         {
             return Ok(string_lit.to_owned());
         } else {
-            return wrap_str(string_lit.to_owned(), context.config.max_width(), shape)
-                .max_width_error(shape.width, span);
+            let string = string_lit.to_owned();
+            validate_shape(&string, shape, context.config, span)?;
+            return Ok(string);
         }
     }
 
@@ -1319,25 +1316,19 @@ fn rewrite_int_lit(
             HexLiteralCase::Lower => Some(symbol_stripped.to_ascii_lowercase()),
         };
         if let Some(hex_lit) = hex_lit {
-            return wrap_str(
-                format!(
-                    "0x{}{}",
-                    hex_lit,
-                    token_lit.suffix.as_ref().map_or("", |s| s.as_str())
-                ),
-                context.config.max_width(),
-                shape,
-            )
-            .max_width_error(shape.width, span);
+            let string = format!(
+                "0x{}{}",
+                hex_lit,
+                token_lit.suffix.as_ref().map_or("", |s| s.as_str())
+            );
+            validate_shape(&string, shape, context.config, span)?;
+            return Ok(string);
         }
     }
 
-    wrap_str(
-        context.snippet(span).to_owned(),
-        context.config.max_width(),
-        shape,
-    )
-    .max_width_error(shape.width, span)
+    let string = context.snippet(span).to_owned();
+    validate_shape(&string, shape, context.config, span)?;
+    Ok(string)
 }
 
 fn choose_separator_tactic(context: &RewriteContext<'_>, span: Span) -> Option<SeparatorTactic> {

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -7,7 +7,7 @@ use crate::rewrite::{Rewrite, RewriteContext, RewriteErrorExt, RewriteResult};
 use crate::shape::Shape;
 use crate::spanned::Spanned;
 use crate::utils::{
-    first_line_width, is_single_line, last_line_width, trimmed_last_line_width, wrap_str,
+    filtered_str_fits, first_line_width, is_single_line, last_line_width, trimmed_last_line_width,
 };
 
 /// Sigils that decorate a binop pair.
@@ -102,7 +102,10 @@ fn rewrite_pairs_one_line<T: Rewrite>(
         return None;
     }
 
-    wrap_str(result, context.config.max_width(), shape)
+    if !filtered_str_fits(&result, context.config.max_width(), shape) {
+        return None;
+    }
+    Some(result)
 }
 
 fn rewrite_pairs_multiline<T: Rewrite>(

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -322,7 +322,7 @@ impl Shape {
         }
     }
 
-    fn exceeds_max_width_error(&self, span: Span) -> ExceedsMaxWidthError {
+    pub(crate) fn exceeds_max_width_error(&self, span: Span) -> ExceedsMaxWidthError {
         ExceedsMaxWidthError {
             configured_width: self.width,
             span,

--- a/src/string.rs
+++ b/src/string.rs
@@ -6,7 +6,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::config::Config;
 use crate::shape::Shape;
-use crate::utils::{unicode_str_width, wrap_str};
+use crate::utils::{filtered_str_fits, unicode_str_width};
 
 const MIN_STRING: usize = 10;
 
@@ -150,7 +150,10 @@ pub(crate) fn rewrite_string<'a>(
     }
 
     result.push_str(fmt.closer);
-    wrap_str(result, fmt.config.max_width(), fmt.shape)
+    if !filtered_str_fits(&result, fmt.config.max_width(), fmt.shape) {
+        return None;
+    }
+    Some(result)
 }
 
 /// Returns the index to the end of the URL if the split at index of the given string includes a

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use rustc_ast::ast::{
     self, Attribute, MetaItem, MetaItemKind, NestedMetaItem, NodeId, Path, Visibility,
     VisibilityKind,
@@ -7,11 +5,12 @@ use rustc_ast::ast::{
 use rustc_ast::ptr;
 use rustc_ast_pretty::pprust;
 use rustc_span::{BytePos, LocalExpnId, Span, Symbol, SyntaxContext, sym, symbol};
+use std::borrow::Cow;
 use unicode_width::UnicodeWidthStr;
 
 use crate::comment::{CharClasses, FullCodeCharKind, LineClasses, filter_normal_code};
 use crate::config::{Config, StyleEdition};
-use crate::rewrite::RewriteContext;
+use crate::rewrite::{ExceedsMaxWidthError, RewriteContext};
 use crate::shape::{Indent, Shape};
 
 #[inline]
@@ -384,13 +383,16 @@ macro_rules! skip_out_of_file_lines_range_visitor {
     };
 }
 
-// Wraps String in an Option. Returns Some when the string adheres to the
-// Rewrite constraints defined for the Rewrite trait and None otherwise.
-pub(crate) fn wrap_str(s: String, max_width: usize, shape: Shape) -> Option<String> {
-    if filtered_str_fits(&s, max_width, shape) {
-        Some(s)
+pub(crate) fn validate_shape(
+    string: &str,
+    shape: Shape,
+    config: &Config,
+    span: Span,
+) -> Result<(), ExceedsMaxWidthError> {
+    if filtered_str_fits(&string, config.max_width(), shape) {
+        Ok(())
     } else {
-        None
+        Err(shape.exceeds_max_width_error(span))
     }
 }
 


### PR DESCRIPTION
This ultimately re-uses `Shape::exceeds_max_width_error` more to be a tad DRYer.