### PR TITLE
Enable Cargo's new build-dir layout in tests+ci

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,4 +38,5 @@ jobs:
     - name: Build and Test
       env:
         RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: cargo run --manifest-path ci/Cargo.toml build-and-test

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -34,4 +34,5 @@ jobs:
     - name: Build and Test
       env:
         RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: cargo run --manifest-path ci/Cargo.toml build-and-test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,4 +60,5 @@ jobs:
     - name: Build and Test
       env:
         RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: cargo run --manifest-path ci/Cargo.toml build-and-test

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1130,8 +1130,23 @@ fn rustfmt() -> PathBuf {
     let mut me = env::current_exe().expect("failed to get current executable");
     // Chop of the test name.
     me.pop();
-    // Chop off `deps`.
-    me.pop();
+
+    // Handle Cargo's old and new filesystem layouts
+    // * v1: `target/<profile>/deps/test-bin-[HASH][EXE]`
+    // * v2: `target/<profile>/build/<pkgname>/[HASH]/out/test-bin-[HASH][EXE]`
+    if me.ends_with("deps") {
+        // Chop off `deps`.
+        me.pop();
+    } else if me.ends_with("out") {
+        // Chop off `out`.
+        me.pop();
+        // Chop off `<hash>`.
+        me.pop();
+        // Chop off `<pkgname>`.
+        me.pop();
+        // Chop off `build`.
+        me.pop();
+    }
 
     me.push("rustfmt");
     assert!(

--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -10,8 +10,17 @@ use rustfmt_config_proc_macro::rustfmt_only_ci_test;
 fn cargo_fmt(args: &[&str]) -> (String, String) {
     let mut bin_dir = env::current_exe().unwrap();
     bin_dir.pop(); // chop off test exe name
+
+    // Handle Cargo's old and new filesystem layouts
+    // * v1: `target/<profile>/deps/test-bin-[HASH][EXE]`
+    // * v2: `target/<profile>/build/<pkgname>/[HASH]/out/test-bin-[HASH][EXE]`
     if bin_dir.ends_with("deps") {
         bin_dir.pop();
+    } else if bin_dir.ends_with("out") {
+        bin_dir.pop(); // chop off `out`
+        bin_dir.pop(); // chop off `<hash>`
+        bin_dir.pop(); // chop off `<pkgname>`
+        bin_dir.pop(); // chop off `build`
     }
     let cmd = bin_dir.join(format!("cargo-fmt{}", env::consts::EXE_SUFFIX));
 


### PR DESCRIPTION
Split out of https://github.com/rust-lang/rust/pull/155439 which enables Cargo's new build-dir layout in tests and CI.

### Background

Cargo is planning to stabilize a rework to the build-dir file layout tracked in https://github.com/rust-lang/cargo/issues/15010. (Stabilization PR is currently in FPC https://github.com/rust-lang/cargo/pull/16807)
Our last remaining blocker to merging is preparing `rust-lang/rust` to work with the new layout so the Cargo submodule can be merged after stabilization. 

The [`build-dir`](https://doc.rust-lang.org/stable/cargo/reference/build-cache.html)s file system layout is considered an implementation detail of Cargo is subject to changes. Note that this is different than `artifact-dir` which is stable. (Together these are usually referred to as the `target-dir`)

### Changes

This PR has 2 commits:
1. Add backwards compatible changes to the rustfmt tests to properly handle the new layout
2. Enable the new layout in CI using `CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT` 

cc: @ytmimi