### PR TITLE
fix: don't apply field init shorthand inside macro calls

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1928,8 +1928,13 @@ pub(crate) fn rewrite_field(
         let expr = field.expr.rewrite_result(context, expr_shape);
         let is_lit = matches!(field.expr.kind, ast::ExprKind::Lit(_));
         match expr {
+            // A macro can give `Field: value` its own meaning, so shortening `a: a` to `a` may
+            // change what it expands to. In `winnow::seq!` the result no longer compiles.
             Ok(ref e)
-                if !is_lit && e.as_str() == name && context.config.use_field_init_shorthand() =>
+                if !is_lit
+                    && e.as_str() == name
+                    && context.config.use_field_init_shorthand()
+                    && !context.inside_macro() =>
             {
                 Ok(attrs_str + name)
             }

--- a/tests/source/issue-6795.rs
+++ b/tests/source/issue-6795.rs
@@ -1,0 +1,40 @@
+// rustfmt-use_field_init_shorthand: true
+
+foo!(Foo { a: a });
+
+fn main() {
+    foo!(Foo { a: a });
+    foo![Foo { a: a }];
+    foo! { Foo { a: a } }
+
+    seq!(Task { a });
+    seq!(Task { a: b });
+    seq!(Task { a: 1 });
+    seq!(Task { a: a, ..base });
+    seq!(Task { #[attr] a: a });
+    seq!(Task { a: Inner { b: b } });
+    seq!(Task { a: a }.build());
+    let _ = Foo { a: seq!(Task { b: b }) };
+
+    // `vec!` is formatted as an array, so the shorthand still applies.
+    vec![Foo { a: a }];
+    vec![vec![Foo { a: a }]];
+    foo!(vec![Foo { a: a }]);
+
+    // std/core prelude macros, where the shorthand would be safe.
+    assert_eq!(Foo { a: a }, x);
+    debug_assert_eq!(Foo { a: a }, x);
+    matches!(v, Foo { a: a });
+    assert_matches!(v, Foo { a: a });
+    assert!(matches!(v, Foo { a: a }));
+
+    // A shorthand already written by hand is kept.
+    assert_eq!(Foo { a }, x);
+    debug_assert_eq!(Foo { a }, x);
+    matches!(v, Foo { a });
+    assert_matches!(v, Foo { a });
+    assert!(matches!(v, Foo { a }));
+
+    let _ = Foo { a: a };
+    let _ = Foo { a: Inner { b: b } };
+}

--- a/tests/target/issue-6795.rs
+++ b/tests/target/issue-6795.rs
@@ -1,0 +1,45 @@
+// rustfmt-use_field_init_shorthand: true
+
+foo!(Foo { a: a });
+
+fn main() {
+    foo!(Foo { a: a });
+    foo![Foo { a: a }];
+    foo! { Foo { a: a } }
+
+    seq!(Task { a });
+    seq!(Task { a: b });
+    seq!(Task { a: 1 });
+    seq!(Task { a: a, ..base });
+    seq!(Task {
+        #[attr]
+        a: a
+    });
+    seq!(Task { a: Inner { b: b } });
+    seq!(Task { a: a }.build());
+    let _ = Foo {
+        a: seq!(Task { b: b }),
+    };
+
+    // `vec!` is formatted as an array, so the shorthand still applies.
+    vec![Foo { a }];
+    vec![vec![Foo { a }]];
+    foo!(vec![Foo { a: a }]);
+
+    // std/core prelude macros, where the shorthand would be safe.
+    assert_eq!(Foo { a: a }, x);
+    debug_assert_eq!(Foo { a: a }, x);
+    matches!(v, Foo { a: a });
+    assert_matches!(v, Foo { a: a });
+    assert!(matches!(v, Foo { a: a }));
+
+    // A shorthand already written by hand is kept.
+    assert_eq!(Foo { a }, x);
+    debug_assert_eq!(Foo { a }, x);
+    matches!(v, Foo { a });
+    assert_matches!(v, Foo { a });
+    assert!(matches!(v, Foo { a }));
+
+    let _ = Foo { a };
+    let _ = Foo { a: Inner { b } };
+}


### PR DESCRIPTION
## Summary

Closes #6795.

With `use_field_init_shorthand = true`, rustfmt turns a working invocation into one that does not compile:

```rust
seq!(PrimitiveTask {
    name: name,
    preconditions: preconditions,
});

// becomes
seq!(PrimitiveTask { name, preconditions });
```

Adding `!context.inside_macro()` to the guard limits the shorthand to positions where rustfmt knows the two forms mean the same thing.

## Review notes

Macros that do take ordinary expressions lose the shorthand as well, including `assert_eq!(x, Foo { a: a })`. Nothing in an invocation says whether a macro passes its arguments through or reinterprets them, so rustfmt has to be conservative.

`vec!` keeps the shorthand because `rewrite_macro_inner` calls `leave_macro` and formats the contents as an array. That does not happen once it is nested in another macro, which is why `foo!(vec![Foo { a: a }])` keeps the long form.
