### PR TITLE
Use merge queue

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,5 @@
 name: integration
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 permissions:

--- a/.github/workflows/rustdoc_check.yml
+++ b/.github/workflows/rustdoc_check.yml
@@ -1,8 +1,6 @@
 name: rustdoc check
 on:
-  push:
-    branches:
-      - main
+  merge_group:
   pull_request:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: test
 on:
-  push:
-    branches:
-      - main
+  merge_group:
   pull_request:
 
 permissions:


### PR DESCRIPTION
Use merge queue for the test and rustdoc_check workflows.

I noticed that the integration workflow wasn't actually blocking PRs from being merged. So I just removed it from `main` and only let it run on pull requests. Let me know if you want to make it blocking.

Should be merged in cooperation with https://github.com/rust-lang/team/pull/2636 (by an infra admin).