### PR TITLE
Fix `use` <2024 identifier sorting transitivity

### DIFF
--- a/tests/source/use-identifier-order-mixed-edition.rs
+++ b/tests/source/use-identifier-order-mixed-edition.rs
@@ -1,0 +1,13 @@
+// rustfmt-edition: 2024
+// rustfmt-style_edition: 2021
+// rustfmt-reorder_imports: true
+
+use a::{
+    Big, small, t_i_n_y, HUGE, SCREAMING_LOUDLY, or_quietly, OrInTheMiddle
+};
+
+use a::{
+    _bind_this_one_has_underscore, A1, A2, A3, A4, A5, A6, A7, A9, UnescapeOptions, bind_11,
+    bind_12, build_13, check_14, check_15, coerce_16, construct_17, construct_18, create_19, df_20,
+    expand_21,
+};

--- a/tests/source/use-identifier-order.rs
+++ b/tests/source/use-identifier-order.rs
@@ -1,0 +1,13 @@
+// rustfmt-edition: 2021
+// rustfmt-style_edition: 2021
+// rustfmt-reorder_imports: true
+
+use a::{
+    Big, small, t_i_n_y, HUGE, SCREAMING_LOUDLY, or_quietly, OrInTheMiddle
+};
+
+use a::{
+    _bind_this_one_has_underscore, A1, A2, A3, A4, A5, A6, A7, A9, UnescapeOptions, bind_11,
+    bind_12, build_13, check_14, check_15, coerce_16, construct_17, construct_18, create_19, df_20,
+    expand_21,
+};

--- a/tests/target/use-identifier-order-mixed-edition.rs
+++ b/tests/target/use-identifier-order-mixed-edition.rs
@@ -1,0 +1,11 @@
+// rustfmt-edition: 2024
+// rustfmt-style_edition: 2021
+// rustfmt-reorder_imports: true
+
+use a::{or_quietly, small, t_i_n_y, Big, OrInTheMiddle, HUGE, SCREAMING_LOUDLY};
+
+use a::{
+    _bind_this_one_has_underscore, bind_11, bind_12, build_13, check_14, check_15, coerce_16,
+    construct_17, construct_18, create_19, df_20, expand_21, UnescapeOptions, A1, A2, A3, A4, A5,
+    A6, A7, A9,
+};

--- a/tests/target/use-identifier-order.rs
+++ b/tests/target/use-identifier-order.rs
@@ -1,0 +1,11 @@
+// rustfmt-edition: 2021
+// rustfmt-style_edition: 2021
+// rustfmt-reorder_imports: true
+
+use a::{or_quietly, small, t_i_n_y, Big, OrInTheMiddle, HUGE, SCREAMING_LOUDLY};
+
+use a::{
+    _bind_this_one_has_underscore, bind_11, bind_12, build_13, check_14, check_15, coerce_16,
+    construct_17, construct_18, create_19, df_20, expand_21, UnescapeOptions, A1, A2, A3, A4, A5,
+    A6, A7, A9,
+};


### PR DESCRIPTION
The sorting tries to create a lowercase>Capital>SCREAMING relation, but does this in a way that causes non-transitive behavior for identifiers starting with `_`. These identifiers are neither Capital nor SCREAMING so they are always compared via lexicographic ASCII matching.

This causes a problem, because `A < _ < a` lexicographically in ASCII. But `A > a` with our special case rules!

When doing these manual comparisons, hitting these issues is very easy. To fix this, we can simply create a sorting key that mirrors our desired order and sort that normally. This way, it's guaranteed to have all the necessary properties.

By *always* sorting uppercase identifiers first, we ensure that `A > _`.

fixes #6668

This may cause formatting changes if there are identifiers starting with `_` in use items, but that breakage is necessary as the previous formatting was completely arbitrary and subject to change by the standard library (and prone to crash rustfmt alltogether).