### PR TITLE
refactor: apply clippy::unnecessary_lazy_evaluations

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -260,7 +260,7 @@ impl Rewrite for ast::MetaItemInner {
 fn has_newlines_before_after_comment(comment: &str) -> (&str, &str) {
     // Look at before and after comment and see if there are any empty lines.
     let comment_begin = comment.find('/');
-    let len = comment_begin.unwrap_or_else(|| comment.len());
+    let len = comment_begin.unwrap_or(comment.len());
     let mlb = count_newlines(&comment[..len]) > 1;
     let mla = if comment_begin.is_none() {
         mlb

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,7 +387,7 @@ fn format_code_block(
     let block_len = formatted
         .snippet
         .rfind('}')
-        .unwrap_or_else(|| formatted.snippet.len());
+        .unwrap_or(formatted.snippet.len());
 
     // It's possible that `block_len < FN_MAIN_PREFIX.len()`. This can happen if the code block was
     // formatted into the empty string, leading to the enclosing `fn main() {\n}` being formatted

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -669,7 +669,7 @@ pub(crate) fn get_comment_end(
     if is_last {
         return post_snippet
             .find_uncommented(terminator)
-            .unwrap_or_else(|| post_snippet.len());
+            .unwrap_or(post_snippet.len());
     }
 
     let mut block_open_index = post_snippet.find("/*");
@@ -725,14 +725,12 @@ pub(crate) fn has_extra_newline(post_snippet: &str, comment_end: usize) -> bool 
         .len_utf8();
     // Everything from the separator to the next item.
     let test_snippet = &post_snippet[comment_end - len_last..];
-    let first_newline = test_snippet
-        .find('\n')
-        .unwrap_or_else(|| test_snippet.len());
+    let first_newline = test_snippet.find('\n').unwrap_or(test_snippet.len());
     // From the end of the first line of comments.
     let test_snippet = &test_snippet[first_newline..];
     let first = test_snippet
         .find(|c: char| !c.is_whitespace())
-        .unwrap_or_else(|| test_snippet.len());
+        .unwrap_or(test_snippet.len());
     // From the end of the first line of comments to the next non-whitespace char.
     let test_snippet = &test_snippet[..first];
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -85,21 +85,21 @@ pub(crate) trait RewriteErrorExt<T> {
 
 impl<T> RewriteErrorExt<T> for Option<T> {
     fn max_width_error(self, width: usize, span: Span) -> Result<T, RewriteError> {
-        self.ok_or_else(|| RewriteError::ExceedsMaxWidth {
+        self.ok_or(RewriteError::ExceedsMaxWidth {
             configured_width: width,
             span: span,
         })
     }
 
     fn macro_error(self, kind: MacroErrorKind, span: Span) -> Result<T, RewriteError> {
-        self.ok_or_else(|| RewriteError::MacroFailure {
+        self.ok_or(RewriteError::MacroFailure {
             kind: kind,
             span: span,
         })
     }
 
     fn unknown_error(self) -> Result<T, RewriteError> {
-        self.ok_or_else(|| RewriteError::Unknown)
+        self.ok_or(RewriteError::Unknown)
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `Option::unwrap_or_else(|| s.len())` with `unwrap_or(s.len())` in `src/attr.rs`, `src/lib.rs`, and `src/lists.rs` (4 sites).
- Replaces `Option::ok_or_else(|| RewriteError::..)` with `ok_or(RewriteError::..)` in `src/rewrite.rs` (3 sites — `ExceedsMaxWidth`, `MacroFailure`, `Unknown`).
- Addresses `clippy::unnecessary_lazy_evaluations`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::unnecessary_lazy_evaluations`.

All eagerly-evaluated fallbacks here are trivial: `.len()` on `&str`/`String`/slices is O(1) and side-effect free, and the `RewriteError` variants are plain enum/struct constructors. No observable behavior change.