### PR TITLE
implemented fix for issue 5249

### DIFF
--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -77,6 +77,7 @@ const SPECIAL_CASE_ATTR: &[(&str, usize)] = &[
 pub(crate) enum OverflowableItem<'a> {
     Expr(&'a ast::Expr),
     GenericParam(&'a ast::GenericParam),
+    GenericArg(&'a ast::GenericArg),
     MacroArg(&'a MacroArg),
     MetaItemInner(&'a ast::MetaItemInner),
     SegmentParam(&'a SegmentParam<'a>),
@@ -122,6 +123,7 @@ impl<'a> OverflowableItem<'a> {
         match self {
             OverflowableItem::Expr(expr) => f(*expr),
             OverflowableItem::GenericParam(gp) => f(*gp),
+            OverflowableItem::GenericArg(gp) => f(*gp),
             OverflowableItem::MacroArg(macro_arg) => f(*macro_arg),
             OverflowableItem::MetaItemInner(nmi) => f(*nmi),
             OverflowableItem::SegmentParam(sp) => f(*sp),
@@ -259,6 +261,7 @@ macro_rules! impl_into_overflowable_item_for_rustfmt_types {
 impl_into_overflowable_item_for_ast_node!(
     Expr,
     GenericParam,
+    GenericArg,
     MetaItemInner,
     FieldDef,
     Ty,

--- a/tests/source/issue-5249/issue_5249.rs
+++ b/tests/source/issue-5249/issue_5249.rs
@@ -1,0 +1,14 @@
+fn long_generic_args_list() {
+    x.f::<
+        A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A, A,
+                        A, A, A, A, A, A, A, A, A, A, A, A,
+    >();
+}
+
+fn long_items_in_generic_args_list() {
+    x.f::<
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+            AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>
+        >();
+}

--- a/tests/source/issue-5249/multi_chain_method_call.rs
+++ b/tests/source/issue-5249/multi_chain_method_call.rs
@@ -1,0 +1,53 @@
+fn chained_method_calls_short_generic_args_list_long_method_args_list() {
+    x.f::<A, B, C>(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE).g::<A, B, C>(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn chained_method_calls_short_generic_args_list_long_method_args_list_with_inline_comments() {
+    x.f::<
+        A, // Something about arg A
+        B,
+        C,
+    >(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE).g::<
+        A, // Something about arg A
+        B,
+        C,
+    >(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn chained_method_calls_short_generic_args_list_long_method_args_list_with_inline_comments_in_both_lists(
+) {
+    x.f::<
+        A, // Something about arg A
+        B,
+        C,
+    >(
+        AAAAAAAA, BBBBBBBBB, // Something about arg BBBBBBBBB
+        CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    ).g::<
+        A, // Something about arg A
+        B,
+        C,
+    >(
+        AAAAAAAA, BBBBBBBBB, // Something about arg BBBBBBBBB
+        CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    );
+}
+
+fn chained_method_calls_short_generic_args_list_long_method_args_list_with_block_comments() {
+    x.f::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    ).g::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    );
+}
+
+fn chained_method_calls_short_generic_args_list_long_method_args_list_with_block_comments_in_both_lists(
+) {
+    x.f::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, /* Something about arg BBBBBBBBB */ CCCCCCCCC, DDDDDDDDDD,
+        EEEEEEEEEE,
+    ).g::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, /* Something about arg BBBBBBBBB */ CCCCCCCCC, DDDDDDDDDD,
+        EEEEEEEEEE,
+    );
+}

--- a/tests/source/issue-5249/single_line_generic_args.rs
+++ b/tests/source/issue-5249/single_line_generic_args.rs
@@ -1,0 +1,20 @@
+fn short_generic_args_list() {
+    x.f::<
+        A,
+        B, C
+        >();
+}
+
+fn short_generic_args_list_with_inline_comments() {
+    x.f::<
+        A, // Something about arg A
+        B, C
+        >();
+}
+
+fn short_generic_args_list_with_block_comments() {
+    x.f::<
+        A, /* Something about arg A */
+        B, C
+        >();
+}

--- a/tests/source/issue-5249/with_comments.rs
+++ b/tests/source/issue-5249/with_comments.rs
@@ -1,0 +1,54 @@
+fn long_items_in_generic_args_list_inline_comment() {
+    x.f::<
+        // Pre comment
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>, // Inline
+            AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        // Post Comment
+    >();
+}
+
+fn long_items_in_generic_args_list_multi_line_inline_comment() {
+    x.f::<
+        // Pre comment
+        // Pre comment
+        // Pre comment
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>, // Inline
+        // Inline
+        // Inline
+            AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        // Post Comment
+        // Post Comment
+        // Post Comment
+    >();
+}
+
+fn long_items_in_generic_args_list_block_comment() {
+    x.f::<
+        /* Pre comment */
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>, /* Inline */
+            AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        /* Post Comment */
+    >();
+}
+
+fn long_items_in_generic_args_list_multi_line_block_comment() {
+    x.f::<
+        /* Pre comment
+         * Pre comment
+         * Pre comment
+         */
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>, /* Inline
+        * Inline
+        * Inline
+        */
+            AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        /* Post Comment
+         * Post Comment
+         * Post Comment
+         */
+    >();
+}

--- a/tests/source/issue-5249/with_method_arguments.rs
+++ b/tests/source/issue-5249/with_method_arguments.rs
@@ -1,0 +1,35 @@
+fn short_generic_args_list_long_method_args_list() {
+    x.f::<
+        A,
+        B, C
+        >(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn short_generic_args_list_long_method_args_list_with_inline_comments() {
+    x.f::<
+        A, // Something about arg A
+        B, C
+        >(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn short_generic_args_list_long_method_args_list_with_inline_comments_in_both_lists() {
+    x.f::<
+        A, // Something about arg A
+        B, C
+        >(AAAAAAAA, BBBBBBBBB, // Something about arg BBBBBBBBB
+            CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn short_generic_args_list_long_method_args_list_with_block_comments() {
+    x.f::<
+        A, /* Something about arg A */
+        B, C
+        >(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn short_generic_args_list_long_method_args_list_with_block_comments_in_both_lists() {
+    x.f::<
+        A, /* Something about arg A */
+        B, C
+        >(AAAAAAAA, BBBBBBBBB, /* Something about arg BBBBBBBBB */ CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}

--- a/tests/source/issue_3191.rs
+++ b/tests/source/issue_3191.rs
@@ -1,0 +1,3 @@
+fn foo() {
+    unprivileged_content.start_all::<script_layout_interface::message::Msg, layout_thread::LayoutThread, script::script_thread::ScriptThread>(true);
+}

--- a/tests/source/issue_5657.rs
+++ b/tests/source/issue_5657.rs
@@ -1,0 +1,13 @@
+// rustfmt-max_width: 80
+
+fn omg() {
+fn bar() {
+self.core
+.exchange::<LeaseBufReader<_, BUFSIZ>, _, LeaseBufWriter<_, BUFSIZ>, _>(
+device_index,
+src,
+dest,
+)
+.map_err(RequestError::from)
+}
+}

--- a/tests/target/issue-5249/issue_5249.rs
+++ b/tests/target/issue-5249/issue_5249.rs
@@ -1,0 +1,42 @@
+fn long_generic_args_list() {
+    x.f::<
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+        A,
+    >();
+}
+
+fn long_items_in_generic_args_list() {
+    x.f::<
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+    >();
+}

--- a/tests/target/issue-5249/multi_chain_method_call.rs
+++ b/tests/target/issue-5249/multi_chain_method_call.rs
@@ -1,0 +1,58 @@
+fn chained_method_calls_short_generic_args_list_long_method_args_list() {
+    x.f::<A, B, C>(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE)
+        .g::<A, B, C>(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn chained_method_calls_short_generic_args_list_long_method_args_list_with_inline_comments() {
+    x.f::<
+        A, // Something about arg A
+        B,
+        C,
+    >(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE)
+        .g::<
+            A, // Something about arg A
+            B,
+            C,
+        >(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn chained_method_calls_short_generic_args_list_long_method_args_list_with_inline_comments_in_both_lists(
+) {
+    x.f::<
+        A, // Something about arg A
+        B,
+        C,
+    >(
+        AAAAAAAA, BBBBBBBBB, // Something about arg BBBBBBBBB
+        CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    )
+    .g::<
+        A, // Something about arg A
+        B,
+        C,
+    >(
+        AAAAAAAA, BBBBBBBBB, // Something about arg BBBBBBBBB
+        CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    );
+}
+
+fn chained_method_calls_short_generic_args_list_long_method_args_list_with_block_comments() {
+    x.f::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    )
+    .g::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    );
+}
+
+fn chained_method_calls_short_generic_args_list_long_method_args_list_with_block_comments_in_both_lists(
+) {
+    x.f::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, /* Something about arg BBBBBBBBB */ CCCCCCCCC, DDDDDDDDDD,
+        EEEEEEEEEE,
+    )
+    .g::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, /* Something about arg BBBBBBBBB */ CCCCCCCCC, DDDDDDDDDD,
+        EEEEEEEEEE,
+    );
+}

--- a/tests/target/issue-5249/single_line_generic_args.rs
+++ b/tests/target/issue-5249/single_line_generic_args.rs
@@ -1,0 +1,15 @@
+fn short_generic_args_list() {
+    x.f::<A, B, C>();
+}
+
+fn short_generic_args_list_with_inline_comments() {
+    x.f::<
+        A, // Something about arg A
+        B,
+        C,
+    >();
+}
+
+fn short_generic_args_list_with_block_comments() {
+    x.f::<A /* Something about arg A */, B, C>();
+}

--- a/tests/target/issue-5249/with_comments.rs
+++ b/tests/target/issue-5249/with_comments.rs
@@ -1,0 +1,54 @@
+fn long_items_in_generic_args_list_inline_comment() {
+    x.f::<
+        // Pre comment
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>, // Inline
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        // Post Comment
+    >();
+}
+
+fn long_items_in_generic_args_list_multi_line_inline_comment() {
+    x.f::<
+        // Pre comment
+        // Pre comment
+        // Pre comment
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>, // Inline
+        // Inline
+        // Inline
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        // Post Comment
+        // Post Comment
+        // Post Comment
+    >();
+}
+
+fn long_items_in_generic_args_list_block_comment() {
+    x.f::<
+        /* Pre comment */
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>, /* Inline */
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        /* Post Comment */
+    >();
+}
+
+fn long_items_in_generic_args_list_multi_line_block_comment() {
+    x.f::<
+        /* Pre comment
+         * Pre comment
+         * Pre comment
+         */
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>, /* Inline
+                                               * Inline
+                                               * Inline
+                                               */
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        AAAA<BBBB::CCCC, (DDDD, EEEE), FFFF>,
+        /* Post Comment
+         * Post Comment
+         * Post Comment
+         */
+    >();
+}

--- a/tests/target/issue-5249/with_method_arguments.rs
+++ b/tests/target/issue-5249/with_method_arguments.rs
@@ -1,0 +1,35 @@
+fn short_generic_args_list_long_method_args_list() {
+    x.f::<A, B, C>(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn short_generic_args_list_long_method_args_list_with_inline_comments() {
+    x.f::<
+        A, // Something about arg A
+        B,
+        C,
+    >(AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE);
+}
+
+fn short_generic_args_list_long_method_args_list_with_inline_comments_in_both_lists() {
+    x.f::<
+        A, // Something about arg A
+        B,
+        C,
+    >(
+        AAAAAAAA, BBBBBBBBB, // Something about arg BBBBBBBBB
+        CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    );
+}
+
+fn short_generic_args_list_long_method_args_list_with_block_comments() {
+    x.f::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, CCCCCCCCC, DDDDDDDDDD, EEEEEEEEEE,
+    );
+}
+
+fn short_generic_args_list_long_method_args_list_with_block_comments_in_both_lists() {
+    x.f::<A /* Something about arg A */, B, C>(
+        AAAAAAAA, BBBBBBBBB, /* Something about arg BBBBBBBBB */ CCCCCCCCC, DDDDDDDDDD,
+        EEEEEEEEEE,
+    );
+}

--- a/tests/target/issue_3191.rs
+++ b/tests/target/issue_3191.rs
@@ -1,0 +1,7 @@
+fn foo() {
+    unprivileged_content.start_all::<
+        script_layout_interface::message::Msg,
+        layout_thread::LayoutThread,
+        script::script_thread::ScriptThread,
+    >(true);
+}

--- a/tests/target/issue_5657.rs
+++ b/tests/target/issue_5657.rs
@@ -1,0 +1,14 @@
+// rustfmt-max_width: 80
+
+fn omg() {
+    fn bar() {
+        self.core
+            .exchange::<
+                LeaseBufReader<_, BUFSIZ>,
+                _,
+                LeaseBufWriter<_, BUFSIZ>,
+                _,
+            >(device_index, src, dest)
+            .map_err(RequestError::from)
+    }
+}


### PR DESCRIPTION
Similar to PR #5252 but copies the structure of `types::rewrite_generic_args`. 

I'm making this PR since #5252 hasn't had any progress since 2022. The tests are copied from #5252.