### PR TITLE
refactor: apply clippy::map_flatten

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -752,8 +752,7 @@ impl CliOptions for GetOptsOptions {
     fn version(&self) -> Option<Version> {
         self.inline_config
             .get("version")
-            .map(|version| Version::from_str(version).ok())
-            .flatten()
+            .and_then(|version| Version::from_str(version).ok())
     }
 }
 


### PR DESCRIPTION
## Summary

- Collapses `Option::map(..).flatten()` into `Option::and_then(..)` in
  `GetOptsOptions::version` (`src/bin/main.rs`).
- Addresses `clippy::map_flatten`, run as a single-rule pass:
  `cargo clippy -- -A clippy::all -W clippy::map_flatten`.