### PR TITLE
deps: Update `annotate-snippets`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,11 +13,12 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.11.5"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
+ "memchr",
  "unicode-width 0.2.2",
 ]
 
@@ -449,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustfmt-format-diff = []
 generic-simd = []
 
 [dependencies]
-annotate-snippets = { version = "0.11" }
+annotate-snippets = { version = "0.12" }
 anyhow = "1.0"
 bytecount = "0.6.9"
 cargo_metadata = "0.23"

--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -1,6 +1,6 @@
 use crate::formatting::FormattingError;
 use crate::{ErrorKind, FormatReport};
-use annotate_snippets::{Annotation, Level, Renderer, Snippet};
+use annotate_snippets::{Annotation, AnnotationKind, Group, Level, Padding, Renderer, Snippet};
 use std::fmt::{self, Display};
 
 /// A builder for [`FormatReportFormatter`].
@@ -57,26 +57,23 @@ impl<'a> Display for FormatReportFormatter<'a> {
         for (file, errors) in errors_by_file {
             for error in errors {
                 let error_kind = error.kind.to_string();
-                let mut message =
-                    error_kind_to_snippet_annotation_level(&error.kind).title(&error_kind);
+                let mut title =
+                    error_kind_to_snippet_annotation_level(&error.kind).primary_title(error_kind);
                 if error.is_internal() {
-                    message = message.id("internal");
+                    title = title.id("internal");
                 }
-
-                let message_suffix = error.msg_suffix();
-                if !message_suffix.is_empty() {
-                    message = message.footer(Level::Note.title(&message_suffix));
-                }
-
-                let origin = format!("{}:{}", file, error.line);
                 let snippet = Snippet::source(&error.line_buffer)
                     .line_start(error.line)
-                    .origin(&origin)
+                    .path(format!("{file}:{}", error.line))
                     .fold(false)
                     .annotations(annotation(error));
-                message = message.snippet(snippet);
-
-                writeln!(f, "{}\n", renderer.render(message))?;
+                let mut group = title.element(snippet);
+                if let Some(message_suffix) = error.msg_suffix() {
+                    group = group.element(Level::NOTE.message(message_suffix));
+                } else {
+                    group = group.element(Padding);
+                }
+                writeln!(f, "{}\n", renderer.render(&[group]))?;
             }
         }
 
@@ -85,10 +82,9 @@ impl<'a> Display for FormatReportFormatter<'a> {
                 "rustfmt has failed to format. See previous {} errors.",
                 self.report.warning_count()
             );
-            let message = Level::Warning.title(&label);
-            writeln!(f, "{}", renderer.render(message))?;
+            let group = Group::with_title(Level::WARNING.primary_title(label));
+            writeln!(f, "{}\n", renderer.render(&[group]))?;
         }
-
         Ok(())
     }
 }
@@ -98,13 +94,13 @@ fn annotation(error: &FormattingError) -> Option<Annotation<'_>> {
     let range_end = range_start + range_length;
 
     if range_length > 0 {
-        Some(Level::Error.span(range_start..range_end))
+        Some(AnnotationKind::Primary.span(range_start..range_end))
     } else {
         None
     }
 }
 
-fn error_kind_to_snippet_annotation_level(error_kind: &ErrorKind) -> Level {
+fn error_kind_to_snippet_annotation_level(error_kind: &ErrorKind) -> Level<'_> {
     match error_kind {
         ErrorKind::LineOverflow(..)
         | ErrorKind::TrailingWhitespace
@@ -114,7 +110,7 @@ fn error_kind_to_snippet_annotation_level(error_kind: &ErrorKind) -> Level {
         | ErrorKind::LostComment
         | ErrorKind::BadAttr
         | ErrorKind::InvalidGlobPattern(_)
-        | ErrorKind::VersionMismatch => Level::Error,
-        ErrorKind::DeprecatedAttr => Level::Warning,
+        | ErrorKind::VersionMismatch => Level::ERROR,
+        ErrorKind::DeprecatedAttr => Level::WARNING,
     }
 }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -342,12 +342,14 @@ impl FormattingError {
         }
     }
 
-    pub(crate) fn msg_suffix(&self) -> &str {
+    pub(crate) fn msg_suffix(&self) -> Option<&str> {
         if self.is_comment || self.is_string {
-            "set `error_on_unformatted = false` to suppress \
-             the warning against comments or string literals\n"
+            Some(
+                "set `error_on_unformatted = false` to suppress \
+             the warning against comments or string literals",
+            )
         } else {
-            ""
+            None
         }
     }
 


### PR DESCRIPTION
As in #6391, rustc has moved to `annotate-snippets` 0.12. This updates rustfmt's dependency to match, following the [migration guide](https://github.com/rust-lang/annotate-snippets-rs/blob/main/CHANGELOG.md#0120---2025-08-28).