### PR TITLE
fix: #6558 don't try to repair invalid self-imports.

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -557,18 +557,7 @@ impl UseTree {
                 self.path = vec![];
                 return self;
             }
-            UseSegmentKind::Slf(None) if self.path.is_empty() && self.visibility.is_some() => {
-                self.path = vec![];
-                return self;
-            }
             _ => (),
-        }
-
-        // Normalise foo::self -> foo.
-        if let UseSegmentKind::Slf(None) = last.kind {
-            if !self.path.is_empty() {
-                return self;
-            }
         }
 
         // Normalise foo::self as bar -> foo as bar.

--- a/tests/source/imports/imports.rs
+++ b/tests/source/imports/imports.rs
@@ -23,8 +23,10 @@ pub use rustc_ast::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, Expr
 
 use rustc_ast::some::{};
 
+// compilation error that will (and should) be ignored by rustfmt #6558
 use self;
 use std::io::{self};
+// compilation error that will (and should) be ignored by rustfmt #6558
 use std::io::self;
 
 mod Foo {

--- a/tests/source/imports/imports_granularity_default-with-dups.rs
+++ b/tests/source/imports/imports_granularity_default-with-dups.rs
@@ -1,6 +1,7 @@
 use crate::lexer;
 use crate::lexer::tokens::TokenData;
 use crate::lexer::{tokens::TokenData};
+// compilation error that will (and should) be ignored by rustfmt #6558
 use crate::lexer::self;
 use crate::lexer::{self};
 use crate::lexer::{self, tokens::TokenData};

--- a/tests/source/issue_6558.rs
+++ b/tests/source/issue_6558.rs
@@ -1,0 +1,5 @@
+// Removing `self` breaks idempotence, leaving it causes a compilation error
+// which the user should be made aware of #6558
+use self;
+use self::self;
+use self::self::self;

--- a/tests/target/imports/imports.rs
+++ b/tests/target/imports/imports.rs
@@ -27,8 +27,11 @@ use rustc_ast::{self};
 use Foo::{Bar, Baz};
 use {Bar /* comment */, /* Pre-comment! */ Foo};
 
-use std::io;
+// compilation error that will (and should) be ignored by rustfmt #6558
+use self;
 use std::io::{self};
+// compilation error that will (and should) be ignored by rustfmt #6558
+use std::io::self;
 
 mod Foo {
     pub use rustc_ast::ast::{

--- a/tests/target/imports/imports_granularity_default-with-dups.rs
+++ b/tests/target/imports/imports_granularity_default-with-dups.rs
@@ -1,6 +1,7 @@
 use crate::lexer;
-use crate::lexer;
 use crate::lexer::tokens::TokenData;
 use crate::lexer::tokens::TokenData;
+// compilation error that will (and should) be ignored by rustfmt #6558
+use crate::lexer::self;
 use crate::lexer::{self};
 use crate::lexer::{self, tokens::TokenData};

--- a/tests/target/issue_6558.rs
+++ b/tests/target/issue_6558.rs
@@ -1,0 +1,5 @@
+// Removing `self` breaks idempotence, leaving it causes a compilation error
+// which the user should be made aware of #6558
+use self;
+use self::self;
+use self::self::self;


### PR DESCRIPTION
Current attempts break idempotence.

As the tests show, paths ending with `self` are now untouched, this PR just removes some code (and adds/modifies some tests).

A potential change here would be to keep this part of the code:

```rust
UseSegmentKind::Slf(None) if self.path.is_empty() && self.visibility.is_some() => {
    self.path = vec![];
    return self;
}
```

In that case 
```rust
use self;
```
would be removed, but not:
```rust
use self::self;
```

Which woud also fix the idempotence issue, but formatting away `use self;`. Although maybe it's best that the compiler inform the user that they're doing something wrong instead of 'sweeping it under the rug' so to say.