### PR TITLE
Add test for and fix issue #6927.

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -700,6 +700,12 @@ impl UseTree {
         if self.path.is_empty() || self.contains_comment() {
             return vec![self];
         }
+        let (mut doc_comments, attributes): (ast::AttrVec, ast::AttrVec) = self
+            .attrs
+            .iter()
+            .cloned()
+            .flat_map(|attrs| attrs.into_iter())
+            .partition(|attr| attr.is_doc_comment());
         match &self.path.clone().last().unwrap().kind {
             UseSegmentKind::List(list) => {
                 if list.len() == 1 && list[0].path.len() == 1 {
@@ -720,7 +726,12 @@ impl UseTree {
                             visibility: self.visibility.clone(),
                             // only retain attributes for `ImportGranularity::Item`
                             attrs: match import_granularity {
-                                ImportGranularity::Item => self.attrs.clone(),
+                                ImportGranularity::Item => Some(
+                                    doc_comments
+                                        .drain(..)
+                                        .chain(attributes.iter().cloned())
+                                        .collect(),
+                                ),
                                 _ => None,
                             },
                         });

--- a/tests/source/issue-6927/rustdoc_comment.rs
+++ b/tests/source/issue-6927/rustdoc_comment.rs
@@ -1,0 +1,10 @@
+// rustfmt-imports_granularity: Item
+
+/// rustdoc comment
+use a::{a, b, c};
+
+// standard comment
+use b::{a, b, c};
+
+#[doc = "also rustdoc comment"]
+use c::{a, b, c};

--- a/tests/target/issue-6927/rustdoc_comment.rs
+++ b/tests/target/issue-6927/rustdoc_comment.rs
@@ -2,9 +2,7 @@
 
 /// rustdoc comment
 use a::a;
-/// rustdoc comment
 use a::b;
-/// rustdoc comment
 use a::c;
 
 // standard comment

--- a/tests/target/issue-6927/rustdoc_comment.rs
+++ b/tests/target/issue-6927/rustdoc_comment.rs
@@ -1,0 +1,20 @@
+// rustfmt-imports_granularity: Item
+
+/// rustdoc comment
+use a::a;
+/// rustdoc comment
+use a::b;
+/// rustdoc comment
+use a::c;
+
+// standard comment
+use b::a;
+use b::b;
+use b::c;
+
+#[doc = "also rustdoc comment"]
+use c::a;
+#[doc = "also rustdoc comment"]
+use c::b;
+#[doc = "also rustdoc comment"]
+use c::c;


### PR DESCRIPTION
The root cause for the [issue](https://github.com/rust-lang/rustfmt/issues/6927) is that upon flattening an import tree `rustfmt` repeats the attributes of the original `use` statement for all the new ones. This makes sense, and in case of `#[cfg...]` attributes it's essential.

The problem occurs because `rustc_ast` treats rustdoc comments as attributes too, with the `rustc_ast::ast::Attribute` type.

Luckily, it has an `is_doc_comment` function. The fix uses that to partition the attributes into rustdoc comments and the rest, and then clone the rest for all new use statements, while keeping the comments only with the first one.