### PR TITLE
Add documented struct field spacing option

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2783,6 +2783,81 @@ struct Foo {
 }
 ```
 
+## `documented_struct_field_blank_lines`
+
+Whether rustfmt inserts blank lines around documented struct field sections.
+
+- **Default value**: `"Preserve"`
+- **Possible values**: `"Preserve"`, `"Always"`, `"Threshold"`
+- **Stable**: No (tracking issue: [#6925](https://github.com/rust-lang/rustfmt/issues/6925))
+
+#### `"Preserve"` (default):
+
+```rust
+struct Foo {
+    a: u32,
+    /// Beta.
+    b: u32,
+    /// Gamma.
+    c: u32,
+}
+```
+
+#### `"Always"`:
+
+```rust
+struct Foo {
+    a: u32,
+
+    /// Beta.
+    b: u32,
+
+    /// Gamma.
+    c: u32,
+}
+```
+
+#### `"Threshold"`:
+
+Use [`documented_struct_field_blank_lines_threshold`](#documented_struct_field_blank_lines_threshold)
+to decide when to apply the spacing.
+
+## `documented_struct_field_blank_lines_threshold`
+
+Minimum total number of fields in a struct before rustfmt inserts blank lines around documented
+struct field sections when `documented_struct_field_blank_lines = "Threshold"`.
+Spacing is applied to each contiguous section of documented fields within a qualifying struct.
+
+- **Default value**: `4`
+- **Possible values**: any non-negative integer
+- **Stable**: No (tracking issue: [#6925](https://github.com/rust-lang/rustfmt/issues/6925))
+
+#### `4` (default):
+
+```rust
+// rustfmt-documented_struct_field_blank_lines: "Threshold"
+// rustfmt-documented_struct_field_blank_lines_threshold: 4
+
+struct Foo {
+    a: u32,
+    /// Beta.
+    b: u32,
+    /// Gamma.
+    c: u32,
+}
+
+struct Bar {
+    a: u32,
+
+    /// Beta.
+    b: u32,
+
+    /// Gamma.
+    c: u32,
+    d: u32,
+}
+```
+
 ## `struct_lit_single_line`
 
 Put small struct literals on a single line

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -123,6 +123,11 @@ create_config! {
         "Width threshold for an array element to be considered short";
     overflow_delimited_expr: OverflowDelimitedExpr, false,
         "Allow trailing bracket/brace delimited expressions to overflow";
+    documented_struct_field_blank_lines: DocumentedStructFieldBlankLinesConfig, false,
+        "Whether to insert blank lines around documented struct field sections";
+    documented_struct_field_blank_lines_threshold: DocumentedStructFieldBlankLinesThreshold, false,
+        "Minimum total number of struct fields required before documented field section spacing \
+        is inserted when documented_struct_field_blank_lines = \"Threshold\"";
     struct_field_align_threshold: StructFieldAlignThreshold, false,
         "Align struct fields if their diffs fits within threshold";
     enum_discrim_align_threshold: EnumDiscrimAlignThreshold, false,
@@ -801,6 +806,8 @@ remove_nested_parens = true
 combine_control_expr = true
 short_array_element_width_threshold = 10
 overflow_delimited_expr = false
+documented_struct_field_blank_lines = "Preserve"
+documented_struct_field_blank_lines_threshold = 4
 struct_field_align_threshold = 0
 enum_discrim_align_threshold = 0
 match_arm_blocks = true
@@ -893,6 +900,8 @@ remove_nested_parens = true
 combine_control_expr = true
 short_array_element_width_threshold = 10
 overflow_delimited_expr = false
+documented_struct_field_blank_lines = "Preserve"
+documented_struct_field_blank_lines_threshold = 4
 struct_field_align_threshold = 0
 enum_discrim_align_threshold = 0
 match_arm_blocks = true

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -135,6 +135,17 @@ pub enum ImportGranularity {
     One,
 }
 
+#[config_type]
+/// How to insert blank lines around documented struct fields.
+pub enum DocumentedStructFieldBlankLines {
+    /// Keep existing spacing.
+    Preserve,
+    /// Always insert blank lines around documented struct field sections.
+    Always,
+    /// Insert blank lines when the struct has at least the configured number of fields.
+    Threshold,
+}
+
 /// Controls how rustfmt should handle case in hexadecimal literals.
 #[config_type]
 pub enum HexLiteralCase {
@@ -661,6 +672,9 @@ config_option_with_style_edition_default!(
     CombineControlExpr, bool, _ => true;
     ShortArrayElementWidthThreshold, usize, _ => 10;
     OverflowDelimitedExpr, bool, _ => false;
+    DocumentedStructFieldBlankLinesConfig, DocumentedStructFieldBlankLines, _ =>
+        DocumentedStructFieldBlankLines::Preserve;
+    DocumentedStructFieldBlankLinesThreshold, usize, _ => 4;
     StructFieldAlignThreshold, usize, _ => 0;
     EnumDiscrimAlignThreshold, usize, _ => 0;
     MatchArmBlocks, bool, _ => true;

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -8,6 +8,7 @@ use rustc_span::{BytePos, Span};
 
 use crate::comment::combine_strs_with_missing_comments;
 use crate::config::lists::*;
+use crate::config::DocumentedStructFieldBlankLines;
 use crate::expr::rewrite_field;
 use crate::items::{rewrite_struct_field, rewrite_struct_field_prefix};
 use crate::lists::{
@@ -31,6 +32,9 @@ pub(crate) trait AlignedItem {
         shape: Shape,
         prefix_max_width: usize,
     ) -> RewriteResult;
+    fn is_documented(&self) -> bool {
+        false
+    }
 }
 
 impl AlignedItem for ast::FieldDef {
@@ -68,6 +72,10 @@ impl AlignedItem for ast::FieldDef {
         prefix_max_width: usize,
     ) -> RewriteResult {
         rewrite_struct_field(context, self, shape, prefix_max_width)
+    }
+
+    fn is_documented(&self) -> bool {
+        self.attrs.iter().any(|attr| attr.is_doc_comment())
     }
 }
 
@@ -235,6 +243,8 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
     )
     .collect::<Vec<_>>();
 
+    insert_blank_lines_between_documented_fields(context, fields, &mut items);
+
     let tactic = definitive_tactic(
         &items,
         ListTactic::HorizontalVertical,
@@ -267,6 +277,61 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
         .trailing_separator(separator_tactic)
         .preserve_newline(true);
     write_list(&items, &fmt).ok()
+}
+
+fn insert_blank_lines_between_documented_fields<T: AlignedItem>(
+    context: &RewriteContext<'_>,
+    fields: &[T],
+    items: &mut [ListItem],
+) {
+    if !should_insert_documented_field_blank_lines(context, fields) {
+        return;
+    }
+
+    let mut run_start = None;
+    for (index, field) in fields.iter().enumerate() {
+        if field.is_documented() {
+            run_start.get_or_insert(index);
+            continue;
+        }
+
+        mark_documented_field_run(items, run_start.take(), index);
+    }
+
+    mark_documented_field_run(items, run_start, fields.len());
+}
+
+fn should_insert_documented_field_blank_lines<T: AlignedItem>(
+    context: &RewriteContext<'_>,
+    fields: &[T],
+) -> bool {
+    match context.config.documented_struct_field_blank_lines() {
+        DocumentedStructFieldBlankLines::Preserve => false,
+        DocumentedStructFieldBlankLines::Always => true,
+        DocumentedStructFieldBlankLines::Threshold => {
+            fields.len() >= context.config.documented_struct_field_blank_lines_threshold()
+        }
+    }
+}
+
+fn mark_documented_field_run(
+    items: &mut [ListItem],
+    run_start: Option<usize>,
+    run_end: usize,
+) {
+    let Some(run_start) = run_start else {
+        return;
+    };
+
+    // `ListItem::new_lines` inserts an extra blank line after the current item,
+    // so a documented section break is represented by marking the preceding item.
+    if run_start > 0 {
+        items[run_start - 1].new_lines = true;
+    }
+
+    for item in &mut items[run_start..run_end.saturating_sub(1)] {
+        item.new_lines = true;
+    }
 }
 
 /// Returns the index in `fields` up to which a field belongs to the current group.

--- a/tests/source/configs/documented_struct_field_blank_lines/always.rs
+++ b/tests/source/configs/documented_struct_field_blank_lines/always.rs
@@ -1,0 +1,11 @@
+// rustfmt-documented_struct_field_blank_lines: Always
+// rustfmt-unstable: true
+
+struct Always {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+    /// Gamma.
+    gamma: u32,
+    delta: u32,
+}

--- a/tests/source/configs/documented_struct_field_blank_lines/preserve.rs
+++ b/tests/source/configs/documented_struct_field_blank_lines/preserve.rs
@@ -1,0 +1,11 @@
+// rustfmt-documented_struct_field_blank_lines: Preserve
+// rustfmt-unstable: true
+
+struct Preserve {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+    /// Gamma.
+    gamma: u32,
+    delta: u32,
+}

--- a/tests/source/configs/documented_struct_field_blank_lines_threshold/3.rs
+++ b/tests/source/configs/documented_struct_field_blank_lines_threshold/3.rs
@@ -1,0 +1,17 @@
+// rustfmt-documented_struct_field_blank_lines: Threshold
+// rustfmt-documented_struct_field_blank_lines_threshold: 3
+// rustfmt-unstable: true
+
+struct BelowThreshold {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+}
+
+struct AtThreshold {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+    /// Gamma.
+    gamma: u32,
+}

--- a/tests/source/configs/documented_struct_field_blank_lines_threshold/4.rs
+++ b/tests/source/configs/documented_struct_field_blank_lines_threshold/4.rs
@@ -1,0 +1,20 @@
+// rustfmt-documented_struct_field_blank_lines: Threshold
+// rustfmt-documented_struct_field_blank_lines_threshold: 4
+// rustfmt-unstable: true
+
+struct BelowThreshold {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+    /// Gamma.
+    gamma: u32,
+}
+
+struct AtThreshold {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+    /// Gamma.
+    gamma: u32,
+    delta: u32,
+}

--- a/tests/target/configs/documented_struct_field_blank_lines/always.rs
+++ b/tests/target/configs/documented_struct_field_blank_lines/always.rs
@@ -1,0 +1,13 @@
+// rustfmt-documented_struct_field_blank_lines: Always
+// rustfmt-unstable: true
+
+struct Always {
+    alpha: u32,
+
+    /// Beta.
+    beta: u32,
+
+    /// Gamma.
+    gamma: u32,
+    delta: u32,
+}

--- a/tests/target/configs/documented_struct_field_blank_lines/preserve.rs
+++ b/tests/target/configs/documented_struct_field_blank_lines/preserve.rs
@@ -1,0 +1,11 @@
+// rustfmt-documented_struct_field_blank_lines: Preserve
+// rustfmt-unstable: true
+
+struct Preserve {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+    /// Gamma.
+    gamma: u32,
+    delta: u32,
+}

--- a/tests/target/configs/documented_struct_field_blank_lines_threshold/3.rs
+++ b/tests/target/configs/documented_struct_field_blank_lines_threshold/3.rs
@@ -1,0 +1,19 @@
+// rustfmt-documented_struct_field_blank_lines: Threshold
+// rustfmt-documented_struct_field_blank_lines_threshold: 3
+// rustfmt-unstable: true
+
+struct BelowThreshold {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+}
+
+struct AtThreshold {
+    alpha: u32,
+
+    /// Beta.
+    beta: u32,
+
+    /// Gamma.
+    gamma: u32,
+}

--- a/tests/target/configs/documented_struct_field_blank_lines_threshold/4.rs
+++ b/tests/target/configs/documented_struct_field_blank_lines_threshold/4.rs
@@ -1,0 +1,22 @@
+// rustfmt-documented_struct_field_blank_lines: Threshold
+// rustfmt-documented_struct_field_blank_lines_threshold: 4
+// rustfmt-unstable: true
+
+struct BelowThreshold {
+    alpha: u32,
+    /// Beta.
+    beta: u32,
+    /// Gamma.
+    gamma: u32,
+}
+
+struct AtThreshold {
+    alpha: u32,
+
+    /// Beta.
+    beta: u32,
+
+    /// Gamma.
+    gamma: u32,
+    delta: u32,
+}


### PR DESCRIPTION
Fixes #6925.

## Summary

Add unstable rustfmt options for inserting blank lines around documented struct field sections:

- `documented_struct_field_blank_lines = "Preserve" | "Always" | "Threshold"`
- `documented_struct_field_blank_lines_threshold = <usize>`

This follows existing rustfmt config patterns better than overloading a single numeric option with a sentinel value.

## Testing

- `cargo test --lib test_dump_default_config -- --nocapture`
- `cargo test --lib test_dump_style_edition_2024_config -- --nocapture`
- `cargo test --lib verify_config_test_names -- --nocapture`
- `cargo test --lib configuration_snippet_tests -- --nocapture`
- `cargo test --lib system_tests -- --nocapture`

## Implementation notes

- The threshold is evaluated against the total number of fields in the struct, not the length of a contiguous documented run.
- Once a struct qualifies, spacing is applied per contiguous documented section within that struct.
- The implementation reuses `ListItem::new_lines` in the vertical field formatter instead of introducing a second spacing path.

## Open points / context

- While implementing this, the original numeric-only shape turned out to be ambiguous around `0` and `1`, especially if `0` was treated as either `Preserve` or `Always`. The enum mode avoids that ambiguity.
- The current tests cover the mode differences and threshold boundaries. They do not add dedicated interaction coverage for cases like `#[rustfmt::skip]` or intervening non-doc comments inside documented sections; those continue to follow the existing contiguous-section logic in `vertical.rs`.

## AI disclosure

This PR was developed with assistance from Codex using GPT-5.5.
