### PR TITLE
refactor: apply clippy::needless_return

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -990,11 +990,11 @@ fn is_table_item(mut s: &str) -> bool {
     // This function may return false positive, but should get its job done in most cases (i.e.
     // markdown tables with two column delimiters).
     s = s.trim_start();
-    return s.starts_with('|')
+    s.starts_with('|')
         && match s.rfind('|') {
             Some(0) | None => false,
             _ => true,
-        };
+        }
 }
 
 /// Given the span, rewrite the missing comment inside it if available.


### PR DESCRIPTION
## Summary

- In `src/comment.rs::is_table_item`, removes the trailing `return …;` so the function ends in a tail expression instead.
- Addresses `clippy::needless_return`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::needless_return`.