### PR TITLE
fix: trim trailing whitespace from lhs when rhs wraps to new line

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -344,13 +344,17 @@ impl UseTree {
         let vis = self.visibility.as_ref().map_or(Cow::from(""), |vis| {
             crate::utils::format_visibility(context, vis)
         });
+        let vis_separator = if vis.is_empty() { "" } else { " " };
         let use_str = self
-            .rewrite_result(context, shape.offset_left(vis.len(), self.span())?)
+            .rewrite_result(
+                context,
+                shape.offset_left(vis.len() + vis_separator.len(), self.span())?,
+            )
             .map(|s| {
                 if s.is_empty() {
                     s
                 } else {
-                    format!("{}use {};", vis, s)
+                    format!("{vis}{vis_separator}use {s};")
                 }
             })?;
         match self.attrs {

--- a/src/items.rs
+++ b/src/items.rs
@@ -349,7 +349,11 @@ impl<'a> FnSig<'a> {
     fn to_str(&self, context: &RewriteContext<'_>) -> String {
         let mut result = String::with_capacity(128);
         // Vis defaultness constness unsafety abi.
-        result.push_str(&*format_visibility(context, self.visibility));
+        let vis = format_visibility(context, self.visibility);
+        result.push_str(&*vis);
+        if !vis.is_empty() {
+            result.push(' ');
+        }
         result.push_str(format_defaultness(self.defaultness));
         result.push_str(format_constness(self.constness));
         self.coroutine_kind
@@ -952,7 +956,11 @@ fn format_impl_ref_and_type(
     } = iimpl;
     let mut result = String::with_capacity(128);
 
-    result.push_str(&format_visibility(context, &item.vis));
+    let vis = format_visibility(context, &item.vis);
+    result.push_str(&vis);
+    if !vis.is_empty() {
+        result.push(' ');
+    }
 
     if let Some(of_trait) = of_trait.as_deref() {
         result.push_str(format_defaultness(of_trait.defaultness));
@@ -1162,9 +1170,10 @@ pub(crate) fn format_trait(
     } = *trait_;
 
     let mut result = String::with_capacity(128);
+    let vis = format_visibility(context, &item.vis);
+    let vis_separator = if vis.is_empty() { "" } else { " " };
     let header = format!(
-        "{}{}{}{}{}trait ",
-        format_visibility(context, &item.vis),
+        "{vis}{vis_separator}{}{}{}{}trait ",
         format_impl_restriction(context, impl_restriction),
         format_constness(constness),
         format_safety(safety),
@@ -1374,8 +1383,9 @@ pub(crate) fn format_trait_alias(
     let g_shape = shape.offset_left(6, span)?.sub_width(2, span)?;
     let generics_str = rewrite_generics(context, alias, &ta.generics, g_shape)?;
     let vis_str = format_visibility(context, vis);
+    let vis_separator = if vis_str.is_empty() { "" } else { " " };
     let constness = format_constness(ta.constness);
-    let lhs = format!("{vis_str}{constness}trait {generics_str} =");
+    let lhs = format!("{vis_str}{vis_separator}{constness}trait {generics_str} =");
     // 1 = ";"
     let trait_alias_bounds = TraitAliasBounds {
         generic_bounds: &ta.bounds,
@@ -1747,7 +1757,12 @@ fn rewrite_ty<R: Rewrite>(
 ) -> RewriteResult {
     let mut result = String::with_capacity(128);
     let TyAliasRewriteInfo(context, indent, generics, after_where_clause, ident, span) = *rw_info;
-    result.push_str(&format!("{}type ", format_visibility(context, vis)));
+    let vis = format_visibility(context, vis);
+    if !vis.is_empty() {
+        result.push_str(&format!("{vis} type "));
+    } else {
+        result.push_str("type ");
+    }
     let ident_str = rewrite_ident(context, ident);
 
     if generics.params.is_empty() {
@@ -1885,16 +1900,19 @@ pub(crate) fn rewrite_struct_field_prefix(
     field: &ast::FieldDef,
 ) -> RewriteResult {
     let vis = format_visibility(context, &field.vis);
+    let vis_separator = if vis.is_empty() { "" } else { " " };
     let mut_restriction = format_mut_restriction(context, &field.mut_restriction);
     let safety = format_safety(field.safety);
     let type_annotation_spacing = type_annotation_spacing(context.config);
     Ok(match field.ident {
         Some(name) => format!(
-            "{vis}{mut_restriction}{safety}{}{}:",
+            "{vis}{vis_separator}{mut_restriction}{safety}{}{}:",
             rewrite_ident(context, name),
             type_annotation_spacing.0
         ),
-        None => format!("{vis}{mut_restriction}{safety}"),
+        None => format!("{vis}{vis_separator}{mut_restriction}{safety}")
+            .trim_end()
+            .to_string(),
     })
 }
 
@@ -1935,6 +1953,8 @@ pub(crate) fn rewrite_struct_field(
     };
     let mut spacing = String::from(if field.ident.is_some() {
         type_annotation_spacing.1
+    } else if !prefix.is_empty() {
+        " "
     } else {
         ""
     });
@@ -1969,6 +1989,13 @@ pub(crate) fn rewrite_struct_field(
 
     let is_prefix_empty = prefix.is_empty();
     // We must use multiline. We are going to put attributes and a field on different lines.
+    // Trim trailing whitespace from the prefix for tuple struct fields to avoid leaving it
+    // behind when the type wraps to the next line (e.g. "pub(crate) " -> "pub(crate)").
+    let prefix = if field.ident.is_none() {
+        prefix.trim_end().to_string()
+    } else {
+        prefix
+    };
     let field_str = rewrite_assign_rhs(context, prefix, &*field.ty, &RhsAssignKind::Ty, shape)?;
     // Remove a leading white-space from `rewrite_assign_rhs()` when rewriting a tuple struct.
     let field_str = if is_prefix_empty {
@@ -2129,9 +2156,10 @@ fn rewrite_static(
         })
         .map_or("".into(), |x| format!("{x}"));
     let colon = colon_spaces(context.config);
+    let vis = format_visibility(context, static_parts.vis);
+    let vis_separator = if vis.is_empty() { "" } else { " " };
     let mut prefix = format!(
-        "{}{}{}{} {}{}{}{}",
-        format_visibility(context, static_parts.vis),
+        "{vis}{vis_separator}{}{}{} {}{}{}{}",
         static_parts.defaultness.map_or("", format_defaultness),
         format_safety(static_parts.safety),
         static_parts.prefix,
@@ -3329,7 +3357,7 @@ fn format_header(
     let mut result = String::with_capacity(128);
     let shape = Shape::indented(offset, context.config);
 
-    result.push_str(format_visibility(context, vis).trim());
+    result.push_str(&format_visibility(context, vis));
 
     // Check for a missing comment between the visibility and the item name.
     let after_vis = vis.span.hi();
@@ -3515,11 +3543,11 @@ impl Rewrite for ast::ForeignItem {
                 // FIXME(#21): we're dropping potential comments in between the
                 // function kw here.
                 let vis = format_visibility(context, &self.vis);
+                let vis_separator = if vis.is_empty() { "" } else { " " };
                 let safety = format_safety(static_foreign_item.safety);
                 let mut_str = format_mutability(static_foreign_item.mutability);
                 let prefix = format!(
-                    "{}{}static {}{}:",
-                    vis,
+                    "{vis}{vis_separator}{}static {}{}:",
                     safety,
                     mut_str,
                     rewrite_ident(context, static_foreign_item.ident)
@@ -3602,7 +3630,11 @@ pub(crate) fn rewrite_mod(
     attrs_shape: Shape,
 ) -> RewriteResult {
     let mut result = String::with_capacity(32);
-    result.push_str(&*format_visibility(context, &item.vis));
+    let vis = format_visibility(context, &item.vis);
+    result.push_str(&*vis);
+    if !vis.is_empty() {
+        result.push(' ');
+    }
     result.push_str("mod ");
     result.push_str(rewrite_ident(context, ident));
     result.push(';');

--- a/src/items.rs
+++ b/src/items.rs
@@ -349,7 +349,11 @@ impl<'a> FnSig<'a> {
     fn to_str(&self, context: &RewriteContext<'_>) -> String {
         let mut result = String::with_capacity(128);
         // Vis defaultness constness unsafety abi.
-        result.push_str(&*format_visibility(context, self.visibility));
+        let vis = format_visibility(context, self.visibility);
+        result.push_str(&*vis);
+        if !vis.is_empty() {
+            result.push(' ');
+        }
         result.push_str(format_defaultness(self.defaultness));
         result.push_str(format_constness(self.constness));
         self.coroutine_kind
@@ -952,7 +956,11 @@ fn format_impl_ref_and_type(
     } = iimpl;
     let mut result = String::with_capacity(128);
 
-    result.push_str(&format_visibility(context, &item.vis));
+    let vis = format_visibility(context, &item.vis);
+    result.push_str(&vis);
+    if !vis.is_empty() {
+        result.push(' ');
+    }
 
     if let Some(of_trait) = of_trait.as_deref() {
         result.push_str(format_defaultness(of_trait.defaultness));
@@ -1162,9 +1170,10 @@ pub(crate) fn format_trait(
     } = *trait_;
 
     let mut result = String::with_capacity(128);
+    let vis = format_visibility(context, &item.vis);
+    let vis_separator = if vis.is_empty() { "" } else { " " };
     let header = format!(
-        "{}{}{}{}{}trait ",
-        format_visibility(context, &item.vis),
+        "{vis}{vis_separator}{}{}{}{}trait ",
         format_impl_restriction(context, impl_restriction),
         format_constness(constness),
         format_safety(safety),
@@ -1374,8 +1383,9 @@ pub(crate) fn format_trait_alias(
     let g_shape = shape.offset_left(6, span)?.sub_width(2, span)?;
     let generics_str = rewrite_generics(context, alias, &ta.generics, g_shape)?;
     let vis_str = format_visibility(context, vis);
+    let vis_separator = if vis_str.is_empty() { "" } else { " " };
     let constness = format_constness(ta.constness);
-    let lhs = format!("{vis_str}{constness}trait {generics_str} =");
+    let lhs = format!("{vis_str}{vis_separator}{constness}trait {generics_str} =");
     // 1 = ";"
     let trait_alias_bounds = TraitAliasBounds {
         generic_bounds: &ta.bounds,
@@ -1745,11 +1755,13 @@ fn rewrite_ty<R: Rewrite>(
 ) -> RewriteResult {
     let mut result = String::with_capacity(128);
     let TyAliasRewriteInfo(context, indent, generics, after_where_clause, ident, span) = *rw_info;
-    result.push_str(&format!(
-        "{}{}type ",
-        format_visibility(context, vis),
-        format_defaultness(defaultness)
-    ));
+    let vis = format_visibility(context, vis);
+    result.push_str(&vis);
+    if !vis.is_empty() {
+        result.push(' ');
+    }
+    result.push_str(format_defaultness(defaultness));
+    result.push_str("type ");
     let ident_str = rewrite_ident(context, ident);
 
     if generics.params.is_empty() {
@@ -1887,16 +1899,19 @@ pub(crate) fn rewrite_struct_field_prefix(
     field: &ast::FieldDef,
 ) -> RewriteResult {
     let vis = format_visibility(context, &field.vis);
+    let vis_separator = if vis.is_empty() { "" } else { " " };
     let mut_restriction = format_mut_restriction(context, &field.mut_restriction);
     let safety = format_safety(field.safety);
     let type_annotation_spacing = type_annotation_spacing(context.config);
     Ok(match field.ident {
         Some(name) => format!(
-            "{vis}{mut_restriction}{safety}{}{}:",
+            "{vis}{vis_separator}{mut_restriction}{safety}{}{}:",
             rewrite_ident(context, name),
             type_annotation_spacing.0
         ),
-        None => format!("{vis}{mut_restriction}{safety}"),
+        None => format!("{vis}{vis_separator}{mut_restriction}{safety}")
+            .trim_end()
+            .to_string(),
     })
 }
 
@@ -1937,6 +1952,8 @@ pub(crate) fn rewrite_struct_field(
     };
     let mut spacing = String::from(if field.ident.is_some() {
         type_annotation_spacing.1
+    } else if !prefix.is_empty() {
+        " "
     } else {
         ""
     });
@@ -1971,6 +1988,13 @@ pub(crate) fn rewrite_struct_field(
 
     let is_prefix_empty = prefix.is_empty();
     // We must use multiline. We are going to put attributes and a field on different lines.
+    // Trim trailing whitespace from the prefix for tuple struct fields to avoid leaving it
+    // behind when the type wraps to the next line (e.g. "pub(crate) " -> "pub(crate)").
+    let prefix = if field.ident.is_none() {
+        prefix.trim_end().to_string()
+    } else {
+        prefix
+    };
     let field_str = rewrite_assign_rhs(context, prefix, &*field.ty, &RhsAssignKind::Ty, shape)?;
     // Remove a leading white-space from `rewrite_assign_rhs()` when rewriting a tuple struct.
     let field_str = if is_prefix_empty {
@@ -2131,9 +2155,10 @@ fn rewrite_static(
         })
         .map_or("".into(), |x| format!("{x}"));
     let colon = colon_spaces(context.config);
+    let vis = format_visibility(context, static_parts.vis);
+    let vis_separator = if vis.is_empty() { "" } else { " " };
     let mut prefix = format!(
-        "{}{}{}{} {}{}{}{}",
-        format_visibility(context, static_parts.vis),
+        "{vis}{vis_separator}{}{}{} {}{}{}{}",
         static_parts.defaultness.map_or("", format_defaultness),
         format_safety(static_parts.safety),
         static_parts.prefix,
@@ -3331,7 +3356,7 @@ fn format_header(
     let mut result = String::with_capacity(128);
     let shape = Shape::indented(offset, context.config);
 
-    result.push_str(format_visibility(context, vis).trim());
+    result.push_str(&format_visibility(context, vis));
 
     // Check for a missing comment between the visibility and the item name.
     let after_vis = vis.span.hi();
@@ -3517,11 +3542,11 @@ impl Rewrite for ast::ForeignItem {
                 // FIXME(#21): we're dropping potential comments in between the
                 // function kw here.
                 let vis = format_visibility(context, &self.vis);
+                let vis_separator = if vis.is_empty() { "" } else { " " };
                 let safety = format_safety(static_foreign_item.safety);
                 let mut_str = format_mutability(static_foreign_item.mutability);
                 let prefix = format!(
-                    "{}{}static {}{}:",
-                    vis,
+                    "{vis}{vis_separator}{}static {}{}:",
                     safety,
                     mut_str,
                     rewrite_ident(context, static_foreign_item.ident)
@@ -3604,7 +3629,11 @@ pub(crate) fn rewrite_mod(
     attrs_shape: Shape,
 ) -> RewriteResult {
     let mut result = String::with_capacity(32);
-    result.push_str(&*format_visibility(context, &item.vis));
+    let vis = format_visibility(context, &item.vis);
+    result.push_str(&*vis);
+    if !vis.is_empty() {
+        result.push(' ');
+    }
     result.push_str("mod ");
     result.push_str(rewrite_ident(context, ident));
     result.push(';');

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1453,10 +1453,10 @@ fn format_lazy_static(
     for (i, (vis, id, ty, expr)) in parsed_elems.iter().enumerate() {
         // Rewrite as a static item.
         let vis = crate::utils::format_visibility(context, vis);
+        let vis_separator = if vis.is_empty() { "" } else { " " };
         let mut stmt = String::with_capacity(128);
         stmt.push_str(&format!(
-            "{}static ref {}: {} =",
-            vis,
+            "{vis}{vis_separator}static ref {}: {} =",
             id,
             ty.rewrite_result(context, nested_shape)?
         ));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,7 +55,7 @@ pub(crate) fn format_visibility(
     vis: &Visibility,
 ) -> Cow<'static, str> {
     match vis.kind {
-        VisibilityKind::Public => Cow::from("pub "),
+        VisibilityKind::Public => Cow::from("pub"),
         VisibilityKind::Inherited => Cow::from(""),
         VisibilityKind::Restricted { ref path, .. } => {
             let Path { ref segments, .. } = **path;
@@ -69,7 +69,7 @@ pub(crate) fn format_visibility(
             let path = segments_iter.collect::<Vec<_>>().join("::");
             let in_str = if is_keyword(&path) { "" } else { "in " };
 
-            Cow::from(format!("pub({in_str}{path}) "))
+            Cow::from(format!("pub({in_str}{path})"))
         }
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -987,6 +987,9 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
     ) {
         let vis_str = utils::format_visibility(&self.get_context(), vis);
         self.push_str(&*vis_str);
+        if !vis_str.is_empty() {
+            self.push_str(" ");
+        }
         self.push_str(format_safety(safety));
         self.push_str("mod ");
         // Calling `to_owned()` to work around borrow checker.

--- a/tests/source/issue-5525.rs
+++ b/tests/source/issue-5525.rs
@@ -1,0 +1,7 @@
+pub struct SomeCallback(
+    pub extern "C" fn(
+        long_argument_name_to_avoid_wrap: u32,
+        second_long_argument_name: u32,
+        third_long_argument_name: u32,
+    ),
+);

--- a/tests/source/issue-5703.rs
+++ b/tests/source/issue-5703.rs
@@ -1,0 +1,21 @@
+struct PubCrate(
+    pub(crate) std::collections::HashMap<some::module::path::TypeNameA, some::module::path::TypeNameB>,
+);
+
+struct PubSuper(
+    pub(super) std::collections::HashMap<some::module::path::TypeNameA, some::module::path::TypeNameB>,
+);
+
+struct PubInPath(
+    pub(in some::module) std::collections::HashMap<some::module::path::TypeNameA, some::module::path::TypeNameB>,
+);
+
+struct PubPlain(
+    pub std::collections::HashMap<some::module::path::TypeNameAaaaaaaaaaa, some::module::path::TypeNameB>,
+);
+
+struct NamedPubCrate {
+    pub(crate) field: std::collections::HashMap<some::module::path::TypeNameA, some::module::path::TypeNameB>,
+}
+
+struct ShortPubCrate(pub(crate) u32);

--- a/tests/source/issue-5997.rs
+++ b/tests/source/issue-5997.rs
@@ -1,0 +1,11 @@
+pub struct Newtype(
+    /// Doc
+    #[doc()] //
+    pub  Vec<u8>,
+);
+
+pub struct Newtype2(
+    /// Doc
+    #[doc()]
+    pub Vec<u8>,
+);

--- a/tests/target/issue-5525.rs
+++ b/tests/target/issue-5525.rs
@@ -1,0 +1,7 @@
+pub struct SomeCallback(
+    pub extern "C" fn(
+        long_argument_name_to_avoid_wrap: u32,
+        second_long_argument_name: u32,
+        third_long_argument_name: u32,
+    ),
+);

--- a/tests/target/issue-5703.rs
+++ b/tests/target/issue-5703.rs
@@ -1,0 +1,28 @@
+struct PubCrate(
+    pub(crate)
+        std::collections::HashMap<some::module::path::TypeNameA, some::module::path::TypeNameB>,
+);
+
+struct PubSuper(
+    pub(super)
+        std::collections::HashMap<some::module::path::TypeNameA, some::module::path::TypeNameB>,
+);
+
+struct PubInPath(
+    pub(in some::module)
+        std::collections::HashMap<some::module::path::TypeNameA, some::module::path::TypeNameB>,
+);
+
+struct PubPlain(
+    pub std::collections::HashMap<
+        some::module::path::TypeNameAaaaaaaaaaa,
+        some::module::path::TypeNameB,
+    >,
+);
+
+struct NamedPubCrate {
+    pub(crate) field:
+        std::collections::HashMap<some::module::path::TypeNameA, some::module::path::TypeNameB>,
+}
+
+struct ShortPubCrate(pub(crate) u32);

--- a/tests/target/issue-5997.rs
+++ b/tests/target/issue-5997.rs
@@ -1,0 +1,11 @@
+pub struct Newtype(
+    /// Doc
+    #[doc()] //
+    pub Vec<u8>,
+);
+
+pub struct Newtype2(
+    /// Doc
+    #[doc()]
+    pub Vec<u8>,
+);

--- a/tests/target/struct_field_doc_comment.rs
+++ b/tests/target/struct_field_doc_comment.rs
@@ -25,17 +25,17 @@ struct MyTuple(
 
 struct MyTuple(
     #[cfg(unix)] // some comment
-    pub  u64,
-    #[cfg(not(unix))] /*block comment */ pub(crate)  u32,
+    pub u64,
+    #[cfg(not(unix))] /*block comment */ pub(crate) u32,
 );
 
 struct MyTuple(
     /// Doc Comments
     /* TODO note to add more to Doc Comments */
-    pub  u32,
+    pub u32,
     /// Doc Comments
     // TODO note
-    pub(crate)  u64,
+    pub(crate) u64,
 );
 
 struct MyStruct {


### PR DESCRIPTION
Fixes #6880, #5703 , #5525, #5997

`rewrite_assign_rhs_with` joins `lhs + rhs`. When the rhs wraps to a new line, trailing whitespace on the lhs (from `format_visibility` returning e.g. `"pub(crate) "`) gets left behind. The fix trims trailing whitespace from lhs when rhs starts with `\n`. Same fix applied to `rewrite_assign_rhs_with_comments`.

Every other caller passes an lhs ending in `=` or `:`, so the trim is a no-op outside the tuple struct field case.

Regression test covers all three parenthesized visibility qualifiers (`pub(crate)`, `pub(super)`, `pub(in path)`) on tuple struct fields with long types, plus `pub` and named struct fields as controls. Previously these tests failed before the fix due to trailing white space. (I couldn't figure out a good way to have an initial atomic commit showing the failure that still passed the test harness).