### PR TITLE
refactor: apply clippy::explicit_auto_deref

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -90,7 +90,7 @@ pub(crate) fn format_expr(
 ) -> RewriteResult {
     skip_out_of_file_lines_range_err!(context, expr.span);
 
-    if contains_skip(&*expr.attrs) {
+    if contains_skip(&expr.attrs) {
         return Ok(context.snippet(expr.span()).to_owned());
     }
     let shape = if expr_type == ExprType::Statement && semicolon_for_expr(context, expr) {
@@ -304,9 +304,7 @@ pub(crate) fn format_expr(
             shape,
             SeparatorPlace::Front,
         ),
-        ast::ExprKind::Index(ref expr, ref index, _) => {
-            rewrite_index(&**expr, &**index, context, shape)
-        }
+        ast::ExprKind::Index(ref expr, ref index, _) => rewrite_index(expr, index, context, shape),
         ast::ExprKind::Repeat(ref expr, ref repeats) => rewrite_pair(
             &**expr,
             &*repeats.value,
@@ -1523,7 +1521,7 @@ pub(crate) fn is_simple_expr(expr: &ast::Expr) -> bool {
         | ast::ExprKind::Unary(_, ref expr) => is_simple_expr(expr),
         ast::ExprKind::Index(ref lhs, ref rhs, _) => is_simple_expr(lhs) && is_simple_expr(rhs),
         ast::ExprKind::Repeat(ref lhs, ref rhs) => {
-            is_simple_expr(lhs) && is_simple_expr(&*rhs.value)
+            is_simple_expr(lhs) && is_simple_expr(&rhs.value)
         }
         _ => false,
     }
@@ -1807,7 +1805,7 @@ fn rewrite_struct_lit<'a>(
     } else {
         let field_iter = fields.iter().map(StructLitField::Regular).chain(
             match struct_rest {
-                ast::StructRest::Base(expr) => Some(StructLitField::Base(&**expr)),
+                ast::StructRest::Base(expr) => Some(StructLitField::Base(expr)),
                 ast::StructRest::Rest(span) => Some(StructLitField::Rest(*span)),
                 ast::StructRest::None => None,
             }

--- a/src/items.rs
+++ b/src/items.rs
@@ -321,7 +321,7 @@ impl<'a> FnSig<'a> {
             constness: method_sig.header.constness,
             defaultness,
             ext: method_sig.header.ext,
-            decl: &*method_sig.decl,
+            decl: &method_sig.decl,
             generics,
             visibility,
         }
@@ -353,7 +353,7 @@ impl<'a> FnSig<'a> {
     fn to_str(&self, context: &RewriteContext<'_>) -> String {
         let mut result = String::with_capacity(128);
         // Vis defaultness constness unsafety abi.
-        result.push_str(&*format_visibility(context, self.visibility));
+        result.push_str(&format_visibility(context, self.visibility));
         result.push_str(format_defaultness(self.defaultness));
         result.push_str(format_constness(self.constness));
         self.coroutine_kind
@@ -1037,7 +1037,7 @@ fn format_impl_ref_and_type(
         IndentStyle::Visual => new_line_offset + trait_ref_overhead,
         IndentStyle::Block => new_line_offset,
     };
-    result.push_str(&*self_ty.rewrite_result(context, Shape::legacy(budget, type_offset))?);
+    result.push_str(&self_ty.rewrite_result(context, Shape::legacy(budget, type_offset))?);
     Ok(result)
 }
 
@@ -2314,7 +2314,7 @@ impl Rewrite for ast::Param {
                 !has_multiple_attr_lines && !has_doc_comments,
             )?;
 
-            if !is_empty_infer(&*self.ty, self.pat.span) {
+            if !is_empty_infer(&self.ty, self.pat.span) {
                 let (before_comment, after_comment) =
                     get_missing_param_comments(context, self.pat.span, self.ty.span, shape);
                 result.push_str(&before_comment);
@@ -3580,7 +3580,7 @@ pub(crate) fn rewrite_mod(
     attrs_shape: Shape,
 ) -> RewriteResult {
     let mut result = String::with_capacity(32);
-    result.push_str(&*format_visibility(context, &item.vis));
+    result.push_str(&format_visibility(context, &item.vis));
     result.push_str("mod ");
     result.push_str(rewrite_ident(context, ident));
     result.push(';');

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -291,7 +291,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         let item_length = items
             .iter()
             .take_while(|ppi| {
-                item_kind.is_same_item_kind(&***ppi)
+                item_kind.is_same_item_kind(ppi)
                     && (!in_group || {
                         let current = self.psess.lookup_line_range(ppi.span());
                         let in_same_group = current.lo < last.hi + 2;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1336,7 +1336,7 @@ pub(crate) fn can_be_overflowed_type(
         ast::TyKind::Tup(..) => context.use_block_indent() && len == 1,
         ast::TyKind::Ref(_, ref mutty)
         | ast::TyKind::PinnedRef(_, ref mutty)
-        | ast::TyKind::Ptr(ref mutty) => can_be_overflowed_type(context, &*mutty.ty, len),
+        | ast::TyKind::Ptr(ref mutty) => can_be_overflowed_type(context, &mutty.ty, len),
         _ => false,
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -982,7 +982,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         attrs: &[ast::Attribute],
     ) {
         let vis_str = utils::format_visibility(&self.get_context(), vis);
-        self.push_str(&*vis_str);
+        self.push_str(&vis_str);
         self.push_str(format_safety(safety));
         self.push_str("mod ");
         // Calling `to_owned()` to work around borrow checker.


### PR DESCRIPTION
## Summary

- Removes redundant explicit deref/borrow patterns (`&*x`, `&**x`, `&***x`) across `src/expr.rs`, `src/items.rs`, `src/reorder.rs`, `src/types.rs`, and `src/visitor.rs`. The compiler's auto-deref coercion produces the same reference type.
- Addresses `clippy::explicit_auto_deref`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::explicit_auto_deref`.

Representative changes:
- `contains_skip(&*expr.attrs)` → `contains_skip(&expr.attrs)`
- `rewrite_index(&**expr, &**index, …)` → `rewrite_index(expr, index, …)`
- `is_same_item_kind(&***ppi)` → `is_same_item_kind(ppi)`
- `result.push_str(&*format_visibility(…))` → `result.push_str(&format_visibility(…))`