### PR TITLE
triagebot: allow more labels to be used by users without write access

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -8,9 +8,9 @@
 [relabel]
 allow-unauthenticated = [
     "C-*",
+    "S-*",
     "needs-triage",
     "regression-*",
-    "S-*",
 ]
 
 # ------------------------------------------------------------------------------
@@ -40,7 +40,6 @@ exclude_labels = [
     "P-*",
     "requires-nightly",
 ]
-
 
 [autolabel."A-CI"]
 trigger_files = [

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -7,8 +7,15 @@
 
 [relabel]
 allow-unauthenticated = [
+    "A-*",
+    "B-*",
     "C-*",
+    "E-*",
+    "F-*",
+    "I-*",
     "S-*",
+    "SO-*",
+    "UO-*",
     "needs-triage",
     "regression-*",
 ]


### PR DESCRIPTION
Noticed when triaging issues.