### PR TITLE
Fix path resolution of `rustfmt` in `cargo-fmt`

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -150,9 +150,12 @@ fn execute() -> i32 {
 }
 
 fn rustfmt_command() -> Command {
-    let rustfmt = env::current_exe()
-        .expect("current executable path invalid")
-        .with_file_name("rustfmt");
+    let rustfmt = match env::var_os("RUSTFMT") {
+        Some(rustfmt) => PathBuf::from(rustfmt),
+        None => env::current_exe()
+            .expect("current executable path invalid")
+            .with_file_name("rustfmt"),
+    };
 
     Command::new(rustfmt)
 }

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -6,7 +6,6 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
-use std::ffi::OsStr;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
@@ -151,11 +150,10 @@ fn execute() -> i32 {
 }
 
 fn rustfmt_command() -> Command {
-    let rustfmt_var = env::var_os("RUSTFMT");
-    let rustfmt = match &rustfmt_var {
-        Some(rustfmt) => rustfmt,
-        None => OsStr::new("rustfmt"),
-    };
+    let rustfmt = env::current_exe()
+        .expect("current executable path invalid")
+        .with_file_name("rustfmt");
+
     Command::new(rustfmt)
 }
 


### PR DESCRIPTION
Instead of resolving `rustfmt` path from RUSTFMT or PATH envs, use the one located in the same directory as `cargo-fmt`. So that `cargo-fmt` uses the expected version of `rustfmt` to avoid accidental use of unrelated versions.

This shouldn't change anything on the current behavior but it should make it easier to test the bootstrapped `cargo-fmt` in rust-lang/rust, since it currently always points to the globally installed `rustfmt`.

Moved from https://github.com/rust-lang/rust/pull/141100