### PR TITLE
 Unicode whitespace stripping in string literal line continuation

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -360,7 +360,9 @@ fn is_new_line(grapheme: &str) -> bool {
 }
 
 fn is_whitespace(grapheme: &str) -> bool {
-    grapheme.chars().all(|c| matches!(c, ' ' | '\t' | '\n' | '\r' | '\x0B' | '\x0C'))
+    grapheme
+        .chars()
+        .all(|c| matches!(c, ' ' | '\t' | '\n' | '\r' | '\x0B' | '\x0C'))
 }
 
 fn is_punctuation(grapheme: &str) -> bool {

--- a/src/string.rs
+++ b/src/string.rs
@@ -73,7 +73,7 @@ pub(crate) fn rewrite_string<'a>(
 
     // Strip line breaks.
     // With this regex applied, all remaining whitespaces are significant
-    let strip_line_breaks_re = Regex::new(r"([^\\](\\\\)*)\\[\n\r][ \t\n\r\x0B\x0C]*").unwrap();
+    let strip_line_breaks_re = Regex::new(r"([^\\](\\\\)*)\\[\n\r][[:space:]]*").unwrap();
     let stripped_str = strip_line_breaks_re.replace_all(orig, "$1");
 
     let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();

--- a/src/string.rs
+++ b/src/string.rs
@@ -73,7 +73,7 @@ pub(crate) fn rewrite_string<'a>(
 
     // Strip line breaks.
     // With this regex applied, all remaining whitespaces are significant
-    let strip_line_breaks_re = Regex::new(r"([^\\](\\\\)*)\\[\n\r][[:space:]]*").unwrap();
+    let strip_line_breaks_re = Regex::new(r"([^\\](\\\\)*)\\[\n\r][ \t\n\r\x0B\x0C]*").unwrap();
     let stripped_str = strip_line_breaks_re.replace_all(orig, "$1");
 
     let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();
@@ -360,7 +360,7 @@ fn is_new_line(grapheme: &str) -> bool {
 }
 
 fn is_whitespace(grapheme: &str) -> bool {
-    grapheme.chars().all(char::is_whitespace)
+    grapheme.chars().all(|c| matches!(c, ' ' | '\t' | '\n' | '\r' | '\x0B' | '\x0C'))
 }
 
 fn is_punctuation(grapheme: &str) -> bool {

--- a/tests/source/string_lit_unicode_ws.rs
+++ b/tests/source/string_lit_unicode_ws.rs
@@ -1,0 +1,6 @@
+// Test that Unicode Pattern_White_Space characters are not stripped after line continuation
+
+fn main() {
+    let str = "who is olaf\
+\u{00A0}This is a rust code example to show a bug in Unicode Pattern WhiteSpace";
+}

--- a/tests/source/string_lit_unicode_ws.rs
+++ b/tests/source/string_lit_unicode_ws.rs
@@ -1,6 +1,5 @@
-// Test that Unicode Pattern_White_Space characters are not stripped after line continuation
-
+// Test Unicode whitespace characters in string literal line continuation
 fn main() {
-    let str = "who is olaf\
-\u{00A0}This is a rust code example to show a bug in Unicode Pattern WhiteSpace";
+    let str = "hello \
+ world";
 }

--- a/tests/target/string_lit_unicode_ws.rs
+++ b/tests/target/string_lit_unicode_ws.rs
@@ -1,0 +1,6 @@
+// Test that Unicode Pattern_White_Space characters are not stripped after line continuation
+
+fn main() {
+    let str = "who is olaf\
+\u{00A0}This is a rust code example to show a bug in Unicode Pattern WhiteSpace";
+}

--- a/tests/target/string_lit_unicode_ws.rs
+++ b/tests/target/string_lit_unicode_ws.rs
@@ -1,6 +1,5 @@
-// Test that Unicode Pattern_White_Space characters are not stripped after line continuation
-
+// Test Unicode whitespace characters in string literal line continuation
 fn main() {
-    let str = "who is olaf\
-\u{00A0}This is a rust code example to show a bug in Unicode Pattern WhiteSpace";
+    let str = "hello \
+ world";
 }


### PR DESCRIPTION
Fixed a bug in src/string.rs where [[:space:]] in the line splitting regex and char::is_whitespace in the is_whitespace function were using Unicode whitespace definitions instead of ASCII whitespace , also added a test 


