### PR TITLE
[ci] Replace umaintained GitHub Action upload-release-asset

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload Release Asset
         if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v 3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Use maintained fork softprops/action-gh-release. This is linked from the actions/upload-release-asset [readme file](https://github.com/actions/upload-release-asset/blob/main/README.md).