### PR TITLE
New configuration option: indent_blank_lines

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -180,6 +180,56 @@ fn bar() {
 
 See also: [`blank_lines_lower_bound`](#blank_lines_lower_bound)
 
+
+## `indent_blank_lines`
+
+Empty lines are indented like items in the same block.
+
+- **Default value**: `false`
+- **Possible values**: `true`, `false`
+- **Stable**: No (tracking issue: TBD)
+
+### Example
+
+#### `false` (default):
+```rust
+fn foo() {
+    println!("a");
+
+    if true {
+        println!("b");
+
+        let Some(x) = Some(x) else {
+            println!("c");
+
+            println!("d");
+        };
+
+        println!("e");
+    }
+}
+```
+
+#### `true`:
+```rust
+fn foo() {
+    println!("a");
+    
+    if true {
+        println!("b");
+        
+        let Some(x) = Some(x) else {
+            println!("c");
+            
+            println!("d");
+        };
+        
+        println!("e");
+    }
+}
+```
+
+
 ## `brace_style`
 
 Brace style for items

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -152,6 +152,8 @@ create_config! {
         "Maximum number of blank lines which can be put between items";
     blank_lines_lower_bound: BlankLinesLowerBound, false,
         "Minimum number of blank lines which must be put between items";
+    indent_blank_lines: IndentBlankLines, false,
+        "Indent blank lines";
     edition: EditionConfig, true, "The edition of the parser (RFC 2052)";
     style_edition: StyleEditionConfig, true, "The edition of the Style Guide (RFC 3338)";
     version: VersionConfig, false, "Version of formatting rules";
@@ -815,6 +817,7 @@ trailing_comma = "Vertical"
 match_block_trailing_comma = false
 blank_lines_upper_bound = 1
 blank_lines_lower_bound = 0
+indent_blank_lines = false
 edition = "2015"
 style_edition = "2015"
 version = "One"
@@ -907,6 +910,7 @@ trailing_comma = "Vertical"
 match_block_trailing_comma = false
 blank_lines_upper_bound = 1
 blank_lines_lower_bound = 0
+indent_blank_lines = false
 edition = "2015"
 style_edition = "2024"
 version = "Two"

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -676,6 +676,7 @@ config_option_with_style_edition_default!(
     MatchBlockTrailingComma, bool, _ => false;
     BlankLinesUpperBound, usize, _ => 1;
     BlankLinesLowerBound, usize, _ => 0;
+    IndentBlankLines, bool, _ => false;
     EditionConfig, Edition, _ => Edition::Edition2015;
     StyleEditionConfig, StyleEdition,
         Edition2024 => StyleEdition::Edition2024, _ => StyleEdition::Edition2015;

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -494,6 +494,7 @@ struct FormatLines<'a> {
     name: &'a FileName,
     skipped_range: &'a [(usize, usize)],
     last_was_space: bool,
+    line_all_space: bool,
     line_len: usize,
     cur_line: usize,
     newline_count: usize,
@@ -514,6 +515,7 @@ impl<'a> FormatLines<'a> {
             name,
             skipped_range,
             last_was_space: false,
+            line_all_space: true,
             line_len: 0,
             cur_line: 1,
             newline_count: 0,
@@ -546,6 +548,7 @@ impl<'a> FormatLines<'a> {
             if self.last_was_space {
                 if self.should_report_error(kind, &ErrorKind::TrailingWhitespace)
                     && !self.is_skipped_line()
+                    && !(self.line_all_space && self.config.indent_blank_lines())
                 {
                     self.push_err(
                         ErrorKind::TrailingWhitespace,
@@ -575,6 +578,7 @@ impl<'a> FormatLines<'a> {
             .contains_line(self.name, self.cur_line);
         self.newline_count += 1;
         self.last_was_space = false;
+        self.line_all_space = true;
         self.line_buffer.clear();
         self.current_line_contains_string_literal = false;
     }
@@ -587,6 +591,7 @@ impl<'a> FormatLines<'a> {
             1
         };
         self.last_was_space = c.is_whitespace();
+        self.line_all_space &= self.last_was_space;
         self.line_buffer.push(c);
         if kind.is_string() {
             self.current_line_contains_string_literal = true;

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -113,26 +113,15 @@ impl<'a> FmtVisitor<'a> {
         }
     }
 
-    fn push_vertical_spaces(&mut self, mut newline_count: usize) {
-        let offset = self.buffer.chars().rev().take_while(|c| *c == '\n').count();
+    fn push_vertical_spaces(&mut self, newline_count: usize) {
+        let old_count = self.buffer.chars().rev().take_while(|c| *c == '\n').count();
         let newline_upper_bound = self.config.blank_lines_upper_bound() + 1;
         let newline_lower_bound = self.config.blank_lines_lower_bound() + 1;
 
-        if newline_count + offset > newline_upper_bound {
-            if offset >= newline_upper_bound {
-                newline_count = 0;
-            } else {
-                newline_count = newline_upper_bound - offset;
-            }
-        } else if newline_count + offset < newline_lower_bound {
-            if offset >= newline_lower_bound {
-                newline_count = 0;
-            } else {
-                newline_count = newline_lower_bound - offset;
-            }
-        }
+        // Clamp new total count to configuration.
+        let total = (old_count + newline_count).clamp(newline_lower_bound, newline_upper_bound);
 
-        let blank_lines = "\n".repeat(newline_count);
+        let blank_lines = "\n".repeat(total.saturating_sub(old_count));
         self.push_str(&blank_lines);
     }
 

--- a/tests/source/configs/indent_blank_lines/true.rs
+++ b/tests/source/configs/indent_blank_lines/true.rs
@@ -1,0 +1,40 @@
+// rustfmt-indent_blank_lines: true
+
+fn foo() {
+    if true {
+        println!("a");
+
+        match 4 {
+            0 => {
+                println!("b");
+
+                println!("c");
+                // FIXME: empty lines between match arms currently ignore this configuration:
+            }
+        
+            x => {
+                x = x
+                    .wrapping_add({
+                        // inner block
+                        let a = 4;
+
+                        a + 5
+                    })
+                    .unwrap();
+					  	 	 	 	    	 
+                if x > 10 {
+                    println!("{x}");
+            
+                    println!("{x}");
+                }
+            }
+        }
+    }
+}
+
+fn bar()
+where
+ 	u32: Sized, // FIXME: empty lines between where bounds ignores it
+					  	 	 	 	    	 
+    i32: Sized,
+{}

--- a/tests/target/configs/indent_blank_lines/true.rs
+++ b/tests/target/configs/indent_blank_lines/true.rs
@@ -1,0 +1,41 @@
+// rustfmt-indent_blank_lines: true
+
+fn foo() {
+    if true {
+        println!("a");
+        
+        match 4 {
+            0 => {
+                println!("b");
+                
+                println!("c");
+                // FIXME: empty lines between match arms currently ignore this configuration:
+            }
+
+            x => {
+                x = x
+                    .wrapping_add({
+                        // inner block
+                        let a = 4;
+                        
+                        a + 5
+                    })
+                    .unwrap();
+                
+                if x > 10 {
+                    println!("{x}");
+                    
+                    println!("{x}");
+                }
+            }
+        }
+    }
+}
+
+fn bar()
+where
+    u32: Sized, // FIXME: empty lines between where bounds ignores it
+
+    i32: Sized,
+{
+}


### PR DESCRIPTION
Implements a new configuration option,`indent_blank_lines`, to indent empty lines left between items.


Relevant issue: https://github.com/rust-lang/rustfmt/issues/887
Important difference: This makes no attempt to preserve the original (horizontal) whitespace on that line; the line is simply indented with the indent of the containing block.

Note: Reviewing each commit individually is highly recommended.

1. The first commit streamlines the logic in the key function without changing behavior.
2. The second fixes some edge cases that are likely not actually possible, and reorganizes the logic in preparation for the third.
3. The third commit actually implements the configuration flag. The mechanism is the same that is used for `blank_lines_{lower/upper}_bound`.
4. The fourth adds a bypass to inhibit the internal error for trailing whitespace when the line in question is *only* whitespace. Ideally this could be made stricter by requiring that it actually is properly indented, but I didn't see any obvious ways to do that at that point in the code.
5. The last commit adds a basic test for the functionality. These probably should be expanded to include some relevant combinations with other configurations like `hard_tabs`.


#### Known issues
Empty lines between `match`-arms or `where`-bounds ignore this setting, and are left unindented. I have not looked into it much further, but `blank_lines_{lower/upper}_bound` already had the same problem so it is not unexpected.