### PR TITLE
Fix misidentification of indented comments

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -256,7 +256,7 @@ fn identify_comment(
     config: &Config,
     is_doc_comment: bool,
 ) -> RewriteResult {
-    let style = comment_style(orig, false);
+    let style = comment_style(orig.trim_start(), false);
 
     // Computes the byte length of line taking into account a newline if the line is part of a
     // paragraph.

--- a/tests/source/issue-6612/hidden_code_in_doc_comment.rs
+++ b/tests/source/issue-6612/hidden_code_in_doc_comment.rs
@@ -1,0 +1,8 @@
+// rustfmt-format_code_in_doc_comments: true
+// rustfmt-edition: 2024
+
+/// ```
+/// println!("1"); // comment
+/// # println!("2")
+/// ```
+struct S;

--- a/tests/source/issue-6612/mixed_comment_types.rs
+++ b/tests/source/issue-6612/mixed_comment_types.rs
@@ -1,0 +1,12 @@
+// rustfmt-edition: 2024
+
+fn wat1() {
+    println!("1"); // double slash comment
+    /* another comment type */
+}
+
+fn wat1() {
+    println!("1"); // double slash comment
+    /* another comment type */
+    //# yet another type
+}

--- a/tests/target/issue-6612/hidden_code_in_doc_comment.rs
+++ b/tests/target/issue-6612/hidden_code_in_doc_comment.rs
@@ -1,0 +1,8 @@
+// rustfmt-format_code_in_doc_comments: true
+// rustfmt-edition: 2024
+
+/// ```
+/// println!("1"); // comment
+/// # println!("2")
+/// ```
+struct S;

--- a/tests/target/issue-6612/mixed_comment_types.rs
+++ b/tests/target/issue-6612/mixed_comment_types.rs
@@ -1,0 +1,12 @@
+// rustfmt-edition: 2024
+
+fn wat1() {
+    println!("1"); // double slash comment
+    /* another comment type */
+}
+
+fn wat1() {
+    println!("1"); // double slash comment
+    /* another comment type */
+    //# yet another type
+}


### PR DESCRIPTION
The comment style detection (i.e. `comment_style`) checks the start of a line to determine the style, so it will misidentify lines starting with spaces, e.g. `  //# some content` would be identified as `CommentStyle::DoubleSlash` and not `CommentStyle::Custom("//# ")` resulting in it determining there to be a comment of `""`, which it then indents and appends a `\n` before writing back the original comment.

Fix this by trimming the line before trying to identify its style.

Fixes: #6612