### PR TITLE
refactor: apply clippy::wrong_self_convention

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -106,7 +106,7 @@ impl<'a> CommentStyle<'a> {
         }
     }
 
-    pub(crate) fn to_str_tuplet(&self) -> (&'a str, &'a str, &'a str) {
+    pub(crate) fn to_str_tuplet(self) -> (&'a str, &'a str, &'a str) {
         (self.opener(), self.closer(), self.line_start())
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -222,7 +222,7 @@ impl PartialConfig {
         ::toml::to_string(&cloned).map_err(ToTomlError)
     }
 
-    pub(super) fn to_parsed_config(
+    pub(super) fn into_parsed_config(
         self,
         style_edition_override: Option<StyleEdition>,
         edition_override: Option<Edition>,
@@ -438,7 +438,7 @@ impl Config {
                     format!("failed to get parent directory for {}", file_path.display())
                 })?;
 
-                Ok(parsed_config.to_parsed_config(style_edition, edition, version, dir))
+                Ok(parsed_config.into_parsed_config(style_edition, edition, version, dir))
             }
             Err(e) => {
                 let err_msg = format!(

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -21,7 +21,7 @@ use crate::lists::{
 };
 use crate::macros::{MacroPosition, rewrite_macro};
 use crate::matches::rewrite_match;
-use crate::overflow::{self, IntoOverflowableItem, OverflowableItem};
+use crate::overflow::{self, AsOverflowableItem, OverflowableItem};
 use crate::pairs::{PairParts, rewrite_all_pairs, rewrite_pair};
 use crate::rewrite::{Rewrite, RewriteContext, RewriteError, RewriteErrorExt, RewriteResult};
 use crate::shape::{Indent, Shape};
@@ -499,7 +499,7 @@ pub(crate) fn format_expr(
         })
 }
 
-pub(crate) fn rewrite_array<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_array<'a, T: 'a + AsOverflowableItem<'a>>(
     name: &'a str,
     exprs: impl Iterator<Item = &'a T>,
     span: Span,
@@ -1973,7 +1973,7 @@ pub(crate) fn rewrite_field(
     }
 }
 
-fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + IntoOverflowableItem<'a>>(
+fn rewrite_tuple_in_visual_indent_style<'a, T: 'a + AsOverflowableItem<'a>>(
     context: &RewriteContext<'_>,
     mut items: impl Iterator<Item = &'a T>,
     span: Span,
@@ -2059,7 +2059,7 @@ fn rewrite_let(
     )
 }
 
-pub(crate) fn rewrite_tuple<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_tuple<'a, T: 'a + AsOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     items: impl Iterator<Item = &'a T>,
     span: Span,

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -117,7 +117,7 @@ impl<'a> OverflowableItem<'a> {
 
     pub(crate) fn map<F, T>(&self, f: F) -> T
     where
-        F: Fn(&dyn IntoOverflowableItem<'a>) -> T,
+        F: Fn(&dyn AsOverflowableItem<'a>) -> T,
     {
         match self {
             OverflowableItem::Expr(expr) => f(*expr),
@@ -215,21 +215,21 @@ impl<'a> OverflowableItem<'a> {
     }
 }
 
-pub(crate) trait IntoOverflowableItem<'a>: Rewrite + Spanned {
-    fn into_overflowable_item(&'a self) -> OverflowableItem<'a>;
+pub(crate) trait AsOverflowableItem<'a>: Rewrite + Spanned {
+    fn as_overflowable_item(&'a self) -> OverflowableItem<'a>;
 }
 
-impl<'a, T: 'a + IntoOverflowableItem<'a>> IntoOverflowableItem<'a> for Box<T> {
-    fn into_overflowable_item(&'a self) -> OverflowableItem<'a> {
-        (**self).into_overflowable_item()
+impl<'a, T: 'a + AsOverflowableItem<'a>> AsOverflowableItem<'a> for Box<T> {
+    fn as_overflowable_item(&'a self) -> OverflowableItem<'a> {
+        (**self).as_overflowable_item()
     }
 }
 
-macro_rules! impl_into_overflowable_item_for_ast_node {
+macro_rules! impl_as_overflowable_item_for_ast_node {
     ($($ast_node:ident),*) => {
         $(
-            impl<'a> IntoOverflowableItem<'a> for ast::$ast_node {
-                fn into_overflowable_item(&'a self) -> OverflowableItem<'a> {
+            impl<'a> AsOverflowableItem<'a> for ast::$ast_node {
+                fn as_overflowable_item(&'a self) -> OverflowableItem<'a> {
                     OverflowableItem::$ast_node(self)
                 }
             }
@@ -237,18 +237,18 @@ macro_rules! impl_into_overflowable_item_for_ast_node {
     }
 }
 
-macro_rules! impl_into_overflowable_item_for_rustfmt_types {
+macro_rules! impl_as_overflowable_item_for_rustfmt_types {
     ([$($ty:ident),*], [$($ty_with_lifetime:ident),*]) => {
         $(
-            impl<'a> IntoOverflowableItem<'a> for $ty {
-                fn into_overflowable_item(&'a self) -> OverflowableItem<'a> {
+            impl<'a> AsOverflowableItem<'a> for $ty {
+                fn as_overflowable_item(&'a self) -> OverflowableItem<'a> {
                     OverflowableItem::$ty(self)
                 }
             }
         )*
         $(
-            impl<'a> IntoOverflowableItem<'a> for $ty_with_lifetime<'a> {
-                fn into_overflowable_item(&'a self) -> OverflowableItem<'a> {
+            impl<'a> AsOverflowableItem<'a> for $ty_with_lifetime<'a> {
+                fn as_overflowable_item(&'a self) -> OverflowableItem<'a> {
                     OverflowableItem::$ty_with_lifetime(self)
                 }
             }
@@ -256,7 +256,7 @@ macro_rules! impl_into_overflowable_item_for_rustfmt_types {
     }
 }
 
-impl_into_overflowable_item_for_ast_node!(
+impl_as_overflowable_item_for_ast_node!(
     Expr,
     GenericParam,
     MetaItemInner,
@@ -265,18 +265,18 @@ impl_into_overflowable_item_for_ast_node!(
     Pat,
     PreciseCapturingArg
 );
-impl_into_overflowable_item_for_rustfmt_types!([MacroArg], [SegmentParam, TuplePatField]);
+impl_as_overflowable_item_for_rustfmt_types!([MacroArg], [SegmentParam, TuplePatField]);
 
 pub(crate) fn into_overflowable_list<'a, T>(
     iter: impl Iterator<Item = &'a T>,
 ) -> impl Iterator<Item = OverflowableItem<'a>>
 where
-    T: 'a + IntoOverflowableItem<'a>,
+    T: 'a + AsOverflowableItem<'a>,
 {
-    iter.map(|x| IntoOverflowableItem::into_overflowable_item(x))
+    iter.map(|x| AsOverflowableItem::as_overflowable_item(x))
 }
 
-pub(crate) fn rewrite_with_parens<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_with_parens<'a, T: 'a + AsOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     ident: &'a str,
     items: impl Iterator<Item = &'a T>,
@@ -300,7 +300,7 @@ pub(crate) fn rewrite_with_parens<'a, T: 'a + IntoOverflowableItem<'a>>(
     .rewrite(shape)
 }
 
-pub(crate) fn rewrite_with_angle_brackets<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_with_angle_brackets<'a, T: 'a + AsOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     ident: &'a str,
     items: impl Iterator<Item = &'a T>,
@@ -322,7 +322,7 @@ pub(crate) fn rewrite_with_angle_brackets<'a, T: 'a + IntoOverflowableItem<'a>>(
     .rewrite(shape)
 }
 
-pub(crate) fn rewrite_with_square_brackets<'a, T: 'a + IntoOverflowableItem<'a>>(
+pub(crate) fn rewrite_with_square_brackets<'a, T: 'a + AsOverflowableItem<'a>>(
     context: &'a RewriteContext<'_>,
     name: &'a str,
     items: impl Iterator<Item = &'a T>,
@@ -367,7 +367,7 @@ struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
-    fn new<T: 'a + IntoOverflowableItem<'a>>(
+    fn new<T: 'a + AsOverflowableItem<'a>>(
         context: &'a RewriteContext<'_>,
         items: impl Iterator<Item = &'a T>,
         ident: &'a str,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -68,15 +68,15 @@ impl Indent {
         self.block_indent + self.alignment
     }
 
-    pub(crate) fn to_string(&self, config: &Config) -> Cow<'static, str> {
+    pub(crate) fn to_string(self, config: &Config) -> Cow<'static, str> {
         self.to_string_inner(config, 1)
     }
 
-    pub(crate) fn to_string_with_newline(&self, config: &Config) -> Cow<'static, str> {
+    pub(crate) fn to_string_with_newline(self, config: &Config) -> Cow<'static, str> {
         self.to_string_inner(config, 0)
     }
 
-    fn to_string_inner(&self, config: &Config, offset: usize) -> Cow<'static, str> {
+    fn to_string_inner(self, config: &Config, offset: usize) -> Cow<'static, str> {
         let (num_tabs, num_spaces) = if config.hard_tabs() {
             (self.block_indent / config.tab_spaces(), self.alignment)
         } else {
@@ -308,7 +308,7 @@ impl Shape {
         Shape { width, ..*self }
     }
 
-    pub(crate) fn to_string_with_newline(&self, config: &Config) -> Cow<'static, str> {
+    pub(crate) fn to_string_with_newline(self, config: &Config) -> Cow<'static, str> {
         let mut offset_indent = self.indent;
         offset_indent.alignment = self.offset;
         offset_indent.to_string_inner(config, 0)


### PR DESCRIPTION
## Summary

Three related fixes, all driven by `clippy::wrong_self_convention`. Run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::wrong_self_convention`.

### 1. `to_*` methods take `self` instead of `&self` (on `Copy` types)

The `to_*` convention is "cheap reference-style conversion", which on `Copy` types is more natural to express by-value than as `&self`. No call site needs to change because `Copy` types are passed implicitly.

- `src/comment.rs`: `CommentStyle::to_str_tuplet`
- `src/shape.rs`: `Indent::to_string`, `Indent::to_string_with_newline`, `Indent::to_string_inner`, `Shape::to_string_with_newline`

### 2. Rename `to_parsed_config` → `into_parsed_config`

`PartialConfig::to_parsed_config` already consumes `self`, so by convention it should be named `into_*`, not `to_*`. The only call site (`src/config/mod.rs`) is updated in the same commit.

### 3. Rename trait `IntoOverflowableItem` → `AsOverflowableItem`

`IntoOverflowableItem::into_overflowable_item` was misnamed: it takes `&self` and returns a wrapper that borrows from `self` (`OverflowableItem<'a>`). The `Into*`/`into_*` convention is reserved for consuming conversions; non-consuming, borrowing conversions should use `As*`/`as_*`.

This rename touches:
- The trait, method, and `Box<T>` blanket impl in `src/overflow.rs`.
- Both `impl_into_overflowable_item_for_*` macros and their invocations.
- Generic bounds on `rewrite_with_parens`, `rewrite_with_angle_brackets`, `rewrite_with_square_brackets`, `Context::new`, and `into_overflowable_list` in `src/overflow.rs`.
- Generic bounds on `rewrite_array`, `rewrite_tuple_in_visual_indent_style`, and `rewrite_tuple` in `src/expr.rs`, plus the corresponding `use` import.

The helper `into_overflowable_list` keeps its name (it transforms an `Iterator<Item = &T>` into `Iterator<Item = OverflowableItem<'a>>`); only the trait and the per-element method are renamed.