### PR TITLE
Fix incorrect strip r# prefix from labels

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -200,14 +200,22 @@ pub(crate) fn format_expr(
         }
         ast::ExprKind::Continue(ref opt_label) => {
             let id_str = match *opt_label {
-                Some(label) => format!(" {}", label.ident),
+                Some(label) => {
+                    // Ident lose the `r#` prefix in raw labels,　so use the original snippet
+                    let label_name = context.snippet(label.ident.span);
+                    format!(" {}", label_name)
+                }
                 None => String::new(),
             };
             Ok(format!("continue{id_str}"))
         }
         ast::ExprKind::Break(ref opt_label, ref opt_expr) => {
             let id_str = match *opt_label {
-                Some(label) => format!(" {}", label.ident),
+                Some(label) => {
+                    // Ident lose the `r#` prefix in raw labels,　so use the original snippet
+                    let label_name = context.snippet(label.ident.span);
+                    format!(" {}", label_name)
+                }
                 None => String::new(),
             };
 

--- a/tests/target/issue-6411.rs
+++ b/tests/target/issue-6411.rs
@@ -1,0 +1,21 @@
+// rustfmt-edition: 2021
+
+fn test_break() {
+    'r#if: {
+        break 'r#if;
+    }
+
+    'r#a: {
+        break 'r#a;
+    }
+}
+
+fn test_continue() {
+    'r#if: {
+        continue 'r#if;
+    }
+
+    'r#a: {
+        continue 'r#a;
+    }
+}


### PR DESCRIPTION
This PR fix #6411 

This PR fixes an issue where rustfmt incorrectly removes the r# prefix in raw labels(introduced in 1.83 https://github.com/rust-lang/rust/pull/126452), causing invalid label names like 'if instead of 'r#if. 