### PR TITLE
Fix comments rewritten too long

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -263,7 +263,7 @@ impl<'a> FmtVisitor<'a> {
         };
 
         let comment_width = ::std::cmp::min(
-            self.config.comment_width(),
+            self.config.comment_width() - self.block_indent.width(),
             self.config.max_width() - self.block_indent.width(),
         );
         let comment_shape = Shape::legacy(comment_width, comment_indent);

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -269,11 +269,7 @@ impl<'a> FmtVisitor<'a> {
             Indent::from_width(self.config, last_line_width(&self.buffer))
         };
 
-        let comment_width = ::std::cmp::min(
-            self.config.comment_width(),
-            self.config.max_width() - self.block_indent.width(),
-        );
-        let comment_shape = Shape::legacy(comment_width, comment_indent);
+        let comment_shape = Shape::indented(comment_indent, self.config).comment(self.config);
 
         if on_same_line {
             match subslice.find('\n') {

--- a/tests/source/issue-5023.rs
+++ b/tests/source/issue-5023.rs
@@ -1,22 +1,15 @@
 // rustfmt-wrap_comments: true
 
+// below we try and force a split at a byte in the middle of a multi-byte
+// character. The two parts of the first line are constructed such that:
+// 1) the entire line is longer than `$comment_width`
+// 2) the length of the second part is such that:
+//   `$comment_width - 3 + $length` is positive _and_ less than the number of
+//   bytes in the multi-byte char
+
+// xxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+// 是
+
 /// A comment to test special unicode characters on boundaries
 /// 是，是，是，是，是，是，是，是，是，是，是，是  it should break right here this goes to the next line
-fn main() {
-    if xxx {
-        let xxx = xxx
-            .into_iter()
-            .filter(|(xxx, xxx)| {
-                if let Some(x) = Some(1) {
-                    // xxxxxxxxxxxxxxxxxx, xxxxxxxxxxxx, xxxxxxxxxxxxxxxxxxxx xxx xxxxxxx, xxxxx xxx
-                    // xxxxxxxxxx. xxxxxxxxxxxxxxxx，xxxxxxxxxxxxxxxxx xxx xxxxxxx
-                    // 是sdfadsdfxxxxxxxxx，sdfaxxxxxx_xxxxx_masdfaonxxx，
-                    if false {
-                        return true;
-                    }
-                }
-                false
-            })
-            .collect();
-    }
-}
+fn main() {}

--- a/tests/source/issue-5023.rs
+++ b/tests/source/issue-5023.rs
@@ -1,5 +1,15 @@
 // rustfmt-wrap_comments: true
 
+// below we try and force a split at a byte in the middle of a multi-byte
+// character. The two parts of the first line are constructed such that:
+// 1) the entire line is longer than `$comment_width`
+// 2) the length of the second part is such that:
+//   `$comment_width - 3 + $length` is positive _and_ less than the number of
+//   bytes in the multi-byte char
+
+// xxxxxxxxxx xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+// 是
+
 /// A comment to test special unicode characters on boundaries
 /// 是，是，是，是，是，是，是，是，是，是，是，是  it should break right here this goes to the next line
 fn main() {

--- a/tests/source/issue_6801.rs
+++ b/tests/source/issue_6801.rs
@@ -1,0 +1,7 @@
+// rustfmt-wrap_comments: true
+
+fn foo() {
+    // this is a comment that could be broken right on max_comment and should break before that
+
+    ()
+}

--- a/tests/source/issue_6801.rs
+++ b/tests/source/issue_6801.rs
@@ -1,0 +1,52 @@
+// rustfmt-wrap_comments: true
+// rustfmt-comment_width: 80
+// rustfmt-max_width: 200
+
+fn foo() {
+    // In this line, the next '.' is exactly at'comment_width'                 . It should break on that dot
+
+    // In this line, 'comment_width' is reached in the middle of ThisVeryLongWord. It should break before that word
+
+    {
+        {
+            {
+                {
+                    // again 'comment_width' is just at the next '.'           . Here's some more stuff
+                    fn f1() {
+                        fn f2() {
+                            fn f3() {
+                                fn f4() {
+                                    fn f5() {
+                                        fn f6() {
+                                            fn f7() {
+                                                fn f8() {
+                                                    fn f9() {
+                                                        fn f10() {
+                                                            fn f11() {
+                                                                // again       . Deeply nested comment
+                                                                fn f12() {
+                                                                    fn f13() {
+                                                                        fn f14() {
+                                                                            fn f15() {
+                                                                                // indentation means this comment starts after 'comment_width'
+                                                                                // we don't touch this comment
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/target/issue-5023.rs
+++ b/tests/target/issue-5023.rs
@@ -1,23 +1,17 @@
 // rustfmt-wrap_comments: true
 
+// below we try and force a split at a byte in the middle of a multi-byte
+// character. The two parts of the first line are constructed such that:
+// 1) the entire line is longer than `$comment_width`
+// 2) the length of the second part is such that:
+//   `$comment_width - 3 + $length` is positive _and_ less than the number of
+//   bytes in the multi-byte char
+
+// xxxxxxxxxx
+// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+// 是
+
 /// A comment to test special unicode characters on boundaries
 /// 是，是，是，是，是，是，是，是，是，是，是，是  it should break right here
 /// this goes to the next line
-fn main() {
-    if xxx {
-        let xxx = xxx
-            .into_iter()
-            .filter(|(xxx, xxx)| {
-                if let Some(x) = Some(1) {
-                    // xxxxxxxxxxxxxxxxxx, xxxxxxxxxxxx, xxxxxxxxxxxxxxxxxxxx xxx xxxxxxx, xxxxx xxx
-                    // xxxxxxxxxx. xxxxxxxxxxxxxxxx，xxxxxxxxxxxxxxxxx xxx xxxxxxx
-                    // 是sdfadsdfxxxxxxxxx，sdfaxxxxxx_xxxxx_masdfaonxxx，
-                    if false {
-                        return true;
-                    }
-                }
-                false
-            })
-            .collect();
-    }
-}
+fn main() {}

--- a/tests/target/issue-5023.rs
+++ b/tests/target/issue-5023.rs
@@ -1,5 +1,16 @@
 // rustfmt-wrap_comments: true
 
+// below we try and force a split at a byte in the middle of a multi-byte
+// character. The two parts of the first line are constructed such that:
+// 1) the entire line is longer than `$comment_width`
+// 2) the length of the second part is such that:
+//   `$comment_width - 3 + $length` is positive _and_ less than the number of
+//   bytes in the multi-byte char
+
+// xxxxxxxxxx
+// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+// 是
+
 /// A comment to test special unicode characters on boundaries
 /// 是，是，是，是，是，是，是，是，是，是，是，是  it should break right here
 /// this goes to the next line

--- a/tests/target/issue-5023.rs
+++ b/tests/target/issue-5023.rs
@@ -20,8 +20,9 @@ fn main() {
             .into_iter()
             .filter(|(xxx, xxx)| {
                 if let Some(x) = Some(1) {
-                    // xxxxxxxxxxxxxxxxxx, xxxxxxxxxxxx, xxxxxxxxxxxxxxxxxxxx xxx xxxxxxx, xxxxx xxx
-                    // xxxxxxxxxx. xxxxxxxxxxxxxxxx，xxxxxxxxxxxxxxxxx xxx xxxxxxx
+                    // xxxxxxxxxxxxxxxxxx, xxxxxxxxxxxx, xxxxxxxxxxxxxxxxxxxx
+                    // xxx xxxxxxx, xxxxx xxx xxxxxxxxxx.
+                    // xxxxxxxxxxxxxxxx，xxxxxxxxxxxxxxxxx xxx xxxxxxx
                     // 是sdfadsdfxxxxxxxxx，sdfaxxxxxx_xxxxx_masdfaonxxx，
                     if false {
                         return true;

--- a/tests/target/issue_6801.rs
+++ b/tests/target/issue_6801.rs
@@ -1,0 +1,8 @@
+// rustfmt-wrap_comments: true
+
+fn foo() {
+    // this is a comment that could be broken right on max_comment and should
+    // break before that
+
+    ()
+}

--- a/tests/target/issue_6801.rs
+++ b/tests/target/issue_6801.rs
@@ -1,0 +1,57 @@
+// rustfmt-wrap_comments: true
+// rustfmt-comment_width: 80
+// rustfmt-max_width: 200
+
+fn foo() {
+    // In this line, the next '.' is exactly at'comment_width'                 .
+    // It should break on that dot
+
+    // In this line, 'comment_width' is reached in the middle of
+    // ThisVeryLongWord. It should break before that word
+
+    {
+        {
+            {
+                {
+                    // again 'comment_width' is just at the next '.'           .
+                    // Here's some more stuff
+                    fn f1() {
+                        fn f2() {
+                            fn f3() {
+                                fn f4() {
+                                    fn f5() {
+                                        fn f6() {
+                                            fn f7() {
+                                                fn f8() {
+                                                    fn f9() {
+                                                        fn f10() {
+                                                            fn f11() {
+                                                                // again       .
+                                                                // Deeply nested
+                                                                // comment
+                                                                fn f12() {
+                                                                    fn f13() {
+                                                                        fn f14() {
+                                                                            fn f15() {
+                                                                                // indentation means this comment starts after 'comment_width'
+                                                                                // we don't touch this comment
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/target/trailing_comments/hard_tabs.rs
+++ b/tests/target/trailing_comments/hard_tabs.rs
@@ -18,10 +18,10 @@ fn lorem_ipsum() {
 	// nunc. Mauris consequat, enim vitae venenatis sollicitudin, dolor orci
 	// bibendum enim, a sagittis nulla nunc quis elit. Phasellus augue. Nunc
 	// suscipit, magna tincidunt lacinia faucibus, lacus tellus ornare purus, a
-	// pulvinar lacus orci eget nibh.  Maecenas sed nibh non lacus tempor faucibus.
-	// In hac habitasse platea dictumst. Vivamus a orci at nulla tristique
-	// condimentum. Donec arcu quam, dictum accumsan, convallis accumsan, cursus sit
-	// amet, ipsum.  In pharetra sagittis nunc.
+	// pulvinar lacus orci eget nibh.  Maecenas sed nibh non lacus tempor
+	// faucibus. In hac habitasse platea dictumst. Vivamus a orci at nulla
+	// tristique condimentum. Donec arcu quam, dictum accumsan, convallis
+	// accumsan, cursus sit amet, ipsum.  In pharetra sagittis nunc.
 	let b = baz();
 
 	let normalized = self.ctfont.all_traits().normalized_weight(); // [-1.0, 1.0]

--- a/tests/target/trailing_comments/soft_tabs.rs
+++ b/tests/target/trailing_comments/soft_tabs.rs
@@ -18,10 +18,10 @@ fn foo() {
     // nunc. Mauris consequat, enim vitae venenatis sollicitudin, dolor orci
     // bibendum enim, a sagittis nulla nunc quis elit. Phasellus augue. Nunc
     // suscipit, magna tincidunt lacinia faucibus, lacus tellus ornare purus, a
-    // pulvinar lacus orci eget nibh.  Maecenas sed nibh non lacus tempor faucibus.
-    // In hac habitasse platea dictumst. Vivamus a orci at nulla tristique
-    // condimentum. Donec arcu quam, dictum accumsan, convallis accumsan, cursus sit
-    // amet, ipsum.  In pharetra sagittis nunc.
+    // pulvinar lacus orci eget nibh.  Maecenas sed nibh non lacus tempor
+    // faucibus. In hac habitasse platea dictumst. Vivamus a orci at nulla
+    // tristique condimentum. Donec arcu quam, dictum accumsan, convallis
+    // accumsan, cursus sit amet, ipsum.  In pharetra sagittis nunc.
     let b = baz();
 
     let normalized = self.ctfont.all_traits().normalized_weight(); // [-1.0, 1.0]

--- a/tests/target/unicode.rs
+++ b/tests/target/unicode.rs
@@ -4,7 +4,8 @@ fn foo() {
     let s = "this line goes to 100: ͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶͶ";
     let s = 42;
 
-    // a comment of length 80, with the starting sigil: ҘҘҘҘҘҘҘҘҘҘ ҘҘҘҘҘҘҘҘҘҘҘҘҘҘ
+    // a comment of length 80, with the starting sigil: ҘҘҘҘҘҘҘҘҘҘ
+    // ҘҘҘҘҘҘҘҘҘҘҘҘҘҘ
     let s = 42;
 }
 


### PR DESCRIPTION
- Simplify test case for issue 5023

    By replacing the code quoted from the issue with a single comment that
    more directly exposes the issue. This is to

    1. Make the underlying issue easier to reason about
    2. Make this test not behave upon the behaviour of indentation length
       when rewriting lines (my main motivation for this change, since it
       makes the followup patch simpler)

    This was tested by partially reverting
    368a9b7cef25c22c3e836453e73d8584b251b578 with the patch:

      diff --git i/src/string.rs w/src/string.rs
      index 3b971188..561e70ac 100644
      --- i/src/string.rs
      +++ w/src/string.rs
      @@ -278,9 +278,6 @@ fn break_string(max_width: usize, trim_end: bool, line_end: &str, input: &[&str]
               }
               cur_index
           };
      -    if max_width_index_in_input == 0 {
      -        return SnippetState::EndOfInput(input.concat());
      -    }

           // Find the position in input for breaking the string
           if line_end.is_empty()

    The re-running tests, or executing `rustmft` directly on this test,
    triggered the panic from the original bug.

- Make comment wrapping indent aware

    When formatting 'missed' spans (I'm still not sure I understand exactly
    what 'missed' means).

    Previously, if `comment_width` was less than `max_width -
    $current_indent` we would format the comment ignoring the length of any
    indentation, so e.g. the following, with `comment_width=38` would not be
    formatted

        fn foo() {
            // The '.' is at 'comment_width' . A

            ()
        }

    This involved rewriting some existing tests, without impacting what
    they're meant to be asserting on. This emphasises that this patch _is
    not_ backwards compatible: while I believe the change to be correct
    (some tests had comments longer than `comment_width` that weren't being
    formatted). So there's a trade-off to be made between correctness and
    stability, since `comment_width` is still not stabilised this may be
    acceptable.

Closes: #6801