### PR TITLE
Add aarch64 to releases

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -17,6 +17,10 @@ jobs:
             os: ubuntu-latest
             rust: nightly
             target: x86_64-unknown-linux-gnu
+          - build: macos-aarch64
+            os: macos-latest
+            rust: nightly
+            target: aarch64-apple-darwin
           - build: macos-x86_64
             os: macos-latest
             rust: nightly


### PR DESCRIPTION
I want to download and use rustfmt without the rest of a rust toolchain in cases where it isn't worth setting up a whole rust toolchain (i.e. CI job to format all code, not necessarily to build everything). Adding an aarch64 release would then allow me to use the same version on my laptop for debugging with [dotslash](https://dotslash-cli.com/)

Also, x86 support on macs is generally not the long term future for macs and aarch64 is. Let's get ahead of the deprecation of x86 by adding the new release target!

I tested this by creating a fake release in my fork, which worked correctly: https://github.com/bigfootjon/rustfmt/releases/tag/test