### PR TITLE
fix: wrap_comments creating invalid code blocks

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -885,6 +885,9 @@ impl<'a> CommentRewrite<'a> {
                 // Remove space if this is an empty comment or a doc comment.
                 self.result.pop();
             }
+            if self.code_block_attr.is_some() && self.is_prev_line_multi_line {
+                self.result.push_str(&self.comment_line_separator);
+            }
             self.result.push_str(line);
             self.fmt.shape = Shape::legacy(self.max_width, self.fmt_indent);
             self.is_prev_line_multi_line = false;

--- a/tests/target/issue-5244/unwrapped.rs
+++ b/tests/target/issue-5244/unwrapped.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments: false
+
+/// Here is me writing some documentation that is too long oh me oh my now some code please!
+/// ```
+/// test
+/// ```
+fn foo() {}

--- a/tests/target/issue-5244/wrapped.rs
+++ b/tests/target/issue-5244/wrapped.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: true
+
+/// Here is me writing some documentation that is too long oh me oh my now some
+/// code please!
+/// ```
+/// test
+/// ```
+fn foo() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rustfmt/issues/5244

This PR fixes the issue in ~#6416~ (duplicate of https://github.com/rust-lang/rustfmt/issues/5244), I have added both the before and after case of the formatting in `tests/`.

Edit (ytmimi): I updated the description