### PR TITLE
Check if function return type fits before rewriting

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2675,7 +2675,12 @@ fn rewrite_fn_base(
                 .unwrap_or(ret_shape)
         };
 
-        if multi_line_ret_str || ret_should_indent {
+        let exceeds_max_width = last_line_width(&result) + ret_str_len > context.config.max_width();
+
+        if multi_line_ret_str
+            || ret_should_indent
+            || (context.config.style_edition() >= StyleEdition::Edition2027 && exceeds_max_width)
+        {
             // Now that we know the proper indent and width, we need to
             // re-layout the return type.
             let ret_str = fd.output.rewrite_result(context, ret_shape)?;

--- a/tests/source/issue_6831_style_edition_2021.rs
+++ b/tests/source/issue_6831_style_edition_2021.rs
@@ -1,0 +1,46 @@
+// rustfmt-style_edition: 2021
+// rustfmt-max_width: 100
+
+impl<T: CapnpWrite>
+    IntoMessage<
+        capnp::message::TypedReader<
+            capnp::message::Builder<capnp::message::HeapAllocator>,
+            T::Capnp,
+        >,
+    > for T
+{
+    // Incorrectly places the return type on a single line
+    fn into_msg(
+        self,
+    ) -> capnp::message::TypedReader<
+        capnp::message::Builder<capnp::message::HeapAllocator>, T::Capnp
+    >
+    {
+        todo!()
+    }
+}
+
+impl<T> Foo for T {
+    fn into_msg_return_type_single_line_99(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type____>
+    {
+        todo!()
+    }
+
+    fn into_msg_return_type_single_line_100(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type_____>
+    {
+        todo!()
+    }
+
+    // Incorrectly places the return type on a single line
+    fn into_msg_return_type_single_line_101(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type______>
+    {
+        todo!()
+    }
+}
+

--- a/tests/source/issue_6831_style_edition_2024.rs
+++ b/tests/source/issue_6831_style_edition_2024.rs
@@ -1,0 +1,46 @@
+// rustfmt-style_edition: 2024
+// rustfmt-max_width: 100
+
+impl<T: CapnpWrite>
+    IntoMessage<
+        capnp::message::TypedReader<
+            capnp::message::Builder<capnp::message::HeapAllocator>,
+            T::Capnp,
+        >,
+    > for T
+{
+    // Incorrectly places the return type on a single line
+    fn into_msg(
+        self,
+    ) -> capnp::message::TypedReader<
+        capnp::message::Builder<capnp::message::HeapAllocator>, T::Capnp
+    >
+    {
+        todo!()
+    }
+}
+
+impl<T> Foo for T {
+    fn into_msg_return_type_single_line_99(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type____>
+    {
+        todo!()
+    }
+
+    fn into_msg_return_type_single_line_100(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type_____>
+    {
+        todo!()
+    }
+
+    // Incorrectly places the return type on a single line
+    fn into_msg_return_type_single_line_101(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type______>
+    {
+        todo!()
+    }
+}
+

--- a/tests/source/issue_6831_style_edition_2027.rs
+++ b/tests/source/issue_6831_style_edition_2027.rs
@@ -1,0 +1,44 @@
+// rustfmt-style_edition: 2027
+// rustfmt-max_width: 100
+
+impl<T: CapnpWrite>
+    IntoMessage<
+        capnp::message::TypedReader<
+            capnp::message::Builder<capnp::message::HeapAllocator>,
+            T::Capnp,
+        >,
+    > for T
+{
+    fn into_msg(
+        self,
+    ) -> capnp::message::TypedReader<
+        capnp::message::Builder<capnp::message::HeapAllocator>, T::Capnp
+    >
+    {
+        todo!()
+    }
+}
+
+impl<T> Foo for T {
+    fn into_msg_return_type_single_line_99(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type____>
+    {
+        todo!()
+    }
+
+    fn into_msg_return_type_single_line_100(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type_____>
+    {
+        todo!()
+    }
+
+
+    fn into_msg_return_type_single_line_101(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type______>
+    {
+        todo!()
+    }
+}

--- a/tests/target/issue_6831_style_edition_2021.rs
+++ b/tests/target/issue_6831_style_edition_2021.rs
@@ -1,0 +1,43 @@
+// rustfmt-style_edition: 2021
+// rustfmt-max_width: 100
+
+impl<T: CapnpWrite>
+    IntoMessage<
+        capnp::message::TypedReader<
+            capnp::message::Builder<capnp::message::HeapAllocator>,
+            T::Capnp,
+        >,
+    > for T
+{
+    // Incorrectly places the return type on a single line
+    fn into_msg(
+        self,
+    ) -> capnp::message::TypedReader<capnp::message::Builder<capnp::message::HeapAllocator>, T::Capnp>
+    {
+        todo!()
+    }
+}
+
+impl<T> Foo for T {
+    fn into_msg_return_type_single_line_99(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type____>
+    {
+        todo!()
+    }
+
+    fn into_msg_return_type_single_line_100(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type_____>
+    {
+        todo!()
+    }
+
+    // Incorrectly places the return type on a single line
+    fn into_msg_return_type_single_line_101(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type______>
+    {
+        todo!()
+    }
+}

--- a/tests/target/issue_6831_style_edition_2024.rs
+++ b/tests/target/issue_6831_style_edition_2024.rs
@@ -1,0 +1,43 @@
+// rustfmt-style_edition: 2024
+// rustfmt-max_width: 100
+
+impl<T: CapnpWrite>
+    IntoMessage<
+        capnp::message::TypedReader<
+            capnp::message::Builder<capnp::message::HeapAllocator>,
+            T::Capnp,
+        >,
+    > for T
+{
+    // Incorrectly places the return type on a single line
+    fn into_msg(
+        self,
+    ) -> capnp::message::TypedReader<capnp::message::Builder<capnp::message::HeapAllocator>, T::Capnp>
+    {
+        todo!()
+    }
+}
+
+impl<T> Foo for T {
+    fn into_msg_return_type_single_line_99(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type____>
+    {
+        todo!()
+    }
+
+    fn into_msg_return_type_single_line_100(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type_____>
+    {
+        todo!()
+    }
+
+    // Incorrectly places the return type on a single line
+    fn into_msg_return_type_single_line_101(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type______>
+    {
+        todo!()
+    }
+}

--- a/tests/target/issue_6831_style_edition_2027.rs
+++ b/tests/target/issue_6831_style_edition_2027.rs
@@ -1,0 +1,45 @@
+// rustfmt-style_edition: 2027
+// rustfmt-max_width: 100
+
+impl<T: CapnpWrite>
+    IntoMessage<
+        capnp::message::TypedReader<
+            capnp::message::Builder<capnp::message::HeapAllocator>,
+            T::Capnp,
+        >,
+    > for T
+{
+    fn into_msg(
+        self,
+    ) -> capnp::message::TypedReader<
+        capnp::message::Builder<capnp::message::HeapAllocator>,
+        T::Capnp,
+    > {
+        todo!()
+    }
+}
+
+impl<T> Foo for T {
+    fn into_msg_return_type_single_line_99(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type____>
+    {
+        todo!()
+    }
+
+    fn into_msg_return_type_single_line_100(
+        self,
+    ) -> some::long::path::to::GenericType<long::path::to::GenericType<some::Type>, some::Type_____>
+    {
+        todo!()
+    }
+
+    fn into_msg_return_type_single_line_101(
+        self,
+    ) -> some::long::path::to::GenericType<
+        long::path::to::GenericType<some::Type>,
+        some::Type______,
+    > {
+        todo!()
+    }
+}


### PR DESCRIPTION
fixes rust-lang/rustfmt#6831

This fix is gated behind `style_edition=2027` because it would impact stable formatting.