### PR TITLE
Don't format fn keywords when not selected with --file-lines

### DIFF
--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -6,13 +6,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::{cmp, fmt, iter, str};
 
-use rustc_span::{SourceFile, Span};
+use rustc_span::SourceFile;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, ser};
 use serde_json as json;
 use thiserror::Error;
-
-use crate::rewrite::RewriteContext;
-use crate::source_map::LineRangeUtils;
 
 /// A range of lines in a file, inclusive of both ends.
 pub struct LineRange {
@@ -278,10 +275,6 @@ impl FileLines {
     /// Returns `true` if all the lines between `lo` and `hi` from `file_name` are in `self`.
     pub(crate) fn contains_range(&self, file_name: &FileName, lo: usize, hi: usize) -> bool {
         self.file_range_matches(file_name, |r| r.contains(Range::new(lo, hi)))
-    }
-
-    pub(crate) fn contains_span(&self, context: &RewriteContext<'_>, span: Span) -> bool {
-        self.contains(&context.psess.lookup_line_range(span))
     }
 }
 

--- a/src/config/file_lines.rs
+++ b/src/config/file_lines.rs
@@ -6,10 +6,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::{cmp, fmt, iter, str};
 
-use rustc_span::SourceFile;
+use rustc_span::{SourceFile, Span};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, ser};
 use serde_json as json;
 use thiserror::Error;
+
+use crate::rewrite::RewriteContext;
+use crate::source_map::LineRangeUtils;
 
 /// A range of lines in a file, inclusive of both ends.
 pub struct LineRange {
@@ -275,6 +278,10 @@ impl FileLines {
     /// Returns `true` if all the lines between `lo` and `hi` from `file_name` are in `self`.
     pub(crate) fn contains_range(&self, file_name: &FileName, lo: usize, hi: usize) -> bool {
         self.file_range_matches(file_name, |r| r.contains(Range::new(lo, hi)))
+    }
+
+    pub(crate) fn contains_span(&self, context: &RewriteContext<'_>, span: Span) -> bool {
+        self.contains(&context.psess.lookup_line_range(span))
     }
 }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -368,38 +368,18 @@ impl<'a> FnSig<'a> {
 
     /// Calculates the span for the parts of the signature before the `fn`
     /// keyword.
-    ///
-    /// The returned span does not include the whitespace between the last
-    /// non-`fn` keyword and `fn`. If there are no keywords before `fn` then the
-    /// returned span is empty.
     fn span_before_fn(
         &self,
         context: &RewriteContext<'_>,
         span: Span,
         ident: symbol::Ident,
     ) -> Span {
-        // Get the span for everything up to the `fn` keyword.
         let before_ident_span = mk_sp(span.lo(), ident.span.lo());
         let fn_lo = context
             .snippet_provider
             .span_before_last(before_ident_span, "fn");
-        let before_fn_span = mk_sp(span.lo(), fn_lo);
 
-        // Scan backwards from `fn` to find the last non-whitespace character.
-        context
-            .snippet(before_fn_span)
-            .char_indices()
-            .rev()
-            .find(|(_, c)| !c.is_whitespace())
-            .map_or_else(
-                || mk_sp(fn_lo, fn_lo),
-                |(idx, c)| {
-                    mk_sp(
-                        before_fn_span.lo(),
-                        before_fn_span.lo() + BytePos((idx + c.len_utf8()) as u32),
-                    )
-                },
-            )
+        mk_sp(span.lo(), fn_lo)
     }
 }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -366,47 +366,40 @@ impl<'a> FnSig<'a> {
         result
     }
 
-    /// Calculates the span for the parts of the signature before the `fn` keyword.
-    fn span_before_fn(&self) -> Span {
-        let mut lo = None;
-        let mut hi = None;
+    /// Calculates the span for the parts of the signature before the `fn`
+    /// keyword.
+    ///
+    /// The returned span does not include the whitespace between the last
+    /// non-`fn` keyword and `fn`. If there are no keywords before `fn` then the
+    /// returned span is empty.
+    fn span_before_fn(
+        &self,
+        context: &RewriteContext<'_>,
+        span: Span,
+        ident: symbol::Ident,
+    ) -> Span {
+        // Get the span for everything up to the `fn` keyword.
+        let before_ident_span = mk_sp(span.lo(), ident.span.lo());
+        let fn_lo = context
+            .snippet_provider
+            .span_before_last(before_ident_span, "fn");
+        let before_fn_span = mk_sp(span.lo(), fn_lo);
 
-        let mut extend_span = |span: Span| {
-            lo = Some(lo.map_or(span.lo(), |lo| min(lo, span.lo())));
-            hi = Some(hi.map_or(span.hi(), |hi| max(hi, span.hi())));
-        };
-
-        if !matches!(self.visibility.kind, ast::VisibilityKind::Inherited) {
-            extend_span(self.visibility.span);
-        }
-
-        match self.defaultness {
-            ast::Defaultness::Default(span) | ast::Defaultness::Final(span) => extend_span(span),
-            ast::Defaultness::Implicit => {}
-        }
-
-        if let ast::Const::Yes(span) = self.constness {
-            extend_span(span);
-        }
-
-        if let Some(coroutine_kind) = self.coroutine_kind.as_ref() {
-            extend_span(coroutine_kind.span());
-        }
-
-        match self.safety {
-            ast::Safety::Unsafe(span) | ast::Safety::Safe(span) => extend_span(span),
-            ast::Safety::Default => {}
-        }
-
-        match self.ext {
-            ast::Extern::Implicit(span) | ast::Extern::Explicit(_, span) => extend_span(span),
-            ast::Extern::None => {}
-        }
-
-        let lo = lo.unwrap_or_else(|| self.visibility.span.lo());
-        let hi = hi.unwrap_or(lo);
-
-        mk_sp(lo, hi)
+        // Scan backwards from `fn` to find the last non-whitespace character.
+        context
+            .snippet(before_fn_span)
+            .char_indices()
+            .rev()
+            .find(|(_, c)| !c.is_whitespace())
+            .map_or_else(
+                || mk_sp(fn_lo, fn_lo),
+                |(idx, c)| {
+                    mk_sp(
+                        before_fn_span.lo(),
+                        before_fn_span.lo() + BytePos((idx + c.len_utf8()) as u32),
+                    )
+                },
+            )
     }
 }
 
@@ -2510,7 +2503,7 @@ fn rewrite_fn_base(
     let mut result = String::with_capacity(1024);
 
     // Everything before `fn`
-    let span_before_fn = fn_sig.span_before_fn();
+    let span_before_fn = fn_sig.span_before_fn(context, span, ident);
     if context
         .config
         .file_lines()

--- a/src/items.rs
+++ b/src/items.rs
@@ -2483,8 +2483,21 @@ fn rewrite_fn_base(
         result.push_str(context.snippet(mk_sp(span_before_fn.lo(), fn_lo)));
     }
 
-    // fn foo
-    result.push_str("fn ");
+    result.push_str("fn");
+
+    // If both `fn` and the ident are selected, put them both on the same line.
+    // Otherwise, preserve the snippet between `fn` and the ident.
+    let fn_ident_span = mk_sp(fn_lo, ident.span.hi());
+    if context
+        .config
+        .file_lines()
+        .contains(&context.psess.lookup_line_range(fn_ident_span))
+    {
+        result.push(' ');
+    } else {
+        let fn_hi = fn_lo + BytePos(2);
+        result.push_str(context.snippet(mk_sp(fn_hi, ident.span.lo())));
+    }
 
     // Generics.
     let overhead = if let FnBraceStyle::SameLine = fn_brace_style {

--- a/src/items.rs
+++ b/src/items.rs
@@ -365,6 +365,49 @@ impl<'a> FnSig<'a> {
         ));
         result
     }
+
+    /// Calculates the span for the parts of the signature before the `fn` keyword.
+    fn span_before_fn(&self) -> Span {
+        let mut lo = None;
+        let mut hi = None;
+
+        let mut extend_span = |span: Span| {
+            lo = Some(lo.map_or(span.lo(), |lo| min(lo, span.lo())));
+            hi = Some(hi.map_or(span.hi(), |hi| max(hi, span.hi())));
+        };
+
+        if !matches!(self.visibility.kind, ast::VisibilityKind::Inherited) {
+            extend_span(self.visibility.span);
+        }
+
+        match self.defaultness {
+            ast::Defaultness::Default(span) | ast::Defaultness::Final(span) => extend_span(span),
+            ast::Defaultness::Implicit => {}
+        }
+
+        if let ast::Const::Yes(span) = self.constness {
+            extend_span(span);
+        }
+
+        if let Some(coroutine_kind) = self.coroutine_kind.as_ref() {
+            extend_span(coroutine_kind.span());
+        }
+
+        match self.safety {
+            ast::Safety::Unsafe(span) | ast::Safety::Safe(span) => extend_span(span),
+            ast::Safety::Default => {}
+        }
+
+        match self.ext {
+            ast::Extern::Implicit(span) | ast::Extern::Explicit(_, span) => extend_span(span),
+            ast::Extern::None => {}
+        }
+
+        let lo = lo.unwrap_or_else(|| self.visibility.span.lo());
+        let hi = hi.unwrap_or(lo);
+
+        mk_sp(lo, hi)
+    }
 }
 
 impl<'a> FmtVisitor<'a> {
@@ -2465,7 +2508,22 @@ fn rewrite_fn_base(
     let where_clause = &fn_sig.generics.where_clause;
 
     let mut result = String::with_capacity(1024);
-    result.push_str(&fn_sig.to_str(context));
+
+    // Everything before `fn`
+    let span_before_fn = fn_sig.span_before_fn();
+    if context
+        .config
+        .file_lines()
+        .contains(&context.psess.lookup_line_range(span_before_fn))
+    {
+        result.push_str(&fn_sig.to_str(context));
+    } else {
+        let before_ident_span = mk_sp(span_before_fn.hi(), ident.span.lo());
+        let fn_lo = context
+            .snippet_provider
+            .span_before_last(before_ident_span, "fn");
+        result.push_str(context.snippet(mk_sp(span_before_fn.lo(), fn_lo)));
+    }
 
     // fn foo
     result.push_str("fn ");

--- a/src/items.rs
+++ b/src/items.rs
@@ -365,22 +365,6 @@ impl<'a> FnSig<'a> {
         ));
         result
     }
-
-    /// Calculates the span for the parts of the signature before the `fn`
-    /// keyword.
-    fn span_before_fn(
-        &self,
-        context: &RewriteContext<'_>,
-        span: Span,
-        ident: symbol::Ident,
-    ) -> Span {
-        let before_ident_span = mk_sp(span.lo(), ident.span.lo());
-        let fn_lo = context
-            .snippet_provider
-            .span_before_last(before_ident_span, "fn");
-
-        mk_sp(span.lo(), fn_lo)
-    }
 }
 
 impl<'a> FmtVisitor<'a> {
@@ -2483,7 +2467,12 @@ fn rewrite_fn_base(
     let mut result = String::with_capacity(1024);
 
     // Everything before `fn`
-    let span_before_fn = fn_sig.span_before_fn(context, span, ident);
+    let before_ident_span = mk_sp(span.lo(), ident.span.lo());
+    let fn_lo = context
+        .snippet_provider
+        .span_before_last(before_ident_span, "fn");
+    let span_before_fn = mk_sp(span.lo(), fn_lo);
+
     if context
         .config
         .file_lines()
@@ -2491,10 +2480,6 @@ fn rewrite_fn_base(
     {
         result.push_str(&fn_sig.to_str(context));
     } else {
-        let before_ident_span = mk_sp(span_before_fn.hi(), ident.span.lo());
-        let fn_lo = context
-            .snippet_provider
-            .span_before_last(before_ident_span, "fn");
         result.push_str(context.snippet(mk_sp(span_before_fn.lo(), fn_lo)));
     }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -2465,6 +2465,7 @@ fn rewrite_fn_base(
     let where_clause = &fn_sig.generics.where_clause;
 
     let mut result = String::with_capacity(1024);
+    let file_lines = context.config.file_lines();
 
     // Everything before `fn`
     let before_ident_span = mk_sp(span.lo(), ident.span.lo());
@@ -2473,11 +2474,7 @@ fn rewrite_fn_base(
         .span_before_last(before_ident_span, "fn");
     let span_before_fn = mk_sp(span.lo(), fn_lo);
 
-    if context
-        .config
-        .file_lines()
-        .contains(&context.psess.lookup_line_range(span_before_fn))
-    {
+    if file_lines.contains_span(context, span_before_fn) {
         result.push_str(&fn_sig.to_str(context));
     } else {
         result.push_str(context.snippet(mk_sp(span_before_fn.lo(), fn_lo)));
@@ -2488,11 +2485,7 @@ fn rewrite_fn_base(
     // If both `fn` and the ident are selected, put them both on the same line.
     // Otherwise, preserve the snippet between `fn` and the ident.
     let fn_ident_span = mk_sp(fn_lo, ident.span.hi());
-    if context
-        .config
-        .file_lines()
-        .contains(&context.psess.lookup_line_range(fn_ident_span))
-    {
+    if file_lines.contains_span(context, fn_ident_span) {
         result.push(' ');
     } else {
         let fn_hi = fn_lo + BytePos(2);

--- a/src/items.rs
+++ b/src/items.rs
@@ -2465,7 +2465,6 @@ fn rewrite_fn_base(
     let where_clause = &fn_sig.generics.where_clause;
 
     let mut result = String::with_capacity(1024);
-    let file_lines = context.config.file_lines();
 
     // Everything before `fn`
     let before_ident_span = mk_sp(span.lo(), ident.span.lo());
@@ -2474,7 +2473,7 @@ fn rewrite_fn_base(
         .span_before_last(before_ident_span, "fn");
     let span_before_fn = mk_sp(span.lo(), fn_lo);
 
-    if file_lines.contains_span(context, span_before_fn) {
+    if file_lines_contains!(context, span_before_fn) {
         result.push_str(&fn_sig.to_str(context));
     } else {
         result.push_str(context.snippet(mk_sp(span_before_fn.lo(), fn_lo)));
@@ -2485,7 +2484,7 @@ fn rewrite_fn_base(
     // If both `fn` and the ident are selected, put them both on the same line.
     // Otherwise, preserve the snippet between `fn` and the ident.
     let fn_ident_span = mk_sp(fn_lo, ident.span.hi());
-    if file_lines.contains_span(context, fn_ident_span) {
+    if file_lines_contains!(context, fn_ident_span) {
         result.push(' ');
     } else {
         let fn_hi = fn_lo + BytePos(2);

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -65,7 +65,7 @@ impl SpanUtils for SnippetProvider {
             offset += additional_offset + needle.len();
         }
 
-        original.lo() + BytePos(offset as u32 - 1)
+        original.lo() + BytePos(offset as u32 - needle.len() as u32)
     }
 
     fn opt_span_after(&self, original: Span, needle: &str) -> Option<BytePos> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -381,6 +381,16 @@ macro_rules! out_of_file_lines_range {
     };
 }
 
+/// Returns `true` if the given span is fully contained by the selected file lines.
+macro_rules! file_lines_contains {
+    ($self:ident, $span:expr) => {
+        $self
+            .config
+            .file_lines()
+            .contains(&$self.psess.lookup_line_range($span))
+    };
+}
+
 macro_rules! skip_out_of_file_lines_range_err {
     ($self:ident, $span:expr) => {
         if out_of_file_lines_range!($self, $span) {

--- a/tests/source/issue-6868-before-fn/fn_and_ident.rs
+++ b/tests/source/issue-6868-before-fn/fn_and_ident.rs
@@ -1,0 +1,16 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fn_and_ident.rs","range":[11,12]}]
+
+pub
+(
+crate
+)
+const
+unsafe
+extern
+"C"
+fn
+foo
+(
+)
+{
+}

--- a/tests/source/issue-6868-before-fn/fully_selected.rs
+++ b/tests/source/issue-6868-before-fn/fully_selected.rs
@@ -1,4 +1,4 @@
-// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fully_selected.rs","range":[3,10]}]
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fully_selected.rs","range":[3,11]}]
 
 pub
 (

--- a/tests/source/issue-6868-before-fn/fully_selected.rs
+++ b/tests/source/issue-6868-before-fn/fully_selected.rs
@@ -1,0 +1,16 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fully_selected.rs","range":[3,10]}]
+
+pub
+(
+crate
+)
+const
+unsafe
+extern
+"C"
+fn
+foo
+(
+)
+{
+}

--- a/tests/source/issue-6868-before-fn/partial.rs
+++ b/tests/source/issue-6868-before-fn/partial.rs
@@ -1,0 +1,16 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/partial.rs","range":[7,8]}]
+
+pub
+(
+crate
+)
+const
+unsafe
+extern
+"C"
+fn
+foo
+(
+)
+{
+}

--- a/tests/source/issue-6868-before-fn/unselected.rs
+++ b/tests/source/issue-6868-before-fn/unselected.rs
@@ -1,0 +1,16 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/unselected.rs","range":[11,14]}]
+
+pub
+(
+crate
+)
+const
+unsafe
+extern
+"C"
+fn
+foo
+(
+)
+{
+}

--- a/tests/target/issue-6868-before-fn/fn_and_ident.rs
+++ b/tests/target/issue-6868-before-fn/fn_and_ident.rs
@@ -1,0 +1,12 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fn_and_ident.rs","range":[11,12]}]
+
+pub
+(
+crate
+)
+const
+unsafe
+extern
+"C"
+fn foo() {
+}

--- a/tests/target/issue-6868-before-fn/fully_selected.rs
+++ b/tests/target/issue-6868-before-fn/fully_selected.rs
@@ -1,0 +1,3 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fully_selected.rs","range":[3,10]}]
+
+pub(crate) const unsafe extern "C" fn foo() {}

--- a/tests/target/issue-6868-before-fn/fully_selected.rs
+++ b/tests/target/issue-6868-before-fn/fully_selected.rs
@@ -1,3 +1,3 @@
-// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fully_selected.rs","range":[3,10]}]
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fully_selected.rs","range":[3,11]}]
 
 pub(crate) const unsafe extern "C" fn foo() {}

--- a/tests/target/issue-6868-before-fn/fully_selected.rs
+++ b/tests/target/issue-6868-before-fn/fully_selected.rs
@@ -1,3 +1,5 @@
 // rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/fully_selected.rs","range":[3,11]}]
 
-pub(crate) const unsafe extern "C" fn foo() {}
+pub(crate) const unsafe extern "C" fn
+foo() {
+}

--- a/tests/target/issue-6868-before-fn/partial.rs
+++ b/tests/target/issue-6868-before-fn/partial.rs
@@ -1,0 +1,12 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/partial.rs","range":[7,8]}]
+
+pub
+(
+crate
+)
+const
+unsafe
+extern
+"C"
+fn foo() {
+}

--- a/tests/target/issue-6868-before-fn/partial.rs
+++ b/tests/target/issue-6868-before-fn/partial.rs
@@ -8,5 +8,6 @@ const
 unsafe
 extern
 "C"
-fn foo() {
+fn
+foo() {
 }

--- a/tests/target/issue-6868-before-fn/unselected.rs
+++ b/tests/target/issue-6868-before-fn/unselected.rs
@@ -1,0 +1,12 @@
+// rustfmt-file_lines: [{"file":"tests/source/issue-6868-before-fn/unselected.rs","range":[11,14]}]
+
+pub
+(
+crate
+)
+const
+unsafe
+extern
+"C"
+fn foo() {
+}


### PR DESCRIPTION
Allow `--file-lines` to skip formatting the leading keywords for a function definition (`pub`, `unsafe`, `extern`, etc.) when not selected. Part of https://github.com/rust-lang/rustfmt/issues/6868.

The behavior I chose is to treat all of the keywords before `fn` as a single unit: We either format all of them, or we format none of them. This seemed like the most reasonable approach because rustfmt will always put all of the keywords on one line, so it didn't make sense to try to support formatting only a couple of the keywords. Treating them all as an indivisible block also keeps the logic simpler here, since there's only one span we have to check for.

I also made a minor tweak to `span_before_last` to allow it to handle multi-character needles. Previously it was only used to find single character needles, and was hardcoding the length of the needle as 1. I wanted to use it to find the span before the `fn` keyword, so I've updated it to take the actual length of the needle into account.

# LLM Usage Disclosure

- [ ] I did not use an LLM to create a change in this PR.
- [x] **I used an LLM to create a change in this PR, and I have explained below how it was used.**

I used an LLM for code exploration, but the code changes and test cases were written by me.