### PR TITLE
refactor: apply clippy::skip_while_next

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -317,16 +317,14 @@ fn break_string(max_width: usize, trim_end: bool, line_end: &str, input: &[&str]
         // No whitespace found, try looking for a punctuation instead
         _ => match (0..max_width_index_in_input)
             .rev()
-            .skip_while(|pos| !is_valid_linebreak(input, *pos))
-            .next()
+            .find(|pos| is_valid_linebreak(input, *pos))
         {
             // Found a punctuation and what is on its left side is big enough.
             Some(index) if index >= MIN_STRING => break_at(index),
             // Either no boundary character was found to the left of `input[max_chars]`, or the line
             // got too small. We try searching for a boundary character to the right.
             _ => match (max_width_index_in_input..input.len())
-                .skip_while(|pos| !is_valid_linebreak(input, *pos))
-                .next()
+                .find(|pos| is_valid_linebreak(input, *pos))
             {
                 // A boundary was found after the line limit
                 Some(index) => break_at(index),


### PR DESCRIPTION
## Summary

- In `src/string.rs::break_string`, replaces both `skip_while(|p| !is_valid_linebreak(input, *p)).next()` calls with `find(|p| is_valid_linebreak(input, *p))`.
- Addresses `clippy::skip_while_next`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::skip_while_next`.

`Iterator::skip_while(pred).next()` returns the first element for which the predicate is false, so inverting the predicate inside `skip_while` is equivalent to using `Iterator::find` directly. The rewrite drops the `!` and the trailing `.next()`.