### PR TITLE
fix: prevent panic when whitespace separates `macro_rules` and `!`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -431,17 +431,8 @@ pub(crate) fn rewrite_macro_def(
     };
 
     let mut header = if def.macro_rules {
-        let macro_rules_hi = context.snippet_provider.span_after(span, "macro_rules");
-        let bang_hi = context
-            .snippet_provider
-            .span_after(span.with_lo(macro_rules_hi), "!");
-        let header_span = span.with_hi(bang_hi);
-        let separator_span = mk_sp(macro_rules_hi, bang_hi - BytePos(1));
-        let header_snippet = if contains_comment(context.snippet(separator_span)) {
-            context.snippet(header_span)
-        } else {
-            "macro_rules!"
-        };
+        let pos = context.snippet_provider.span_after(span, "!");
+        vec![HeaderPart::new("macro_rules!", span.with_hi(pos))]
         vec![HeaderPart::new(header_snippet, header_span)]
     } else {
         let macro_lo = context.snippet_provider.span_before(span, "macro");

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -433,7 +433,6 @@ pub(crate) fn rewrite_macro_def(
     let mut header = if def.macro_rules {
         let pos = context.snippet_provider.span_after(span, "!");
         vec![HeaderPart::new("macro_rules!", span.with_hi(pos))]
-        vec![HeaderPart::new(header_snippet, header_span)]
     } else {
         let macro_lo = context.snippet_provider.span_before(span, "macro");
         let macro_hi = macro_lo + BytePos("macro".len() as u32);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -431,8 +431,18 @@ pub(crate) fn rewrite_macro_def(
     };
 
     let mut header = if def.macro_rules {
-        let pos = context.snippet_provider.span_after(span, "macro_rules!");
-        vec![HeaderPart::new("macro_rules!", span.with_hi(pos))]
+        let macro_rules_hi = context.snippet_provider.span_after(span, "macro_rules");
+        let bang_hi = context
+            .snippet_provider
+            .span_after(span.with_lo(macro_rules_hi), "!");
+        let header_span = span.with_hi(bang_hi);
+        let separator_span = mk_sp(macro_rules_hi, bang_hi - BytePos(1));
+        let header_snippet = if contains_comment(context.snippet(separator_span)) {
+            context.snippet(header_span)
+        } else {
+            "macro_rules!"
+        };
+        vec![HeaderPart::new(header_snippet, header_span)]
     } else {
         let macro_lo = context.snippet_provider.span_before(span, "macro");
         let macro_hi = macro_lo + BytePos("macro".len() as u32);

--- a/tests/source/issue-6985.rs
+++ b/tests/source/issue-6985.rs
@@ -1,0 +1,21 @@
+macro_rules ! say_hello {
+    () => {
+        println!("Hello!")
+    };
+}
+
+macro_rules /* comment */ ! say_goodbye {
+    () => {
+        println!("Goodbye!")
+    };
+}
+
+macro_rules // comment
+! do_nothing {
+    () => {};
+}
+
+fn main() {
+    say_hello!();
+    say_goodbye!()
+}

--- a/tests/target/issue-6985.rs
+++ b/tests/target/issue-6985.rs
@@ -1,0 +1,21 @@
+macro_rules! say_hello {
+    () => {
+        println!("Hello!")
+    };
+}
+
+macro_rules /* comment */ ! say_goodbye {
+    () => {
+        println!("Goodbye!")
+    };
+}
+
+macro_rules // comment
+! do_nothing {
+    () => {};
+}
+
+fn main() {
+    say_hello!();
+    say_goodbye!()
+}

--- a/tests/target/issue-6985.rs
+++ b/tests/target/issue-6985.rs
@@ -4,14 +4,13 @@ macro_rules! say_hello {
     };
 }
 
-macro_rules /* comment */ ! say_goodbye {
+macro_rules! say_goodbye {
     () => {
         println!("Goodbye!")
     };
 }
 
-macro_rules // comment
-! do_nothing {
+macro_rules! do_nothing {
     () => {};
 }
 


### PR DESCRIPTION
Fixes #6985.

`rewrite_macro_def` searched the source span for the contiguous string `macro_rules!`. Since `macro_rules` and `!` are separate tokens, valid source may contain whitespace or comments between them, causing the span lookup to panic.

This now locates the two tokens separately, normalizes whitespace-only separation, and preserves comments between them.