### PR TITLE
Mirror `rust-lang/rust` review labels, enable triagebot `shortcuts` and `review-changes-since` functionality

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -49,6 +49,11 @@ add_labels = ["S-waiting-on-review"]
 # Documentation at: https://forge.rust-lang.org/triagebot/review-changes-since.html
 [review-changes-since]
 
+# Allow reviewers and authors to easily flip between {`S-waiting-on-review`,
+# `S-waiting-on-author`, `S-blocked`}.
+# Documentation at: <https://forge.rust-lang.org/triagebot/shortcuts.html>
+[shortcut]
+
 # ------------------------------------------------------------------------------
 # PR assignments
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Review labels

Currently, `rustfmt` seems to use a set of manually maintained (flipped) labels:

- https://github.com/rust-lang/rustfmt/labels/pr-not-reviewed for new PRs
- https://github.com/rust-lang/rustfmt/labels/pr-waiting-on-author when PRs still need actions from the author
- https://github.com/rust-lang/rustfmt/labels/pr-follow-up-review-pending when a PR has previous review passes but need re-reviews.

This is inconsistent with what `rust-lang/rust` uses, and the PR states tends to also mismatch the status of the label at the moment. This PR proposes that we switch over to the same set of binary labels {https://github.com/rust-lang/rustfmt/labels/S-waiting-on-author, https://github.com/rust-lang/rustfmt/labels/S-waiting-on-review, https://github.com/rust-lang/rustfmt/labels/S-blocked } that `rust-lang/rust` uses, and enable `triagebot`'s automation to help to automatically flip the labels (e.g. flipping to `S-waiting-on-author` when reviewer pressed Request Changes).

I don't think the https://github.com/rust-lang/rustfmt/labels/pr-not-reviewed vs https://github.com/rust-lang/rustfmt/labels/pr-follow-up-review-pending distinction makes a lot of difference in practice. However, we can  still keep the https://github.com/rust-lang/rustfmt/labels/pr-follow-up-review-pending label, since that is previously manually applied anyway.

See also `shortcuts` below.

## `shortcuts`

See <https://forge.rust-lang.org/triagebot/shortcuts.html>:

> Shortcuts are simple commands for performing common tasks.

Basically, convenience method for toggling between the PR states {https://github.com/rust-lang/rustfmt/labels/S-waiting-on-author, https://github.com/rust-lang/rustfmt/labels/S-waiting-on-review, https://github.com/rust-lang/rustfmt/labels/S-blocked } *even when* the user does not have write access to this repo (so cannot use label UI):

```
@rustbot ready   # S-{waiting-on-author,blocked} -> S-waiting-on-review
@rustbot author  # S-{waiting-on-review,blocked} -> S-waiting-on-author
@rustbot blocked # S-waiting-on-{author,review}  -> S-blocked
```

## `review-changes-since`

See <https://forge.rust-lang.org/triagebot/review-changes-since.html>:

> This feature will automatically adjust the body of a GitHub review to include a link to view the changes that happened since the review.

I.e. a rendered page of `range-diff` so that the reviewer don't need to do it locally.

