### PR TITLE
refactor: apply clippy::unnecessary_map_or

### DIFF
--- a/src/closures.rs
+++ b/src/closures.rs
@@ -124,9 +124,10 @@ fn needs_block(
     prefix: &str,
     context: &RewriteContext<'_>,
 ) -> bool {
-    let has_attributes = block.stmts.first().map_or(false, |first_stmt| {
-        !get_attrs_from_stmt(first_stmt).is_empty()
-    });
+    let has_attributes = block
+        .stmts
+        .first()
+        .is_some_and(|first_stmt| !get_attrs_from_stmt(first_stmt).is_empty());
 
     is_unsafe_block(block)
         || block.stmts.len() > 1
@@ -433,9 +434,8 @@ pub(crate) fn rewrite_last_closure(
 
         // When overflowing the closure which consists of a single control flow expression,
         // force to use block if its condition uses multi line.
-        let is_multi_lined_cond = rewrite_cond(context, body, body_shape).map_or(false, |cond| {
-            cond.contains('\n') || cond.len() > body_shape.width
-        });
+        let is_multi_lined_cond = rewrite_cond(context, body, body_shape)
+            .is_some_and(|cond| cond.contains('\n') || cond.len() > body_shape.width);
         if is_multi_lined_cond {
             return rewrite_closure_with_block(body, &prefix, context, body_shape);
         }

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -119,7 +119,7 @@ pub(crate) fn comment_style(orig: &str, normalize_comments: bool) -> CommentStyl
             CommentStyle::Exclamation
         } else if orig.starts_with("/*") {
             CommentStyle::SingleBullet
-        } else if orig.starts_with("///") && orig.chars().nth(3).map_or(true, |c| c != '/') {
+        } else if orig.starts_with("///") && (orig.chars().nth(3) != Some('/')) {
             CommentStyle::TripleSlash
         } else if orig.starts_with("//!") {
             CommentStyle::Doc
@@ -128,7 +128,7 @@ pub(crate) fn comment_style(orig: &str, normalize_comments: bool) -> CommentStyl
         } else {
             CommentStyle::DoubleSlash
         }
-    } else if (orig.starts_with("///") && orig.chars().nth(3).map_or(true, |c| c != '/'))
+    } else if (orig.starts_with("///") && (orig.chars().nth(3) != Some('/')))
         || (orig.starts_with("/**") && !orig.starts_with("/**/"))
     {
         CommentStyle::TripleSlash

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -532,7 +532,7 @@ fn rewrite_empty_block(
     }
 
     let label_str = rewrite_label(context, label);
-    if attrs.map_or(false, |a| !inner_attributes(a).is_empty()) {
+    if attrs.is_some_and(|a| !inner_attributes(a).is_empty()) {
         return None;
     }
 
@@ -1287,7 +1287,7 @@ pub(crate) fn is_simple_block(
     block.stmts.len() == 1
         && stmt_is_expr(&block.stmts[0])
         && !block_contains_comment(context, block)
-        && attrs.map_or(true, |a| a.is_empty())
+        && attrs.is_none_or(|a| a.is_empty())
 }
 
 /// Checks whether a block contains at most one statement or expression, and no
@@ -1299,7 +1299,7 @@ pub(crate) fn is_simple_block_stmt(
 ) -> bool {
     block.stmts.len() <= 1
         && !block_contains_comment(context, block)
-        && attrs.map_or(true, |a| a.is_empty())
+        && attrs.is_none_or(|a| a.is_empty())
 }
 
 fn block_has_statements(block: &ast::Block) -> bool {
@@ -1318,7 +1318,7 @@ pub(crate) fn is_empty_block(
 ) -> bool {
     !block_has_statements(block)
         && !block_contains_comment(context, block)
-        && attrs.map_or(true, |a| inner_attributes(a).is_empty())
+        && attrs.is_none_or(|a| inner_attributes(a).is_empty())
 }
 
 pub(crate) fn stmt_is_expr(stmt: &ast::Stmt) -> bool {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -650,7 +650,7 @@ impl UseTree {
     }
 
     fn has_comment(&self) -> bool {
-        self.list_item.as_ref().map_or(false, ListItem::has_comment)
+        self.list_item.as_ref().is_some_and(ListItem::has_comment)
     }
 
     fn contains_comment(&self) -> bool {
@@ -1034,9 +1034,10 @@ fn rewrite_nested_use_tree(
         }
     }
     let has_nested_list = use_tree_list.iter().any(|use_segment| {
-        use_segment.path.last().map_or(false, |last_segment| {
-            matches!(last_segment.kind, UseSegmentKind::List(..))
-        })
+        use_segment
+            .path
+            .last()
+            .is_some_and(|last_segment| matches!(last_segment.kind, UseSegmentKind::List(..)))
     });
 
     let remaining_width = if has_nested_list {

--- a/src/items.rs
+++ b/src/items.rs
@@ -241,7 +241,7 @@ fn same_line_else_kw_and_brace(
         .last()
         .expect("initializer expression is multi-lined")
         .strip_prefix(indent.as_ref())
-        .map_or(false, |l| !l.starts_with(char::is_whitespace))
+        .is_some_and(|l| !l.starts_with(char::is_whitespace))
 }
 
 fn allow_single_line_let_else_block(result: &str, block: &ast::Block) -> bool {
@@ -485,7 +485,7 @@ impl<'a> FmtVisitor<'a> {
         block: &ast::Block,
         inner_attrs: Option<&[ast::Attribute]>,
     ) -> Option<String> {
-        if fn_str.contains('\n') || inner_attrs.map_or(false, |a| !a.is_empty()) {
+        if fn_str.contains('\n') || inner_attrs.is_some_and(|a| !a.is_empty()) {
             return None;
         }
 
@@ -773,7 +773,7 @@ impl<'a> FmtVisitor<'a> {
                 // different impl items.
                 if prev_kind
                     .as_ref()
-                    .map_or(false, |prev_kind| need_empty_line(prev_kind, &item.kind))
+                    .is_some_and(|prev_kind| need_empty_line(prev_kind, &item.kind))
                 {
                     self.push_str("\n");
                 }
@@ -2497,7 +2497,7 @@ fn rewrite_fn_base(
     let snuggle_angle_bracket = generics_str
         .lines()
         .last()
-        .map_or(false, |l| l.trim_start().len() == 1);
+        .is_some_and(|l| l.trim_start().len() == 1);
 
     // Note that the width and indent don't really matter, we'll re-layout the
     // return type later anyway.
@@ -2583,7 +2583,7 @@ fn rewrite_fn_base(
         params_last_line_contains_comment = param_str
             .lines()
             .last()
-            .map_or(false, |last_line| last_line.contains("//"));
+            .is_some_and(|last_line| last_line.contains("//"));
 
         if context.config.style_edition() >= StyleEdition::Edition2024 {
             if params_last_line_contains_comment {
@@ -2697,10 +2697,10 @@ fn rewrite_fn_base(
             // Try to preserve the layout of the original snippet.
             let original_starts_with_newline = snippet
                 .find(|c| c != ' ')
-                .map_or(false, |i| starts_with_newline(&snippet[i..]));
+                .is_some_and(|i| starts_with_newline(&snippet[i..]));
             let original_ends_with_newline = snippet
                 .rfind(|c| c != ' ')
-                .map_or(false, |i| snippet[i..].ends_with('\n'));
+                .is_some_and(|i| snippet[i..].ends_with('\n'));
             let snippet = snippet.trim();
             if !snippet.is_empty() {
                 result.push(if original_starts_with_newline {
@@ -3407,7 +3407,7 @@ fn format_generics(
     // add missing comments
     let missed_line_comments = missed_comments
         .filter(|missed_comments| !missed_comments.is_empty())
-        .map_or(false, |missed_comments| {
+        .is_some_and(|missed_comments| {
             let is_block = is_last_comment_block(&missed_comments);
             let sep = if is_block { " " } else { "\n" };
             result.push_str(sep);

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -149,32 +149,23 @@ impl ListItem {
     pub(crate) fn is_different_group(&self) -> bool {
         self.inner_as_ref().contains('\n')
             || self.pre_comment.is_some()
-            || self
-                .post_comment
-                .as_ref()
-                .map_or(false, |s| s.contains('\n'))
+            || self.post_comment.as_ref().is_some_and(|s| s.contains('\n'))
     }
 
     pub(crate) fn is_multiline(&self) -> bool {
         self.inner_as_ref().contains('\n')
-            || self
-                .pre_comment
-                .as_ref()
-                .map_or(false, |s| s.contains('\n'))
-            || self
-                .post_comment
-                .as_ref()
-                .map_or(false, |s| s.contains('\n'))
+            || self.pre_comment.as_ref().is_some_and(|s| s.contains('\n'))
+            || self.post_comment.as_ref().is_some_and(|s| s.contains('\n'))
     }
 
     pub(crate) fn has_single_line_comment(&self) -> bool {
         self.pre_comment
             .as_ref()
-            .map_or(false, |comment| comment.trim_start().starts_with("//"))
+            .is_some_and(|comment| comment.trim_start().starts_with("//"))
             || self
                 .post_comment
                 .as_ref()
-                .map_or(false, |comment| comment.trim_start().starts_with("//"))
+                .is_some_and(|comment| comment.trim_start().starts_with("//"))
     }
 
     pub(crate) fn has_comment(&self) -> bool {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1006,7 +1006,7 @@ fn wrap_macro_args_inner(
         result.push_str(&arg.rewrite(context, shape, use_multiple_lines)?);
 
         if use_multiple_lines
-            && (arg.kind.ends_with_space() || iter.peek().map_or(false, |a| a.kind.has_meta_var()))
+            && (arg.kind.ends_with_space() || iter.peek().is_some_and(|a| a.kind.has_meta_var()))
         {
             if arg.kind.ends_with_space() {
                 result.pop();

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -379,7 +379,7 @@ fn flatten_arm_body<'a>(
             } else {
                 let cond_becomes_multi_line = opt_shape
                     .and_then(|shape| rewrite_cond(context, expr, shape))
-                    .map_or(false, |cond| cond.contains('\n'));
+                    .is_some_and(|cond| cond.contains('\n'));
                 if cond_becomes_multi_line {
                     (false, &*body)
                 } else {

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -245,7 +245,7 @@ impl<'a> FmtVisitor<'a> {
             .rev()
             .find(|rev_c| ![' ', '\t'].contains(rev_c));
 
-        let fix_indent = last_char.map_or(true, |rev_c| ['{', '\n'].contains(&rev_c));
+        let fix_indent = last_char.is_none_or(|rev_c| ['{', '\n'].contains(&rev_c));
         let mut on_same_line = false;
 
         let comment_indent = if fix_indent {

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -446,7 +446,7 @@ impl<'a> Context<'a> {
                     | ast::ExprKind::While(..)
                     | ast::ExprKind::Match(..) => {
                         let multi_line = rewrite_cond(self.context, expr, shape)
-                            .map_or(false, |cond| cond.contains('\n'));
+                            .is_some_and(|cond| cond.contains('\n'));
 
                         if multi_line {
                             None
@@ -549,7 +549,7 @@ impl<'a> Context<'a> {
                         .items
                         .last()
                         .and_then(|last_item| last_item.rewrite(self.context, self.nested_shape));
-                    let no_newline = rw.as_ref().map_or(false, |s| !s.contains('\n'));
+                    let no_newline = rw.as_ref().is_some_and(|s| !s.contains('\n'));
                     if no_newline {
                         list_items[self.items.len() - 1].item = rw.unknown_error();
                     } else {
@@ -740,14 +740,14 @@ impl<'a> Context<'a> {
 fn need_block_indent(s: &str, shape: Shape) -> bool {
     s.lines().skip(1).any(|s| {
         s.find(|c| !char::is_whitespace(c))
-            .map_or(false, |w| w + 1 < shape.indent.width())
+            .is_some_and(|w| w + 1 < shape.indent.width())
     })
 }
 
 fn can_be_overflowed(context: &RewriteContext<'_>, items: &[OverflowableItem<'_>]) -> bool {
     items
         .last()
-        .map_or(false, |x| x.can_be_overflowed(context, items.len()))
+        .is_some_and(|x| x.can_be_overflowed(context, items.len()))
 }
 
 /// Returns a shape for the last argument which is going to be overflowed.

--- a/src/parse/macros/mod.rs
+++ b/src/parse/macros/mod.rs
@@ -141,7 +141,7 @@ pub(crate) fn parse_macro_args(
                     }
                     return None;
                 }
-                _ if args.last().map_or(false, MacroArg::is_item) => continue,
+                _ if args.last().is_some_and(MacroArg::is_item) => continue,
                 _ => return None,
             }
 

--- a/src/parse/session.rs
+++ b/src/parse/session.rs
@@ -97,7 +97,7 @@ fn default_dcx(
     show_parse_errors: bool,
     color: Color,
 ) -> DiagCtxt {
-    let supports_color = term::stderr().map_or(false, |term| term.supports_color());
+    let supports_color = term::stderr().is_some_and(|term| term.supports_color());
     let emit_color = if supports_color {
         ColorConfig::from(color)
     } else {

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -623,7 +623,7 @@ fn rewrite_tuple_pat(
         (&pat_vec[..], span)
     };
 
-    let is_last_pat_dotdot = pat_vec.last().map_or(false, |p| p.is_dotdot());
+    let is_last_pat_dotdot = pat_vec.last().is_some_and(|p| p.is_dotdot());
     let add_comma = path_str.is_none() && pat_vec.len() == 1 && !is_last_pat_dotdot;
     let path_str = path_str.unwrap_or_default();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -197,12 +197,12 @@ pub(crate) fn is_single_line(s: &str) -> bool {
 
 #[inline]
 pub(crate) fn first_line_contains_single_line_comment(s: &str) -> bool {
-    s.lines().next().map_or(false, |l| l.contains("//"))
+    s.lines().next().is_some_and(|l| l.contains("//"))
 }
 
 #[inline]
 pub(crate) fn last_line_contains_single_line_comment(s: &str) -> bool {
-    s.lines().last().map_or(false, |l| l.contains("//"))
+    s.lines().last().is_some_and(|l| l.contains("//"))
 }
 
 #[inline]
@@ -280,9 +280,7 @@ fn is_skip_nested(meta_item: &MetaItemInner) -> bool {
 
 #[inline]
 pub(crate) fn contains_skip(attrs: &[Attribute]) -> bool {
-    attrs
-        .iter()
-        .any(|a| a.meta().map_or(false, |a| is_skip(&a)))
+    attrs.iter().any(|a| a.meta().is_some_and(|a| is_skip(&a)))
 }
 
 #[inline]
@@ -472,7 +470,7 @@ pub(crate) fn starts_with_newline(s: &str) -> bool {
 
 #[inline]
 pub(crate) fn first_line_ends_with(s: &str, c: char) -> bool {
-    s.lines().next().map_or(false, |l| l.ends_with(c))
+    s.lines().next().is_some_and(|l| l.ends_with(c))
 }
 
 // States whether an expression's last line exclusively consists of closing

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -132,7 +132,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
             let snippet = self.snippet(mk_sp(self.last_pos, stmt.span().lo()));
             let original_starts_with_newline = snippet
                 .find(|c| c != ' ')
-                .map_or(false, |i| starts_with_newline(&snippet[i..]));
+                .is_some_and(|i| starts_with_newline(&snippet[i..]));
             let snippet = snippet.trim();
             if !snippet.is_empty() {
                 // FIXME(calebcartwright 2021-01-03) - This exists strictly to maintain legacy
@@ -933,7 +933,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         // Extract leading `use ...;`.
         let items: Vec<_> = stmts
             .iter()
-            .take_while(|stmt| stmt.to_item().map_or(false, is_use_item))
+            .take_while(|stmt| stmt.to_item().is_some_and(is_use_item))
             .filter_map(|stmt| stmt.to_item())
             .collect();
 


### PR DESCRIPTION
## Summary

- Replaces `Option::map_or(false, |x| ..)` with `Option::is_some_and(..)` and
  `Option::map_or(true, |x| ..)` with `Option::is_none_or(..)` across `src/`.
- One occurrence in `src/comment.rs` is further simplified to a direct
  `Option` equality check (`orig.chars().nth(3) != Some('/')`).
- Addresses `clippy::unnecessary_map_or`, run as a single-rule pass:
  `cargo clippy -- -A clippy::all -W clippy::unnecessary_map_or`.