### PR TITLE
chore(deps): bump annotate-snippets to 0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,12 +13,12 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e35ed54e5ea7997c14ed4c70ba043478db1112e98263b3b035907aa197d991"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
 dependencies = [
  "anstyle",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -560,7 +560,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-properties",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -862,6 +862,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"


### PR DESCRIPTION
### Summary

`Cargo.lock`-only bump of `annotate-snippets` from `0.11.4` to `0.11.5`. The `Cargo.toml` requirement stays at `"0.11"` (semver-compatible), so no API adaptation and no breaking change. Prerequisite for #6902 to cover the full reproducer in #6850.

### Why this is needed

The reproducer in #6850 (a 120-snowman string literal triggering `LineOverflow` with `error_on_unformatted`) trips **two** independent col-vs-byte bugs. The rustfmt-side one is fixed in #6902; the second hides in `annotate-snippets 0.11.4` itself, in its long-line truncation path at `src/renderer/display_list.rs:351–373`:

```rust
let mut taken = 0;
let code: String = text.chars().skip(left).take_while(|ch| {
    let next = unicode_width::UnicodeWidthChar::width(*ch).unwrap_or(1);
    if taken + next > right - left { return false; }
    taken += next;          // taken is visual width
    true
}).collect();
if self.margin.was_cut_right(line_len) {
    code[..taken.saturating_sub(3)].fmt(f)?;  // ← taken used as byte index
    "...".fmt(f)?;
}
```

Same class of bug as the one #6902 fixes on the rustfmt side: `taken` accumulates `unicode_width` (visual columns) but `code[..taken.saturating_sub(3)]` is a byte slice on a UTF-8 String. On multibyte content the boundary falls inside a codepoint and panics with `end byte index N is not a char boundary` at `display_list.rs:369`.

Before #6902, the rustfmt-side bug fired first and masked this one. Once #6902 starts feeding `annotate-snippets` correct byte ranges, the issue's full reproducer hits this upstream panic instead.

`annotate-snippets` **fixed this in 0.11.5** (release notes: `Fix unicode handling in margin-based rendering`). Because `Cargo.toml` already declares `annotate-snippets = "0.11"`, the bump is just a `cargo update -p annotate-snippets` — `Cargo.lock` change only.