### PR TITLE
Fixes adjustment of max_width within macros

### DIFF
--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -423,6 +423,63 @@ macro_rules! create_config {
                 )+
             }
 
+            /// Reduces the maximum width of the configuration.
+            ///
+            /// This method is intended to be used when creating a forked
+            /// configuration for a particular formatting context in which the
+            /// total available width needs to be reduced. This reduces the
+            /// size of max_width, and all other properties affected by small
+            /// heuristics, without treating those adjustments as overrides.
+            ///
+            /// As an example use case, this method is used when formatting
+            /// arms within a declarative macro.
+            #[allow(unreachable_pub)]
+            pub fn reduce_max_width(&mut self, delta: usize) {
+                self.adjust_max_width(-1 * delta as isize);
+            }
+
+            /// Increases the maximum width of the configuration.
+            ///
+            /// This method is intended to be used when creating a forked
+            /// configuration for a particular formatting context in which the
+            /// total available width needs to be reduced. This reduces the
+            /// size of max_width, and all other properties affected by small
+            /// heuristics, without treating those adjustments as overrides.
+            ///
+            /// As an example use case, this method is used when formatting
+            /// arms within a declarative macro.
+            #[allow(unreachable_pub)]
+            pub fn increase_max_width(&mut self, delta: usize) {
+                self.adjust_max_width(delta as isize);
+            }
+
+            /// Adjusts the maximum width of the configuration.
+            ///
+            /// This method is intended to be used when creating a forked
+            /// configuration for a particular formatting context in which the
+            /// total available width needs to be reduced. This reduces the
+            /// size of max_width, and all other properties affected by small
+            /// heuristics, without treating those adjustments as overrides.
+            ///
+            /// As an example use case, this method is used when formatting
+            /// arms within a declarative macro.
+            fn adjust_max_width(&mut self, delta: isize) {
+                let adjust = |value: usize| (value as isize + delta) as usize;
+
+                self.array_width.2 = adjust(self.array_width.2);
+                self.attr_fn_like_width.2 = adjust(self.attr_fn_like_width.2);
+                self.chain_width.2 = adjust(self.chain_width.2);
+                self.fn_call_width.2 = adjust(self.fn_call_width.2);
+                self.single_line_if_else_max_width.2 = adjust(self.single_line_if_else_max_width.2);
+                self.single_line_let_else_max_width.2 =
+                    adjust(self.single_line_let_else_max_width.2);
+                self.struct_lit_width.2 = adjust(self.struct_lit_width.2);
+                self.struct_variant_width.2 = adjust(self.struct_variant_width.2);
+
+                self.max_width.2 = adjust(self.max_width.2);
+                self.set_heuristics();
+            }
+
             fn set_width_heuristics(&mut self, heuristics: WidthHeuristics) {
                 let max_width = self.max_width.2;
                 let get_width_value = |

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -423,6 +423,63 @@ macro_rules! create_config {
                 )+
             }
 
+            /// Reduces the maximum width of the configuration.
+            ///
+            /// This method is intended to be used when creating a forked
+            /// configuration for a particular formatting context in which the
+            /// total available width needs to be reduced. This reduces the
+            /// size of max_width, and all other properties affected by small
+            /// heuristics, without treating those adjustments as overrides.
+            ///
+            /// As an example use case, this method is used when formatting
+            /// arms within a declarative macro.
+            #[allow(unreachable_pub)]
+            pub fn reduce_max_width(&mut self, delta: usize) {
+                self.adjust_max_width(-(delta as isize));
+            }
+
+            /// Increases the maximum width of the configuration.
+            ///
+            /// This method is intended to be used when creating a forked
+            /// configuration for a particular formatting context in which the
+            /// total available width needs to be reduced. This increases the
+            /// size of max_width, and all other properties affected by small
+            /// heuristics, without treating those adjustments as overrides.
+            ///
+            /// As an example use case, this method is used when formatting
+            /// arms within a declarative macro.
+            #[allow(unreachable_pub)]
+            pub fn increase_max_width(&mut self, delta: usize) {
+                self.adjust_max_width(delta as isize);
+            }
+
+            /// Adjusts the maximum width of the configuration.
+            ///
+            /// This method is intended to be used when creating a forked
+            /// configuration for a particular formatting context in which the
+            /// total available width needs to be reduced. This adjusts the
+            /// size of max_width, and all other properties affected by small
+            /// heuristics, without treating those adjustments as overrides.
+            ///
+            /// As an example use case, this method is used when formatting
+            /// arms within a declarative macro.
+            fn adjust_max_width(&mut self, delta: isize) {
+                let adjust = |value: usize| (value as isize + delta) as usize;
+
+                self.array_width.2 = adjust(self.array_width.2);
+                self.attr_fn_like_width.2 = adjust(self.attr_fn_like_width.2);
+                self.chain_width.2 = adjust(self.chain_width.2);
+                self.fn_call_width.2 = adjust(self.fn_call_width.2);
+                self.single_line_if_else_max_width.2 = adjust(self.single_line_if_else_max_width.2);
+                self.single_line_let_else_max_width.2 =
+                    adjust(self.single_line_let_else_max_width.2);
+                self.struct_lit_width.2 = adjust(self.struct_lit_width.2);
+                self.struct_variant_width.2 = adjust(self.struct_variant_width.2);
+
+                self.max_width.2 = adjust(self.max_width.2);
+                self.set_heuristics();
+            }
+
             fn set_width_heuristics(&mut self, heuristics: WidthHeuristics) {
                 let max_width = self.max_width.2;
                 let get_width_value = |

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1338,15 +1338,13 @@ impl MacroBranch {
         } else {
             shape.indent.block_indent(&config)
         };
-        let new_width = config.max_width() - body_indent.width();
-        config.set().max_width(new_width);
+        config.reduce_max_width(body_indent.width());
 
         // First try to format as items, then as statements.
         let new_body_snippet = match crate::format_snippet(&body_str, &config, true) {
             Some(new_body) => new_body,
             None => {
-                let new_width = new_width + config.tab_spaces();
-                config.set().max_width(new_width);
+                config.increase_max_width(config.tab_spaces());
                 match crate::format_code_block(&body_str, &config, true) {
                     Some(new_body) => new_body,
                     None => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1361,15 +1361,13 @@ impl MacroBranch {
         } else {
             shape.indent.block_indent(&config)
         };
-        let new_width = config.max_width() - body_indent.width();
-        config.set().max_width(new_width);
+        config.reduce_max_width(body_indent.width());
 
         // First try to format as items, then as statements.
         let new_body_snippet = match crate::format_snippet(&body_str, &config, true) {
             Some(new_body) => new_body,
             None => {
-                let new_width = new_width + config.tab_spaces();
-                config.set().max_width(new_width);
+                config.increase_max_width(config.tab_spaces());
                 match crate::format_code_block(&body_str, &config, true) {
                     Some(new_body) => new_body,
                     None => {

--- a/tests/source/issue-6651/custom_width.rs
+++ b/tests/source/issue-6651/custom_width.rs
@@ -1,0 +1,21 @@
+// rustfmt-format_macro_bodies: true
+// rustfmt-max_width: 82
+// rustfmt-fn_call_width: 76
+
+macro_rules! short {
+    () => {
+        m!(a, b, c);
+    };
+}
+
+macro_rules! medium {
+    () => {
+        m!(aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddd);
+    };
+}
+
+macro_rules! long {
+    () => {
+        m!(aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddddddddd);
+    };
+}

--- a/tests/source/issue-6651/default.rs
+++ b/tests/source/issue-6651/default.rs
@@ -1,0 +1,19 @@
+// rustfmt-format_macro_bodies: true
+
+macro_rules! short {
+    () => {
+        m!(a, b, c);
+    };
+}
+
+macro_rules! medium {
+    () => {
+        m!(aaaaaaaaaa, bbbbbbbbbb, cccccccccc, ddddddddd);
+    };
+}
+
+macro_rules! long {
+    () => {
+        m!(aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddddddddd);
+    };
+}

--- a/tests/target/issue-6651/custom_width.rs
+++ b/tests/target/issue-6651/custom_width.rs
@@ -16,6 +16,11 @@ macro_rules! medium {
 
 macro_rules! long {
     () => {
-        m!(aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddddddddd);
+        m!(
+            aaaaaaaaaaaaaaaa,
+            bbbbbbbbbbbbbbbb,
+            cccccccccccccccc,
+            ddddddddddddddd
+        );
     };
 }

--- a/tests/target/issue-6651/custom_width.rs
+++ b/tests/target/issue-6651/custom_width.rs
@@ -1,0 +1,21 @@
+// rustfmt-format_macro_bodies: true
+// rustfmt-max_width: 82
+// rustfmt-fn_call_width: 76
+
+macro_rules! short {
+    () => {
+        m!(a, b, c);
+    };
+}
+
+macro_rules! medium {
+    () => {
+        m!(aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddd);
+    };
+}
+
+macro_rules! long {
+    () => {
+        m!(aaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbb, cccccccccccccccc, ddddddddddddddd);
+    };
+}

--- a/tests/target/issue-6651/default.rs
+++ b/tests/target/issue-6651/default.rs
@@ -1,0 +1,24 @@
+// rustfmt-format_macro_bodies: true
+
+macro_rules! short {
+    () => {
+        m!(a, b, c);
+    };
+}
+
+macro_rules! medium {
+    () => {
+        m!(aaaaaaaaaa, bbbbbbbbbb, cccccccccc, ddddddddd);
+    };
+}
+
+macro_rules! long {
+    () => {
+        m!(
+            aaaaaaaaaaaaaaaa,
+            bbbbbbbbbbbbbbbb,
+            cccccccccccccccc,
+            ddddddddddddddd
+        );
+    };
+}


### PR DESCRIPTION
Fixes #5404.

Minimal example:
```rust
macro_rules! foo {
    () => {
        println!("Hello, world!");
    };
}
```

Without this change:
```sh
> cargo run --bin rustfmt -- --config-path=/dev/null --config=max_width=100 --config=fn_call_width=100 ~/Desktop/example.rs
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/rustfmt --config-path=/dev/null --config=max_width=100 --config=fn_call_width=100 /Users/cameron/Desktop/example.rs`
`fn_call_width` cannot have a value that exceeds `max_width`. `fn_call_width` will be set to the same value as `max_width`
```

With this change:
```sh
> cargo run --bin rustfmt -- --config-path=/dev/null --config=max_width=100 --config=fn_call_width=100 ~/Desktop/example.rs
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/rustfmt --config-path=/dev/null --config=max_width=100 --config=fn_call_width=100 /Users/cameron/Desktop/example.rs`
```