### PR TITLE
fix: avoid leaking wrapper space from doc comment code block formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,8 +388,11 @@ fn format_code_block(
         .snippet
         .rfind('}')
         // trim whitespace when using `fn_single_line=true`
-        // 
-        .map(|i| formatted.snippet[..i].strip_suffix(char::is_whitespace).map_or(i, str::len))
+        .map(|i| {
+            formatted.snippet[..i]
+                .strip_suffix(char::is_whitespace)
+                .map_or(i, str::len)
+        })
         .unwrap_or_else(|| formatted.snippet.len());
 
     // It's possible that `block_len < FN_MAIN_PREFIX.len()`. This can happen if the code block was

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,6 +382,22 @@ fn format_code_block(
     // Remove wrapping main block
     formatted.unwrap_code_block();
 
+    // If wrapper collapsed to a single line like `fn main() { stmt }`,
+    // extract the body directly so the wrapper's space before `}`
+    // does not leak into final snippet.
+    if let Some(body) = formatted
+        .snippet
+        .trim_end_matches('\n')
+        .strip_prefix(FN_MAIN_PREFIX.trim_end())
+        .and_then(|s| s.strip_prefix(' '))
+        .and_then(|s| s.strip_suffix(" }"))
+    {
+        return Some(FormattedSnippet {
+            snippet: body.to_owned(),
+            non_formatted_ranges: formatted.non_formatted_ranges,
+        });
+    }
+
     // Trim "fn main() {" on the first line and "}" on the last line,
     // then unindent the whole code block.
     let block_len = formatted

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,27 +382,12 @@ fn format_code_block(
     // Remove wrapping main block
     formatted.unwrap_code_block();
 
-    // If wrapper collapsed to a single line like `fn main() { stmt }`,
-    // extract the body directly so the wrapper's space before `}`
-    // does not leak into final snippet.
-    if let Some(body) = formatted
-        .snippet
-        .trim_end_matches('\n')
-        .strip_prefix(FN_MAIN_PREFIX.trim_end())
-        .and_then(|s| s.strip_prefix(' '))
-        .and_then(|s| s.strip_suffix(" }"))
-    {
-        return Some(FormattedSnippet {
-            snippet: body.to_owned(),
-            non_formatted_ranges: formatted.non_formatted_ranges,
-        });
-    }
-
     // Trim "fn main() {" on the first line and "}" on the last line,
     // then unindent the whole code block.
     let block_len = formatted
         .snippet
         .rfind('}')
+        .map(|i| formatted.snippet[..i].strip_suffix(' ').map_or(i, str::len))
         .unwrap_or_else(|| formatted.snippet.len());
 
     // It's possible that `block_len < FN_MAIN_PREFIX.len()`. This can happen if the code block was

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,8 +387,9 @@ fn format_code_block(
     let block_len = formatted
         .snippet
         .rfind('}')
-        // trim and trailing whitespace we added, e.g. if we format to fn main { some_func(); }
-        .map(|i| formatted.snippet[..i].strip_suffix(' ').map_or(i, str::len))
+        // trim whitespace when using `fn_single_line=true`
+        // 
+        .map(|i| formatted.snippet[..i].strip_suffix(char::is_whitespace).map_or(i, str::len))
         .unwrap_or_else(|| formatted.snippet.len());
 
     // It's possible that `block_len < FN_MAIN_PREFIX.len()`. This can happen if the code block was

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,6 +387,7 @@ fn format_code_block(
     let block_len = formatted
         .snippet
         .rfind('}')
+        // trim and trailing whitespace we added, e.g. if we format to fn main { some_func(); }
         .map(|i| formatted.snippet[..i].strip_suffix(' ').map_or(i, str::len))
         .unwrap_or_else(|| formatted.snippet.len());
 

--- a/tests/target/issue-6832.rs
+++ b/tests/target/issue-6832.rs
@@ -1,0 +1,8 @@
+// rustfmt-format_code_in_doc_comments: true
+// rustfmt-fn_single_line: true
+// rustfmt-error_on_unformatted: true
+
+/// ```rust
+/// let font = String::from("hello");
+/// ```
+fn main() {}

--- a/tests/target/issue-6832.rs
+++ b/tests/target/issue-6832.rs
@@ -4,4 +4,9 @@
 /// ```rust
 /// let font = String::from("hello");
 /// ```
-fn main() {}
+fn ascii_string() {}
+
+/// ```rust
+/// let font = String::from("hello 👋😁");
+/// ```
+fn unicode_chars() {}

--- a/tests/target/issue-6832.rs
+++ b/tests/target/issue-6832.rs
@@ -1,6 +1,5 @@
 // rustfmt-format_code_in_doc_comments: true
 // rustfmt-fn_single_line: true
-// rustfmt-error_on_unformatted: true
 
 /// ```rust
 /// let font = String::from("hello");


### PR DESCRIPTION
fixes #6832

### Summary

Fixes a bug in doc comment code block formatting where `rustfmt` can introduce a trailing space and then report left behind trailing whitespace (if `error_on_unformatted = true`).

This happens with the following configuration:

```toml
format_code_in_doc_comments = true
fn_single_line = true
```

### Fix

Handle the single-line wrapped case when extracting the formatted code block body so wrapper-added whitespace is not preserved in the returned snippet.

The current fix is narrowly scoped to catch only single-line functions in doc comments. A simpler solution would be to wrap the final result with `remove_trailing_white_spaces()`, but I don’t think it’s ideal since it would somehow impact more cases.