### PR TITLE
refactor: apply clippy::redundant_field_names

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -136,7 +136,7 @@ impl ListItem {
         ListItem {
             pre_comment: None,
             pre_comment_style: ListItemCommentStyle::None,
-            item: item,
+            item,
             post_comment: None,
             new_lines: false,
         }

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -151,10 +151,7 @@ fn rewrite_reorderable_or_regroupable_items(
                         .map(|use_tree| {
                             let item = use_tree.rewrite_top_level(context, nested_shape);
                             if let Some(list_item) = use_tree.list_item {
-                                ListItem {
-                                    item: item,
-                                    ..list_item
-                                }
+                                ListItem { item, ..list_item }
                             } else {
                                 ListItem::from_item(item)
                             }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -87,15 +87,12 @@ impl<T> RewriteErrorExt<T> for Option<T> {
     fn max_width_error(self, width: usize, span: Span) -> Result<T, RewriteError> {
         self.ok_or_else(|| RewriteError::ExceedsMaxWidth {
             configured_width: width,
-            span: span,
+            span,
         })
     }
 
     fn macro_error(self, kind: MacroErrorKind, span: Span) -> Result<T, RewriteError> {
-        self.ok_or_else(|| RewriteError::MacroFailure {
-            kind: kind,
-            span: span,
-        })
+        self.ok_or_else(|| RewriteError::MacroFailure { kind, span })
     }
 
     fn unknown_error(self) -> Result<T, RewriteError> {


### PR DESCRIPTION
## Summary

- Replaces explicit `field: field` patterns with field init shorthand in:
  - `src/lists.rs::ListItem::from_item` (`item: item` → `item`)
  - `src/reorder.rs::rewrite_reorderable_or_regroupable_items` (`ListItem { item: item, ..list_item }` → `ListItem { item, ..list_item }`)
  - `src/rewrite.rs::RewriteErrorExt::max_width_error` and `macro_error` (`span: span`, `kind: kind`)
- Addresses `clippy::redundant_field_names`, run as a single-rule pass: `cargo clippy -- -A clippy::all -W clippy::redundant_field_names`.