### PR TITLE
fix: don't duplicate type bounds when a comment precedes the where clause

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1762,6 +1762,10 @@ fn rewrite_ty<R: Rewrite>(
         result.push_str(&generics_str);
     }
 
+    // The bounds are written out here, so anything the `where` clause treats as a
+    // missing comment has to start after them, not after the generics.
+    let mut span_end_before_where = generics.span.hi();
+
     if let Some(bounds) = generic_bounds_opt {
         if !bounds.is_empty() {
             // 2 = `: `
@@ -1771,6 +1775,7 @@ fn rewrite_ty<R: Rewrite>(
                 .rewrite_result(context, shape)
                 .map(|s| format!(": {}", s))?;
             result.push_str(&type_bounds);
+            span_end_before_where = bounds.last().unwrap().span().hi();
         }
     }
 
@@ -1787,7 +1792,7 @@ fn rewrite_ty<R: Rewrite>(
         false,
         "=",
         None,
-        generics.span.hi(),
+        span_end_before_where,
         option,
     )?;
     result.push_str(&before_where_clause_str);

--- a/tests/source/issue-6234.rs
+++ b/tests/source/issue-6234.rs
@@ -1,0 +1,9 @@
+trait Foo {
+    type Bar<'a>: Baz1 // comment
+     where Self: 'a;
+}
+
+trait Qux {
+    type Bar: Baz1 + Baz2 // comment
+     where Self: Sized;
+}

--- a/tests/target/issue-6234.rs
+++ b/tests/target/issue-6234.rs
@@ -1,0 +1,13 @@
+trait Foo {
+    type Bar<'a>: Baz1
+    // comment
+    where
+        Self: 'a;
+}
+
+trait Qux {
+    type Bar: Baz1 + Baz2
+    // comment
+    where
+        Self: Sized;
+}


### PR DESCRIPTION
## Summary

Closes #6234.

`rewrite_where_clause` takes a `span_end_before_where` argument marking where the source it still has to account for begins. `missing_span_before_after_where` turns it into the span handed to `rewrite_missing_comment`:

```rust
let missing_span_before = mk_sp(before_item_span_end, where_span.lo());
```

`rewrite_ty` passed `generics.span.hi()` for that argument, which points just past the type alias generics. The bounds sit between there and the `where` keyword, and `rewrite_ty` writes them into `result` itself a few lines earlier, so the span covered text that had already been emitted. When that region also holds a comment, `rewrite_missing_comment` emits the whole region and the bounds come out a second time.

`type Bar<'a>: Baz1 // comment` followed by a where clause formatted to `type Bar<'a>: Baz1` and then `: Baz1 // comment` on the next line, which does not parse.

Recording the end of the last bound as the span start, in the same branch that writes the bounds, restores the contract. Aliases without bounds keep `generics.span.hi()`, since nothing between the generics and the `where` has been written at that point.

## Review notes

#6815 was forked out of this issue and is not addressed here. There the comment sits between the bounds and the `;` of an alias that has no where clause, a region no span is computed for at all, so it needs new handling rather than a corrected argument.
