### PR TITLE
refactor: apply clippy::io_other_error

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -259,10 +259,9 @@ fn get_rustfmt_info(args: &[String]) -> Result<i32, io::Error> {
         .args(args)
         .spawn()
         .map_err(|e| match e.kind() {
-            io::ErrorKind::NotFound => io::Error::new(
-                io::ErrorKind::Other,
-                "Could not run rustfmt, please make sure it is in your PATH.",
-            ),
+            io::ErrorKind::NotFound => {
+                io::Error::other("Could not run rustfmt, please make sure it is in your PATH.")
+            }
             _ => e,
         })?;
     let result = command.wait()?;
@@ -373,10 +372,7 @@ fn get_targets(
     }
 
     if targets.is_empty() {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Failed to find targets".to_owned(),
-        ))
+        Err(io::Error::other("Failed to find targets".to_owned()))
     } else {
         Ok(targets)
     }
@@ -534,10 +530,9 @@ fn run_rustfmt(
             .args(fmt_args)
             .spawn()
             .map_err(|e| match e.kind() {
-                io::ErrorKind::NotFound => io::Error::new(
-                    io::ErrorKind::Other,
-                    "Could not run rustfmt, please make sure it is in your PATH.",
-                ),
+                io::ErrorKind::NotFound => {
+                    io::Error::other("Could not run rustfmt, please make sure it is in your PATH.")
+                }
                 _ => e,
             })?;
 
@@ -565,7 +560,7 @@ fn get_cargo_metadata(manifest_path: Option<&Path>) -> Result<cargo_metadata::Me
             cmd.other_options(vec![]);
             match cmd.exec() {
                 Ok(metadata) => Ok(metadata),
-                Err(error) => Err(io::Error::new(io::ErrorKind::Other, error.to_string())),
+                Err(error) => Err(io::Error::other(error.to_string())),
             }
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -507,7 +507,7 @@ fn get_toml_path(dir: &Path) -> Result<Option<PathBuf>, Error> {
                 if !matches!(e.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) {
                     let ctx = format!("Failed to get metadata for config file {:?}", &config_file);
                     let err = anyhow::Error::new(e).context(ctx);
-                    return Err(Error::new(ErrorKind::Other, err));
+                    return Err(Error::other(err));
                 }
             }
             _ => {}

--- a/src/format-diff/main.rs
+++ b/src/format-diff/main.rs
@@ -109,10 +109,9 @@ fn run_rustfmt(files: &HashSet<String>, ranges: &[Range]) -> Result<(), FormatDi
         .status()?;
 
     if !exit_status.success() {
-        return Err(FormatDiffError::IoError(io::Error::new(
-            io::ErrorKind::Other,
-            format!("rustfmt failed with {exit_status}"),
-        )));
+        return Err(FormatDiffError::IoError(io::Error::other(format!(
+            "rustfmt failed with {exit_status}"
+        ))));
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Replaces `io::Error::new(io::ErrorKind::Other, ..)` with
  `io::Error::other(..)` across:
  - `src/cargo-fmt/main.rs` (3 sites)
  - `src/config/mod.rs` (1 site)
  - `src/format-diff/main.rs` (1 site)
- Addresses `clippy::io_other_error`, run as a single-rule pass:
  `cargo clippy -- -A clippy::all -W clippy::io_other_error`.