### PR TITLE
fix: split a line exceeding the maximum width

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1996,7 +1996,11 @@ fn rewrite_let(
     // TODO(ytmimi) comments could appear between `let` and the `pat`
 
     // 4 = "let ".len()
-    let pat_shape = shape.offset_left(4, pat.span)?;
+    let mut pat_shape = shape.offset_left(4, pat.span)?;
+    if context.config.style_edition() >= StyleEdition::Edition2027 {
+        // 2 for the length of " ="
+        pat_shape = pat_shape.sub_width(2, pat.span)?;
+    }
     let pat_str = pat.rewrite_result(context, pat_shape)?;
     result.push_str(&pat_str);
 

--- a/tests/source/issue-6202/long_pat.rs
+++ b/tests/source/issue-6202/long_pat.rs
@@ -1,0 +1,14 @@
+// max_width = 120
+// error_on_line_overflow = true
+// style_edition = "2027"
+
+impl EarlyLintPass for NeedlessContinue {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        if let ExprKind::Loop(body, label, ..) | ExprKind::While(_, body, label) | ExprKind::ForLoop { body, label, .. } =
+            &expr.kind
+            && !in_external_macro(cx.sess, expr.span)
+        {
+            check_final_block_stmt(cx, body, label, expr.span.ctxt());
+        }
+    }
+}

--- a/tests/target/issue-6202/long_pat.rs
+++ b/tests/target/issue-6202/long_pat.rs
@@ -1,0 +1,15 @@
+// max_width = 120
+// error_on_line_overflow = true
+// style_edition = "2027"
+
+impl EarlyLintPass for NeedlessContinue {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        if let ExprKind::Loop(body, label, ..)
+        | ExprKind::While(_, body, label)
+        | ExprKind::ForLoop { body, label, .. } = &expr.kind
+            && !in_external_macro(cx.sess, expr.span)
+        {
+            check_final_block_stmt(cx, body, label, expr.span.ctxt());
+        }
+    }
+}


### PR DESCRIPTION
The trailing `  =` was not taken into account when rewriting the pattern. This caused an error of the pattern exceeding the `max_width`.

This PR is nearly identical to #6224, but the change is gated on `StyleEdition::Edition2027` or newer.

Fixes #6202.