### PR TITLE
fix: #6520, move comment above line if it would cross out the type in…

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1015,6 +1015,18 @@ pub(crate) fn rewrite_missing_comment(
     }
 }
 
+pub(crate) fn comment_reaches_end_of_line(
+    span: Span,
+    context: &RewriteContext<'_>,
+    normalize_comments: bool,
+) -> bool {
+    let missing_snippet = context.snippet(span);
+    let trimmed_snippet = missing_snippet.trim();
+    comment_style(trimmed_snippet, normalize_comments)
+        .closer()
+        .is_empty()
+}
+
 /// Recover the missing comments in the specified span, if available.
 /// The layout of the comments will be preserved as long as it does not break the code
 /// and its total width does not exceed the max width.

--- a/src/items.rs
+++ b/src/items.rs
@@ -11,8 +11,9 @@ use tracing::debug;
 
 use crate::attr::filter_inline_attrs;
 use crate::comment::{
-    FindUncommented, combine_strs_with_missing_comments, contains_comment, is_last_comment_block,
-    recover_comment_removed, recover_missing_comment_in_span, rewrite_missing_comment,
+    FindUncommented, combine_strs_with_missing_comments, comment_reaches_end_of_line,
+    contains_comment, is_last_comment_block, recover_comment_removed,
+    recover_missing_comment_in_span, rewrite_missing_comment,
 };
 use crate::config::lists::*;
 use crate::config::{BraceStyle, Config, IndentStyle, StyleEdition};
@@ -2212,6 +2213,17 @@ fn is_empty_infer(ty: &ast::Ty, pat_span: Span) -> bool {
     }
 }
 
+struct CommentAfterColon {
+    content: Option<String>,
+    reaches_end_of_line: bool,
+}
+
+impl CommentAfterColon {
+    fn content(&self) -> &str {
+        self.content.as_deref().unwrap_or("")
+    }
+}
+
 /// Recover any missing comments between the param and the type.
 ///
 /// # Returns
@@ -2223,7 +2235,7 @@ fn get_missing_param_comments(
     pat_span: Span,
     ty_span: Span,
     shape: Shape,
-) -> (String, String) {
+) -> (String, CommentAfterColon) {
     let missing_comment_span = mk_sp(pat_span.hi(), ty_span.lo());
 
     let span_before_colon = {
@@ -2246,7 +2258,25 @@ fn get_missing_param_comments(
     let comment_after_colon = rewrite_missing_comment(span_after_colon, shape, context)
         .ok()
         .filter(|comment| !comment.is_empty())
-        .map_or(String::new(), |comment| format!("{} ", comment));
+        .map_or(
+            CommentAfterColon {
+                content: None,
+                reaches_end_of_line: false,
+            },
+            |comment| {
+                let reaches_end_of_line =
+                    comment_reaches_end_of_line(span_after_colon, context, false);
+                let content = if reaches_end_of_line {
+                    comment
+                } else {
+                    format!("{} ", comment)
+                };
+                CommentAfterColon {
+                    content: Some(content),
+                    reaches_end_of_line,
+                }
+            },
+        );
     (comment_before_colon, comment_after_colon)
 }
 
@@ -2297,9 +2327,21 @@ impl Rewrite for ast::Param {
             if !is_empty_infer(&*self.ty, self.pat.span) {
                 let (before_comment, after_comment) =
                     get_missing_param_comments(context, self.pat.span, self.ty.span, shape);
-                result.push_str(&before_comment);
-                result.push_str(colon_spaces(context.config));
-                result.push_str(&after_comment);
+
+                // In the specific case of comment after line reaching the end of that line,
+                // put the comment on-top to keep it from obscuring the following type
+                if after_comment.reaches_end_of_line {
+                    let mut reordered = after_comment.content().to_string();
+                    reordered.push_str(&shape.indent.to_string_with_newline(context.config));
+                    reordered.push_str(&result);
+                    result = reordered;
+                    result.push_str(&before_comment);
+                    result.push_str(colon_spaces(context.config));
+                } else {
+                    result.push_str(&before_comment);
+                    result.push_str(colon_spaces(context.config));
+                    result.push_str(after_comment.content());
+                }
                 let overhead = last_line_width(&result);
                 let max_width = shape
                     .width
@@ -2327,7 +2369,7 @@ impl Rewrite for ast::Param {
                     )?;
                     result.push_str(&before_comment);
                     result.push_str(colon_spaces(context.config));
-                    result.push_str(&after_comment);
+                    result.push_str(after_comment.content());
                     let overhead = last_line_width(&result);
                     let max_width = shape
                         .width

--- a/tests/source/issue_6520.rs
+++ b/tests/source/issue_6520.rs
@@ -1,0 +1,17 @@
+pub fn foo(x: // comment here
+u32) {}
+
+pub fn bar(x: // comment here
+u32, y: i32) {}
+
+pub fn baz(
+    my_arg1: i32,
+    my_arg2: u32,
+    my_arg3: bool,
+    my_arg4: // other comment here
+    f32,
+    my_arg5: String,
+    my_arg6: u32,
+    my_arg7: bool,
+) {
+}

--- a/tests/target/issue_6520.rs
+++ b/tests/target/issue_6520.rs
@@ -1,0 +1,24 @@
+pub fn foo(
+    // comment here
+    x: u32,
+) {
+}
+
+pub fn bar(
+    // comment here
+    x: u32,
+    y: i32,
+) {
+}
+
+pub fn baz(
+    my_arg1: i32,
+    my_arg2: u32,
+    my_arg3: bool,
+    // other comment here
+    my_arg4: f32,
+    my_arg5: String,
+    my_arg6: u32,
+    my_arg7: bool,
+) {
+}


### PR DESCRIPTION
… a function arg.

fixes #6520

A bit unsure about this one.

The problem is that if you have a comment that spans to the end of the line, then pushing the `ty_str` after it will make that `ty_str` part of the comment.

It's similar to this https://github.com/rust-lang/rustfmt/issues/2976 except isolates comments that do not close themselves.

There's some nuance here, since the decision has to be made where to put the comment. Putting it on top is the simplest, putting it last on the line would require making sure that nothing follows the comment.

Lastly, checking the comment style processes the span again, which is why that's only done conditionally if there is some comment there, so it shouldn't hit most cases. The alternative is a bigger refactor where either the comment style is identified before being passed down to `identify_comment`, or that metadata is propagated up from the caller. Neither of those options seemed nice.