### PR TITLE
fix: preserve blank lines when removing empty statements consistently

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -8,7 +8,7 @@ use crate::config::file_lines::FileLines;
 use crate::coverage::transform_missing_snippet;
 use crate::shape::{Indent, Shape};
 use crate::source_map::LineRangeUtils;
-use crate::utils::{count_lf_crlf, count_newlines, last_line_width, mk_sp};
+use crate::utils::{count_lf_crlf, count_newlines, is_empty_stmt_snippet, last_line_width, mk_sp};
 use crate::visitor::FmtVisitor;
 
 struct SnippetStatus {
@@ -113,7 +113,7 @@ impl<'a> FmtVisitor<'a> {
         }
     }
 
-    fn push_vertical_spaces(&mut self, mut newline_count: usize) {
+    pub(crate) fn push_vertical_spaces(&mut self, mut newline_count: usize) {
         let offset = self.buffer.chars().rev().take_while(|c| *c == '\n').count();
         let newline_upper_bound = self.config.blank_lines_upper_bound() + 1;
         let newline_lower_bound = self.config.blank_lines_lower_bound() + 1;
@@ -237,8 +237,11 @@ impl<'a> FmtVisitor<'a> {
             .chars()
             .rev()
             .find(|rev_c| ![' ', '\t'].contains(rev_c));
+        // A removed empty statement should not make the following comment look same-line.
+        let preceded_by_empty_stmt = is_empty_stmt_snippet(&snippet[..offset]);
 
-        let fix_indent = last_char.map_or(true, |rev_c| ['{', '\n'].contains(&rev_c));
+        let fix_indent =
+            preceded_by_empty_stmt || last_char.map_or(true, |rev_c| ['{', '\n'].contains(&rev_c));
         let mut on_same_line = false;
 
         let comment_indent = if fix_indent {
@@ -249,6 +252,7 @@ impl<'a> FmtVisitor<'a> {
             self.push_str(&indent_str);
             self.block_indent
         } else if self.config.style_edition() >= StyleEdition::Edition2024
+            && !preceded_by_empty_stmt
             && !snippet.starts_with('\n')
         {
             // The comment appears on the same line as the previous formatted code.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,9 @@ use rustc_ast_pretty::pprust;
 use rustc_span::{BytePos, LocalExpnId, Span, Symbol, SyntaxContext, sym, symbol};
 use unicode_width::UnicodeWidthStr;
 
-use crate::comment::{CharClasses, FullCodeCharKind, LineClasses, filter_normal_code};
+use crate::comment::{
+    CharClasses, FullCodeCharKind, LineClasses, filter_normal_code, find_comment_end,
+};
 use crate::config::{Config, StyleEdition};
 use crate::rewrite::RewriteContext;
 use crate::shape::{Indent, Shape};
@@ -352,6 +354,29 @@ pub(crate) fn count_lf_crlf(input: &str) -> (usize, usize) {
 pub(crate) fn count_newlines(input: &str) -> usize {
     // Using bytes to omit UTF-8 decoding
     bytecount::count(input.as_bytes(), b'\n')
+}
+
+pub(crate) fn is_empty_stmt_snippet(snippet: &str) -> bool {
+    let trimmed = snippet.trim();
+    !trimmed.is_empty() && trimmed.chars().all(|c| c == ';')
+}
+
+pub(crate) fn comment_after_empty_stmt(line_suffix: &str) -> Option<&str> {
+    let trimmed_suffix = line_suffix.trim_start();
+
+    if trimmed_suffix.starts_with("//") {
+        return Some(trimmed_suffix.trim_end());
+    }
+
+    if trimmed_suffix.starts_with("/*") {
+        let comment_len = find_comment_end(trimmed_suffix)?;
+        let (comment, suffix) = trimmed_suffix.split_at(comment_len);
+        if suffix.trim().is_empty() || is_empty_stmt_snippet(suffix) {
+            return Some(comment.trim_end());
+        }
+    }
+
+    None
 }
 
 // For format_missing and last_pos, need to use the source callsite (if applicable).

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -27,8 +27,8 @@ use crate::spanned::Spanned;
 use crate::stmt::Stmt;
 use crate::utils::{
     self, comment_after_empty_stmt, contains_skip, count_newlines, depr_skip_annotation,
-    format_safety, inner_attributes, is_empty_stmt_snippet, last_line_width, mk_sp,
-    ptr_vec_to_ref_vec, rewrite_ident, starts_with_newline,
+    format_safety, inner_attributes, last_line_width, mk_sp, ptr_vec_to_ref_vec, rewrite_ident,
+    starts_with_newline,
 };
 use crate::{Edition, ErrorKind, FormatReport, FormattingError};
 
@@ -122,12 +122,13 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         if stmt.is_empty() {
             // If the statement is empty, just skip over it. Before that, make sure any comment
             // snippet preceding the semicolon is picked up.
-            let prefix = self.snippet(mk_sp(self.last_pos, stmt.span().lo()));
-            let original_starts_with_newline = prefix
+            let snippet = self.snippet(mk_sp(self.last_pos, stmt.span().lo()));
+            let original_starts_with_newline = snippet
                 .find(|c| c != ' ')
-                .map_or(false, |i| starts_with_newline(&prefix[i..]));
-            let trimmed_prefix = prefix.trim();
-            if !trimmed_prefix.is_empty() {
+                .map_or(false, |i| starts_with_newline(&snippet[i..]));
+            let newline_count = count_newlines(snippet);
+            let snippet = snippet.trim();
+            if !snippet.is_empty() {
                 // FIXME(calebcartwright 2021-01-03) - This exists strictly to maintain legacy
                 // formatting where rustfmt would preserve redundant semicolons on Items in a
                 // statement position.
@@ -140,12 +141,11 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     }
 
                     self.push_str(&self.block_indent.to_string(self.config));
-                    self.push_str(trimmed_prefix);
+                    self.push_str(snippet);
                 }
             } else if include_empty_semi {
                 self.push_str(";");
             } else {
-                let prefix_newlines = count_newlines(prefix);
                 let line_suffix = self
                     .snippet_provider
                     .span_to_snippet(mk_sp(stmt.span().hi(), self.snippet_provider.end_pos()))
@@ -156,7 +156,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     .unwrap_or("");
 
                 if let Some(comment) = comment_after_empty_stmt(line_suffix) {
-                    self.push_vertical_spaces(prefix_newlines);
+                    self.push_vertical_spaces(newline_count);
                     self.push_str(&self.block_indent.to_string(self.config));
                     self.push_str(comment);
 
@@ -165,7 +165,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     return;
                 }
 
-                let blank_lines = prefix_newlines.saturating_sub(1);
+                let blank_lines = newline_count.saturating_sub(1);
                 if blank_lines > 0 {
                     self.push_str(&"\n".repeat(blank_lines));
                 }
@@ -313,8 +313,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     }
                     let span_in_between = mk_sp(last_hi, span.lo() + BytePos::from_usize(offset));
                     let snippet_in_between = self.snippet(span_in_between);
-                    let mut comment_on_same_line = !snippet_in_between.contains('\n')
-                        && !is_empty_stmt_snippet(snippet_in_between);
+                    let mut comment_on_same_line = !snippet_in_between.contains('\n');
 
                     let mut comment_shape =
                         Shape::indented(self.block_indent, config).comment(config);
@@ -377,8 +376,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     }
                 }
                 CodeCharKind::Normal if skip_normal(&sub_slice) => {
-                    extra_newline = count_newlines(&sub_slice) >= 2
-                        || (prev_ends_with_newline && sub_slice.contains('\n'));
+                    extra_newline = prev_ends_with_newline && sub_slice.contains('\n');
                     continue;
                 }
                 CodeCharKind::Normal => {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -26,8 +26,9 @@ use crate::source_map::{LineRangeUtils, SpanUtils};
 use crate::spanned::Spanned;
 use crate::stmt::Stmt;
 use crate::utils::{
-    self, contains_skip, count_newlines, depr_skip_annotation, format_safety, inner_attributes,
-    last_line_width, mk_sp, ptr_vec_to_ref_vec, rewrite_ident, starts_with_newline,
+    self, comment_after_empty_stmt, contains_skip, count_newlines, depr_skip_annotation,
+    format_safety, inner_attributes, is_empty_stmt_snippet, last_line_width, mk_sp,
+    ptr_vec_to_ref_vec, rewrite_ident, starts_with_newline,
 };
 use crate::{Edition, ErrorKind, FormatReport, FormattingError};
 
@@ -121,12 +122,12 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         if stmt.is_empty() {
             // If the statement is empty, just skip over it. Before that, make sure any comment
             // snippet preceding the semicolon is picked up.
-            let snippet = self.snippet(mk_sp(self.last_pos, stmt.span().lo()));
-            let original_starts_with_newline = snippet
+            let prefix = self.snippet(mk_sp(self.last_pos, stmt.span().lo()));
+            let original_starts_with_newline = prefix
                 .find(|c| c != ' ')
-                .map_or(false, |i| starts_with_newline(&snippet[i..]));
-            let snippet = snippet.trim();
-            if !snippet.is_empty() {
+                .map_or(false, |i| starts_with_newline(&prefix[i..]));
+            let trimmed_prefix = prefix.trim();
+            if !trimmed_prefix.is_empty() {
                 // FIXME(calebcartwright 2021-01-03) - This exists strictly to maintain legacy
                 // formatting where rustfmt would preserve redundant semicolons on Items in a
                 // statement position.
@@ -139,10 +140,35 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     }
 
                     self.push_str(&self.block_indent.to_string(self.config));
-                    self.push_str(snippet);
+                    self.push_str(trimmed_prefix);
                 }
             } else if include_empty_semi {
                 self.push_str(";");
+            } else {
+                let prefix_newlines = count_newlines(prefix);
+                let line_suffix = self
+                    .snippet_provider
+                    .span_to_snippet(mk_sp(stmt.span().hi(), self.snippet_provider.end_pos()))
+                    .map(|s| match s.find('\n') {
+                        Some(newline) => &s[..=newline],
+                        None => s,
+                    })
+                    .unwrap_or("");
+
+                if let Some(comment) = comment_after_empty_stmt(line_suffix) {
+                    self.push_vertical_spaces(prefix_newlines);
+                    self.push_str(&self.block_indent.to_string(self.config));
+                    self.push_str(comment);
+
+                    let consumed_len = line_suffix.trim_end_matches(['\n', '\r']).len();
+                    self.last_pos = stmt.span().hi() + BytePos::from_usize(consumed_len);
+                    return;
+                }
+
+                let blank_lines = prefix_newlines.saturating_sub(1);
+                if blank_lines > 0 {
+                    self.push_str(&"\n".repeat(blank_lines));
+                }
             }
             self.last_pos = stmt.span().hi();
             return;
@@ -287,7 +313,8 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     }
                     let span_in_between = mk_sp(last_hi, span.lo() + BytePos::from_usize(offset));
                     let snippet_in_between = self.snippet(span_in_between);
-                    let mut comment_on_same_line = !snippet_in_between.contains('\n');
+                    let mut comment_on_same_line = !snippet_in_between.contains('\n')
+                        && !is_empty_stmt_snippet(snippet_in_between);
 
                     let mut comment_shape =
                         Shape::indented(self.block_indent, config).comment(config);
@@ -350,7 +377,8 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                     }
                 }
                 CodeCharKind::Normal if skip_normal(&sub_slice) => {
-                    extra_newline = prev_ends_with_newline && sub_slice.contains('\n');
+                    extra_newline = count_newlines(&sub_slice) >= 2
+                        || (prev_ends_with_newline && sub_slice.contains('\n'));
                     continue;
                 }
                 CodeCharKind::Normal => {

--- a/tests/source/issue-6816.rs
+++ b/tests/source/issue-6816.rs
@@ -1,0 +1,51 @@
+fn a() {
+    let v1 = 1;
+    ;
+
+    let v2 = 2;
+}
+
+fn b() {
+    let v1 = 1;
+
+    ;
+    let v2 = 2;
+}
+
+fn c() {
+    let v1 = 1;
+
+    ; // comment
+}
+
+fn d() {
+    let v1 = 1;
+
+
+
+    ; // comment
+    let v2 = 2;
+}
+
+fn e() {
+
+    let v1 = 1;
+
+    
+    ; let v2 = 2;
+
+
+    ; // comment
+    let v3 = 3;
+}
+
+fn f() {
+    let v1 = 1;
+
+    {
+
+        ; // comment
+
+        
+    }
+}

--- a/tests/target/issue-6816.rs
+++ b/tests/target/issue-6816.rs
@@ -1,0 +1,41 @@
+fn a() {
+    let v1 = 1;
+
+    let v2 = 2;
+}
+
+fn b() {
+    let v1 = 1;
+
+    let v2 = 2;
+}
+
+fn c() {
+    let v1 = 1;
+
+    // comment
+}
+
+fn d() {
+    let v1 = 1;
+
+    // comment
+    let v2 = 2;
+}
+
+fn e() {
+    let v1 = 1;
+
+    let v2 = 2;
+
+    // comment
+    let v3 = 3;
+}
+
+fn f() {
+    let v1 = 1;
+
+    {
+        // comment
+    }
+}


### PR DESCRIPTION
fixes #6816

### Summary

Fix formatting around empty statements (`;`) so removing them does not break surrounding blank lines or comment placement. Before this change, `rustfmt` could behave inconsistently when an empty statement appeared by itself or before a trailing comment (described in original issue).

### Fix

Improved the handling of removed empty statements by __preserving__ following same-line comments, aligning blank-line behavior with `rustfmt`'s standard vertical spacing, avoiding incorrect comment recovery on stripped semicolons.

In practice, it is consistent for the following three cases:

- if a line only contains a redundant `;`, removes that line and lets normal newline handling apply
- if a line is `; <comment>`, removes only the redundant `;` and keeps the comment correctly indented on its own line
- surrounding blank lines respect the configured upper/lower bounds