### PR TITLE
Fix hybrid formatting of struct patterns containing `..`

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -470,9 +470,7 @@ impl UseTree {
                     style_edition,
                 });
             }
-            UseTreeKind::Nested {
-                items: ref list, ..
-            } => {
+            UseTreeKind::Nested { items: ref list, .. } => {
                 // Extract comments between nested use items.
                 // This needs to be done before sorting use items.
                 let items = itemize_list(

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -478,8 +478,22 @@ fn rewrite_struct_pat(
         fields_str.push_str("..");
     }
 
+    // one_line_width was reduced by ellipsis_str.len() via struct_lit_shape,
+    // but fields_str now includes those chars after the ellipsis block above.
+    let adjusted_one_line_width = if ellipsis {
+        one_line_width + ellipsis_str.len()
+    } else {
+        one_line_width
+    };
     // ast::Pat doesn't have attrs so use &[]
-    let fields_str = wrap_struct_field(context, &[], &fields_str, shape, v_shape, one_line_width)?;
+    let fields_str = wrap_struct_field(
+        context,
+        &[],
+        &fields_str,
+        shape,
+        v_shape,
+        adjusted_one_line_width,
+    )?;
     Ok(format!("{path_str} {{{fields_str}}}"))
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -396,13 +396,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         let indent = self.block_indent;
         let block;
         let rewrite = match fk {
-            visit::FnKind::Fn(
-                _,
-                _,
-                ast::Fn {
-                    body: Some(ref b), ..
-                },
-            ) => {
+            visit::FnKind::Fn(_, _, ast::Fn { body: Some(ref b), .. }) => {
                 block = b;
                 self.rewrite_fn_before_block(
                     indent,

--- a/tests/source/issue-6827.rs
+++ b/tests/source/issue-6827.rs
@@ -1,0 +1,13 @@
+fn main() {
+    // case 1: fits on one line
+    x = X { field1, field2, xx };
+    let X { field1, field2, .. } = x;
+
+    // case 2: literal is too wide (vertical), pattern should be single-line
+    x = X { field1, field2x, xx };
+    let X { field1, field2x, .. } = x;
+
+    // case 3: both literal and pattern are too wide — both vertical
+    x = X { field1, field2, field3, xx };
+    let X { field1, field2, field3, .. } = x;
+}

--- a/tests/target/configs/single_line_let_else_max_width/100.rs
+++ b/tests/target/configs/single_line_let_else_max_width/100.rs
@@ -45,13 +45,7 @@ fn main() {
         return Ok(None);
     };
 
-    let Stmt::Expr(
-        Expr::Call(ExprCall {
-            args: some_args, ..
-        }),
-        _,
-    ) = last_stmt
-    else {
+    let Stmt::Expr(Expr::Call(ExprCall { args: some_args, .. }), _) = last_stmt else {
         return Err(Error::new(
             last_stmt.span(),
             "expected last expression to be `Some(match (..) { .. })`",

--- a/tests/target/configs/single_line_let_else_max_width/50.rs
+++ b/tests/target/configs/single_line_let_else_max_width/50.rs
@@ -47,13 +47,7 @@ fn main() {
         return Ok(None);
     };
 
-    let Stmt::Expr(
-        Expr::Call(ExprCall {
-            args: some_args, ..
-        }),
-        _,
-    ) = last_stmt
-    else {
+    let Stmt::Expr(Expr::Call(ExprCall { args: some_args, .. }), _) = last_stmt else {
         return Err(Error::new(
             last_stmt.span(),
             "expected last expression to be `Some(match (..) { .. })`",

--- a/tests/target/configs/single_line_let_else_max_width/zero.rs
+++ b/tests/target/configs/single_line_let_else_max_width/zero.rs
@@ -51,13 +51,7 @@ fn main() {
         return Ok(None);
     };
 
-    let Stmt::Expr(
-        Expr::Call(ExprCall {
-            args: some_args, ..
-        }),
-        _,
-    ) = last_stmt
-    else {
+    let Stmt::Expr(Expr::Call(ExprCall { args: some_args, .. }), _) = last_stmt else {
         return Err(Error::new(
             last_stmt.span(),
             "expected last expression to be `Some(match (..) { .. })`",

--- a/tests/target/issue-6827.rs
+++ b/tests/target/issue-6827.rs
@@ -1,0 +1,27 @@
+fn main() {
+    // case 1: fits on one line
+    x = X { field1, field2, xx };
+    let X { field1, field2, .. } = x;
+
+    // case 2: literal is too wide (vertical), pattern should be single-line
+    x = X {
+        field1,
+        field2x,
+        xx,
+    };
+    let X { field1, field2x, .. } = x;
+
+    // case 3: both literal and pattern are too wide — both vertical
+    x = X {
+        field1,
+        field2,
+        field3,
+        xx,
+    };
+    let X {
+        field1,
+        field2,
+        field3,
+        ..
+    } = x;
+}

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -578,9 +578,9 @@ fn issue_3030() {
 
 fn issue_3005() {
     match *token {
-        Token::Dimension {
-            value, ref unit, ..
-        } if num_context.is_ok(context.parsing_mode, value) => {
+        Token::Dimension { value, ref unit, .. }
+            if num_context.is_ok(context.parsing_mode, value) =>
+        {
             return NoCalcLength::parse_dimension(context, value, unit)
                 .map(LengthOrPercentage::Length)
                 .map_err(|()| location.new_unexpected_token_error(token.clone()));


### PR DESCRIPTION
## Summary

- `struct_lit_shape` computes `h_shape.width` already reduced by `len(", ..")` to reserve space for the ellipsis suffix. After `write_list`, we then append `", .."` to `fields_str`, making it 4 chars longer. `wrap_struct_field` was comparing this augmented string against the original (already-reduced) `one_line_width`, so patterns with fields near the width budget got incorrectly flagged as too wide and wrapped vertically.
- Fix: introduce `adjusted_one_line_width = one_line_width + ellipsis_str.len()` before the `wrap_struct_field` call, so the threshold matches what's actually in `fields_str`.
- Updated three `single_line_let_else_max_width` test targets and `match.rs` where the fix causes struct patterns with `..` to stay on one line.
- Reformatted `src/imports.rs` and `src/visitor.rs` to match the new output (required by the self-test).

## Test Plan

- [ ] `cargo test` passes
- [ ] `tests/source/issue-6827.rs` covers all three cases from the issue: single-line, previously-hybrid (now single-line), and genuinely-too-wide (vertical)
- [ ] Idempotency check passes for all new and updated targets

Fixes #6827
