### PR TITLE
Allow also allow literals as first item of single line let chain

### DIFF
--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -1,4 +1,4 @@
-use rustc_ast::ast;
+use rustc_ast::{ast, token};
 use rustc_span::Span;
 
 use crate::config::IndentStyle;
@@ -266,13 +266,17 @@ struct PairList<'a, 'b, T: Rewrite> {
     span: Span,
 }
 
-fn is_ident(expr: &ast::Expr) -> bool {
+fn is_ident_or_bool_lit(expr: &ast::Expr) -> bool {
     match &expr.kind {
         ast::ExprKind::Path(None, path) if path.segments.len() == 1 => true,
+        ast::ExprKind::Lit(token::Lit {
+            kind: token::LitKind::Bool,
+            ..
+        }) => true,
         ast::ExprKind::Unary(_, expr)
         | ast::ExprKind::AddrOf(_, _, expr)
         | ast::ExprKind::Paren(expr)
-        | ast::ExprKind::Try(expr) => is_ident(expr),
+        | ast::ExprKind::Try(expr) => is_ident_or_bool_lit(expr),
         _ => false,
     }
 }
@@ -290,10 +294,10 @@ impl<'a, 'b> PairList<'a, 'b, ast::Expr> {
             return false;
         }
 
-        let fist_item_is_ident = is_ident(self.list[0].0);
+        let fist_item_is_ident_or_bool_lit = is_ident_or_bool_lit(self.list[0].0);
         let second_item_is_let_chain = matches!(self.list[1].0.kind, ast::ExprKind::Let(..));
 
-        fist_item_is_ident && second_item_is_let_chain
+        fist_item_is_ident_or_bool_lit && second_item_is_let_chain
     }
 }
 

--- a/tests/source/let_chains.rs
+++ b/tests/source/let_chains.rs
@@ -20,6 +20,11 @@ fn test_single_line_let_chain() {
     if a && let Some(b) = foo() {
     }
 
+    // first item in let-chain is a bool literal
+    if true && let Some(x) = y {
+
+    }
+
     // first item in let-chain is a unary ! with an ident
     let unary_not = if !from_hir_call
         && let Some(p) = parent
@@ -91,11 +96,6 @@ fn test_multi_line_let_chain() {
 
     // function call
     if a() && let Some(x) = y {
-
-    }
-
-    // bool literal
-    if true && let Some(x) = y {
 
     }
 

--- a/tests/target/let_chains.rs
+++ b/tests/target/let_chains.rs
@@ -50,6 +50,9 @@ fn test_single_line_let_chain() {
     // first item in let-chain is an ident
     if a && let Some(b) = foo() {}
 
+    // first item in let-chain is a bool literal
+    if true && let Some(x) = y {}
+
     // first item in let-chain is a unary ! with an ident
     let unary_not = if !from_hir_call && let Some(p) = parent {};
 
@@ -99,11 +102,6 @@ fn test_multi_line_let_chain() {
 
     // function call
     if a()
-        && let Some(x) = y
-    {}
-
-    // bool literal
-    if true
         && let Some(x) = y
     {}
 


### PR DESCRIPTION
Also allow literals as the first item in a single line let chain, not just idents. This will most probably not occur in most real-world code, but it makes things a little bit more consistent. While rustfmt allows any literal type, like also string literals, those will not create valid rust code. Only bool literals will.

Implements suggestion from https://github.com/rust-lang/rust/pull/110568#discussion_r1841155819 .