### PR TITLE
Introduce required `language_edition` and `style_edition` inputs for Diff Check

### DIFF
--- a/.github/workflows/check_diff.yml
+++ b/.github/workflows/check_diff.yml
@@ -8,6 +8,9 @@ on:
       branch_name:
         description: 'Name of the feature branch on the forked repo'
         required: true
+      language_edition:
+        description: 'Language edition to run both rustfmt with; can be overridden by language edition settings in `rustfmt_configs`'
+        required: true
       style_edition:
         description: 'Style edition to run both rustfmt with; can be overridden by style edition settings in `rustfmt_configs`'
         required: true
@@ -33,4 +36,4 @@ jobs:
         rustup target add x86_64-unknown-linux-gnu
 
     - name: check diff
-      run: bash ${GITHUB_WORKSPACE}/ci/check_diff.sh ${{ github.event.inputs.clone_url }} ${{ github.event.inputs.branch_name }} ${{ github.events.inputs.style_edition }} ${{ github.event.inputs.commit_hash || github.event.inputs.branch_name }} ${{ github.event.inputs.rustfmt_configs }}
+      run: bash ${GITHUB_WORKSPACE}/ci/check_diff.sh ${{ github.event.inputs.clone_url }} ${{ github.event.inputs.branch_name }} ${{ github.events.inputs.language_edition }} ${{ github.events.inputs.style_edition }} ${{ github.event.inputs.commit_hash || github.event.inputs.branch_name }} ${{ github.event.inputs.rustfmt_configs }}


### PR DESCRIPTION
So that when manually dispatching the Diff Check workflow, an explicit pair of {language edition, style edition} are specified.

- E.g. if language edition is not specified, `rustfmt` will default to Edition 2015 like `rustc`, which can cause a lot of parse errors in the current set of candidate projects used for comparing `rustfmt` behaviors since they tend to be on Edition 2024.
- Similarly, when style edition is not specified, `rustfmt` can pick a *lower* default style edition than the actual language edition, which can also lead to unexpected diff check outcomes.

Note that the language/style editions specified with `language_edition`/`style_edition` inputs can still be overridden by `rustfmt_configs`, but the intention is to make sure the `language_edition`/`style_edition` are always specified.

Context: https://github.com/rust-lang/rustfmt/pull/6681#issuecomment-3438539702

### Separate `--edition`/`--style-edition` vs `--config=edition=...,style_edition=...`

See discussion in [#t-rustfmt > style edition flag vs config](https://rust-lang.zulipchat.com/#narrow/channel/357797-t-rustfmt/topic/style.20edition.20flag.20vs.20config/with/562293485).

In this PR I use the `--config=style_edition=$STYLE_EDITION` form, because I'm not actually sure what's the precedence order of mixed invocations (example below), so I just used `--config=style_edition=$STYLE_EDITION` where later `style_editions` specified in optional `rustfmt_configs` should take precedence over this input.

```sh
$ rustfmt --style-edition=2024 --config=style_edition=2021
$ rustfmt --config=style_edition=2021 --style-edition=2024
```

### Review remarks

The first commit in this PR is a drive-by fix for `rusfmt` -> `rustfmt` that was bothering me, should not contain any functional changes.

The following commits are the actual script/workflow changes.