### PR TITLE
Migrate `rustfmt` to Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = "Apache-2.0 OR MIT"
 build = "build.rs"
 categories = ["development-tools"]
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "rustfmt"
@@ -54,7 +54,9 @@ tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 unicode-segmentation = "1.9"
 unicode-width = "0.1"
-unicode-properties = { version = "0.1", default-features = false, features = ["general-category"] }
+unicode-properties = { version = "0.1", default-features = false, features = [
+    "general-category",
+] }
 
 rustfmt-config_proc_macro = { version = "0.3", path = "config_proc_macro" }
 semver = "1.0.21"

--- a/check_diff/Cargo.toml
+++ b/check_diff/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "check_diff"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/config_proc_macro/Cargo.toml
+++ b/config_proc_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustfmt-config_proc_macro"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 description = "A collection of procedural macros for rustfmt"
 license = "Apache-2.0 OR MIT"
 categories = ["development-tools::procedural-macro-helpers"]
@@ -13,7 +13,12 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", default-features = false, features = ["full", "parsing", "proc-macro", "printing"] }
+syn = { version = "2.0", default-features = false, features = [
+    "full",
+    "parsing",
+    "proc-macro",
+    "printing",
+] }
 
 [dev-dependencies]
 serde = { version = "1.0.160", features = ["derive"] }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -249,10 +249,8 @@ impl Rewrite for ast::MetaItemInner {
 
     fn rewrite_result(&self, context: &RewriteContext<'_>, shape: Shape) -> RewriteResult {
         match self {
-            ast::MetaItemInner::MetaItem(ref meta_item) => meta_item.rewrite_result(context, shape),
-            ast::MetaItemInner::Lit(ref l) => {
-                rewrite_literal(context, l.as_token_lit(), l.span, shape)
-            }
+            ast::MetaItemInner::MetaItem(meta_item) => meta_item.rewrite_result(context, shape),
+            ast::MetaItemInner::Lit(l) => rewrite_literal(context, l.as_token_lit(), l.span, shape),
         }
     }
 }
@@ -342,7 +340,7 @@ impl Rewrite for ast::Attribute {
                 return Ok(snippet.to_owned());
             }
 
-            if let Some(ref meta) = self.meta() {
+            if let Some(meta) = self.meta() {
                 // This attribute is possibly a doc attribute needing normalization to a doc comment
                 if context.config.normalize_doc_attributes() && meta.has_name(sym::doc) {
                     if let Some(ref literal) = meta.value_str() {
@@ -546,8 +544,8 @@ pub(crate) trait MetaVisitor<'ast> {
 
     fn visit_meta_item_inner(&mut self, nm: &'ast ast::MetaItemInner) {
         match nm {
-            ast::MetaItemInner::MetaItem(ref meta_item) => self.visit_meta_item(meta_item),
-            ast::MetaItemInner::Lit(ref lit) => self.visit_meta_item_lit(lit),
+            ast::MetaItemInner::MetaItem(meta_item) => self.visit_meta_item(meta_item),
+            ast::MetaItemInner::Lit(lit) => self.visit_meta_item_lit(lit),
         }
     }
 

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -235,7 +235,7 @@ impl ChainItemKind {
                         data.args
                             .iter()
                             .filter_map(|x| match x {
-                                ast::AngleBracketedArg::Arg(ref generic_arg) => {
+                                ast::AngleBracketedArg::Arg(generic_arg) => {
                                     Some(generic_arg.clone())
                                 }
                                 _ => None,

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -158,12 +158,12 @@ impl UseSegment {
     // Check if self == other with their aliases removed.
     fn equal_except_alias(&self, other: &Self) -> bool {
         match (&self.kind, &other.kind) {
-            (UseSegmentKind::Ident(ref s1, _), UseSegmentKind::Ident(ref s2, _)) => s1 == s2,
+            (UseSegmentKind::Ident(s1, _), UseSegmentKind::Ident(s2, _)) => s1 == s2,
             (UseSegmentKind::Slf(_), UseSegmentKind::Slf(_))
             | (UseSegmentKind::Super(_), UseSegmentKind::Super(_))
             | (UseSegmentKind::Crate(_), UseSegmentKind::Crate(_))
             | (UseSegmentKind::Glob, UseSegmentKind::Glob) => true,
-            (UseSegmentKind::List(ref list1), UseSegmentKind::List(ref list2)) => list1 == list2,
+            (UseSegmentKind::List(list1), UseSegmentKind::List(list2)) => list1 == list2,
             _ => false,
         }
     }
@@ -591,7 +591,7 @@ impl UseTree {
         if aliased_self {
             match self.path.last_mut() {
                 Some(UseSegment {
-                    kind: UseSegmentKind::Ident(_, ref mut old_rename),
+                    kind: UseSegmentKind::Ident(_, old_rename),
                     ..
                 }) => {
                     assert!(old_rename.is_none());
@@ -667,7 +667,7 @@ impl UseTree {
                 }),
             )
             | (None, None) => true,
-            (Some(ref a), Some(ref b)) => is_same_visibility(a, b),
+            (Some(a), Some(b)) => is_same_visibility(a, b),
             _ => false,
         }
     }
@@ -922,9 +922,7 @@ impl Ord for UseSegment {
         }
 
         match (&self.kind, &other.kind) {
-            (Slf(ref a), Slf(ref b))
-            | (Super(ref a), Super(ref b))
-            | (Crate(ref a), Crate(ref b)) => match (a, b) {
+            (Slf(a), Slf(b)) | (Super(a), Super(b)) | (Crate(a), Crate(b)) => match (a, b) {
                 (Some(sa), Some(sb)) => {
                     if self.style_edition >= StyleEdition::Edition2024 {
                         version_sort(sa.trim_start_matches("r#"), sb.trim_start_matches("r#"))
@@ -935,7 +933,7 @@ impl Ord for UseSegment {
                 (_, _) => a.cmp(b),
             },
             (Glob, Glob) => Ordering::Equal,
-            (Ident(ref pia, ref aa), Ident(ref pib, ref ab)) => {
+            (Ident(pia, aa), Ident(pib, ab)) => {
                 let (ia, ib) = if self.style_edition >= StyleEdition::Edition2024 {
                     (pia.trim_start_matches("r#"), pib.trim_start_matches("r#"))
                 } else {
@@ -977,7 +975,7 @@ impl Ord for UseSegment {
                     (None, None) => Ordering::Equal,
                 }
             }
-            (List(ref a), List(ref b)) => {
+            (List(a), List(b)) => {
                 for (a, b) in a.iter().zip(b.iter()) {
                     let ord = a.cmp(b);
                     if ord != Ordering::Equal {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ impl Input {
 
     fn to_directory_ownership(&self) -> Option<DirectoryOwnership> {
         match self {
-            Input::File(ref file) => {
+            Input::File(file) => {
                 // If there exists a directory with the same name as an input,
                 // then the input should be parsed as a sub module.
                 let file_stem = file.file_stem()?;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -843,7 +843,7 @@ impl MacroArgParser {
                 ) => {
                     break;
                 }
-                TokenTree::Token(ref t, _) => {
+                TokenTree::Token(t, _) => {
                     buffer.push_str(&pprust::token_to_string(t));
                 }
                 _ => return None,
@@ -939,7 +939,7 @@ impl MacroArgParser {
                 ) if self.is_meta_var => {
                     self.add_meta_variable(&mut iter)?;
                 }
-                TokenTree::Token(ref t, _) => self.update_buffer(t),
+                TokenTree::Token(t, _) => self.update_buffer(t),
                 &TokenTree::Delimited(_dspan, _spacing, delimited, ref tts) => {
                     if !self.buf.is_empty() {
                         if next_space(&self.last_tok.kind) == SpaceState::Always {

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -140,7 +140,7 @@ impl<'a> OverflowableItem<'a> {
             OverflowableItem::MacroArg(MacroArg::Expr(expr)) => is_simple_expr(expr),
             OverflowableItem::MetaItemInner(meta_item_inner) => match meta_item_inner {
                 ast::MetaItemInner::Lit(..) => true,
-                ast::MetaItemInner::MetaItem(ref meta_item) => {
+                ast::MetaItemInner::MetaItem(meta_item) => {
                     matches!(meta_item.kind, ast::MetaItemKind::Word)
                 }
             },
@@ -169,7 +169,7 @@ impl<'a> OverflowableItem<'a> {
     pub(crate) fn to_expr(&self) -> Option<&'a ast::Expr> {
         match self {
             OverflowableItem::Expr(expr) => Some(expr),
-            OverflowableItem::MacroArg(MacroArg::Expr(ref expr)) => Some(expr),
+            OverflowableItem::MacroArg(MacroArg::Expr(expr)) => Some(expr),
             _ => None,
         }
     }
@@ -178,8 +178,8 @@ impl<'a> OverflowableItem<'a> {
         match self {
             OverflowableItem::Expr(expr) => can_be_overflowed_expr(context, expr, len),
             OverflowableItem::MacroArg(macro_arg) => match macro_arg {
-                MacroArg::Expr(ref expr) => can_be_overflowed_expr(context, expr, len),
-                MacroArg::Ty(ref ty) => can_be_overflowed_type(context, ty, len),
+                MacroArg::Expr(expr) => can_be_overflowed_expr(context, expr, len),
+                MacroArg::Ty(ty) => can_be_overflowed_type(context, ty, len),
                 MacroArg::Pat(..) => false,
                 MacroArg::Item(..) => len == 1,
                 MacroArg::Keyword(..) => false,
@@ -197,7 +197,10 @@ impl<'a> OverflowableItem<'a> {
         }
     }
 
-    fn special_cases(&self, config: &Config) -> impl Iterator<Item = &(&'static str, usize)> {
+    fn special_cases(
+        &self,
+        config: &Config,
+    ) -> impl Iterator<Item = &(&'static str, usize)> + use<'_> {
         let base_cases = match self {
             OverflowableItem::MacroArg(..) => SPECIAL_CASE_MACROS,
             OverflowableItem::MetaItemInner(..) => SPECIAL_CASE_ATTR,

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -156,14 +156,13 @@ impl<'a> Parser<'a> {
 
     fn parse_crate_mod(&mut self) -> Result<ast::Crate, ParserError> {
         let mut parser = AssertUnwindSafe(&mut self.parser);
-        let err = Err(ParserError::ParsePanicError);
         match catch_unwind(move || parser.parse_crate_mod()) {
             Ok(Ok(k)) => Ok(k),
             Ok(Err(db)) => {
                 db.emit();
-                err
+                Err(ParserError::ParsePanicError)
             }
-            Err(_) => err,
+            Err(_) => Err(ParserError::ParsePanicError),
         }
     }
 }

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -56,22 +56,22 @@ fn is_short_pattern_inner(context: &RewriteContext<'_>, pat: &ast::Pat) -> bool 
             }
             _ => unreachable!(),
         },
-        ast::PatKind::Ident(_, _, ref pat) => pat.is_none(),
+        ast::PatKind::Ident(_, _, pat) => pat.is_none(),
         ast::PatKind::Struct(..)
         | ast::PatKind::MacCall(..)
         | ast::PatKind::Slice(..)
         | ast::PatKind::Path(..)
         | ast::PatKind::Range(..)
         | ast::PatKind::Guard(..) => false,
-        ast::PatKind::Tuple(ref subpats) => subpats.len() <= 1,
-        ast::PatKind::TupleStruct(_, ref path, ref subpats) => {
+        ast::PatKind::Tuple(subpats) => subpats.len() <= 1,
+        ast::PatKind::TupleStruct(_, path, subpats) => {
             path.segments.len() <= 1 && subpats.len() <= 1
         }
-        ast::PatKind::Box(ref p)
-        | PatKind::Deref(ref p)
-        | ast::PatKind::Ref(ref p, _)
-        | ast::PatKind::Paren(ref p) => is_short_pattern_inner(context, &*p),
-        PatKind::Or(ref pats) => pats.iter().all(|p| is_short_pattern_inner(context, p)),
+        ast::PatKind::Box(p)
+        | PatKind::Deref(p)
+        | ast::PatKind::Ref(p, _)
+        | ast::PatKind::Paren(p) => is_short_pattern_inner(context, &*p),
+        PatKind::Or(pats) => pats.iter().all(|p| is_short_pattern_inner(context, p)),
     }
 }
 
@@ -88,7 +88,7 @@ impl<'a, T: Rewrite> Rewrite for RangeOperand<'a, T> {
     fn rewrite_result(&self, context: &RewriteContext<'_>, shape: Shape) -> RewriteResult {
         match &self.operand {
             None => Ok("".to_owned()),
-            Some(ref exp) => exp.rewrite_result(context, shape),
+            Some(exp) => exp.rewrite_result(context, shape),
         }
     }
 }

--- a/src/rustfmt_diff.rs
+++ b/src/rustfmt_diff.rs
@@ -162,7 +162,7 @@ impl OutputWriter {
     // Terminal in its `terminal` field.
     pub(crate) fn writeln(&mut self, msg: &str, color: Option<term::color::Color>) {
         match &mut self.terminal {
-            Some(ref mut t) => {
+            Some(t) => {
                 if let Some(color) = color {
                     t.fg(color).unwrap();
                 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -820,7 +820,7 @@ fn idempotent_check(
     opt_config: &Option<PathBuf>,
 ) -> Result<FormatReport, IdempotentCheckError> {
     let sig_comments = read_significant_comments(filename);
-    let config = if let Some(ref config_file_path) = opt_config {
+    let config = if let Some(config_file_path) = opt_config {
         let (edition, style_edition, version) = get_editions_from_comments(&sig_comments);
         Config::from_toml_path(config_file_path, edition, style_edition, version)
             .expect("`rustfmt.toml` not found")

--- a/src/types.rs
+++ b/src/types.rs
@@ -150,8 +150,8 @@ pub(crate) enum SegmentParam<'a> {
 impl<'a> SegmentParam<'a> {
     fn from_generic_arg(arg: &ast::GenericArg) -> SegmentParam<'_> {
         match arg {
-            ast::GenericArg::Lifetime(ref lt) => SegmentParam::LifeTime(lt),
-            ast::GenericArg::Type(ref ty) => SegmentParam::Type(ty),
+            ast::GenericArg::Lifetime(lt) => SegmentParam::LifeTime(lt),
+            ast::GenericArg::Type(ty) => SegmentParam::Type(ty),
             ast::GenericArg::Const(const_) => SegmentParam::Const(const_),
         }
     }
@@ -555,7 +555,7 @@ fn rewrite_generic_args(
     span: Span,
 ) -> RewriteResult {
     match gen_args {
-        ast::GenericArgs::AngleBracketed(ref data) => {
+        ast::GenericArgs::AngleBracketed(data) => {
             if data.args.is_empty() {
                 Ok("".to_owned())
             } else {
@@ -575,7 +575,7 @@ fn rewrite_generic_args(
                 overflow::rewrite_with_angle_brackets(context, "", args.iter(), shape, span)
             }
         }
-        ast::GenericArgs::Parenthesized(ref data) => format_function_type(
+        ast::GenericArgs::Parenthesized(data) => format_function_type(
             data.inputs.iter().map(|x| &**x),
             &data.output,
             false,
@@ -684,7 +684,7 @@ impl Rewrite for ast::GenericParam {
         let mut param = String::with_capacity(128);
 
         let param_start = if let ast::GenericParamKind::Const {
-            ref ty,
+            ty,
             kw_span,
             default,
         } = &self.kind
@@ -1177,7 +1177,7 @@ fn join_bounds_inner(
     // Whether a GenericBound item is a PathSegment segment that includes internal array
     // that contains more than one item
     let is_item_with_multi_items_array = |item: &ast::GenericBound| match item {
-        ast::GenericBound::Trait(ref poly_trait_ref, ..) => {
+        ast::GenericBound::Trait(poly_trait_ref, ..) => {
             let segments = &poly_trait_ref.trait_ref.path.segments;
             if segments.len() > 1 {
                 true

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -259,7 +259,7 @@ fn is_skip(meta_item: &MetaItem) -> bool {
 #[inline]
 fn is_skip_nested(meta_item: &MetaItemInner) -> bool {
     match meta_item {
-        MetaItemInner::MetaItem(ref mi) => is_skip(mi),
+        MetaItemInner::MetaItem(mi) => is_skip(mi),
         MetaItemInner::Lit(_) => false,
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -387,13 +387,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         let indent = self.block_indent;
         let block;
         let rewrite = match fk {
-            visit::FnKind::Fn(
-                _,
-                _,
-                ast::Fn {
-                    body: Some(ref b), ..
-                },
-            ) => {
+            visit::FnKind::Fn(_, _, ast::Fn { body: Some(b), .. }) => {
                 block = b;
                 self.rewrite_fn_before_block(
                     indent,
@@ -647,7 +641,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             (ast::AssocItemKind::Const(c), AssocImplItem) => {
                 self.visit_static(&StaticParts::from_impl_item(ai, c.ident))
             }
-            (ast::AssocItemKind::Fn(ref fn_kind), _) => {
+            (ast::AssocItemKind::Fn(fn_kind), _) => {
                 let ast::Fn {
                     defaultness,
                     ref sig,
@@ -675,10 +669,10 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     self.push_rewrite(ai.span, rewrite);
                 }
             }
-            (ast::AssocItemKind::Type(ref ty_alias), _) => {
+            (ast::AssocItemKind::Type(ty_alias), _) => {
                 self.visit_ty_alias_kind(ty_alias, &ai.vis, visitor_kind, ai.span);
             }
-            (ast::AssocItemKind::MacCall(ref mac), _) => {
+            (ast::AssocItemKind::MacCall(mac), _) => {
                 self.visit_mac(mac, MacroPosition::Item);
             }
             _ => unreachable!(),
@@ -835,7 +829,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 );
             } else {
                 match &attr.kind {
-                    ast::AttrKind::Normal(ref normal)
+                    ast::AttrKind::Normal(normal)
                         if self.is_unknown_rustfmt_attr(&normal.item.path.segments) =>
                     {
                         let file_name = self.psess.span_to_filename(attr.span);
@@ -943,7 +937,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         let ident_str = rewrite_ident(&self.get_context(), ident).to_owned();
         self.push_str(&ident_str);
 
-        if let ast::ModKind::Loaded(ref items, ast::Inline::Yes, ref spans, _) = mod_kind {
+        if let ast::ModKind::Loaded(items, ast::Inline::Yes, spans, _) = mod_kind {
             let ast::ModSpans {
                 inner_span,
                 inject_use_span: _,

--- a/tests/cargo-fmt/source/issue_3164/Cargo.toml
+++ b/tests/cargo-fmt/source/issue_3164/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "issue_3164"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Most of the suggestions from `cargo fix --edition` are accepted.
- Effectfull destructors are almost exclusively from `ThinVec` and diagnostics handler.
- We are not matching the new fragments covered by `expr` so instead of `expr_2021` we shall continue to use `expr` from Edition 2024.