### PR TITLE
Fix broken test annotations for `tests/source/issue-6202/long_pat.rs`

### DIFF
--- a/tests/source/issue-6202/long_pat.rs
+++ b/tests/source/issue-6202/long_pat.rs
@@ -1,6 +1,7 @@
-// max_width = 120
-// error_on_line_overflow = true
-// style_edition = "2027"
+// rustfmt-max_width: 120
+// rustfmt-error_on_line_overflow: true
+// rustfmt-style_edition: 2027
+// rustfmt-edition: 2024
 
 impl EarlyLintPass for NeedlessContinue {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {

--- a/tests/target/issue-6202/long_pat.rs
+++ b/tests/target/issue-6202/long_pat.rs
@@ -1,6 +1,7 @@
-// max_width = 120
-// error_on_line_overflow = true
-// style_edition = "2027"
+// rustfmt-max_width: 120
+// rustfmt-error_on_line_overflow: true
+// rustfmt-style_edition: 2027
+// rustfmt-edition: 2024
 
 impl EarlyLintPass for NeedlessContinue {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {


### PR DESCRIPTION
1. The test annotations have the wrong syntax.
2. The test is missing a Rust language Edition (>= 2024) for if-let chains.

Detected in a subtree sync attempt (https://github.com/rust-lang/rustfmt/pull/6743), and so is a blocker for the subtree sync.