### PR TITLE
refactor: apply clippy::needless_splitn

### DIFF
--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -463,7 +463,7 @@ impl<'a> Context<'a> {
 
         if let Some(rewrite) = rewrite {
             // splitn(2, *).next().unwrap() is always safe.
-            let rewrite_first_line = Ok(rewrite.splitn(2, '\n').next().unwrap().to_owned());
+            let rewrite_first_line = Ok(rewrite.split('\n').next().unwrap().to_owned());
             last_list_item.item = rewrite_first_line;
             Some(rewrite)
         } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -213,13 +213,13 @@ pub(crate) fn is_attributes_extendable(attrs_str: &str) -> bool {
 /// The width of the first line in s.
 #[inline]
 pub(crate) fn first_line_width(s: &str) -> usize {
-    unicode_str_width(s.splitn(2, '\n').next().unwrap_or(""))
+    unicode_str_width(s.split('\n').next().unwrap_or(""))
 }
 
 /// The width of the last line in s.
 #[inline]
 pub(crate) fn last_line_width(s: &str) -> usize {
-    unicode_str_width(s.rsplitn(2, '\n').next().unwrap_or(""))
+    unicode_str_width(s.rsplit('\n').next().unwrap_or(""))
 }
 
 /// The total used width of the last line.

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -276,7 +276,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         let comment_snippet = self.snippet(span);
 
         let align_to_right = if unindent_comment && contains_comment(comment_snippet) {
-            let first_lines = comment_snippet.splitn(2, '/').next().unwrap_or("");
+            let first_lines = comment_snippet.split('/').next().unwrap_or("");
             last_line_width(first_lines) > last_line_width(comment_snippet)
         } else {
             false


### PR DESCRIPTION
## Summary

- Replaces `splitn(2, ..).next()` with `split(..).next()` in
  `src/overflow.rs` and `src/visitor.rs`.
- Replaces `rsplitn(2, ..).next()` with `rsplit(..).next()` in
  `src/utils.rs`.
- Addresses `clippy::needless_splitn`, run as a single-rule pass:
  `cargo clippy -- -A clippy::all -W clippy::needless_splitn`.

When only the first element is consumed, the `splitn(2, ..)` upper bound
is redundant — `split` / `rsplit` are equally lazy iterators. Pure
refactor, no behavior changes intended. Touches 3 files.