### PR TITLE
Use formatting prefix for rustfmt errors

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -408,7 +408,7 @@ fn format_and_emit_report<T: Write>(session: &mut Session<'_, T>, input: Input) 
             }
         }
         Err(msg) => {
-            eprintln!("Error writing files: {msg}");
+            eprintln!("Error formatting files: {msg}");
             session.add_operational_error();
         }
     }

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -125,22 +125,26 @@ fn rustfmt_usage_text() {
 }
 
 #[test]
-fn check_mode_mod_resolution_error_uses_formatting_prefix() {
+fn mod_resolution_error_multiple_candidate_files() {
     // See also https://github.com/rust-lang/rustfmt/issues/5167
     let default_path = Path::new("tests/mod-resolver/issue-5167/src/a.rs");
     let secondary_path = Path::new("tests/mod-resolver/issue-5167/src/a/mod.rs");
     let error_message = format!(
-        concat!(
-            "Error formatting files: failed to resolve mod `a`: ",
-            "file for module found at both {:?} and {:?}"
-        ),
+        "file for module found at both {:?} and {:?}",
         default_path.canonicalize().unwrap(),
         secondary_path.canonicalize().unwrap(),
     );
 
+    let args = ["tests/mod-resolver/issue-5167/src/lib.rs"];
+    let (_stdout, stderr) = rustfmt(&args);
+    assert!(stderr.contains(&error_message))
+}
+
+#[test]
+fn check_mode_error_uses_formatting_prefix() {
     let args = ["--check", "tests/mod-resolver/issue-5167/src/lib.rs"];
     let (_stdout, stderr) = rustfmt(&args);
-    assert_eq!(stderr.trim(), error_message)
+    assert!(stderr.contains("Error formatting files:"))
 }
 
 #[test]

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -125,19 +125,22 @@ fn rustfmt_usage_text() {
 }
 
 #[test]
-fn mod_resolution_error_multiple_candidate_files() {
+fn check_mode_mod_resolution_error_uses_formatting_prefix() {
     // See also https://github.com/rust-lang/rustfmt/issues/5167
     let default_path = Path::new("tests/mod-resolver/issue-5167/src/a.rs");
     let secondary_path = Path::new("tests/mod-resolver/issue-5167/src/a/mod.rs");
     let error_message = format!(
-        "file for module found at both {:?} and {:?}",
+        concat!(
+            "Error formatting files: failed to resolve mod `a`: ",
+            "file for module found at both {:?} and {:?}"
+        ),
         default_path.canonicalize().unwrap(),
         secondary_path.canonicalize().unwrap(),
     );
 
-    let args = ["tests/mod-resolver/issue-5167/src/lib.rs"];
+    let args = ["--check", "tests/mod-resolver/issue-5167/src/lib.rs"];
     let (_stdout, stderr) = rustfmt(&args);
-    assert!(stderr.contains(&error_message))
+    assert_eq!(stderr.trim(), error_message)
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rustfmt/issues/6971.

Uses `Error formatting files:` as the mode-independent error prefix.
