### PR TITLE
refactor: apply clippy::into_iter_on_ref

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -467,7 +467,7 @@ fn get_targets_with_hitlist(
 ) -> Result<(), io::Error> {
     let metadata = get_cargo_metadata(manifest_path)?;
     let mut workspace_hitlist: BTreeSet<&str> =
-        BTreeSet::from_iter(hitlist.into_iter().map(|s| s.as_str()));
+        BTreeSet::from_iter(hitlist.iter().map(|s| s.as_str()));
 
     for package in metadata.packages {
         if workspace_hitlist.remove(package.name.as_ref()) {


### PR DESCRIPTION
## Summary

- In `src/cargo-fmt/main.rs::get_targets_with_hitlist`, replaces `hitlist.into_iter().map(|s| s.as_str())` with `hitlist.iter().map(|s| s.as_str())`.
- Addresses `clippy::into_iter_on_ref`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::into_iter_on_ref`.

Calling `into_iter()` on a reference is misleading — it does not consume the collection, it just yields `&T` (same as `iter()`). Spelling it `iter()` matches what the code actually does.