### PR TITLE
triagebot: autolabel merged PRs with `release-notes`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -22,6 +22,11 @@ exclude_labels = [
     "C-tracking-issue",
 ]
 
+# By default, we will tag merged PRs with `release-notes`; they can be removed
+# manually if we determine that a PR does not need relnotes.
+[autolabel."release-notes"]
+pr_merged = true
+
 [autolabel."A-CI"]
 trigger_files = [
     ".github/workflows",


### PR DESCRIPTION
`release-notes` is intended to be manually removed if a merged PR does not need relnotes.

Context was:

> The label helps us know what set of PRs we should consider when putting together the CHANGELOG entry before we do the full subtree-sync with r-l/rust.

r? @ytmimi (as discussed)