### PR TITLE
Show what `use_field_init_shorthand = true` does

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -3020,15 +3020,13 @@ Use field initialize shorthand if possible.
 struct Foo {
     x: u32,
     y: u32,
-    z: u32,
 }
 
 fn main() {
     let x = 1;
     let y = 2;
-    let z = 3;
-    let a = Foo { x, y, z };
-    let b = Foo { x: x, y: y, z: z };
+    let a = Foo { x, y };
+    let b = Foo { x: x, y: y };
 }
 ```
 
@@ -3038,14 +3036,13 @@ fn main() {
 struct Foo {
     x: u32,
     y: u32,
-    z: u32,
 }
 
 fn main() {
     let x = 1;
     let y = 2;
-    let z = 3;
-    let a = Foo { x, y, z };
+    let a = Foo { x, y };
+    let b = Foo { x, y };
 }
 ```
 


### PR DESCRIPTION
It did not include `b` for the `use_field_init_shorthand = true` case, which is a mistake as it is the one thing that will be changed by this option.

The rather long examples were also made shorter by dropping `z`.