### PR TITLE
docs: clarify the editions behavior and it's consequences on formatting

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2806,12 +2806,12 @@ Controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338]
 - **Possible values**: `"2015"`, `"2018"`, `"2021"`, `"2024"` (unstable variant)
 - **Stable**: No
 
-This option is inferred from the `edition` if not specified.
+This option is inferred from the [`edition`](#edition) if not specified.
 
 See [Rust Style Editions] for details on style editions.
 Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the style edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
 
-To ensure consistent formatting, it is recommended to specify the `edition` or `style_edition` in a `rustfmt.toml` configuration file. For example:
+To ensure consistent formatting, it is recommended to specify the [`edition`](#edition) or `style_edition` in a `rustfmt.toml` configuration file. For example:
 
 ```toml
 style_edition = "2024"

--- a/Configurations.md
+++ b/Configurations.md
@@ -2800,7 +2800,7 @@ See also [`max_width`](#max_width) and [`use_small_heuristics`](#use_small_heuri
 
 ## `style_edition`
 
-Controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338])
+Controls the edition of the [Rust Style Guide](https://doc.rust-lang.org/nightly/style-guide/editions.html?highlight=editions#rust-style-editions) to use for formatting ([RFC 3338])
 
 - **Default value**: `"2015"`
 - **Possible values**: `"2015"`, `"2018"`, `"2021"`, `"2024"` (unstable variant)

--- a/Configurations.md
+++ b/Configurations.md
@@ -2800,13 +2800,15 @@ See also [`max_width`](#max_width) and [`use_small_heuristics`](#use_small_heuri
 
 ## `style_edition`
 
-Controls the edition of the [Rust Style Guide](https://doc.rust-lang.org/nightly/style-guide/editions.html?highlight=editions#rust-style-editions) to use for formatting ([RFC 3338])
+Controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338])
 
 - **Default value**: `"2015"`
 - **Possible values**: `"2015"`, `"2018"`, `"2021"`, `"2024"` (unstable variant)
 - **Stable**: No
 
 This option is inferred from the `edition` if not specified.
+
+See [Rust Style Editions] for details on style editions.
 Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the style edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
 
 To ensure consistent formatting, it is recommended to specify the `edition` or `style_edition` in a `rustfmt.toml` configuration file. For example:
@@ -2817,6 +2819,7 @@ style_edition = "2024"
 
 Alternatively, you can use the `--style-edition` flag when running `rustfmt` directly.
 
+[Rust Style Editions]: https://doc.rust-lang.org/nightly/style-guide/editions.html?highlight=editions#rust-style-editions
 [Rust Style Guide]: https://doc.rust-lang.org/nightly/style-guide/
 [RFC 3338]: https://rust-lang.github.io/rfcs/3338-style-evolution.html
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -537,9 +537,10 @@ Specifies which edition is used by the parser.
 - **Possible values**: `"2015"`, `"2018"`, `"2021"`, `"2024"`
 - **Stable**: Yes
 
-Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
+The `edition` option determines the Rust language edition used for parsing the code. This is important for syntax compatibility but does not directly control formatting behavior (see [style_edition](#style_edition)).
 
-To ensure consistent formatting, it is recommended to specify the edition in a `rustfmt.toml` configuration file. For example:
+When running `cargo fmt`, the `edition` is automatically inferred from the `Cargo.toml` file. However, when running `rustfmt` directly, the `edition` must be explicitly set in the configuration file or via the command line.
+For example in your `rustfmt.toml` file:
 
 ```toml
 edition = "2018"
@@ -2804,6 +2805,17 @@ Controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338]
 - **Default value**: `"2015"`
 - **Possible values**: `"2015"`, `"2018"`, `"2021"`, `"2024"` (unstable variant)
 - **Stable**: No
+
+This option is inferred from the `edition` if not specified.
+Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the style edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
+
+To ensure consistent formatting, it is recommended to specify the `edition` or `style_edition` in a `rustfmt.toml` configuration file. For example:
+
+```toml
+style_edition = "2024"
+```
+
+Alternatively, you can use the `--style-edition` flag when running `rustfmt` directly.
 
 [Rust Style Guide]: https://doc.rust-lang.org/nightly/style-guide/
 [RFC 3338]: https://rust-lang.github.io/rfcs/3338-style-evolution.html

--- a/Configurations.md
+++ b/Configurations.md
@@ -537,13 +537,15 @@ Specifies which edition is used by the parser.
 - **Possible values**: `"2015"`, `"2018"`, `"2021"`, `"2024"`
 - **Stable**: Yes
 
-Rustfmt is able to pick up the edition used by reading the `Cargo.toml` file if executed
-through the Cargo's formatting tool `cargo fmt`. Otherwise, the edition needs to be specified
-in your config file:
+Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
+
+To ensure consistent formatting, it is recommended to specify the edition in a `rustfmt.toml` configuration file. For example:
 
 ```toml
 edition = "2018"
 ```
+
+Alternatively, you can use the `--edition` flag when running `rustfmt` directly.
 
 ## `empty_item_single_line`
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -539,7 +539,7 @@ Specifies which edition is used by the parser.
 
 The `edition` option determines the Rust language edition used for parsing the code. This is important for syntax compatibility but does not directly control formatting behavior (see [style_edition](#style_edition)).
 
-When running `cargo fmt`, the `edition` is automatically inferred from the `Cargo.toml` file. However, when running `rustfmt` directly, the `edition` must be explicitly set in the configuration file or via the command line.
+When running `cargo fmt`, the `edition` is automatically read from the `Cargo.toml` file. However, when running `rustfmt` directly the `edition` defaults to 2015 if not explicitly configured. For consistent parsing between rustfmt and `cargo fmt` you should configure the `edition`.
 For example in your `rustfmt.toml` file:
 
 ```toml
@@ -2808,10 +2808,10 @@ Controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338]
 
 This option is inferred from the [`edition`](#edition) if not specified.
 
-See [Rust Style Editions] for details on style editions.
-Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the style edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
+See [Rust Style Editions] for details on formatting differences between style editions.
+rustfmt has a default style edition of `2015` while `cargo fmt` infers the style edition from the `edition` set in `Cargo.toml`. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the style edition is not explicitly configured.
 
-To ensure consistent formatting, it is recommended to specify the [`edition`](#edition) or `style_edition` in a `rustfmt.toml` configuration file. For example:
+To ensure consistent formatting, it is recommended to specify the `style_edition` in a `rustfmt.toml` configuration file. For example:
 
 ```toml
 style_edition = "2024"

--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ edition = "2024"
 
 ### Style Editions
 
-The option `style_edition` controls the edition of the [Rust Style Guide](https://doc.rust-lang.org/nightly/style-guide/editions.html?highlight=editions#rust-style-editions) to use for formatting ([RFC 3338](https://rust-lang.github.io/rfcs/3338-style-evolution.html))
+Controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338])
 It is inferred from `edition` if not explicitly set, and defaults to the `2015` edition.
 
+See [Rust Style Editions] for details on style editions.
 Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
 
 To ensure consistent formatting, it is recommended to specify the `edition` or `style_edition` in a `rustfmt.toml` configuration file. For example:
@@ -193,6 +194,9 @@ To ensure consistent formatting, it is recommended to specify the `edition` or `
 ```toml
 style_edition = "2024"
 ```
+[Rust Style Editions]: https://doc.rust-lang.org/nightly/style-guide/editions.html?highlight=editions#rust-style-editions
+[Rust Style Guide]: https://doc.rust-lang.org/nightly/style-guide/
+[RFC 3338]: https://rust-lang.github.io/rfcs/3338-style-evolution.html
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -171,25 +171,22 @@ See [GitHub page](https://rust-lang.github.io/rustfmt/) for details.
 ### Rust's Editions
 
 The `edition` option determines the Rust language edition used for parsing the code. This is important for syntax compatibility but does not directly control formatting behavior (see [Style Editions](#style-editions)).
-By default, Rustfmt uses the `2015` edition.
 
-When running `cargo fmt`, the `edition` is automatically inferred from the `Cargo.toml` file. However, when running `rustfmt` directly, the `edition` must be explicitly set in the configuration file or via the command line.
-
+When running `cargo fmt`, the `edition` is automatically read from the `Cargo.toml` file. However, when running `rustfmt` directly the `edition` defaults to 2015 if not explicitly configured. For consistent parsing between rustfmt and `cargo fmt` you should configure the `edition`.
 For example in your `rustfmt.toml` file:
 
 ```toml
-edition = "2024"
+edition = "2018"
 ```
 
 ### Style Editions
 
-Controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338])
-It is inferred from `edition` if not explicitly set, and defaults to the `2015` edition.
+This option is inferred from the [`edition`](#rusts-editions) if not specified.
 
-See [Rust Style Editions] for details on style editions.
-Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
+See [Rust Style Editions] for details on formatting differences between style editions.
+rustfmt has a default style edition of `2015` while `cargo fmt` infers the style edition from the `edition` set in `Cargo.toml`. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the style edition is not explicitly configured.
 
-To ensure consistent formatting, it is recommended to specify the `edition` or `style_edition` in a `rustfmt.toml` configuration file. For example:
+To ensure consistent formatting, it is recommended to specify the `style_edition` in a `rustfmt.toml` configuration file. For example:
 
 ```toml
 style_edition = "2024"

--- a/README.md
+++ b/README.md
@@ -170,12 +170,28 @@ See [GitHub page](https://rust-lang.github.io/rustfmt/) for details.
 
 ### Rust's Editions
 
-Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
+The `edition` option determines the Rust language edition used for parsing the code. This is important for syntax compatibility but does not directly control formatting behavior (see [Style Editions](#style-editions)).
+By default, Rustfmt uses the `2015` edition.
 
-To ensure consistent formatting, it is recommended to specify the edition in a `rustfmt.toml` configuration file. For example:
+When running `cargo fmt`, the `edition` is automatically inferred from the `Cargo.toml` file. However, when running `rustfmt` directly, the `edition` must be explicitly set in the configuration file or via the command line.
+
+For example in your `rustfmt.toml` file:
 
 ```toml
 edition = "2024"
+```
+
+### Style Editions
+
+The option `style_edition` controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338])
+It is inferred from `edition` if not explicitly set, and defaults to the `2015` edition.
+
+Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
+
+To ensure consistent formatting, it is recommended to specify the `edition` or `style_edition` in a `rustfmt.toml` configuration file. For example:
+
+```toml
+style_edition = "2024"
 ```
 
 ## Tips
@@ -224,7 +240,7 @@ edition = "2024"
   | checkstyle | emits in a checkstyle format | Yes |
   | json | emits diffs in a json format | Yes |
 
-* When using `rustfmt` directly in a Cargo project, set the `edition` in `rustfmt.toml` to the same value as in `Cargo.toml` to ensure consistent formatting. For more details, see the [Rust's Editions](#rusts-editions) section.
+* When using `rustfmt` directly in a Cargo project, set the `style_edition` or `edition` in `rustfmt.toml` to the same value as in `Cargo.toml` to ensure consistent formatting. For more details, see the [Style Editions](#style-editions) and [Rust's Editions](#rusts-editions) sections.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,13 @@ See [GitHub page](https://rust-lang.github.io/rustfmt/) for details.
 
 ### Rust's Editions
 
-Rustfmt is able to pick up the edition used by reading the `Cargo.toml` file if
-executed through the Cargo's formatting tool `cargo fmt`. Otherwise, the edition
-needs to be specified in `rustfmt.toml`, e.g., with `edition = "2018"`.
+Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.
+
+To ensure consistent formatting, it is recommended to specify the edition in a `rustfmt.toml` configuration file. For example:
+
+```toml
+edition = "2024"
+```
 
 ## Tips
 
@@ -219,6 +223,8 @@ needs to be specified in `rustfmt.toml`, e.g., with `edition = "2018"`.
   | coverage | displays how much of the input file was processed | Yes |
   | checkstyle | emits in a checkstyle format | Yes |
   | json | emits diffs in a json format | Yes |
+
+* When using `rustfmt` directly in a Cargo project, set the `edition` in `rustfmt.toml` to the same value as in `Cargo.toml` to ensure consistent formatting. For more details, see the [Rust's Editions](#rusts-editions) section.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ style_edition = "2024"
 
 ## Tips
 
+* When using `rustfmt` directly in a Cargo project, Cargo will determine [`edition`](#rusts-editions) from `Cargo.toml`, but rustfmt will not, as it has its own configuration file, `rustfmt.toml`.
+  To ensure consistent parsing between `cargo fmt` and `rustfmt`, you should configure the [`edition`](#rusts-editions) in your `rustfmt.toml` file.
+  To ensure consistent formatting between `cargo fmt` and `rustfmt`, you should configure the [`style_edition`](#style-editions) in your `rustfmt.toml` file.
+
 * For things you do not want rustfmt to mangle, use `#[rustfmt::skip]`
 * To prevent rustfmt from formatting a macro or an attribute,
   use `#[rustfmt::skip::macros(target_macro_name)]` or
@@ -240,8 +244,6 @@ style_edition = "2024"
   | coverage | displays how much of the input file was processed | Yes |
   | checkstyle | emits in a checkstyle format | Yes |
   | json | emits diffs in a json format | Yes |
-
-* When using `rustfmt` directly in a Cargo project, set the `style_edition` or `edition` in `rustfmt.toml` to the same value as in `Cargo.toml` to ensure consistent formatting. For more details, see the [Style Editions](#style-editions) and [Rust's Editions](#rusts-editions) sections.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ edition = "2024"
 
 ### Style Editions
 
-The option `style_edition` controls the edition of the [Rust Style Guide] to use for formatting ([RFC 3338])
+The option `style_edition` controls the edition of the [Rust Style Guide](https://doc.rust-lang.org/nightly/style-guide/editions.html?highlight=editions#rust-style-editions) to use for formatting ([RFC 3338](https://rust-lang.github.io/rfcs/3338-style-evolution.html))
 It is inferred from `edition` if not explicitly set, and defaults to the `2015` edition.
 
 Starting with the 2024 edition, Rust introduced changes to default formatting. This can lead to inconsistencies between `rustfmt` and `cargo fmt` if the edition is not explicitly configured. This is because `cargo fmt` automatically picks up the edition from `Cargo.toml`, while `rustfmt` defaults to the `2015` edition unless otherwise specified.

--- a/README.md
+++ b/README.md
@@ -197,9 +197,8 @@ style_edition = "2024"
 
 ## Tips
 
-* When using `rustfmt` directly in a Cargo project, Cargo will determine [`edition`](#rusts-editions) from `Cargo.toml`, but rustfmt will not, as it has its own configuration file, `rustfmt.toml`.
-  To ensure consistent parsing between `cargo fmt` and `rustfmt`, you should configure the [`edition`](#rusts-editions) in your `rustfmt.toml` file.
-  To ensure consistent formatting between `cargo fmt` and `rustfmt`, you should configure the [`style_edition`](#style-editions) in your `rustfmt.toml` file.
+* To ensure consistent parsing between `cargo fmt` and `rustfmt`, you should configure the [`edition`](#rusts-editions) in your `rustfmt.toml` file.
+* To ensure consistent formatting between `cargo fmt` and `rustfmt`, you should configure the [`style_edition`](#style-editions) in your `rustfmt.toml` file.
 
 * For things you do not want rustfmt to mangle, use `#[rustfmt::skip]`
 * To prevent rustfmt from formatting a macro or an attribute,


### PR DESCRIPTION
When using `rustfmt` directly on a project targeting the 2024 edition, the formatting differs from `cargo fmt` because `rustfmt` defaults to the 2015 edition. This discrepancy causes inconsistencies, especially when tools like editors automatically run `rustfmt` on save, leading to files being reformatted to the 2015 edition style.

I tried to explain this behavior concisely in the docs.
Fixes #6483.