### PR TITLE
refactor: apply clippy::assign_op_pattern

### DIFF
--- a/src/sort.rs
+++ b/src/sort.rs
@@ -95,7 +95,7 @@ impl<'a> Iterator for VersionChunkIter<'a> {
         let (_, next) = chars.next()?;
 
         if next == '_' {
-            self.start = self.start + next.len_utf8();
+            self.start += next.len_utf8();
             return Some(VersionChunk::Underscore);
         }
 


### PR DESCRIPTION
## Summary

- In `src/sort.rs::VersionChunkIter::next`, rewrites `self.start = self.start + next.len_utf8()` as `self.start += next.len_utf8()`.
- Addresses `clippy::assign_op_pattern`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::assign_op_pattern`.