### PR TITLE
refactor: apply clippy::needless_borrow

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -300,7 +300,7 @@ impl Rewrite for ChainItem {
             ChainItemKind::Parent {
                 ref expr,
                 parens: true,
-            } => crate::expr::rewrite_paren(context, &expr, shape, expr.span)?,
+            } => crate::expr::rewrite_paren(context, expr, shape, expr.span)?,
             ChainItemKind::Parent {
                 ref expr,
                 parens: false,
@@ -367,7 +367,7 @@ impl ChainItem {
             format!("::<{}>", type_list.join(", "))
         };
         let callee_str = format!(".{}{}", rewrite_ident(context, method_name), type_str);
-        rewrite_call(context, &callee_str, &args, span, shape)
+        rewrite_call(context, &callee_str, args, span, shape)
     }
 }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2321,7 +2321,7 @@ fn choose_rhs<R: Rewrite>(
 
             match (orig_rhs, new_rhs) {
                 (Ok(ref orig_rhs), Ok(ref new_rhs))
-                    if !filtered_str_fits(&new_rhs, context.config.max_width(), new_shape) =>
+                    if !filtered_str_fits(new_rhs, context.config.max_width(), new_shape) =>
                 {
                     Ok(format!("{before_space_str}{orig_rhs}"))
                 }

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -65,7 +65,7 @@ impl<'a> Display for FormatReportFormatter<'a> {
 
                 let message_suffix = error.msg_suffix();
                 if !message_suffix.is_empty() {
-                    message = message.footer(Level::Note.title(&message_suffix));
+                    message = message.footer(Level::Note.title(message_suffix));
                 }
 
                 let origin = format!("{}:{}", file, error.line);

--- a/src/items.rs
+++ b/src/items.rs
@@ -1859,7 +1859,7 @@ fn rewrite_ty<R: Rewrite>(
         let option = WhereClauseOption::new(true, WhereClauseSpace::Newline);
         let after_where_clause_str = rewrite_where_clause(
             context,
-            &after_where_clause,
+            after_where_clause,
             context.config.brace_style(),
             Shape::indented(indent, context.config),
             false,
@@ -2489,7 +2489,7 @@ fn rewrite_fn_base(
     let generics_str = rewrite_generics(
         context,
         rewrite_ident(context, ident),
-        &fn_sig.generics,
+        fn_sig.generics,
         shape,
     )?;
     result.push_str(&generics_str);
@@ -2734,7 +2734,7 @@ fn rewrite_fn_base(
     }
     let where_clause_str = rewrite_where_clause(
         context,
-        &where_clause,
+        where_clause,
         context.config.brace_style(),
         Shape::indented(indent, context.config),
         true,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -822,7 +822,7 @@ impl MacroArgParser {
 
         // Parse '*', '+' or '?.
         for tok in iter {
-            self.set_last_tok(&tok);
+            self.set_last_tok(tok);
             if first {
                 first = false;
             }
@@ -970,7 +970,7 @@ impl MacroArgParser {
                 }
             }
 
-            self.set_last_tok(&tok);
+            self.set_last_tok(tok);
         }
 
         // We are left with some stuff in the buffer. Since there is nothing

--- a/src/overflow.rs
+++ b/src/overflow.rs
@@ -584,7 +584,7 @@ impl<'a> Context<'a> {
 
                     if tactic == DefinitiveListTactic::Vertical {
                         if let Some((all_simple, num_args_before)) =
-                            maybe_get_args_offset(self.ident, &self.items, &self.context.config)
+                            maybe_get_args_offset(self.ident, &self.items, self.context.config)
                         {
                             let one_line = all_simple
                                 && definitive_tactic(

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -151,7 +151,7 @@ pub(crate) fn version_sort(a: &str, b: &str) -> std::cmp::Ordering {
                 (VersionChunk::Str(ca), VersionChunk::Str(cb))
                 | (VersionChunk::Str(ca), VersionChunk::Number { source: cb, .. })
                 | (VersionChunk::Number { source: ca, .. }, VersionChunk::Str(cb)) => {
-                    match ca.cmp(&cb) {
+                    match ca.cmp(cb) {
                         std::cmp::Ordering::Equal => {
                             continue;
                         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -499,14 +499,14 @@ impl Rewrite for ast::WherePredicate {
         let mut result = String::with_capacity(attrs_str.len() + pred_str.len() + 1);
         result.push_str(&attrs_str);
         let pred_start = self.span.lo();
-        let line_len = last_line_width(&attrs_str) + 1 + first_line_width(&pred_str);
+        let line_len = last_line_width(&attrs_str) + 1 + first_line_width(pred_str);
         if let Some(last_attr) = self.attrs.last().filter(|last_attr| {
             contains_comment(context.snippet(mk_sp(last_attr.span.hi(), pred_start)))
         }) {
             result = combine_strs_with_missing_comments(
                 context,
                 &result,
-                &pred_str,
+                pred_str,
                 mk_sp(last_attr.span.hi(), pred_start),
                 Shape {
                     width: shape.width.min(context.config.inline_attribute_width()),
@@ -525,7 +525,7 @@ impl Rewrite for ast::WherePredicate {
                     result.push(' ');
                 }
             }
-            result.push_str(&pred_str);
+            result.push_str(pred_str);
         }
 
         Ok(result)


### PR DESCRIPTION
## Summary

- Removes 12 redundant `&` borrows where the callee already takes a reference, across `src/chains.rs`, `src/expr.rs`, `src/format_report_formatter.rs`, `src/items.rs`, `src/macros.rs`, `src/overflow.rs`, `src/sort.rs`, and `src/types.rs`.
- Addresses `clippy::needless_borrow`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::needless_borrow`.

Representative changes:
- `rewrite_paren(context, &expr, …)` → `rewrite_paren(context, expr, …)`
- `rewrite_call(context, &callee_str, &args, …)` → `… , args, …`
- `rewrite_where_clause(context, &after_where_clause, …)` → `… , after_where_clause, …`
- `rewrite_generics(context, …, &fn_sig.generics, …)` → `… , fn_sig.generics, …`
- `maybe_get_args_offset(…, &self.context.config)` → `… , self.context.config`
- `ca.cmp(&cb)` → `ca.cmp(cb)` (and similar)
- `first_line_width(&pred_str)` → `first_line_width(pred_str)`

In every case the argument was already an `&T`, so the extra `&` was reborrowed to the same type — no observable change.