### PR TITLE
fix: properly wrap long `impl trait` function parameters

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1016,9 +1016,14 @@ impl Rewrite for ast::Ty {
                 }
                 let rw = if context.config.style_edition() <= StyleEdition::Edition2021 {
                     it.rewrite_result(context, shape)
+                } else if context.config.style_edition() == StyleEdition::Edition2024 {
+                    join_bounds(context, shape, it, false)
                 } else {
+                    let offset = "impl ".len();
+                    let shape = shape.offset_left(offset, self.span())?;
                     join_bounds(context, shape, it, false)
                 };
+
                 rw.map(|it_str| {
                     let space = if it_str.is_empty() { "" } else { " " };
                     format!("impl{}{}", space, it_str)

--- a/tests/source/issue_6381_style_edition_2027.rs
+++ b/tests/source/issue_6381_style_edition_2027.rs
@@ -1,0 +1,11 @@
+// rustfmt-style_edition: 2027
+
+fn my_function_no_wrap_at_exactly_100_characters_wide(
+    my_long_impl_trait_parameter: impl Into<LongTypeNameThatMakesThisWholeLineExactly100Chars_____>,
+) {
+}
+
+fn my_function_wraps_at_at_exactly_101_characters_wide(
+    my_long_impl_trait_parameter: impl Into<LongTypeNameThatMakesThisWholeLineExactly101Chars______>,
+) {
+}

--- a/tests/target/issue_6381_style_edition_2024.rs
+++ b/tests/target/issue_6381_style_edition_2024.rs
@@ -1,0 +1,11 @@
+// rustfmt-style_edition: 2024
+
+fn my_function_no_wrap_at_exactly_100_characters_wide(
+    my_long_impl_trait_parameter: impl Into<LongTypeNameThatMakesThisWholeLineExactly100Chars_____>,
+) {
+}
+
+fn my_function_wraps_at_at_exactly_101_characters_wide(
+    my_long_impl_trait_parameter: impl Into<LongTypeNameThatMakesThisWholeLineExactly101Chars______>,
+) {
+}

--- a/tests/target/issue_6381_style_edition_2027.rs
+++ b/tests/target/issue_6381_style_edition_2027.rs
@@ -1,0 +1,13 @@
+// rustfmt-style_edition: 2027
+
+fn my_function_no_wrap_at_exactly_100_characters_wide(
+    my_long_impl_trait_parameter: impl Into<LongTypeNameThatMakesThisWholeLineExactly100Chars_____>,
+) {
+}
+
+fn my_function_wraps_at_at_exactly_101_characters_wide(
+    my_long_impl_trait_parameter: impl Into<
+        LongTypeNameThatMakesThisWholeLineExactly101Chars______,
+    >,
+) {
+}


### PR DESCRIPTION
Fixes #6381 

Before we weren't taking the length of `impl ` into account so the trait thought it had more room than it actually did to format itself on a single line.