### PR TITLE
Fix wrapping of bodyless fn signatures at max width

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -2618,10 +2618,14 @@ fn rewrite_fn_base(
                 // the closing parenthesis of the param and the arrow '->' is considered.
                 let mut sig_length = result.len() + indent.width() + ret_str_len + 1;
 
-                // If there is no where-clause, take into account the space after the return type
-                // and the brace.
+                // Account for the trailing syntax that will be placed on the same line
+                // after the return type.
                 if where_clause.predicates.is_empty() {
-                    sig_length += 2;
+                    sig_length += match fn_brace_style {
+                        FnBraceStyle::None => 1,     // 1 = `;`
+                        FnBraceStyle::SameLine => 2, // 2 = ` {`
+                        FnBraceStyle::NextLine => 0,
+                    };
                 }
 
                 sig_length > context.config.max_width()

--- a/tests/source/issue-6539.rs
+++ b/tests/source/issue-6539.rs
@@ -1,0 +1,3 @@
+pub trait Manager {
+    fn attach_device(&self, seat_id: &str, sysfs_path: &str, interactive: bool) -> zbus::Result<()>;
+}

--- a/tests/target/issue-6539.rs
+++ b/tests/target/issue-6539.rs
@@ -1,0 +1,3 @@
+pub trait Manager {
+    fn attach_device(&self, seat_id: &str, sysfs_path: &str, interactive: bool) -> zbus::Result<()>;
+}


### PR DESCRIPTION
Fixes #6539.

This updates the signature width calculation to account for the trailing syntax used by the current `FnBraceStyle`.

Previously, the return type width check always accounted for the same-line function body case. That effectively treated bodyless function declarations as if they ended with ` {`, even though `FnBraceStyle::None` declarations end with `;`.

As a result, a bodyless signature exactly at `max_width` could be calculated as one character too long and have its return type wrapped unnecessarily.

This change accounts for the same-line trailing syntax according to `FnBraceStyle`:

- `None`: `;`
- `SameLine`: ` {`
- `NextLine`: no trailing syntax on the same line

A regression test has been added for a bodyless trait method whose signature is exactly 100 characters wide.

Tested with `cargo test`.