### PR TITLE
Handle `cargo fmt --manifest-path` when specifying the workspace's root `Cargo.toml`

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -364,11 +364,16 @@ fn get_targets_root_only(
     targets: &mut BTreeSet<Target>,
 ) -> Result<(), io::Error> {
     let metadata = get_cargo_metadata(manifest_path)?;
+    // `workspace_root_path` is the path to the workspace's root directory
     let workspace_root_path = PathBuf::from(&metadata.workspace_root).canonicalize()?;
     let (in_workspace_root, current_dir_manifest) = if let Some(target_manifest) = manifest_path {
+        // `target_manifest` is the canonicalized path to a `Cargo.toml` file
+        let target_manifest = target_manifest.canonicalize()?;
         (
-            workspace_root_path == target_manifest,
-            target_manifest.canonicalize()?,
+            target_manifest
+                .parent()
+                .is_some_and(|manifest| workspace_root_path == manifest),
+            target_manifest,
         )
     } else {
         let current_dir = env::current_dir()?.canonicalize()?;

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -387,11 +387,16 @@ fn get_targets_root_only(
     targets: &mut BTreeSet<Target>,
 ) -> Result<(), io::Error> {
     let metadata = get_cargo_metadata(manifest_path)?;
+    // `workspace_root_path` is the path to the workspace's root directory
     let workspace_root_path = PathBuf::from(&metadata.workspace_root).canonicalize()?;
     let (in_workspace_root, current_dir_manifest) = if let Some(target_manifest) = manifest_path {
+        // `target_manifest` is the canonicalized path to a `Cargo.toml` file
+        let target_manifest = target_manifest.canonicalize()?;
         (
-            workspace_root_path == target_manifest,
-            target_manifest.canonicalize()?,
+            target_manifest
+                .parent()
+                .is_some_and(|manifest_dir| workspace_root_path == manifest_dir),
+            target_manifest,
         )
     } else {
         let current_dir = env::current_dir()?.canonicalize()?;

--- a/src/cargo-fmt/test/targets.rs
+++ b/src/cargo-fmt/test/targets.rs
@@ -14,11 +14,12 @@ mod all_targets {
         source_root: &str,
         exp_targets: &[ExpTarget],
         exp_num_targets: usize,
+        strategy: CargoFmtStrategy,
     ) {
         let root_path = Path::new("tests/cargo-fmt/source").join(source_root);
         let get_path = |exp: &str| PathBuf::from(&root_path).join(exp).canonicalize().unwrap();
         let manifest_path = Path::new(&root_path).join(manifest_suffix);
-        let targets = get_targets(&CargoFmtStrategy::All, Some(manifest_path.as_path()))
+        let targets = get_targets(&strategy, Some(manifest_path.as_path()))
             .expect("Targets should have been loaded");
 
         assert_eq!(targets.len(), exp_num_targets);
@@ -58,6 +59,7 @@ mod all_targets {
                 "divergent-crate-dir-names",
                 &exp_targets,
                 3,
+                CargoFmtStrategy::All,
             );
         }
 
@@ -113,6 +115,7 @@ mod all_targets {
                 "workspaces/path-dep-above",
                 &exp_targets,
                 6,
+                CargoFmtStrategy::All,
             );
         }
 

--- a/src/cargo-fmt/test/targets.rs
+++ b/src/cargo-fmt/test/targets.rs
@@ -134,4 +134,32 @@ mod all_targets {
             assert_correct_targets_loaded("ws/a/d/f/Cargo.toml");
         }
     }
+
+    mod cargo_fmt_strategy_root {
+        use super::*;
+
+        #[test]
+        fn assert_correct_targets_loaded_from_root() {
+            let exp_targets = &[
+                ExpTarget {
+                    path: "inner_bin/src/main.rs",
+                    edition: Edition::E2021,
+                    kind: "bin",
+                },
+                ExpTarget {
+                    path: "inner_lib/src/lib.rs",
+                    edition: Edition::E2021,
+                    kind: "lib",
+                },
+            ];
+
+            super::assert_correct_targets_loaded(
+                "Cargo.toml",
+                "issues_6517",
+                exp_targets,
+                2,
+                CargoFmtStrategy::Root,
+            );
+        }
+    }
 }

--- a/tests/cargo-fmt/source/issues_6517/Cargo.toml
+++ b/tests/cargo-fmt/source/issues_6517/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["inner_bin", "inner_lib"]

--- a/tests/cargo-fmt/source/issues_6517/inner_bin/Cargo.toml
+++ b/tests/cargo-fmt/source/issues_6517/inner_bin/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "inner_bin"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/tests/cargo-fmt/source/issues_6517/inner_bin/src/main.rs
+++ b/tests/cargo-fmt/source/issues_6517/inner_bin/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/cargo-fmt/source/issues_6517/inner_lib/Cargo.toml
+++ b/tests/cargo-fmt/source/issues_6517/inner_lib/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "inner_lib"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/tests/cargo-fmt/source/issues_6517/inner_lib/src/lib.rs
+++ b/tests/cargo-fmt/source/issues_6517/inner_lib/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
Fixes #6517

The underlying issue was an incorrect comparison between a `Cargo.toml` **file path** and the workspace's root **directory path**. Now that we're comparing two directory paths `in_workspace_root` gets set correctly, and `cargo-fmt` is able to find all the workspace's package targets.

PR best reviewed 1 commit at a time.
