### PR TITLE
fix: don't leave trailing whitespace before a skipped impl item

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -357,8 +357,10 @@ impl<'a> FmtVisitor<'a> {
 
                 status.cur_line += 1;
                 status.line_start = i + 1;
-            } else if c.is_whitespace() && status.last_wspace.is_none() {
-                status.last_wspace = Some(i);
+            } else if c.is_whitespace() {
+                if status.last_wspace.is_none() {
+                    status.last_wspace = Some(i);
+                }
             } else {
                 status.last_wspace = None;
             }

--- a/tests/source/issue-5521.rs
+++ b/tests/source/issue-5521.rs
@@ -1,0 +1,29 @@
+// Whitespace on the otherwise blank line before a `#[rustfmt::skip]` item has to be
+// removed regardless of how many whitespace characters it is made of.
+impl Even for Foo {
+    const FAIL: &'static str = "";
+    
+    #[rustfmt::skip]
+    fn to_style(&self, template: &str) {}
+}
+
+impl Odd for Foo {
+    const FAIL: &'static str = "";
+   
+    #[rustfmt::skip]
+    fn to_style(&self, template: &str) {}
+}
+
+impl Single for Foo {
+    const FAIL: &'static str = "";
+ 
+    #[rustfmt::skip]
+    fn to_style(&self, template: &str) {}
+}
+
+impl Tabs for Foo {
+    const FAIL: &'static str = "";
+		
+    #[rustfmt::skip]
+    fn to_style(&self, template: &str) {}
+}

--- a/tests/target/issue-5521.rs
+++ b/tests/target/issue-5521.rs
@@ -1,0 +1,29 @@
+// Whitespace on the otherwise blank line before a `#[rustfmt::skip]` item has to be
+// removed regardless of how many whitespace characters it is made of.
+impl Even for Foo {
+    const FAIL: &'static str = "";
+
+    #[rustfmt::skip]
+    fn to_style(&self, template: &str) {}
+}
+
+impl Odd for Foo {
+    const FAIL: &'static str = "";
+
+    #[rustfmt::skip]
+    fn to_style(&self, template: &str) {}
+}
+
+impl Single for Foo {
+    const FAIL: &'static str = "";
+
+    #[rustfmt::skip]
+    fn to_style(&self, template: &str) {}
+}
+
+impl Tabs for Foo {
+    const FAIL: &'static str = "";
+
+    #[rustfmt::skip]
+    fn to_style(&self, template: &str) {}
+}


### PR DESCRIPTION
## Summary

Closes #5521

## Review notes

Whitespace characters on the blank line before the skipped item:

| written | before | after |
| --- | --- | --- |
| 1 | 0 | 0 |
| 2 | 2 | 0 |
| 3 | 2 | 0 |
| 4 | 4 | 0 |
| 11 | 10 | 0 |
| 12 | 12 | 0 |

The skipped item has to be a non-first item of an impl block. The same whitespace in a `mod`, in a function body, at the top level, or before the first impl item is trimmed elsewhere and was never affected, so the test uses that one shape for all four cases.

#4706 was raised on the issue as a possible duplicate. There the whitespace is inside the body of the skipped item, which the attribute asks rustfmt to leave alone. Here it sits between the previous item and the attribute, outside any skipped span.
