### PR TITLE
Begin labelling new issues with `needs-triage`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -5,8 +5,19 @@
 # Labels
 # ------------------------------------------------------------------------------
 
+[relabel]
+allow-unauthenticated = [
+    "needs-triage",
+]
+
 [autolabel."pr-not-reviewed"]
 new_pr = true
+
+[autolabel."needs-triage"]
+new_issue = true
+exclude_labels = [
+    "C-tracking-issue",
+]
 
 # ------------------------------------------------------------------------------
 # PR assignments


### PR DESCRIPTION
Part of [#t-rustfmt > Triage labels](https://rust-lang.zulipchat.com/#narrow/channel/357797-t-rustfmt/topic/Triage.20labels/with/546729144).

The main motivation here is to distinguish between issues that have not received any triaging (not even an initial pass), versus issues that have. It's intended that the https://github.com/rust-lang/rustfmt/labels/needs-triage label will be removed once a team member or contributor has performed an initial triage on the issue.

Triage docs and label docs are intended as follow-ups, since I still need to investigate how to effectively triage rustfmt issues and PRs.

The `[relabel]` section with https://github.com/rust-lang/rustfmt/labels/needs-triage as `allow-unauthenticated` will allow users without write access to this repo to remove the https://github.com/rust-lang/rustfmt/labels/needs-triage label through `@rustbot label: -needs-triage`. There are other labels that should also go in here, but left as a follow-up PR to restrict scope of this PR.