### PR TITLE
Update CHANGELOG for v1.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Allow `NotADirectory` errors when looking up rustfmt configuration files [#6624](https://github.com/rust-lang/rustfmt/pull/6624)
 - Prevent panic when sorting imports starting with a `_` for `style_edition=2015|2018|2021` [#6668](https://github.com/rust-lang/rustfmt/issues/6668)
 - Properly wrap long `impl trait` function parameters at the `max_width` when setting `style_edition=2027` [#6381](https://github.com/rust-lang/rustfmt/issues/6381)
+- Better support for deduplicating imports when setting `imports_granularity=Module` [#6243](https://github.com/rust-lang/rustfmt/issues/6243)
 
 ### Changed
 - Stabilize `style_edition=2024` and stabilize the `style_edition` command line option [#6431](https://github.com/rust-lang/rustfmt/pull/6431) [rust-lang/rust#134929](https://github.com/rust-lang/rust/pull/134929)


### PR DESCRIPTION
Looking at all the PRs with the `release-notes` label, these seemed to me like all the outstanding entries that needed to be mentioned.

r? @jieyouxu 