### PR TITLE
Fix idempotency issue with raw strings

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1368,7 +1368,6 @@ where
                 match chr {
                     '"' => {
                         if sharps == 0 {
-                            char_kind = FullCodeCharKind::Normal;
                             CharClassesStatus::Normal
                         } else if is_raw_string_suffix(&mut self.base, sharps) {
                             CharClassesStatus::RawStringSuffix(sharps)
@@ -1859,6 +1858,20 @@ mod test {
         assert_eq!((FullCodeCharKind::InComment, '/'), iter.next().unwrap());
         assert_eq!((FullCodeCharKind::EndComment, '\n'), iter.next().unwrap());
         assert_eq!((FullCodeCharKind::Normal, '\n'), iter.next().unwrap());
+        assert_eq!(None, iter.next());
+    }
+
+    #[test]
+    fn char_classes_hashless_raw_string() {
+        let mut iter = CharClasses::new("r\"a\nb\",".chars());
+
+        assert_eq!((FullCodeCharKind::InString, 'r'), iter.next().unwrap());
+        assert_eq!((FullCodeCharKind::InString, '"'), iter.next().unwrap());
+        assert_eq!((FullCodeCharKind::InString, 'a'), iter.next().unwrap());
+        assert_eq!((FullCodeCharKind::InString, '\n'), iter.next().unwrap());
+        assert_eq!((FullCodeCharKind::InString, 'b'), iter.next().unwrap());
+        assert_eq!((FullCodeCharKind::InString, '"'), iter.next().unwrap());
+        assert_eq!((FullCodeCharKind::Normal, ','), iter.next().unwrap());
         assert_eq!(None, iter.next());
     }
 

--- a/tests/source/issue-6161.rs
+++ b/tests/source/issue-6161.rs
@@ -1,0 +1,8 @@
+fn f() {
+my_macro! {
+    m =>
+    "a": r"bb
+            ccc
+",
+};
+}

--- a/tests/target/issue-6161.rs
+++ b/tests/target/issue-6161.rs
@@ -1,0 +1,8 @@
+fn f() {
+    my_macro! {
+        m =>
+        "a": r"bb
+            ccc
+",
+    };
+}


### PR DESCRIPTION
Fixes rust-lang/rustfmt#6161

`CharClasses` classifies the closing quote of `r"..."` as `Normal`, while `"..."` and `r#"..."#` classify theirs as `InString`. When that quote starts a line, `LineClasses` fails to mark the line as `EndString`, so `trim_left_preserve_layout` treats it as code with zero leading whitespace. The minimum indentation of the macro body is then always zero and every run indents the body one more level.