### PR TITLE
Convert error line buffer to space indentation

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -593,13 +593,22 @@ impl<'a> FormatLines<'a> {
         }
     }
 
+    fn line_buffer_with_leading_spaces(&self) -> String {
+        if self.config.hard_tabs() {
+            let leading_tabs = self.line_buffer.chars().take_while(|&c| c == '\t').count();
+            " ".repeat(self.config.tab_spaces() * leading_tabs) + &self.line_buffer[leading_tabs..]
+        } else {
+            self.line_buffer.clone()
+        }
+    }
+
     fn push_err(&mut self, kind: ErrorKind, is_comment: bool, is_string: bool) {
         self.errors.push(FormattingError {
             line: self.cur_line,
             kind,
             is_comment,
             is_string,
-            line_buffer: self.line_buffer.clone(),
+            line_buffer: self.line_buffer_with_leading_spaces(),
         });
     }
 


### PR DESCRIPTION
The type of indentation is not important for error reporting. However, keeping the indentation as tabs has two issues:

1. rustfmt keeps track of widths, not character offsets. For space indentation, these two are the same. For tab indentation, this leads to issues like [1].
2. annotate-snippet-rs always format leading tabs as four spaces. Thus, formatter error reporting is not faithful and ranges will not be marked correctly (or need another transformation).

Replacing tabs with spaces for error reporting as early as possible solves these issues.

[1] https://github.com/rust-lang/rustfmt/issues/6442