### PR TITLE
Fix normalize_doc_attributes configuration docs

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2150,9 +2150,9 @@ Convert `#![doc]` and `#[doc]` attributes to `//!` and `///` doc comments.
 #### `false` (default):
 
 ```rust
-#![doc = "Example documentation"]
+#![doc = " Example documentation"]
 
-#[doc = "Example item documentation"]
+#[doc = " Example item documentation"]
 pub enum Bar {}
 
 /// Example item documentation
@@ -2163,6 +2163,9 @@ pub enum Foo {}
 
 ```rust
 //! Example documentation
+
+/// Example item documentation
+pub enum Bar {}
 
 /// Example item documentation
 pub enum Foo {}


### PR DESCRIPTION
Tracking issue for `normalize_doc_attributes`: #3351

- update the `normalize_doc_attributes = true` example to keep the `Bar` item after its doc attribute is normalized
- adjust the example doc attribute strings to include the leading space that corresponds to the rendered doc comments

