### PR TITLE
Format paths in `derive` attribute

### DIFF
--- a/tests/source/issue-6343.rs
+++ b/tests/source/issue-6343.rs
@@ -1,0 +1,16 @@
+#[derive(serde :: Serialize)]
+enum Something {
+    Variant
+}
+
+#[derive(
+    serde :: Serialize,
+    IReallyLoveToWriteLongDerives,
+    Debug,
+    Eq,
+    PartialEq, Ord, PartialOrd,
+    Hash, Clone, Copy, Default
+)]
+enum SomethingComplex {
+    Variant5
+}

--- a/tests/target/issue-6343.rs
+++ b/tests/target/issue-6343.rs
@@ -1,0 +1,21 @@
+#[derive(serde::Serialize)]
+enum Something {
+    Variant,
+}
+
+#[derive(
+    serde::Serialize,
+    IReallyLoveToWriteLongDerives,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Clone,
+    Copy,
+    Default,
+)]
+enum SomethingComplex {
+    Variant5,
+}


### PR DESCRIPTION
Resolves https://github.com/rust-lang/rustfmt/issues/6343

Now I try to format paths in derive macro attribute. It is especially visible in for example [sea-orm-cli](https://www.sea-ql.org/SeaORM/docs/generate-entity/sea-orm-cli/) and other crates that generate derive attributes.