### PR TITLE
refactor: apply clippy::non_canonical_partial_ord_impl

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -315,15 +315,15 @@ impl PartialEq for Target {
     }
 }
 
-impl PartialOrd for Target {
-    fn partial_cmp(&self, other: &Target) -> Option<Ordering> {
-        Some(self.path.cmp(&other.path))
-    }
-}
-
 impl Ord for Target {
     fn cmp(&self, other: &Target) -> Ordering {
         self.path.cmp(&other.path)
+    }
+}
+
+impl PartialOrd for Target {
+    fn partial_cmp(&self, other: &Target) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
## Summary

- In `src/cargo-fmt/main.rs`, reworks the manual `PartialOrd for Target` impl so `partial_cmp` is defined as `Some(self.cmp(other))` rather than duplicating the `self.path.cmp(&other.path)` body that already lives in `Ord::cmp`.
- Reorders the impl blocks so `Ord` precedes `PartialOrd`, matching the canonical pattern.
- Addresses `clippy::non_canonical_partial_ord_impl`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::non_canonical_partial_ord_impl`.

When a type implements both `Ord` and `PartialOrd` by hand, `partial_cmp` must agree with `cmp`. Routing `partial_cmp` through `cmp` removes the risk of the two impls drifting out of sync if the ordering logic is ever changed.