### PR TITLE
docs: pull latest version from tags instead of releases in docs page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -148,8 +148,8 @@
                   .map(tag => tag.name)
                   .filter(tag => tag.startsWith('v') && !excludedTagVersions.has(tag));
 
-                const latestRelease = tags.find(tag => !tag.name.includes('rc'));
-                this.viewVersion = latestRelease.name;
+                const latestRelease = tagOptions.find(tag => !tag.includes('rc'));
+                this.viewVersion = latestRelease;
                 this.versionOptions = this.versionOptions.concat(tagOptions);
               },
                 async outputHtml() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -108,7 +108,6 @@
         </div>
         <script>
             const RustfmtTagsUrl = 'https://api.github.com/repos/rust-lang/rustfmt/tags';
-            const RustfmtLatestUrl = 'https://api.github.com/repos/rust-lang/rustfmt/releases/latest';
             const UrlHash = window.location.hash.replace(/^#/, '');
             const queryParams = new URLSearchParams(window.location.search);
             const searchParam = queryParams.get('search');
@@ -134,18 +133,25 @@
                 scrolledOnce: false,
               },
               asyncComputed: {
-                async updateVersion() {
-                  let latest;
-                  try {
-                    latest = (await axios.get(RustfmtLatestUrl)).data;
-                  } catch(err) {
-                      console.log(err);
-                    return;
-                  }
-                  if (versionParam == null) {
-                    this.viewVersion = latest.name;
-                  }
-                },
+              async pullTags() {
+                let tags;
+                try {
+                  tags = (await axios.get(RustfmtTagsUrl)).data;
+                } catch(e) {
+                  this.handleReqFailure(e);
+                  return;
+                }
+
+                const excludedTagVersions = new Set(['v0.7', 'v0.8.1']);
+
+                const tagOptions = tags
+                  .map(tag => tag.name)
+                  .filter(tag => tag.startsWith('v') && !excludedTagVersions.has(tag));
+
+                const latestRelease = tags.find(tag => !tag.name.includes('rc'));
+                this.viewVersion = latestRelease.name;
+                this.versionOptions = this.versionOptions.concat(tagOptions);
+              },
                 async outputHtml() {
                   if (this.viewVersion !== this.oldViewVersion) {
                     const ConfigurationMdUrl =
@@ -206,22 +212,6 @@
                     renderer,
                   });
                 }
-              },
-              created: async function() {
-                let tags;
-                try {
-                  tags = (await axios.get(RustfmtTagsUrl)).data;
-                } catch(e) {
-                  this.handleReqFailure(e);
-                  return;
-                }
-
-                const excludedTagVersions = new Set(['v0.7', 'v0.8.1']);
-
-                const tagOptions = tags
-                  .map(tag => tag.name)
-                  .filter(tag => tag.startsWith('v') && !excludedTagVersions.has(tag));
-                this.versionOptions = this.versionOptions.concat(tagOptions);
               },
               updated() {
                 if (UrlHash === '') return;


### PR DESCRIPTION
I hacked a quick fix to  #6485.