### PR TITLE
Add Stable status to merge_imports configuration docs (#6643)

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2059,7 +2059,7 @@ This option is deprecated. Use `imports_granularity = "Crate"` instead.
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
-- **Stable**: No
+- **Stable**: No (tracking issue: [#3362](https://github.com/rust-lang/rustfmt/issues/3362))
 
 #### `false` (default):
 
@@ -2074,7 +2074,6 @@ use foo::{e, f};
 ```rust
 use foo::{a, b, c, d, e, f, g};
 ```
-
 ## `newline_style`
 
 Unix or Windows line endings

--- a/Configurations.md
+++ b/Configurations.md
@@ -2059,6 +2059,7 @@ This option is deprecated. Use `imports_granularity = "Crate"` instead.
 
 - **Default value**: `false`
 - **Possible values**: `true`, `false`
+- **Stable**: No
 
 #### `false` (default):
 
@@ -2073,7 +2074,6 @@ use foo::{e, f};
 ```rust
 use foo::{a, b, c, d, e, f, g};
 ```
-
 
 ## `newline_style`
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -2074,6 +2074,8 @@ use foo::{e, f};
 ```rust
 use foo::{a, b, c, d, e, f, g};
 ```
+
+
 ## `newline_style`
 
 Unix or Windows line endings


### PR DESCRIPTION
- Add '- **Stable**: No' line to merge_imports section
- Remove extra blank line before newline_style section
- Follow same format as other deprecated options like reorder_imports

Closes #6643