### PR TITLE
Fixed ICE when formatting files outside of toml dir

### DIFF
--- a/src/ignore_path.rs
+++ b/src/ignore_path.rs
@@ -22,10 +22,15 @@ impl IgnorePathSet {
     pub(crate) fn is_match(&self, file_name: &FileName) -> bool {
         match file_name {
             FileName::Stdin => false,
-            FileName::Real(p) => self
-                .ignore_set
-                .matched_path_or_any_parents(p, false)
-                .is_ignore(),
+            FileName::Real(p) => {
+                if p.is_absolute() && !p.starts_with(self.ignore_set.path()) {
+                    false
+                } else {
+                    self.ignore_set
+                        .matched_path_or_any_parents(p, false)
+                        .is_ignore()
+                }
+            }
         }
     }
 }
@@ -69,5 +74,22 @@ mod test {
         assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/what.rs"))));
         assert!(ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz/a.rs"))));
         assert!(!ignore_path_set.is_match(&FileName::Real(PathBuf::from("bar_dir/baz/what.rs"))));
+    }
+
+    #[nightly_only_test]
+    #[test]
+    fn test_ignore_path_outside_root() {
+        //See: https://github.com/rust-lang/rustfmt/issues/6843
+        use crate::config::{Config, FileName};
+        use crate::ignore_path::IgnorePathSet;
+
+        let config_path = std::env::temp_dir().join("a").join("rustfmt.toml");
+        let file_path = std::env::temp_dir().join("b").join("foo.rs");
+
+        let config = Config::from_toml(r#"ignore = ["bar.rs"]"#, &config_path).unwrap();
+        let ignore_path_set = IgnorePathSet::from_ignore_list(&config.ignore()).unwrap();
+
+        //should not panic
+        assert!(!ignore_path_set.is_match(&FileName::Real(file_path)));
     }
 }


### PR DESCRIPTION
Fixes: #6843 

The panic was happening due to a [line](https://github.com/BurntSushi/ripgrep/blob/4519153e5e461527f4bca45b042fff45c4ec6fb9/crates/ignore/src/gitignore.rs#L232) in the ignore crate: 
```rust 
assert!(!path.has_root(), "path is expected to be under the root");
```

### Fix
- Added a guard that returns false when checking if a file matches an ignore pattern, if the ignore rule's directory is not an ancestor of the file's absolute path. 
- Added a regression test

**N.b.**: This assumes that rustfmt ignore rules are supposed to be for that directory and below