### PR TITLE
fix: prevent panic when formatting complex generics

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -3325,7 +3325,20 @@ fn format_generics(
     used_width: usize,
 ) -> Option<String> {
     let shape = Shape::legacy(context.budget(used_width + offset.width()), offset);
-    let mut result = rewrite_generics(context, "", generics, shape).ok()?;
+    let mut result = match rewrite_generics(context, "", generics, shape) {
+        Ok(r) => r,
+        Err(_) => {
+            // First attempt failed, try with infinite width for complex generics
+            let wide_shape = shape.infinite_width();
+            match rewrite_generics(context, "", generics, wide_shape) {
+                Ok(r) => r,
+                Err(_) => {
+                    // If even that fails, preserve original formatting from source
+                    context.snippet(generics.span).to_string()
+                }
+            }
+        }
+    };
 
     // If the generics are not parameterized then generics.span.hi() == 0,
     // so we use span.lo(), which is the position after `struct Foo`.

--- a/tests/source/issue-6571.rs
+++ b/tests/source/issue-6571.rs
@@ -1,0 +1,16 @@
+// Regression test for panic when formatting very long generic constraints
+// This used to cause rustfmt to panic at src/items.rs:556 with "Option::unwrap() on a None value"
+pub enum TestEnum<
+    T: std::collections::HashMap<String, Vec<Box<dyn std::fmt::Debug + Send + Sync + 'static>>> + Clone + Default + PartialEq + Eq + std::fmt::Debug + serde::Serialize + serde::Deserialize<'static> + Send + Sync + 'static = std::collections::HashMap<String, Vec<Box<dyn std::fmt::Debug + Send + Sync + 'static>>>,
+> {
+    Variant1(T),
+    Variant2 { field: T },
+}
+
+// More realistic example from real codebase
+pub enum ElementInit<
+    P: wrt_foundation::MemoryProvider + Clone + Default + PartialEq + Eq = wrt_foundation::NoStdProvider<1024>,
+> {
+    FuncIndices(crate::WasmVec<u32, P>),
+    Expressions(crate::WasmVec<crate::WasmVec<u8, P>, P>),
+}

--- a/tests/target/issue-6571.rs
+++ b/tests/target/issue-6571.rs
@@ -1,0 +1,16 @@
+// Regression test for panic when formatting very long generic constraints
+// This used to cause rustfmt to panic at src/items.rs:556 with "Option::unwrap() on a None value"
+pub enum TestEnum<
+    T: std::collections::HashMap<String, Vec<Box<dyn std::fmt::Debug + Send + Sync + 'static>>> + Clone + Default + PartialEq + Eq + std::fmt::Debug + serde::Serialize + serde::Deserialize<'static> + Send + Sync + 'static = std::collections::HashMap<String, Vec<Box<dyn std::fmt::Debug + Send + Sync + 'static>>>,
+> {
+    Variant1(T),
+    Variant2 { field: T },
+}
+
+// More realistic example from real codebase
+pub enum ElementInit<
+    P: wrt_foundation::MemoryProvider + Clone + Default + PartialEq + Eq = wrt_foundation::NoStdProvider<1024>,
+> {
+    FuncIndices(crate::WasmVec<u32, P>),
+    Expressions(crate::WasmVec<crate::WasmVec<u8, P>, P>),
+}


### PR DESCRIPTION
Fixes #6571

## Problem
rustfmt panics with `Option::unwrap() on a None value` when formatting enums with very long generic type constraints. This occurs when the generic constraints exceed the available width budget (~80-100 characters), causing `rewrite_generics` to fail and `format_generics` to return `None`, which is then unwrapped.

## Solution
This PR implements a three-tier fallback strategy in `format_generics`:

1. **First attempt**: Try formatting with normal width constraint
2. **Second attempt**: If that fails, retry with infinite width using `shape.infinite_width()`  
3. **Fallback**: If even that fails, preserve the original source formatting

## Changes
- Modified `format_generics` function in `src/items.rs` to handle width budget exhaustion gracefully
- Added regression test case `issue-6571.rs` to prevent future regressions

## Testing
- All existing tests pass
- New regression test verifies the fix works for complex generic constraints
- Tested on the original failing codebase that triggered the issue

This fix ensures rustfmt can process files with complex generic constraints without crashing, while maintaining proper formatting where possible.