### PR TITLE
Implement remove_nested_blocks option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2227,6 +2227,39 @@ fn main() {
 }
 ```
 
+## `remove_nested_blocks`
+
+Works similarly to [`remove_nested_parens`](#remove_nested_parens), but removes nested blocks.
+
+- **Default value**: `false`,
+- **Possible values**: `true`, `false`
+- **Stable**: No
+
+
+#### `true`:
+```rust
+fn main() {
+    {
+        foo();
+    }
+}
+```
+
+#### `false` (default):
+```rust
+fn main() {
+    {
+        {
+            {
+                {
+                    foo();
+                }
+            }
+        }
+    }
+}
+```
+
 
 ## `reorder_impl_items`
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -2235,31 +2235,33 @@ Works similarly to [`remove_nested_parens`](#remove_nested_parens), but removes 
 - **Possible values**: `true`, `false`
 - **Stable**: No
 
-
-#### `true`:
-```rust
-fn main() {
-    {
-        foo();
-    }
-}
-```
+Blocks with any sort of comments or attributes, `unsafe` and `const` blocks will not be removed.
 
 #### `false` (default):
 ```rust
 fn main() {
     {
         {
+            // comment
             {
-                {
-                    foo();
-                }
+                foo();
             }
         }
     }
 }
 ```
 
+#### `true`:
+```rust
+fn main() {
+    {
+        // comment
+        {
+            foo();
+        }
+    }
+}
+```
 
 ## `reorder_impl_items`
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -117,6 +117,7 @@ create_config! {
 
     // Misc.
     remove_nested_parens: RemoveNestedParens, true, "Remove nested parens";
+    remove_nested_blocks: RemoveNestedBlocks, false, "Remove nested blocks";
     combine_control_expr: CombineControlExpr, false, "Combine control expressions with function \
         calls";
     short_array_element_width_threshold: ShortArrayElementWidthThreshold, true,
@@ -796,6 +797,7 @@ space_after_colon = true
 spaces_around_ranges = false
 binop_separator = "Front"
 remove_nested_parens = true
+remove_nested_blocks = false
 combine_control_expr = true
 short_array_element_width_threshold = 10
 overflow_delimited_expr = false
@@ -887,6 +889,7 @@ space_after_colon = true
 spaces_around_ranges = false
 binop_separator = "Front"
 remove_nested_parens = true
+remove_nested_blocks = false
 combine_control_expr = true
 short_array_element_width_threshold = 10
 overflow_delimited_expr = true

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -658,6 +658,7 @@ config_option_with_style_edition_default!(
 
     // Misc.
     RemoveNestedParens, bool, _ => true;
+    RemoveNestedBlocks, bool, _ => false;
     CombineControlExpr, bool, _ => true;
     ShortArrayElementWidthThreshold, usize, _ => 10;
     OverflowDelimitedExpr, bool, Edition2024 => true, _ => false;

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -676,12 +676,15 @@ fn rewrite_block_inner(
     context: &RewriteContext<'_>,
     shape: Shape,
     can_be_removed: bool,
+    // ^ this is a fix for const blocks, which are not removed, but are passed identically to blocks
 ) -> RewriteResult {
     debug!("rewrite_block : {:?}", context.snippet(block.span));
     let prefix = block_prefix(context, block, shape)?;
 
     let no_attrs = attrs.is_none() || attrs.unwrap().is_empty();
 
+    // If the option `remove_nested_blocks` is enabled, we remove all unnecessary nested blocks.
+    // Blocks with any sort of comments or attributes, unsafe and const blocks will not be removed.
     if context.config.remove_nested_blocks()
         && can_be_removed
         && prefix.is_empty()

--- a/tests/source/remove_nested_blocks.rs
+++ b/tests/source/remove_nested_blocks.rs
@@ -1,0 +1,102 @@
+// rustfmt-remove_nested_blocks: true
+fn foo() {}
+
+// The way it is implemented right now, only 'naked' blocks are removed.
+// This means unsafe blocks, const blocks, blocks with labels and attributes,
+// blocks belonging to other constructs such as loops are not removed.
+fn main() {
+    {
+        {
+            {
+                foo();
+            }
+        }
+    }
+    // The next block will be removed
+    {
+        {
+            // Blocks with comments are not removed
+            {
+                {
+                    /* second comment */
+                    {
+                        foo();
+                    }
+                }
+            }
+        }
+    }
+    {
+        {
+            /*
+             * multi-line comment
+             */
+            foo();
+        }
+    }
+    {{{{{{{foo();}}}}}}}
+    {{/*comment*/{{{foo();}}}}}
+    {{/*comment*/{{/*comment*/{foo();}}}}}
+    {
+        const { const {} }
+    }
+    const { const {} }
+    unsafe { unsafe {} }
+    // As const and unsafe blocks are not 'naked' blocks, they are not removed.
+    unsafe {
+        unsafe {
+            {
+                const {
+                    const {
+                        {
+                            foo();
+                        }
+                    }
+                }
+            }
+        }
+    }
+    const {
+        unsafe {
+            {
+                unsafe {
+                    const {
+                        {
+                            foo();
+                        }
+                    }
+                }
+            }
+        }
+    }
+    {
+        'label1: {
+            'label2: {
+                foo();
+            }
+        }
+    }
+    'outer: loop {
+        {
+            'inner: loop {
+                {
+                    foo();
+                }
+            }
+        }
+    }
+    if let Some(x) = 5f64.map(|x| Ok(x)) {
+        {
+            if let Some(x) = 5f64.map(|x| Ok(x)) {
+                foo();
+            }
+        }
+    }
+    if false {
+        { {} }
+    }
+    #[cfg(debug)]
+    {
+        { {} }
+    }
+}

--- a/tests/target/remove_nested_blocks.rs
+++ b/tests/target/remove_nested_blocks.rs
@@ -1,0 +1,99 @@
+// rustfmt-remove_nested_blocks: true
+fn foo() {}
+
+// The way it is implemented right now, only 'naked' blocks are removed.
+// This means unsafe blocks, const blocks, blocks with labels and attributes,
+// blocks belonging to other constructs such as loops are not removed.
+fn main() {
+    {
+        foo();
+    }
+    // The next block will be removed
+    {
+        // Blocks with comments are not removed
+        {
+            /* second comment */
+            {
+                foo();
+            }
+        }
+    }
+    {
+        /*
+         * multi-line comment
+         */
+        foo();
+    }
+    {
+        foo();
+    }
+    {
+        /*comment*/
+        {
+            foo();
+        }
+    }
+    {
+        /*comment*/
+        {
+            /*comment*/
+            {
+                foo();
+            }
+        }
+    }
+    const { const {} }
+    const { const {} }
+    unsafe { unsafe {} }
+    // As const and unsafe blocks are not 'naked' blocks, they are not removed.
+    unsafe {
+        unsafe {
+            const {
+                const {
+                    {
+                        foo();
+                    }
+                }
+            }
+        }
+    }
+    const {
+        unsafe {
+            unsafe {
+                const {
+                    {
+                        foo();
+                    }
+                }
+            }
+        }
+    }
+    'label1: {
+        'label2: {
+            foo();
+        }
+    }
+    'outer: loop {
+        {
+            'inner: loop {
+                {
+                    foo();
+                }
+            }
+        }
+    }
+    if let Some(x) = 5f64.map(|x| Ok(x)) {
+        {
+            if let Some(x) = 5f64.map(|x| Ok(x)) {
+                foo();
+            }
+        }
+    }
+    if false {
+        {}
+    }
+    #[cfg(debug)]
+    {
+        {}
+    }
+}


### PR DESCRIPTION
Implements new feature that removes nested blocks #5616.
The feature is similar to `remove_nested_parens`. Blocks with any sort of comments or attributes, `unsafe` and `const` blocks will not be removed. This however will not remove all nested blocks, instead it will leave the innermost block (similar to `remove_nested_parens`). That behavior differs from suggested in the issue, and I'm not sure which one is better.

I'm not fully satisfied with my implementation, so any suggestions are appreciated. 
I also was not sure what do do if nested blocks are of different kind (nested `const` and/or `unsafe` blocks), so I decided to only remove 'naked' blocks, and just never remove `const` and `unsafe` blocks. There is some merit to removing `unsafe` or `const` blocks when only blocks of one kind are nested, but for the sake of consistency I decided to not do that. An example of such problematic situation:
```rust
// rustfmt-remove_nested_blocks: true
fn foo() {}
fn one_kind() {
    { // <- this block would be removed if not for this comment
        const { const {} }
    }
}
fn mixed() {
    unsafe {
        unsafe {
            { // <- this block would be removed if not for this comment
                const {
                    const {
                        { // this block will not be removed regardless of the comment
                            foo();
                        }
                    }
                }
            }
        }
    }
}
```
As I said, for now both `mixed`, and `one_kind` functions would only remove the blocks annotated by comments.
I'm open for suggestions regarding the behavior, since the feature in the original issue was very loosely defined (also blocks are more tricky than parentheses)