### PR TITLE
Don't format statements that are outside of the selected file-lines range

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -148,6 +148,14 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             return;
         }
 
+        // Preserve original source snippet if the statement isn't in the selected file lines.
+        if out_of_file_lines_range!(self, stmt.span()) {
+            let stmt_span = source!(self, stmt.span());
+            self.push_str(self.snippet(mk_sp(self.last_pos, stmt_span.hi())));
+            self.last_pos = stmt_span.hi();
+            return;
+        }
+
         match stmt.as_ast_node().kind {
             ast::StmtKind::Item(ref item) => {
                 self.visit_item(item);

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -118,6 +118,14 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     fn visit_stmt(&mut self, stmt: &Stmt<'_>, include_empty_semi: bool) {
         debug!("visit_stmt: {}", self.psess.span_to_debug_info(stmt.span()));
 
+        // Preserve original source snippet if the statement isn't in the selected file lines.
+        if out_of_file_lines_range!(self, stmt.span()) {
+            let stmt_span = source!(self, stmt.span());
+            self.push_str(self.snippet(mk_sp(self.last_pos, stmt_span.hi())));
+            self.last_pos = stmt_span.hi();
+            return;
+        }
+
         if stmt.is_empty() {
             // If the statement is empty, just skip over it. Before that, make sure any comment
             // snippet preceding the semicolon is picked up.
@@ -145,14 +153,6 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 self.push_str(";");
             }
             self.last_pos = stmt.span().hi();
-            return;
-        }
-
-        // Preserve original source snippet if the statement isn't in the selected file lines.
-        if out_of_file_lines_range!(self, stmt.span()) {
-            let stmt_span = source!(self, stmt.span());
-            self.push_str(self.snippet(mk_sp(self.last_pos, stmt_span.hi())));
-            self.last_pos = stmt_span.hi();
             return;
         }
 

--- a/tests/source/issue-6863/empty-stmt.rs
+++ b/tests/source/issue-6863/empty-stmt.rs
@@ -1,0 +1,7 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6863/empty-stmt.rs","range":[5,5]}]
+
+fn main() {
+;
+println!("b");
+;
+}

--- a/tests/source/issue-6863/fn-stmts.rs
+++ b/tests/source/issue-6863/fn-stmts.rs
@@ -1,0 +1,7 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6863/fn-stmts.rs","range":[5,5]}]
+
+fn main() {
+println!("a");
+println!("b");
+println!("c");
+}

--- a/tests/target/issue-6863/empty-stmt.rs
+++ b/tests/target/issue-6863/empty-stmt.rs
@@ -1,0 +1,7 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6863/empty-stmt.rs","range":[5,5]}]
+
+fn main() {
+;
+    println!("b");
+;
+}

--- a/tests/target/issue-6863/fn-stmts.rs
+++ b/tests/target/issue-6863/fn-stmts.rs
@@ -1,0 +1,7 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6863/fn-stmts.rs","range":[5,5]}]
+
+fn main() {
+println!("a");
+    println!("b");
+println!("c");
+}


### PR DESCRIPTION
Fix for https://github.com/rust-lang/rustfmt/issues/6863. Check if a statement is covered by `--file-lines` before formatting it, preserving the original source snippet, including the preceding whitespace, if the statement is not selected.