### PR TITLE
Remove unused `syntux.rs`

### DIFF
--- a/src/syntux.rs
+++ b/src/syntux.rs
@@ -1,4 +1,0 @@
-//! This module defines a thin abstract layer on top of the rustc's parser and syntax libraries.
-
-pub(crate) mod parser;
-pub(crate) mod session;


### PR DESCRIPTION
We are currently using the parse module instead of the syntux module.

https://github.com/rust-lang/rustfmt/blob/28beb81318eea17fab77594139c65906e7ae3218/src/lib.rs#L86

https://github.com/rust-lang/rustfmt/blob/d0762f032b4a5ed636a1ebae0b82647f2cce2998/src/parse/mod.rs#L1-L3