### PR TITLE
Add test case for issue#6099

### DIFF
--- a/src/test/parser.rs
+++ b/src/test/parser.rs
@@ -69,3 +69,10 @@ fn crate_parsing_stashed_diag2() {
     let filename = "tests/parser/stashed-diag2.rs";
     assert_parser_error(filename);
 }
+
+#[test]
+fn parser_error_const_missing_type() {
+    // See also https://github.com/rust-lang/rustfmt/issues/6099
+    let filename = "tests/parser/issue-6099.rs";
+    assert_parser_error(filename);
+}

--- a/tests/parser/issue-6099.rs
+++ b/tests/parser/issue-6099.rs
@@ -1,0 +1,1 @@
+const BAR = 42;


### PR DESCRIPTION
closes #6099 

> This one is a little different because `const BAR = 42;` will be rejected by the parser. You should see a similar error message if you run rustfmt on that input:
> 
> ```
> 
> error: missing type for `const` item
> 
>  --> <stdin>:1:10
> 
>   |
> 
> 1 | const BAR = 42;
> 
>   |          ^ help: provide a type for the item: `: <type>`
> 
> ```
> 
> You should be able to add another parser error test to [src/test/parser.rs](https://github.com/rust-lang/rustfmt/blob/master/src/test/parser.rs) 

 _Originally posted by @ytmimi in [#6099](https://github.com/rust-lang/rustfmt/issues/6099#issuecomment-1988907389)_