### PR TITLE
Actually enable triagebot `range-diff`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -56,8 +56,13 @@ remove_labels = ["S-waiting-on-author"]
 # Those labels are added when PR author requests a review from an assignee
 add_labels = ["S-waiting-on-review"]
 
+# Enable comments linking to triagebot range-diff when a PR is rebased
+# onto a different base commit.
+# Documentation at: https://forge.rust-lang.org/triagebot/range-diff.html
+[range-diff]
+
 # Adds at the end of a review body a link to view the changes that happened
-# since the review
+# since the review.
 # Documentation at: https://forge.rust-lang.org/triagebot/review-changes-since.html
 [review-changes-since]
 


### PR DESCRIPTION
I kinda confused `review-changes-since` versus `range-diff`:

- `review-changes-since` is moreso for "changes going forward since last approving review".
- `range-diff` is actually the, well, range-diff I was thinking of.