### PR TITLE
test(check_diff): add unicode-rs repos to diff check suite

### DIFF
--- a/check_diff/src/main.rs
+++ b/check_diff/src/main.rs
@@ -37,6 +37,10 @@ const REPOS: &[&str] = &[
     "https://github.com/serde-rs/serde.git",
     "https://github.com/SergioBenitez/Rocket.git",
     "https://github.com/Stebalien/tempfile.git",
+    // Unicode / international text coverage (see rustfmt#5884)
+    "https://github.com/unicode-rs/unicode-width.git",
+    "https://github.com/unicode-rs/unicode-segmentation.git",
+    "https://github.com/unicode-rs/unicode-normalization.git",
 ];
 
 /// Inputs for the check_diff script


### PR DESCRIPTION
## Summary

Contributes to #5884.

Adds three `unicode-rs` repositories to the curated `check_diff` repo list to improve coverage of formatting with varied Unicode text:

- `unicode-width`
- `unicode-segmentation`
- `unicode-normalization`

`icu4x` was not included here because it uses `cargo make` for its build; happy to follow up separately if maintainers want that wired in.

## Test plan

- [x] `cargo build` in `check_diff/`
- [ ] CI