### PR TITLE
Add test case for issue#6082

### DIFF
--- a/tests/source/issue-6082.rs
+++ b/tests/source/issue-6082.rs
@@ -1,0 +1,5 @@
+macro_rules! test {
+    ($T:ident, $b:lifetime) => {
+        Box<$T<$b>>
+    };
+}

--- a/tests/target/issue-6082.rs
+++ b/tests/target/issue-6082.rs
@@ -1,0 +1,5 @@
+macro_rules! test {
+    ($T:ident, $b:lifetime) => {
+        Box<$T<$b>>
+    };
+}


### PR DESCRIPTION
Related to #6099, #6082

> If you want, you can also add the code snippet from https://github.com/rust-lang/rustfmt/issues/6082#issuecomment-1952590404 as a separate test case, which deals with the same issue and contains a complete code snippet without any parse errors. No problem if not. If you choose to also include that code snippet all you'd need to do is add it to a file in the `tests/target` directory, which is typically what you'd do when adding test cases to rustfmt.  

 _Originally posted by @ytmimi in [#6099](https://github.com/rust-lang/rustfmt/issues/6099#issuecomment-1989813317)_