### PR TITLE
fix: Fmt struct field patters with cfgs

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -468,12 +468,19 @@ impl Rewrite for PatField {
                     self.pat.rewrite_result(context, nested_shape)?
                 )
             };
+
+            let combine_shape = if context.config.style_edition() >= StyleEdition::Edition2027 {
+                shape
+            } else {
+                nested_shape
+            };
+
             combine_strs_with_missing_comments(
                 context,
                 &attrs_str,
                 &pat_and_id_str,
                 mk_sp(hi_pos, self.pat.span.lo()),
-                nested_shape,
+                combine_shape,
                 false,
             )
         }

--- a/tests/source/issue_5920_style_edition_2024.rs
+++ b/tests/source/issue_5920_style_edition_2024.rs
@@ -1,0 +1,25 @@
+// rustfmt-style_edition: 2024
+
+struct Demo {
+    field_name_foo: (),
+    field_name_bar: (),
+    #[cfg(feature = "diagnostics")]
+    field_name_baz: (),
+    field_name_tux: (),
+}
+
+fn main() {
+    let Demo {
+        field_name_foo,
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: _,
+        field_name_bar,
+        field_name_tux,
+    } = Demo {
+        field_name_foo: (),
+        field_name_bar: (),
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: (),
+        field_name_tux: (),
+    };
+}

--- a/tests/source/issue_5920_style_edition_2027.rs
+++ b/tests/source/issue_5920_style_edition_2027.rs
@@ -1,0 +1,25 @@
+// rustfmt-style_edition: 2027
+
+struct Demo {
+    field_name_foo: (),
+    field_name_bar: (),
+    #[cfg(feature = "diagnostics")]
+    field_name_baz: (),
+    field_name_tux: (),
+}
+
+fn main() {
+    let Demo {
+        field_name_foo,
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: _,
+        field_name_bar,
+        field_name_tux,
+    } = Demo {
+        field_name_foo: (),
+        field_name_bar: (),
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: (),
+        field_name_tux: (),
+    };
+}

--- a/tests/source/issue_5982_style_edition_2024.rs
+++ b/tests/source/issue_5982_style_edition_2024.rs
@@ -1,0 +1,67 @@
+// rustfmt-style_edition: 2024
+// See https://github.com/rust-lang/rustfmt/issues/5982 and
+// https://github.com/rust-lang/rustfmt/issues/5920
+
+// https://github.com/rust-lang/rustfmt/issues/5982
+struct Foo {
+    #[cfg(all())]
+    something_long_enough_to_wrap_foo: i32,
+    #[cfg(all())]
+    something_long_enough_to_wrap_bar: i32,
+}
+
+fn example() {
+    let Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: bar_var,
+    } = Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo: 111,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: 222,
+    };
+}
+
+// The same, but with leading comments on the fields.
+fn example_with_comments() {
+    let Foo {
+        // comment on shorthand field
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo,
+        // comment on non-shorthand field
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: bar_var,
+    } = Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo: 111,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: 222,
+    };
+}
+
+// https://github.com/rust-lang/rustfmt/issues/5920
+struct Demo {
+    field_name_foo: (),
+    field_name_bar: (),
+    #[cfg(feature = "diagnostics")]
+    field_name_baz: (),
+    field_name_tux: (),
+}
+
+fn main() {
+    let Demo {
+        field_name_foo,
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: _,
+        field_name_bar,
+        field_name_tux,
+    } = Demo {
+        field_name_foo: (),
+        field_name_bar: (),
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: (),
+        field_name_tux: (),
+    };
+}

--- a/tests/source/issue_5982_style_edition_2024.rs
+++ b/tests/source/issue_5982_style_edition_2024.rs
@@ -1,8 +1,5 @@
 // rustfmt-style_edition: 2024
-// See https://github.com/rust-lang/rustfmt/issues/5982 and
-// https://github.com/rust-lang/rustfmt/issues/5920
 
-// https://github.com/rust-lang/rustfmt/issues/5982
 struct Foo {
     #[cfg(all())]
     something_long_enough_to_wrap_foo: i32,
@@ -38,30 +35,5 @@ fn example_with_comments() {
         something_long_enough_to_wrap_foo: 111,
         #[cfg(all())]
         something_long_enough_to_wrap_bar: 222,
-    };
-}
-
-// https://github.com/rust-lang/rustfmt/issues/5920
-struct Demo {
-    field_name_foo: (),
-    field_name_bar: (),
-    #[cfg(feature = "diagnostics")]
-    field_name_baz: (),
-    field_name_tux: (),
-}
-
-fn main() {
-    let Demo {
-        field_name_foo,
-        #[cfg(feature = "diagnostics")]
-        field_name_baz: _,
-        field_name_bar,
-        field_name_tux,
-    } = Demo {
-        field_name_foo: (),
-        field_name_bar: (),
-        #[cfg(feature = "diagnostics")]
-        field_name_baz: (),
-        field_name_tux: (),
     };
 }

--- a/tests/source/issue_5982_style_edition_2027.rs
+++ b/tests/source/issue_5982_style_edition_2027.rs
@@ -1,8 +1,5 @@
 // rustfmt-style_edition: 2027
-// See https://github.com/rust-lang/rustfmt/issues/5982 and
-// https://github.com/rust-lang/rustfmt/issues/5920
 
-// https://github.com/rust-lang/rustfmt/issues/5982
 struct Foo {
     #[cfg(all())]
     something_long_enough_to_wrap_foo: i32,
@@ -38,30 +35,5 @@ fn example_with_comments() {
         something_long_enough_to_wrap_foo: 111,
         #[cfg(all())]
         something_long_enough_to_wrap_bar: 222,
-    };
-}
-
-// https://github.com/rust-lang/rustfmt/issues/5920
-struct Demo {
-    field_name_foo: (),
-    field_name_bar: (),
-    #[cfg(feature = "diagnostics")]
-    field_name_baz: (),
-    field_name_tux: (),
-}
-
-fn main() {
-    let Demo {
-        field_name_foo,
-        #[cfg(feature = "diagnostics")]
-        field_name_baz: _,
-        field_name_bar,
-        field_name_tux,
-    } = Demo {
-        field_name_foo: (),
-        field_name_bar: (),
-        #[cfg(feature = "diagnostics")]
-        field_name_baz: (),
-        field_name_tux: (),
     };
 }

--- a/tests/source/issue_5982_style_edition_2027.rs
+++ b/tests/source/issue_5982_style_edition_2027.rs
@@ -1,0 +1,67 @@
+// rustfmt-style_edition: 2027
+// See https://github.com/rust-lang/rustfmt/issues/5982 and
+// https://github.com/rust-lang/rustfmt/issues/5920
+
+// https://github.com/rust-lang/rustfmt/issues/5982
+struct Foo {
+    #[cfg(all())]
+    something_long_enough_to_wrap_foo: i32,
+    #[cfg(all())]
+    something_long_enough_to_wrap_bar: i32,
+}
+
+fn example() {
+    let Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: bar_var,
+    } = Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo: 111,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: 222,
+    };
+}
+
+// The same, but with leading comments on the fields.
+fn example_with_comments() {
+    let Foo {
+        // comment on shorthand field
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo,
+        // comment on non-shorthand field
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: bar_var,
+    } = Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo: 111,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: 222,
+    };
+}
+
+// https://github.com/rust-lang/rustfmt/issues/5920
+struct Demo {
+    field_name_foo: (),
+    field_name_bar: (),
+    #[cfg(feature = "diagnostics")]
+    field_name_baz: (),
+    field_name_tux: (),
+}
+
+fn main() {
+    let Demo {
+        field_name_foo,
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: _,
+        field_name_bar,
+        field_name_tux,
+    } = Demo {
+        field_name_foo: (),
+        field_name_bar: (),
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: (),
+        field_name_tux: (),
+    };
+}

--- a/tests/target/issue_5920_style_edition_2024.rs
+++ b/tests/target/issue_5920_style_edition_2024.rs
@@ -1,0 +1,25 @@
+// rustfmt-style_edition: 2024
+
+struct Demo {
+    field_name_foo: (),
+    field_name_bar: (),
+    #[cfg(feature = "diagnostics")]
+    field_name_baz: (),
+    field_name_tux: (),
+}
+
+fn main() {
+    let Demo {
+        field_name_foo,
+        #[cfg(feature = "diagnostics")]
+            field_name_baz: _,
+        field_name_bar,
+        field_name_tux,
+    } = Demo {
+        field_name_foo: (),
+        field_name_bar: (),
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: (),
+        field_name_tux: (),
+    };
+}

--- a/tests/target/issue_5920_style_edition_2027.rs
+++ b/tests/target/issue_5920_style_edition_2027.rs
@@ -1,0 +1,25 @@
+// rustfmt-style_edition: 2027
+
+struct Demo {
+    field_name_foo: (),
+    field_name_bar: (),
+    #[cfg(feature = "diagnostics")]
+    field_name_baz: (),
+    field_name_tux: (),
+}
+
+fn main() {
+    let Demo {
+        field_name_foo,
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: _,
+        field_name_bar,
+        field_name_tux,
+    } = Demo {
+        field_name_foo: (),
+        field_name_bar: (),
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: (),
+        field_name_tux: (),
+    };
+}

--- a/tests/target/issue_5982_style_edition_2024.rs
+++ b/tests/target/issue_5982_style_edition_2024.rs
@@ -1,8 +1,5 @@
 // rustfmt-style_edition: 2024
-// See https://github.com/rust-lang/rustfmt/issues/5982 and
-// https://github.com/rust-lang/rustfmt/issues/5920
 
-// https://github.com/rust-lang/rustfmt/issues/5982
 struct Foo {
     #[cfg(all())]
     something_long_enough_to_wrap_foo: i32,
@@ -38,30 +35,5 @@ fn example_with_comments() {
         something_long_enough_to_wrap_foo: 111,
         #[cfg(all())]
         something_long_enough_to_wrap_bar: 222,
-    };
-}
-
-// https://github.com/rust-lang/rustfmt/issues/5920
-struct Demo {
-    field_name_foo: (),
-    field_name_bar: (),
-    #[cfg(feature = "diagnostics")]
-    field_name_baz: (),
-    field_name_tux: (),
-}
-
-fn main() {
-    let Demo {
-        field_name_foo,
-        #[cfg(feature = "diagnostics")]
-            field_name_baz: _,
-        field_name_bar,
-        field_name_tux,
-    } = Demo {
-        field_name_foo: (),
-        field_name_bar: (),
-        #[cfg(feature = "diagnostics")]
-        field_name_baz: (),
-        field_name_tux: (),
     };
 }

--- a/tests/target/issue_5982_style_edition_2024.rs
+++ b/tests/target/issue_5982_style_edition_2024.rs
@@ -1,0 +1,67 @@
+// rustfmt-style_edition: 2024
+// See https://github.com/rust-lang/rustfmt/issues/5982 and
+// https://github.com/rust-lang/rustfmt/issues/5920
+
+// https://github.com/rust-lang/rustfmt/issues/5982
+struct Foo {
+    #[cfg(all())]
+    something_long_enough_to_wrap_foo: i32,
+    #[cfg(all())]
+    something_long_enough_to_wrap_bar: i32,
+}
+
+fn example() {
+    let Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo,
+        #[cfg(all())]
+            something_long_enough_to_wrap_bar: bar_var,
+    } = Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo: 111,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: 222,
+    };
+}
+
+// The same, but with leading comments on the fields.
+fn example_with_comments() {
+    let Foo {
+        // comment on shorthand field
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo,
+        // comment on non-shorthand field
+        #[cfg(all())]
+            something_long_enough_to_wrap_bar: bar_var,
+    } = Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo: 111,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: 222,
+    };
+}
+
+// https://github.com/rust-lang/rustfmt/issues/5920
+struct Demo {
+    field_name_foo: (),
+    field_name_bar: (),
+    #[cfg(feature = "diagnostics")]
+    field_name_baz: (),
+    field_name_tux: (),
+}
+
+fn main() {
+    let Demo {
+        field_name_foo,
+        #[cfg(feature = "diagnostics")]
+            field_name_baz: _,
+        field_name_bar,
+        field_name_tux,
+    } = Demo {
+        field_name_foo: (),
+        field_name_bar: (),
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: (),
+        field_name_tux: (),
+    };
+}

--- a/tests/target/issue_5982_style_edition_2027.rs
+++ b/tests/target/issue_5982_style_edition_2027.rs
@@ -1,8 +1,5 @@
 // rustfmt-style_edition: 2027
-// See https://github.com/rust-lang/rustfmt/issues/5982 and
-// https://github.com/rust-lang/rustfmt/issues/5920
 
-// https://github.com/rust-lang/rustfmt/issues/5982
 struct Foo {
     #[cfg(all())]
     something_long_enough_to_wrap_foo: i32,
@@ -38,30 +35,5 @@ fn example_with_comments() {
         something_long_enough_to_wrap_foo: 111,
         #[cfg(all())]
         something_long_enough_to_wrap_bar: 222,
-    };
-}
-
-// https://github.com/rust-lang/rustfmt/issues/5920
-struct Demo {
-    field_name_foo: (),
-    field_name_bar: (),
-    #[cfg(feature = "diagnostics")]
-    field_name_baz: (),
-    field_name_tux: (),
-}
-
-fn main() {
-    let Demo {
-        field_name_foo,
-        #[cfg(feature = "diagnostics")]
-        field_name_baz: _,
-        field_name_bar,
-        field_name_tux,
-    } = Demo {
-        field_name_foo: (),
-        field_name_bar: (),
-        #[cfg(feature = "diagnostics")]
-        field_name_baz: (),
-        field_name_tux: (),
     };
 }

--- a/tests/target/issue_5982_style_edition_2027.rs
+++ b/tests/target/issue_5982_style_edition_2027.rs
@@ -1,0 +1,67 @@
+// rustfmt-style_edition: 2027
+// See https://github.com/rust-lang/rustfmt/issues/5982 and
+// https://github.com/rust-lang/rustfmt/issues/5920
+
+// https://github.com/rust-lang/rustfmt/issues/5982
+struct Foo {
+    #[cfg(all())]
+    something_long_enough_to_wrap_foo: i32,
+    #[cfg(all())]
+    something_long_enough_to_wrap_bar: i32,
+}
+
+fn example() {
+    let Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: bar_var,
+    } = Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo: 111,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: 222,
+    };
+}
+
+// The same, but with leading comments on the fields.
+fn example_with_comments() {
+    let Foo {
+        // comment on shorthand field
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo,
+        // comment on non-shorthand field
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: bar_var,
+    } = Foo {
+        #[cfg(all())]
+        something_long_enough_to_wrap_foo: 111,
+        #[cfg(all())]
+        something_long_enough_to_wrap_bar: 222,
+    };
+}
+
+// https://github.com/rust-lang/rustfmt/issues/5920
+struct Demo {
+    field_name_foo: (),
+    field_name_bar: (),
+    #[cfg(feature = "diagnostics")]
+    field_name_baz: (),
+    field_name_tux: (),
+}
+
+fn main() {
+    let Demo {
+        field_name_foo,
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: _,
+        field_name_bar,
+        field_name_tux,
+    } = Demo {
+        field_name_foo: (),
+        field_name_bar: (),
+        #[cfg(feature = "diagnostics")]
+        field_name_baz: (),
+        field_name_tux: (),
+    };
+}


### PR DESCRIPTION
### Fixes
#5982 and #5920.



### Desription
the non-shorthand branch passed the block-indented nested_shape to combine_strs_with_missing_comments. That call decides where the whole field lands relative to its attribute, so it should use the field's own shape (exactly as the shorthand branch already does.
  
### Question

Not sure if this change requires the edition gate or not? As a default I have gated it behind 2027 edition.