### PR TITLE
refactor: apply clippy::borrow_deref_ref

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -360,8 +360,8 @@ pub(crate) fn format_expr(
                         default_sp_delim(Some(lhs), Some(rhs))
                     };
                     rewrite_pair(
-                        &*lhs,
-                        &*rhs,
+                        lhs,
+                        rhs,
                         PairParts::infix(&sp_delim),
                         context,
                         shape,
@@ -374,7 +374,7 @@ pub(crate) fn format_expr(
                     } else {
                         default_sp_delim(None, Some(rhs))
                     };
-                    rewrite_unary_prefix(context, &sp_delim, &*rhs, shape)
+                    rewrite_unary_prefix(context, &sp_delim, rhs, shape)
                 }
                 (Some(lhs), None) => {
                     let sp_delim = if context.config.spaces_around_ranges() {
@@ -382,7 +382,7 @@ pub(crate) fn format_expr(
                     } else {
                         default_sp_delim(Some(lhs), None)
                     };
-                    rewrite_unary_suffix(context, &sp_delim, &*lhs, shape)
+                    rewrite_unary_suffix(context, &sp_delim, lhs, shape)
                 }
                 (None, None) => Ok(delim.to_owned()),
             }

--- a/src/items.rs
+++ b/src/items.rs
@@ -1850,7 +1850,7 @@ fn rewrite_ty<R: Rewrite>(
         } else {
             shape
         };
-        rewrite_assign_rhs(context, lhs, &*ty, &RhsAssignKind::Ty, shape)?
+        rewrite_assign_rhs(context, lhs, ty, &RhsAssignKind::Ty, shape)?
     } else {
         result
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1464,7 +1464,7 @@ fn format_lazy_static(
         result.push_str(&rewrite_assign_rhs(
             context,
             stmt,
-            &*expr,
+            expr,
             &RhsAssignKind::Expr(&expr.kind, expr.span),
             nested_shape.sub_width(1, expr.span)?,
         )?);

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -351,7 +351,7 @@ fn block_can_be_flattened<'a>(
                 && is_simple_block(context, block, Some(&expr.attrs))
                 && !stmt_is_expr_mac(&block.stmts[0]) =>
         {
-            Some(&*block)
+            Some(block)
         }
         _ => None,
     }
@@ -381,16 +381,16 @@ fn flatten_arm_body<'a>(
                     .and_then(|shape| rewrite_cond(context, expr, shape))
                     .map_or(false, |cond| cond.contains('\n'));
                 if cond_becomes_multi_line {
-                    (false, &*body)
+                    (false, body)
                 } else {
-                    (can_extend(expr), &*expr)
+                    (can_extend(expr), expr)
                 }
             }
         } else {
-            (false, &*body)
+            (false, body)
         }
     } else {
-        (can_extend(body), &*body)
+        (can_extend(body), body)
     }
 }
 

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -72,7 +72,7 @@ fn is_short_pattern_inner(context: &RewriteContext<'_>, pat: &ast::Pat) -> bool 
         ast::PatKind::Box(ref p)
         | PatKind::Deref(ref p)
         | ast::PatKind::Ref(ref p, _, _)
-        | ast::PatKind::Paren(ref p) => is_short_pattern_inner(context, &*p),
+        | ast::PatKind::Paren(ref p) => is_short_pattern_inner(context, p),
         PatKind::Or(ref pats) => pats.iter().all(|p| is_short_pattern_inner(context, p)),
     }
 }


### PR DESCRIPTION
## Summary

- Removes redundant `&*x` patterns where `x` is already a reference type (`&T`, `&Box<T>`, `&P<T>`, …). Deref-then-reborrow yields the same `&T`, so the operators add nothing.
- Touches `src/expr.rs`, `src/items.rs`, `src/macros.rs`, `src/matches.rs`, and `src/patterns.rs` — 12 sites in total.
- Addresses `clippy::borrow_deref_ref`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::borrow_deref_ref`.

Representative changes:
- `rewrite_pair(&*lhs, &*rhs, …)` → `rewrite_pair(lhs, rhs, …)`
- `rewrite_unary_prefix(context, &sp_delim, &*rhs, shape)` → `… , rhs, shape`
- `rewrite_assign_rhs(context, lhs, &*ty, …)` → `… , ty, …`
- `Some(&*block)` → `Some(block)`
- `is_short_pattern_inner(context, &*p)` → `is_short_pattern_inner(context, p)`

This is a narrower sibling of `clippy::explicit_auto_deref` — `borrow_deref_ref` specifically targets the `&*x` no-op when `x: &T`, which auto-deref does not need to mediate at all.