### PR TITLE
[WIP] feat: imports: flatten last {self} segments

### DIFF
--- a/src/imports.rs
+++ b/src/imports.rs
@@ -262,12 +262,24 @@ fn flatten_use_trees(
 ) -> Vec<UseTree> {
     // Return non-sorted single occurrence of the use-trees text string;
     // order is by first occurrence of the use-tree.
-    use_trees
-        .into_iter()
-        .flat_map(|tree| tree.flatten(import_granularity))
-        .map(UseTree::nest_trailing_self)
-        .unique()
-        .collect()
+
+    // if import granularity is item, we should avoid nesting trailing self
+    // to not introduce List segments.
+    if import_granularity == ImportGranularity::Item {
+        use_trees
+            .into_iter()
+            .flat_map(|tree| tree.flatten(import_granularity))
+            .map(UseTree::flatten_trailing_self)
+            .unique()
+            .collect()
+    } else {
+        use_trees
+            .into_iter()
+            .flat_map(|tree| tree.flatten(import_granularity))
+            .map(UseTree::nest_trailing_self)
+            .unique()
+            .collect()
+    }
 }
 
 impl fmt::Debug for UseTree {
@@ -764,6 +776,64 @@ impl UseTree {
                 style_edition,
             });
         }
+        self
+    }
+
+    /// If this tree ends in `::self` or `::{self}`, flattens trailing self
+    /// into the parent ident segment, preserving aliases for the `self` segment.
+    fn flatten_trailing_self(mut self) -> UseTree {
+        let [
+            ..,
+            // the parent segment can not have an alias with Rust code that
+            // parses, but we check for it using the None pattern anyway to
+            // avoid manipulating ill-formed UseTree's.
+            UseSegment {
+                kind: UseSegmentKind::Ident(_, None),
+                ..
+            },
+            UseSegment {
+                kind: last_segment_kind @ (UseSegmentKind::Slf(..) | UseSegmentKind::List(..)),
+                ..
+            },
+        ] = self.path.as_slice()
+        else {
+            return self;
+        };
+
+        // pre-check to make sure the last List segment contains only
+        // a single Slf segment inside
+        if let UseSegmentKind::List(ref trees) = last_segment_kind {
+            if trees.len() != 1
+                || trees[0].path.len() != 1
+                || !matches!(trees[0].path[0].kind, UseSegmentKind::Slf(_))
+            {
+                return self;
+            }
+        }
+
+        let self_segment = self.path.pop().unwrap();
+        let parent_segment = self.path.last_mut().unwrap();
+
+        let self_alias = match self_segment.kind {
+            UseSegmentKind::Slf(slf_alias) => slf_alias,
+            UseSegmentKind::List(mut inner_trees) => {
+                let mut inner_tree = inner_trees.pop().unwrap();
+                let UseSegmentKind::Slf(slf_alias) = inner_tree.path.pop().unwrap().kind else {
+                    // pre-checked for List above
+                    unreachable!();
+                };
+                slf_alias
+            }
+            // checked in function entry above
+            _ => unreachable!(),
+        };
+
+        let UseSegmentKind::Ident(_, ref mut parent_alias) = parent_segment.kind else {
+            // checked in function entry above
+            unreachable!();
+        };
+
+        *parent_alias = self_alias;
         self
     }
 }

--- a/tests/target/imports/imports_granularity_item.rs
+++ b/tests/target/imports/imports_granularity_item.rs
@@ -9,8 +9,8 @@ use a::h::j;
 use a::l::m;
 use a::l::n::o;
 use a::l::p::*;
-use a::l::{self};
-use a::q::{self};
+use a::l;
+use a::q;
 
 use b::c;
 use b::d;


### PR DESCRIPTION
this PR adds a feature that aims to do these conversions when in `Item` imports granularity:

```rs
// from
use std::io::{self};
// to
use std::io;

// from
use std::io::{self, Write}
// to
use std::io::Write;
use std::io;
```

## rationale

3rd and 1st clause of https://doc.rust-lang.org/style-guide/items.html?highlight=imports#normalisation combined.

<details> 
  <summary>personal rationale</summary>

The `Item` imports granularity is to have a single Item for each import. while `use thing::{self};` satisfies being a single import, it often gets formatted like this:<br>
```rs
use thing::{
    self,
};
```
which goes against the use case of `Item` granularity for having a flat column of `use` keywords, and not introduce random indentations everywhere, and avoid cognitive load caused by the `self`. you'll usually never see `use a::self;` or `use a::{self};` in `Item` import granularity, as it is meaningless module indirection overhead. in fact, i'd argue `self` imports in general in `Item` import granularity are completely useless.
</details>

## HELP NEEDED

i currently implemented half of the functionality inside `flatten_use_trees` using a new method for `UseTree` named `flatten_trailing_self`. I mostly don't know the codebase, there was a feature i wanted and i decided to implement it so its sloppy but it works EXCEPT while flattening the last List segment that only contains a single `Slf` segment, the comments surrounding them (if any) are lost.

i modified a single test (you can see in the commit diff) to reflect all of the changes this PR should make. the rest of the test file should stay intact (preserving the comments) without flattening the List segment to the parent ident, and i have no idea how to do it properly.

it probably mostly goes through `UseTree.list_item` but i'm not sure. any and all help is appreciated!