### PR TITLE
refactor: apply clippy::legacy_numeric_constants

### DIFF
--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -198,7 +198,7 @@ fn struct_field_prefix_max_min_width<T: AlignedItem>(
                 .rewrite_prefix(context, shape)
                 .map(|field_str| trimmed_last_line_width(&field_str))
         })
-        .fold_ok((0, ::std::usize::MAX), |(max_len, min_len), len| {
+        .fold_ok((0, usize::MAX), |(max_len, min_len), len| {
             (cmp::max(max_len, len), cmp::min(min_len, len))
         })
         .unwrap_or((0, 0))


### PR DESCRIPTION
## Summary

- In `src/vertical.rs::struct_field_prefix_max_min_width`, replaces `::std::usize::MAX` with `usize::MAX`.
- Addresses `clippy::legacy_numeric_constants`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::legacy_numeric_constants`.

The associated-constant form (`usize::MAX`, `u32::MAX`, …) has been stable since Rust 1.43 and is the form the standard library recommends; the `std::usize::MAX` module path is soft-deprecated.