### PR TITLE
Fix panic from tab-expansion bug in LineOverflow

### DIFF
--- a/tests/source/issue-6632.rs
+++ b/tests/source/issue-6632.rs
@@ -1,0 +1,14 @@
+macro_rules! impl_routes_and_health {
+	($($feature:literal, $variant:ident),* $(,)?) => {
+		impl EitherState {
+			pub(crate) fn service_name(&self) -> &'static str {
+				match self {
+					$(
+						#[cfg(feature = $feature)]
+						Self::$variant(s) => s.service_name(),// BuildService::service_name(s.clone()),
+					)*
+				}
+			}
+		}
+	};
+}

--- a/tests/target/issue-6632.rs
+++ b/tests/target/issue-6632.rs
@@ -1,0 +1,14 @@
+macro_rules! impl_routes_and_health {
+	($($feature:literal, $variant:ident),* $(,)?) => {
+		impl EitherState {
+			pub(crate) fn service_name(&self) -> &'static str {
+				match self {
+					$(
+						#[cfg(feature = $feature)]
+						Self::$variant(s) => s.service_name(),// BuildService::service_name(s.clone()),
+					)*
+				}
+			}
+		}
+	};
+}


### PR DESCRIPTION
LineOverflow diagnostics treated visual columns (tabs expanded) as byte offsets, so a line with tabs could produced an out-of-bounds annotation and a panic. Now emits a normal overflow diagnostic.

Fixes #6632