### PR TITLE
Contrib docs: note how to run a binary directly

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -116,6 +116,46 @@ If you want to test modified `cargo-fmt`, or run `rustfmt` on the whole project 
 RUSTFMT="./target/debug/rustfmt" cargo run --bin cargo-fmt -- --manifest-path path/to/project/you/want2test/Cargo.toml
 ```
 
+#### Running a binary directly
+
+You may want to run one of the built binaries directly, for example to connect
+it to a debugger. Since `rustfmt` uses `rustc_driver` it needs to be linked
+against the version of that library for the current toolchain, without
+configuring anything you are likely to run into errors like:
+
+```
+./target/debug/rustfmt: error while loading shared libraries: librustc_driver-63b8deb6c23747dd.so: cannot open shared object file: No such file or directory
+```
+
+This library will be in the sysroot of the current toolchain, which will be
+printed by `rustc --print sysroot`, so we'll need to include that in the
+system's dynamic library search path. On GNU/Linux this can be done by setting
+the `LD_LIBRARY_PATH` variable, e.g. using Bash:
+
+```
+LD_LIBRARY_PATH="$(rustc --print sysroot)/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" ./target/debug/rustfmt
+```
+
+On MacOS there is the `DYLD_LIBRARY_PATH` variable, e.g. using Bash:
+
+```
+DYLD_LIBRARY_PATH="$(rustc --print sysroot)/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" ./target/debug/rustfmt
+```
+
+And under Windows the `PATH` environment variable, e.g. using Bash:
+
+```
+PATH="$(rustc --print sysroot)/bin${PATH:+:${PATH}}"
+```
+
+Continuing the GNU/Linux example, you can invoke a debugger, e.g. `rust-gdb`,
+like:
+
+```
+LD_LIBRARY_PATH="$(rustc --print sysroot)/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" rust-gdb --args ./target/debug/rustfmt --check some_file.rs
+
+```
+
 ### Gate formatting changes
 
 A change that introduces a different code-formatting must be gated on the


### PR DESCRIPTION
Because it took me a moment to figure this out when I was wanting to run
`rustfmt` through a debugger.

For references of the variable to set to modify behaviour see
Windows[1], glibc[2], MacOS[3]

Note the examples use Bash parameter expansion, specifically the form
`${parameter:+word}`[4], to avoid potentially adding an empty element to
`LD_LIBRARY_PATH` that could be a security issue (see[5])

Some history: there used to be a note in `README.md` about setting this
variable, but that was removed with
2e75f23de810d8fad44c19de6690eebc0fbeaac3. However, with the addition of
`rustc_driver` with d7fa2ee3e6eae1a7fe4526249ce61caaa3d448d4 (original
upstream[6]) this is required again.

Link: https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order [1]
Link: https://www.man7.org/linux/man-pages/man3/dlopen.3.html [2]
Link: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen.3.html [3]
Link: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html [4]
Link: https://github.com/rust-lang/rustfmt/issues/2923 [5]
Link: https://github.com/rust-lang/rust/commit/8c000a68c5988f6e04c74180d4c0107a996110db [6]