### PR TITLE
Fix incorrect whitespace modifications to non-rust code blocks

### DIFF
--- a/tests/source/issue-6015/complete_code_block_leading_blank_line.rs
+++ b/tests/source/issue-6015/complete_code_block_leading_blank_line.rs
@@ -1,0 +1,7 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```text
+///
+/// This is a non-rust code block
+/// ```
+struct S;

--- a/tests/source/issue-6015/incomplete_code_block_leadling_blank_line.rs
+++ b/tests/source/issue-6015/incomplete_code_block_leadling_blank_line.rs
@@ -1,0 +1,6 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```text
+///
+/// This is a non-rust code block
+struct S;

--- a/tests/source/issue-6609/complete_code_block_trailing_blank_line.rs
+++ b/tests/source/issue-6609/complete_code_block_trailing_blank_line.rs
@@ -1,0 +1,10 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// Some comment.
+///
+/// ```text
+/// This is a non-rust code block
+///
+///
+/// ```
+struct S;

--- a/tests/source/issue-6609/incomplete_code_block_trailing_blank_line.rs
+++ b/tests/source/issue-6609/incomplete_code_block_trailing_blank_line.rs
@@ -1,0 +1,9 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// Some comment.
+///
+/// ```text
+/// This is a non-rust code block
+///
+///
+struct S;

--- a/tests/target/issue-6015/complete_code_block_leading_blank_line.rs
+++ b/tests/target/issue-6015/complete_code_block_leading_blank_line.rs
@@ -1,0 +1,7 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```text
+///
+/// This is a non-rust code block
+/// ```
+struct S;

--- a/tests/target/issue-6015/incomplete_code_block_leadling_blank_line.rs
+++ b/tests/target/issue-6015/incomplete_code_block_leadling_blank_line.rs
@@ -1,0 +1,6 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// ```text
+///
+/// This is a non-rust code block
+struct S;

--- a/tests/target/issue-6609/complete_code_block_trailing_blank_line.rs
+++ b/tests/target/issue-6609/complete_code_block_trailing_blank_line.rs
@@ -1,0 +1,10 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// Some comment.
+///
+/// ```text
+/// This is a non-rust code block
+///
+///
+/// ```
+struct S;

--- a/tests/target/issue-6609/incomplete_code_block_trailing_blank_line.rs
+++ b/tests/target/issue-6609/incomplete_code_block_trailing_blank_line.rs
@@ -1,0 +1,9 @@
+// rustfmt-format_code_in_doc_comments: true
+
+/// Some comment.
+///
+/// ```text
+/// This is a non-rust code block
+///
+///
+struct S;


### PR DESCRIPTION
* Fix whitespace was being prepended to leading blank line
* Fix trailing blank line was being stripped

Fixes: #6609
Fixes: #6015