### PR TITLE
fix: prevent panic on inner attributes in a loop body inside a closure

### DIFF
--- a/src/closures.rs
+++ b/src/closures.rs
@@ -14,7 +14,7 @@ use crate::rewrite::{Rewrite, RewriteContext, RewriteError, RewriteErrorExt, Rew
 use crate::shape::Shape;
 use crate::source_map::SpanUtils;
 use crate::types::rewrite_bound_params;
-use crate::utils::{NodeIdExt, last_line_width, left_most_sub_expr, stmt_expr};
+use crate::utils::{NodeIdExt, last_line_width, left_most_sub_expr, outer_attributes, stmt_expr};
 
 // This module is pretty messy because of the rules around closures and blocks:
 // FIXME - the below is probably no longer true in full.
@@ -166,6 +166,8 @@ fn rewrite_closure_with_block(
         return Err(RewriteError::Unknown);
     }
 
+    // `body.attrs` may hold inner attributes from a nested block, e.g. `while cond { #![attr] }`.
+    let outer_attrs = outer_attributes(&body.attrs);
     let block = ast::Block {
         stmts: thin_vec![ast::Stmt {
             id: ast::NodeId::root(),
@@ -174,8 +176,7 @@ fn rewrite_closure_with_block(
         }],
         id: ast::NodeId::root(),
         rules: ast::BlockCheckMode::Default,
-        span: body
-            .attrs
+        span: outer_attrs
             .first()
             .map(|attr| attr.span.to(body.span))
             .unwrap_or(body.span),
@@ -184,7 +185,7 @@ fn rewrite_closure_with_block(
         context,
         "",
         &block,
-        Some(&body.attrs),
+        Some(&outer_attrs),
         None,
         shape,
         false,

--- a/tests/source/issue_6209.rs
+++ b/tests/source/issue_6209.rs
@@ -1,0 +1,33 @@
+fn while_loop() {
+    thread::spawn(|| { while i < days.len() {
+        #![allow(clippy::indexing_slicing)]
+        w |= days[i].bit_value();
+        i += 1;
+    }});
+}
+
+fn for_loop() {
+    thread::spawn(|| { for i in 0..days.len() {
+        #![allow(clippy::indexing_slicing)]
+        w |= days[i].bit_value();
+    }});
+}
+
+fn empty_loop_body() {
+    thread::spawn(|| { while true {
+        #![allow(clippy::indexing_slicing)]
+    }});
+}
+
+fn closure_body_without_block() {
+    thread::spawn(|| while i < days.len() {
+        #![allow(clippy::indexing_slicing)]
+        w |= days[i].bit_value();
+    });
+}
+
+fn outer_attribute_still_formatted() {
+    thread::spawn(|| { #[allow(clippy::indexing_slicing)] while i < days.len() {
+        w |= days[i].bit_value();
+    }});
+}

--- a/tests/target/issue_6209.rs
+++ b/tests/target/issue_6209.rs
@@ -1,0 +1,44 @@
+fn while_loop() {
+    thread::spawn(|| {
+        while i < days.len() {
+            #![allow(clippy::indexing_slicing)]
+            w |= days[i].bit_value();
+            i += 1;
+        }
+    });
+}
+
+fn for_loop() {
+    thread::spawn(|| {
+        for i in 0..days.len() {
+            #![allow(clippy::indexing_slicing)]
+            w |= days[i].bit_value();
+        }
+    });
+}
+
+fn empty_loop_body() {
+    thread::spawn(|| {
+        while true {
+            #![allow(clippy::indexing_slicing)]
+        }
+    });
+}
+
+fn closure_body_without_block() {
+    thread::spawn(|| {
+        while i < days.len() {
+            #![allow(clippy::indexing_slicing)]
+            w |= days[i].bit_value();
+        }
+    });
+}
+
+fn outer_attribute_still_formatted() {
+    thread::spawn(|| {
+        #[allow(clippy::indexing_slicing)]
+        while i < days.len() {
+            w |= days[i].bit_value();
+        }
+    });
+}


### PR DESCRIPTION
## Summary

Closes #6209.

A block has nowhere to store attributes, so an inner attribute written in a loop body is attached to the loop expression with `AttrStyle::Inner`. `rewrite_closure_with_block` wraps the closure body in an artificial block and forwards the body's attributes to it. That assumes the `|| #[attr] foo()` shape, where the attributes precede the body, which is what the artificial block's span is widened to cover. When an inner attribute is forwarded instead, `visit_block` emits it and pushes `last_pos` past it. The loop statement that follows starts before that point, so `push_rewrite` asks to format a backwards span.

Filtering the body's attributes to the outer ones is a no-op for the shape the code was written for, since `rewrite_block_with_visitor` already narrows what it receives to inner attributes.

## Review notes

Inner attributes are still dropped from the output, so the expected output in the new tests does not contain them. That is a separate pre-existing bug (#5973) which affects loops with or without a closure and is not touched here.

#6010 fixes that one by plumbing the loop's inner attributes through `ControlFlow`. I applied it on top of this branch to check the two compose: there is no panic and the attributes come back, so the only change is that the expected output added here will need updating when #6010 lands.
