### PR TITLE
Respect file-lines range per predicate in where clauses

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -93,7 +93,7 @@ fn format_derive(
             })?;
 
             let items = itemize_list(
-                context.snippet_provider,
+                context,
                 item_spans,
                 ")",
                 ",",

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -310,7 +310,7 @@ fn rewrite_closure_fn_decl(
     let ret_str = fn_decl.output.rewrite_result(context, param_shape)?;
 
     let param_items = itemize_list(
-        context.snippet_provider,
+        context,
         fn_decl.inputs.iter(),
         "|",
         ",",

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1843,7 +1843,7 @@ fn rewrite_struct_lit<'a>(
         };
 
         let items = itemize_list(
-            context.snippet_provider,
+            context,
             field_iter,
             "}",
             ",",
@@ -1995,7 +1995,7 @@ fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + IntoOverflowableItem<'a>>(
     let list_lo = context.snippet_provider.span_after(span, "(");
     let nested_shape = shape.sub_width(2, span)?.visual_indent(1);
     let items = itemize_list(
-        context.snippet_provider,
+        context,
         items,
         ")",
         ",",

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -476,7 +476,7 @@ impl UseTree {
                 // Extract comments between nested use items.
                 // This needs to be done before sorting use items.
                 let items = itemize_list(
-                    context.snippet_provider,
+                    context,
                     list.iter().map(|(tree, _)| tree),
                     "}",
                     ",",

--- a/src/items.rs
+++ b/src/items.rs
@@ -614,9 +614,10 @@ impl<'a> FmtVisitor<'a> {
             .max()
             .unwrap_or(&0);
 
+        let enum_context = self.get_context();
         let itemize_list_with = |one_line_width: usize| {
             itemize_list(
-                self.snippet_provider,
+                &enum_context,
                 enum_def.variants.iter(),
                 "}",
                 ",",
@@ -2852,7 +2853,7 @@ fn rewrite_params(
         return Ok(comment.to_owned());
     }
     let param_items: Vec<_> = itemize_list(
-        context.snippet_provider,
+        context,
         params.iter(),
         ")",
         ",",
@@ -3130,19 +3131,13 @@ fn rewrite_bounds_on_where_clause(
     let end_of_preds = predicates[len - 1].span().hi();
     let span_end = span_end.unwrap_or(end_of_preds);
     let items = itemize_list(
-        context.snippet_provider,
+        context,
         predicates.iter(),
         terminator,
         ",",
         |pred| pred.span().lo(),
         |pred| pred.span().hi(),
-        |pred| {
-            if out_of_file_lines_range!(context, pred.span()) {
-                Ok(context.snippet(pred.span()).to_owned())
-            } else {
-                pred.rewrite_result(context, shape)
-            }
-        },
+        |pred| pred.rewrite_result(context, shape),
         span_start,
         span_end,
         false,
@@ -3222,19 +3217,13 @@ fn rewrite_where_clause(
     let end_of_preds = predicates[len - 1].span().hi();
     let span_end = span_end.unwrap_or(end_of_preds);
     let items = itemize_list(
-        context.snippet_provider,
+        context,
         predicates.iter(),
         terminator,
         ",",
         |pred| pred.span().lo(),
         |pred| pred.span().hi(),
-        |pred| {
-            if out_of_file_lines_range!(context, pred.span()) {
-                Ok(context.snippet(pred.span()).to_owned())
-            } else {
-                pred.rewrite_result(context, Shape::legacy(budget, offset))
-            }
-        },
+        |pred| pred.rewrite_result(context, Shape::legacy(budget, offset)),
         span_start,
         span_end,
         false,

--- a/src/items.rs
+++ b/src/items.rs
@@ -3186,6 +3186,12 @@ fn rewrite_where_clause(
         return Ok(String::new());
     }
 
+    if !context.config.file_lines().is_all() && out_of_file_lines_range!(context, where_span) {
+        return Ok(context
+            .snippet(mk_sp(span_end_before_where, where_span.hi()))
+            .to_owned());
+    }
+
     if context.config.indent_style() == IndentStyle::Block {
         return rewrite_where_clause_rfc_style(
             context,

--- a/src/items.rs
+++ b/src/items.rs
@@ -3186,7 +3186,7 @@ fn rewrite_where_clause(
         return Ok(String::new());
     }
 
-    if !context.config.file_lines().is_all() && out_of_file_lines_range!(context, where_span) {
+    if out_of_file_lines_range!(context, where_span) {
         return Ok(context
             .snippet(mk_sp(span_end_before_where, where_span.hi()))
             .to_owned());

--- a/src/items.rs
+++ b/src/items.rs
@@ -3136,7 +3136,13 @@ fn rewrite_bounds_on_where_clause(
         ",",
         |pred| pred.span().lo(),
         |pred| pred.span().hi(),
-        |pred| pred.rewrite_result(context, shape),
+        |pred| {
+            if out_of_file_lines_range!(context, pred.span()) {
+                Ok(context.snippet(pred.span()).to_owned())
+            } else {
+                pred.rewrite_result(context, shape)
+            }
+        },
         span_start,
         span_end,
         false,
@@ -3222,7 +3228,13 @@ fn rewrite_where_clause(
         ",",
         |pred| pred.span().lo(),
         |pred| pred.span().hi(),
-        |pred| pred.rewrite_result(context, Shape::legacy(budget, offset)),
+        |pred| {
+            if out_of_file_lines_range!(context, pred.span()) {
+                Ok(context.snippet(pred.span()).to_owned())
+            } else {
+                pred.rewrite_result(context, Shape::legacy(budget, offset))
+            }
+        },
         span_start,
         span_end,
         false,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -10,11 +10,11 @@ use crate::config::lists::*;
 use crate::config::{Config, IndentStyle};
 use crate::rewrite::{ExceedsMaxWidthError, RewriteContext, RewriteError, RewriteResult};
 use crate::shape::{Indent, Shape};
+use crate::source_map::LineRangeUtils;
 use crate::utils::{
     count_newlines, first_line_width, last_line_width, mk_sp, starts_with_newline,
     unicode_str_width,
 };
-use crate::visitor::SnippetProvider;
 
 pub(crate) struct ListFormatting<'a> {
     tactic: DefinitiveListTactic,
@@ -564,7 +564,7 @@ pub(crate) struct ListItems<'a, I, F1, F2, F3>
 where
     I: Iterator,
 {
-    snippet_provider: &'a SnippetProvider,
+    context: &'a RewriteContext<'a>,
     inner: Peekable<I>,
     get_lo: F1,
     get_hi: F2,
@@ -751,10 +751,14 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|item| {
+            let lo = (self.get_lo)(&item);
+            let hi = (self.get_hi)(&item);
+            let context = self.context;
+
             // Pre-comment
-            let pre_snippet = self
+            let pre_snippet = context
                 .snippet_provider
-                .span_to_snippet(mk_sp(self.prev_span_end, (self.get_lo)(&item)))
+                .span_to_snippet(mk_sp(self.prev_span_end, lo))
                 .unwrap_or("");
             let (pre_comment, pre_comment_style) = extract_pre_comment(pre_snippet);
 
@@ -763,9 +767,9 @@ where
                 Some(next_item) => (self.get_lo)(next_item),
                 None => self.next_span_start,
             };
-            let post_snippet = self
+            let post_snippet = context
                 .snippet_provider
-                .span_to_snippet(mk_sp((self.get_hi)(&item), next_start))
+                .span_to_snippet(mk_sp(hi, next_start))
                 .unwrap_or("");
             let is_last = self.inner.peek().is_none();
             let comment_end =
@@ -774,14 +778,17 @@ where
             let post_comment =
                 extract_post_comment(post_snippet, comment_end, self.separator, is_last);
 
-            self.prev_span_end = (self.get_hi)(&item) + BytePos(comment_end as u32);
+            self.prev_span_end = hi + BytePos(comment_end as u32);
 
+            let item_span = mk_sp(lo, hi);
             ListItem {
                 pre_comment,
                 pre_comment_style,
                 // leave_last is set to true only for rewrite_items
                 item: if self.inner.peek().is_none() && self.leave_last {
                     Err(RewriteError::SkipFormatting)
+                } else if out_of_file_lines_range!(context, item_span) {
+                    Ok(context.snippet(item_span).to_owned())
                 } else {
                     (self.get_item_string)(&item)
                 },
@@ -795,7 +802,7 @@ where
 #[allow(clippy::too_many_arguments)]
 // Creates an iterator over a list's items with associated comments.
 pub(crate) fn itemize_list<'a, T, I, F1, F2, F3>(
-    snippet_provider: &'a SnippetProvider,
+    context: &'a RewriteContext<'a>,
     inner: I,
     terminator: &'a str,
     separator: &'a str,
@@ -813,7 +820,7 @@ where
     F3: Fn(&T) -> RewriteResult,
 {
     ListItems {
-        snippet_provider,
+        context,
         inner: inner.peekable(),
         get_lo,
         get_hi,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -465,7 +465,7 @@ pub(crate) fn rewrite_macro_def(
     }
 
     let branch_items = itemize_list(
-        context.snippet_provider,
+        context,
         parsed_def.branches.iter(),
         "}",
         ";",

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -222,7 +222,7 @@ fn rewrite_match_arms(
         .chain(repeat(true));
     let beginning_verts = collect_beginning_verts(context, arms);
     let items = itemize_list(
-        context.snippet_provider,
+        context,
         arms.iter()
             .zip(is_last_iter)
             .zip(beginning_verts.into_iter())

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -625,7 +625,7 @@ impl<'a> Context<'a> {
         debug!("items: {:?}", self.items);
 
         let items = itemize_list(
-            self.context.snippet_provider,
+            self.context,
             self.items.iter(),
             self.suffix,
             ",",

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -429,7 +429,7 @@ fn rewrite_struct_pat(
     )?;
 
     let items = itemize_list(
-        context.snippet_provider,
+        context,
         fields.iter(),
         terminator,
         ",",
@@ -651,7 +651,7 @@ fn count_wildcard_suffix_len(
     let mut suffix_len = 0;
 
     let items: Vec<_> = itemize_list(
-        context.snippet_provider,
+        context,
         patterns.iter(),
         ")",
         ",",

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -110,7 +110,7 @@ fn rewrite_reorderable_or_regroupable_items(
             let cloned = normalized_items.clone();
             // Add comments before merging.
             let list_items = itemize_list(
-                context.snippet_provider,
+                context,
                 cloned.iter(),
                 "",
                 ";",
@@ -169,7 +169,7 @@ fn rewrite_reorderable_or_regroupable_items(
         }
         _ => {
             let list_items = itemize_list(
-                context.snippet_provider,
+                context,
                 reorderable_items.iter(),
                 "",
                 ";",

--- a/src/types.rs
+++ b/src/types.rs
@@ -380,7 +380,7 @@ where
         (comment, tactic)
     } else {
         let items = itemize_list(
-            context.snippet_provider,
+            context,
             inputs,
             ")",
             ",",

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -222,7 +222,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
     }
 
     let mut items = itemize_list(
-        context.snippet_provider,
+        context,
         fields.iter(),
         "}",
         ",",

--- a/tests/source/file-lines-where-clause-skip.rs
+++ b/tests/source/file-lines-where-clause-skip.rs
@@ -1,0 +1,9 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-where-clause-skip.rs","range":[8,8]}]
+
+fn foo<T>() where
+T: Clone,
+T: Copy,
+T: Default,
+{
+    let x=1;
+}

--- a/tests/source/file-lines-where-clause.rs
+++ b/tests/source/file-lines-where-clause.rs
@@ -1,0 +1,9 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-where-clause.rs","range":[5,5]}]
+
+fn foo<T, U, V>()
+where
+    T:  Clone + Debug,
+    U:  Copy,
+    V: Default,
+{
+}

--- a/tests/source/file-lines-where-clause.rs
+++ b/tests/source/file-lines-where-clause.rs
@@ -2,8 +2,8 @@
 
 fn foo<T, U, V>()
 where
-    T:  Clone + Debug,
-    U:  Copy,
-    V: Default,
+    T     :     Clone      +     Debug,
+    U    :       Copy,
+    V   :        Default,
 {
 }

--- a/tests/target/file-lines-where-clause-skip.rs
+++ b/tests/target/file-lines-where-clause-skip.rs
@@ -1,0 +1,9 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-where-clause-skip.rs","range":[8,8]}]
+
+fn foo<T>() where
+T: Clone,
+T: Copy,
+T: Default,
+{
+    let x = 1;
+}

--- a/tests/target/file-lines-where-clause.rs
+++ b/tests/target/file-lines-where-clause.rs
@@ -1,0 +1,9 @@
+// rustfmt-file_lines: [{"file":"tests/source/file-lines-where-clause.rs","range":[5,5]}]
+
+fn foo<T, U, V>()
+where
+    T: Clone + Debug,
+    U:  Copy,
+    V: Default,
+{
+}

--- a/tests/target/file-lines-where-clause.rs
+++ b/tests/target/file-lines-where-clause.rs
@@ -3,7 +3,7 @@
 fn foo<T, U, V>()
 where
     T: Clone + Debug,
-    U:  Copy,
-    V: Default,
+    U    :       Copy,
+    V   :        Default,
 {
 }


### PR DESCRIPTION
Solves https://github.com/rust-lang/rustfmt/issues/6872

## Summary
- `rewrite_bounds_on_where_clause` (Block/RFC indent path) and the Visual-indent path in `rewrite_where_clause` both unconditionally rewrote every predicate, causing the entire where clause to be reformatted even when only a subset of predicate lines were selected via `--file-lines`
- Fixed by checking `out_of_file_lines_range!` per predicate inside the `itemize_list` closure — predicates outside the selected range now fall back to their original source text, predicates inside are formatted normally
- Follows the same pattern already used in `src/expr.rs`, `src/stmt.rs`, and `src/visitor.rs`
- Adds `tests/source/file-lines-where-clause.rs` + `tests/target/file-lines-where-clause.rs` to cover the partial-formatting case

## Test Plan
- [x] `cargo test` passes
- [x] New test `file-lines-where-clause` verifies that only the predicate on the selected line is reformatted; out-of-range predicates retain their original text
- [x] Existing `file-lines-*` tests continue to pass (no regression in full-range formatting)
- [x] Idempotency check passes (formatting the output a second time is a no-op)
