### PR TITLE
Add rustc's sysroot/lib to LD_LIBRARY_PATH

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,8 @@
 
 cargo build --release
 
+export LD_LIBRARY_PATH="$(rustc --print sysroot)/lib:${LD_LIBRARY_PATH}"
+
 target/release/rustfmt src/lib.rs
 target/release/rustfmt src/bin/main.rs
 target/release/rustfmt src/cargo-fmt/main.rs


### PR DESCRIPTION
The default way to use rust is rustup. Rustup maintains its own sysroot. This is fine for most rust applications, as they don't dynamically link to anything in that sysroot. rustfmt does, however, and thus must be called with the correct LD_LIBRARY_PATH.

(I'm honestly not sure whether anybody checks bootstrap.sh. Quite a few of the tests are failing and the script is not referenced anywhere.)