### PR TITLE
fix: wrap function without a body exceeding 100 characters (#6539)

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2602,10 +2602,20 @@ fn rewrite_fn_base(
                 // the closing parenthesis of the param and the arrow '->' is considered.
                 let mut sig_length = result.len() + indent.width() + ret_str_len + 1;
 
-                // If there is no where-clause, take into account the space after the return type
-                // and the brace.
+                // If there is no where-clause.
                 if where_clause.predicates.is_empty() {
-                    sig_length += 2;
+                    if context.config.style_edition() >= StyleEdition::Edition2027 {
+                        let line_ending_overhead = match fn_brace_style {
+                            FnBraceStyle::NextLine => 0, // No brace to account for
+                            FnBraceStyle::SameLine => 2, // Trailing space and brace, e.g. ` {`
+                            FnBraceStyle::None => 1,     // Trailing `;`
+                        };
+                        sig_length += line_ending_overhead;
+                    } else {
+                        // Take into account the space after the return type and the brace.
+                        // 2 = ' {'
+                        sig_length += 2;
+                    }
                 }
 
                 sig_length > context.config.max_width()

--- a/tests/source/issue-6539/issue_example.rs
+++ b/tests/source/issue-6539/issue_example.rs
@@ -1,0 +1,7 @@
+// rustfmt-style_edition: 2027
+
+pub trait Trait {
+    fn a_one_hundred_column_fn_decl_no_body(&self, aaa: f64, b: f64, c: f64, d: f64, e: f64) -> f64;
+
+    fn a_one_hundred_one_column_fn_decl_no_body(self, a: f64, b: f64, c: f64, d: f64, e: f64) -> f64;
+}

--- a/tests/target/issue-6539/issue_example.rs
+++ b/tests/target/issue-6539/issue_example.rs
@@ -1,0 +1,14 @@
+// rustfmt-style_edition: 2027
+
+pub trait Trait {
+    fn a_one_hundred_column_fn_decl_no_body(&self, aaa: f64, b: f64, c: f64, d: f64, e: f64) -> f64;
+
+    fn a_one_hundred_one_column_fn_decl_no_body(
+        self,
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+    ) -> f64;
+}


### PR DESCRIPTION
Hopefully these changes suggested by @chrisduerr and the test case I provided fix the original problem. Let me know if more tests are needed!

Closes #6539 

Running the new tests without the proposed changes to src/items.rs:

```diff
Mismatch at tests/source/issue-6539/100-column-trait-fn.rs:1:
 // rustfmt-style_edition: 2027
 
 pub trait Trait {
-    fn a_one_hundred_column_fn_decl_no_body(&self, aaa: f64, b: f64, c: f64, d: f64, e: f64) -> f64;
+    fn a_one_hundred_column_fn_decl_no_body(&self, aaa: f64, b: f64, c: f64, d: f64, e: f64)
+    -> f64;
 
     fn a_one_hundred_one_column_fn_decl_no_body(
         self,

Mismatch at tests/target/issue-6539/100-column-trait-fn.rs:1:
 // rustfmt-style_edition: 2027
 
 pub trait Trait {
-    fn a_one_hundred_column_fn_decl_no_body(&self, aaa: f64, b: f64, c: f64, d: f64, e: f64) -> f64;
+    fn a_one_hundred_column_fn_decl_no_body(&self, aaa: f64, b: f64, c: f64, d: f64, e: f64)
+    -> f64;
 
     fn a_one_hundred_one_column_fn_decl_no_body(
         self,
```

Tests are passing with these changes.