### PR TITLE
Improve error for nightly-only '--message-format' args

### DIFF
--- a/src/cargo-fmt/test/message_format.rs
+++ b/src/cargo-fmt/test/message_format.rs
@@ -1,7 +1,10 @@
 use super::*;
 
+use rustfmt_config_proc_macro::{nightly_only_test, stable_only_test};
+
+#[nightly_only_test]
 #[test]
-fn invalid_message_format() {
+fn invalid_message_format_nightly() {
     assert_eq!(
         convert_message_format_to_rustfmt_args("awesome", &mut vec![]),
         Err(String::from(
@@ -10,6 +13,18 @@ fn invalid_message_format() {
     );
 }
 
+#[stable_only_test]
+#[test]
+fn invalid_message_format_stable() {
+    assert_eq!(
+        convert_message_format_to_rustfmt_args("awesome", &mut vec![]),
+        Err(String::from(
+            "invalid --message-format value: awesome. Allowed values are: short|human"
+        )),
+    );
+}
+
+#[nightly_only_test]
 #[test]
 fn json_message_format_and_check_arg() {
     let mut args = vec![String::from("--check")];
@@ -21,6 +36,7 @@ fn json_message_format_and_check_arg() {
     );
 }
 
+#[nightly_only_test]
 #[test]
 fn json_message_format_and_emit_arg() {
     let mut args = vec![String::from("--emit"), String::from("checkstyle")];
@@ -32,6 +48,18 @@ fn json_message_format_and_emit_arg() {
     );
 }
 
+#[stable_only_test]
+#[test]
+fn json_message_format_non_nightly() {
+    assert_eq!(
+        convert_message_format_to_rustfmt_args("json", &mut vec![]),
+        Err(String::from(
+            "--message-format json is only supported in nightly builds"
+        )),
+    );
+}
+
+#[nightly_only_test]
 #[test]
 fn json_message_format() {
     let mut args = vec![String::from("--edition"), String::from("2018")];


### PR DESCRIPTION
Previously on a stable build (`json` is only supported in `nightly` builds):

    $ cargo fmt --message-format json
    Invalid value for `--emit` - using an unstable value without `--unstable-features`

With this change:

    $ CFG_RELEASE_CHANNEL=stable cargo make bin-build
    $ PATH="./target/debug:$PATH" cargo fmt --message-format json
    --message-format json is only supported in nightly builds
    This utility formats all bin and lib files of the current crate using rustfmt.
    <-- SNIP: the rest of the usage follows -->

This behaviour is similar to how args to `--emit` are handled in `rustfmt`.

This change also drops displaying `json` as an option to `--message-format` on stable builds:

    $ PATH="./target/debug:$PATH" cargo fmt --help | grep --max-count 1 --after-context 1 message-format
        --message-format <message-format>
            Specify message-format: short|human

This required rewriting the check for nightly builds (copying from the one in `src/release_channel.rs`) to be `const` so I could rewrite the `--message-format` flag's help string.

Fixes #6752