### PR TITLE
tests: cover trailing whitespace annotations on multibyte lines

### DIFF
--- a/tests/warning/snapshots/issue_6826.snap
+++ b/tests/warning/snapshots/issue_6826.snap
@@ -1,0 +1,18 @@
+---
+source: src/test/mod.rs
+---
+error[internal]: not formatted because a comment would be lost
+ --> tests/warning/source/issue_6826.rs:2
+  |
+2 |         c.is_ascii_alphanumeric() // 123
+  |
+  = note: set `error_on_unformatted = false` to suppress the warning against comments or string literals
+
+error[internal]: left behind trailing whitespace
+ --> tests/warning/source/issue_6826.rs:3:3:20
+  |
+3 |         || c == '。' 
+  |                     ^
+  |
+
+warning: rustfmt has failed to format. See previous 2 errors.

--- a/tests/warning/source/issue_6826.rs
+++ b/tests/warning/source/issue_6826.rs
@@ -1,0 +1,5 @@
+pub fn check(c: char) -> bool {
+        c.is_ascii_alphanumeric() // 123
+        || c == '。' 
+        || c == '、'
+}


### PR DESCRIPTION
## Summary

Closes #6826.

The panic came from an assertion in `annotate-snippets` 0.9.x that compared a char count against byte offsets:

```rust
let source_len = slice.source.chars().count();
if source_len < x.range.1 { panic!("SourceAnnotation range ... is bigger than source length ...") }
```

rustfmt's own range was already correct. `FormattingError::format_len` builds it from `str::rfind` and `line_buffer.len()`, both byte based, so any annotated line holding a multibyte character pushed `range.1` past the char count. The assertion is gone since 0.11, which the tree picked up in e6bc6298, so there is nothing to change on the rustfmt side. This adds the reproducer to the warning snapshot suite.

## Review notes

The fixture panics under 1.8.0-nightly (2026-02-18) with the message from the issue, `SourceAnnotation range (21, 22) is bigger than source length 20`, raised while rendering the second of the two errors. Under 1.9.0-nightly (2026-03-04) both are reported without panicking, which is what the snapshot records.
