### PR TITLE
Add common issue templates and adjust triagebot configurations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,71 @@
+---
+name: General rustfmt bug Report
+about: Create a general bug report for rustfmt. Prefer more specialized issue templates if applicable.
+labels: C-bug
+---
+<!--
+Thank you for filing a bug report! 🐛 Please provide a short summary of the bug,
+along with any information you feel relevant to replicating the bug.
+-->
+
+## Summary
+
+<!--
+Please include a reproducer for the bug you are describing.
+If possible, try to provide a Minimal, Complete and Verifiable example.
+You can read "Rust Bug Minimization Patterns" for how to create smaller examples.
+http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
+-->
+
+I tried to format this code:
+
+```rust
+<code>
+```
+
+### Expected behavior
+
+I expected to see this happen: *explanation*
+
+### Actual behavior
+
+Instead, this happened: *explanation*
+
+
+## Configuration
+
+<!--
+Include any CLI options used, and include the configuration file (e.g.
+`rustfmt.toml`).
+-->
+
+`rustfmt` cli options used (if applicable):
+
+```bash
+$ <rustfmt_options>
+```
+
+`rustfmt` configuration file (e.g. `rustfmt.toml`, if applicable):
+
+```md
+<configuration_file>
+```
+
+
+## Reproduction Steps
+
+<!-- Include any steps that might be needed to reproduce this behavior -->
+
+1. ...
+
+
+## Meta
+<!--
+If you're using the stable version of rustfmt, you should also check if the
+bug also exists in the beta or nightly versions.
+-->
+
+`rustfmt --version`:
+```
+<version>
+```

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Create a feature request for rustfmt.
+labels: C-feature-request
+---
+<!--
+Please note that rustfmt's core scope is to pretty-print a parsed program's AST
+according to the rules defined in the Rust Style Guide. Supporting this function
+and its associated maintenance takes top priority. Any other features, such as
+auxiliary formatting configuration options, are secondary to that core mission.
+-->
+
+## Feature Request
+
+### Summary
+
+<!-- Please summarize what feature you are requesting. -->
+
+### Motivation
+
+<!--
+- Can you say more on why this feature would be desirable to the wider Rust
+  community as well?
+- Can you give example snippets to demonstrate the difference between having
+  and not having the proposed feature?  
+-->
+
+### Related configuration options
+
+<!--
+- Are there stable/unstable formatting configuration options related to this
+  feature request?
+-->

--- a/.github/ISSUE_TEMPLATE/ice.md
+++ b/.github/ISSUE_TEMPLATE/ice.md
@@ -1,0 +1,77 @@
+---
+name: rustfmt Internal Compiler Error (ICE)
+about: Create a report for an internal compiler error in rustfmt.
+labels: C-bug, I-ICE
+title: "[ICE]: "
+---
+<!--
+Thank you for finding an Internal Compiler Error! 🧊 If possible, try to provide
+a Minimal, Complete and Verifiable example. You can read "Rust Bug Minimization
+Patterns" for how to create smaller examples.
+http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
+-->
+
+## Code
+
+```Rust
+<code>
+```
+
+
+## Configuration
+
+<!--
+Include any CLI options used, and include the configuration file (e.g.
+`rustfmt.toml`).
+-->
+
+`rustfmt` cli options used (if applicable):
+
+```bash
+$ <rustfmt_options>
+```
+
+`rustfmt` configuration file (e.g. `rustfmt.toml`, if applicable):
+
+```md
+<configuration_file>
+```
+
+
+## Reproduction Steps
+
+<!-- Include any steps that might be needed to reproduce this behavior -->
+
+1. ...
+
+
+## Meta
+<!--
+If you're using the stable version of rustfmt, you should also check if the
+bug also exists in the beta or nightly versions.
+-->
+
+`rustfmt --version`:
+```
+<version>
+```
+
+
+## Error output
+
+```
+<output>
+```
+
+<!--
+Include a backtrace in the code block below.
+-->
+<details><summary><strong>Backtrace</strong></summary>
+<p>
+
+```
+<backtrace>
+```
+
+</p>
+</details>

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -1,0 +1,66 @@
+---
+name: Regression
+about: Report something that unexpectedly changed between rustfmt versions.
+labels: C-bug, regression-untriaged
+---
+<!--
+Thank you for filing a regression report! 🐛 A regression is something that changed between
+versions of rustfmt but was not supposed to.
+
+Please provide a short summary of the regression, along with any information you
+feel is relevant to replicate it.
+-->
+
+## Summary
+
+<!--
+Please include a reproducer for the bug you are describing.
+If possible, try to provide a Minimal, Complete and Verifiable example.
+You can read "Rust Bug Minimization Patterns" for how to create smaller examples.
+http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
+-->
+
+I tried to format this code:
+
+```rust
+<code>
+```
+
+### Expected behavior
+
+I expected to see this happen: *explanation*
+
+### Actual behavior
+
+Instead, this happened: *explanation*
+
+
+## Meta
+
+### Version it worked on
+
+<!--
+Provide the most recent version this worked on, for example:
+
+It most recently worked on: Rust 1.47
+-->
+
+It most recently worked on: <!-- version -->
+
+### Version with regression
+
+<!--
+Provide the version you are using that has the regression.
+-->
+
+`rustc --version --verbose`:
+```
+<version>
+```
+
+<!--
+If you know when this regression occurred, please add a line like below, replacing `{channel}`
+with one of stable, beta, or nightly.
+
+@rustbot modify labels: +regression-from-stable-to-{channel} -regression-untriaged
+-->

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -7,9 +7,10 @@
 
 [relabel]
 allow-unauthenticated = [
-    "needs-triage",
-    "S-*",
     "C-*",
+    "needs-triage",
+    "regression-*",
+    "S-*",
 ]
 
 # ------------------------------------------------------------------------------

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -28,6 +28,20 @@ exclude_labels = [
 [autolabel."release-notes"]
 pr_merged = true
 
+# Prioritization of regression triaging.
+[autolabel."I-prioritize"]
+trigger_labels = [
+    "regression-from-stable-to-beta",
+    "regression-from-stable-to-nightly",
+    "regression-from-stable-to-stable",
+    "regression-untriaged",
+]
+exclude_labels = [
+    "P-*",
+    "requires-nightly",
+]
+
+
 [autolabel."A-CI"]
 trigger_files = [
     ".github/workflows",


### PR DESCRIPTION
This PR adds some common issue templates, and updates some triagebot label configuration.

## Common issue templates

As discussed in [#t-rustfmt > Bug report template?](https://rust-lang.zulipchat.com/#narrow/channel/357797-t-rustfmt/topic/Bug.20report.20template.3F/with/575205813), this PR adds 4 common issue templates to nudge the issue reporter to include sufficient info + reproducer on initial open, so that issues are more likely to be actionable from the very start (to save some manual nudging and also guide the issue reporter to produce effective issues).

1. General bug report. For *general* classes of bugs. There are two special cases which should instead use the following more specialized templates...
2. Internal Compiler Error (ICE). This is separate since ICE will also have backtraces.
3. Regressions. This is separate because these should receive `regression-*` + `I-prioritization` labels, since regressions have some degree of urgency and needs impact assessment / prioritization.
4. Feature requests. A separate template, which includes a reminder about the core mission/scope of rustfmt versus auxiliary configuration options being necessarily secondary / less prioritized.

## Triagebot configuration updates

In support of the issue templates, this PR also adjusts triagebot to:

- Allow users without write access to adjust `regression-*` labels on issues via `@rustbot label`.
- Automatically attach `I-prioritize` label to `regression-*` issues if they do not already have priority `P-*` labels (or if the issue requires nightly).
  - As a follow-up, we can also setup a prioritization Zulip channel, if needed, like [#t-compiler/prioritization/alerts](https://rust-lang.zulipchat.com/#narrow/channel/245100-t-compiler.2Fprioritization.2Falerts), which `I-prioritize` label will automatically create. 

r? @ytmimi 