### PR TITLE
Skip fn signature when not selected with --file-lines

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -430,6 +430,10 @@ impl<'a> FmtVisitor<'a> {
     ) -> Option<(String, FnBraceStyle)> {
         let context = self.get_context();
 
+        if out_of_file_lines_range!(self, span) {
+            return Some((context.snippet(span).to_owned(), FnBraceStyle::None));
+        }
+
         let mut fn_brace_style = newline_for_brace(self.config, &fn_sig.generics.where_clause);
         let (result, _, force_newline_brace) =
             rewrite_fn_base(&context, indent, ident, fn_sig, span, fn_brace_style).ok()?;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -429,7 +429,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 FnBraceStyle::NextLine => {
                     self.push_str(&self.block_indent.to_string_with_newline(self.config))
                 }
-                FnBraceStyle::None => {},
+                FnBraceStyle::None => {}
             }
             self.last_pos = source!(self, block.span).lo();
         } else {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -429,7 +429,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 FnBraceStyle::NextLine => {
                     self.push_str(&self.block_indent.to_string_with_newline(self.config))
                 }
-                _ => unreachable!(),
+                FnBraceStyle::None => {},
             }
             self.last_pos = source!(self, block.span).lo();
         } else {

--- a/tests/source/issue-6864.rs
+++ b/tests/source/issue-6864.rs
@@ -1,0 +1,13 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6864.rs","range":[10,12]}]
+
+fn messy_signature(
+a: i32,
+b: bool,
+)
+
+    {
+println!("weeeeeee");
+let x =
+a + b
+as i32;
+}

--- a/tests/target/issue-6864.rs
+++ b/tests/target/issue-6864.rs
@@ -1,0 +1,11 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6864.rs","range":[10,12]}]
+
+fn messy_signature(
+a: i32,
+b: bool,
+)
+
+    {
+println!("weeeeeee");
+    let x = a + b as i32;
+}


### PR DESCRIPTION
Skip formatting the signature of a function when `--file-lines` does not overlap with the signature. Mostly fixes https://github.com/rust-lang/rustfmt/issues/6864. There's still a small edge case here where selecting the opening brace of the function will format the entire function signature, but I think the only way to handle that is to support partially formatting the signature, which is tracked by https://github.com/rust-lang/rustfmt/issues/6868.

# LLM Usage Disclosure

- [ ] I did not use an LLM to create a change in this PR.
- [x] **I used an LLM to create a change in this PR, and I have explained below how it was used.**

An LLM was used to assist in exploration of the codebase, but the actual code changes and test case were written by me.