### PR TITLE
refactor: apply clippy::redundant_guards

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -237,8 +237,10 @@ fn rewrite_macro_inner(
             Err(err) => match err {
                 // We will move on to parsing macro args just like other macros
                 // if we could not parse lazy_static! with known syntax
-                RewriteError::MacroFailure { kind, span: _ }
-                    if kind == MacroErrorKind::ParseFailure => {}
+                RewriteError::MacroFailure {
+                    kind: MacroErrorKind::ParseFailure,
+                    span: _,
+                } => {}
                 // If formatting fails even though parsing succeeds, return the err early
                 _ => return Err(err),
             },


### PR DESCRIPTION
## Summary

- In `src/macros.rs::rewrite_macro_inner`, rewrites the arm `RewriteError::MacroFailure { kind, span: _ } if kind == MacroErrorKind::ParseFailure => {}` to use a pattern with the variant inlined: `RewriteError::MacroFailure { kind: MacroErrorKind::ParseFailure, span: _ } => {}`.
- Addresses `clippy::redundant_guards`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::redundant_guards`.

When a match guard is just an equality check against a literal/variant, the constraint can be lifted into the pattern itself — same semantics, less indirection.