### PR TITLE
Prepare v1.10.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustfmt-nightly"
-version = "1.9.0"
+version = "1.10.0"
 description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang/rustfmt"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Part of #6965.

Bump rustfmt version to 1.10.0.

> [!WARNING]
>
> Should only be merged after CHANGELOG updates in #6967.