### PR TITLE
Fix formatting of commented-out empty generic bounds

### DIFF
--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -126,7 +126,8 @@ impl Spanned for ast::GenericParam {
             _ => self.ident.span.lo(),
         };
         let hi = if self.bounds.is_empty() {
-            self.ident.span.hi()
+            self.colon_span
+                .map_or(self.ident.span.hi(), |colon_span| colon_span.hi())
         } else {
             self.bounds.last().unwrap().span().hi()
         };

--- a/tests/source/commented-empty-generic-bound.rs
+++ b/tests/source/commented-empty-generic-bound.rs
@@ -1,0 +1,5 @@
+trait SpinGuardian {}
+
+struct RwLockUpgradeableGuard<'a, T, G: SpinGuardian>(&'a T, G);
+
+impl<T: /*?Sized*/, G: SpinGuardian> RwLockUpgradeableGuard<'_, T, G> {}

--- a/tests/target/commented-empty-generic-bound.rs
+++ b/tests/target/commented-empty-generic-bound.rs
@@ -1,0 +1,5 @@
+trait SpinGuardian {}
+
+struct RwLockUpgradeableGuard<'a, T, G: SpinGuardian>(&'a T, G);
+
+impl<T /*?Sized*/, G: SpinGuardian> RwLockUpgradeableGuard<'_, T, G> {}


### PR DESCRIPTION
Fix #6837

Now for code

```rust
trait SpinGuardian {}

struct RwLockUpgradeableGuard<'a, T, G: SpinGuardian>(&'a T, G);

impl<T: /*?Sized*/, G: SpinGuardian> RwLockUpgradeableGuard<'_, T, G> {}
```

The format result is 
```rust
trait SpinGuardian {}

struct RwLockUpgradeableGuard<'a, T, G: SpinGuardian>(&'a T, G);

impl<T /*?Sized*/, G: SpinGuardian> RwLockUpgradeableGuard<'_, T, G> {}
```