### PR TITLE
fix: broken line:column indicator in errors

### DIFF
--- a/src/format_report_formatter.rs
+++ b/src/format_report_formatter.rs
@@ -62,9 +62,18 @@ impl<'a> Display for FormatReportFormatter<'a> {
                 if error.is_internal() {
                     title = title.id("internal");
                 }
+
+                let line_indicator = if let (_, 0) = error.format_len() {
+                    // When we have a zero width span we don't create an annotiation.
+                    // As a result, we need to manually add the line number where the error occured
+                    format!(":{}", error.line)
+                } else {
+                    String::new()
+                };
+
                 let snippet = Snippet::source(&error.line_buffer)
                     .line_start(error.line)
-                    .path(format!("{file}:{}", error.line))
+                    .path(format!("{file}{line_indicator}"))
                     .fold(false)
                     .annotations(annotation(error));
                 let mut group = title.element(snippet);

--- a/tests/warning/snapshots/issue_6826.snap
+++ b/tests/warning/snapshots/issue_6826.snap
@@ -9,7 +9,7 @@ error[internal]: not formatted because a comment would be lost
   = note: set `error_on_unformatted = false` to suppress the warning against comments or string literals
 
 error[internal]: left behind trailing whitespace
- --> tests/warning/source/issue_6826.rs:3:3:20
+ --> tests/warning/source/issue_6826.rs:3:20
   |
 3 |         || c == '。' 
   |                     ^

--- a/tests/warning/snapshots/line_overflow.snap
+++ b/tests/warning/snapshots/line_overflow.snap
@@ -2,7 +2,7 @@
 source: src/test/mod.rs
 ---
 error[internal]: line formatted, but exceeded maximum width (maximum: 100 (see `max_width` option), found: 109)
- --> tests/warning/source/line_overflow.rs:1:1:101
+ --> tests/warning/source/line_overflow.rs:1:101
   |
 1 | fn this_function_name_is_intentionally_long_enough_to_exceed_the_default_one_hundred_character_maximum_width(
   |                                                                                                     ^^^^^^^^^

--- a/tests/warning/snapshots/multiple_errors.snap
+++ b/tests/warning/snapshots/multiple_errors.snap
@@ -21,14 +21,14 @@ error[internal]: not formatted because a comment would be lost
   = note: set `error_on_unformatted = false` to suppress the warning against comments or string literals
 
 error[internal]: line formatted, but exceeded maximum width (maximum: 100 (see `max_width` option), found: 109)
- --> tests/warning/source/multiple_errors.rs:7:7:101
+ --> tests/warning/source/multiple_errors.rs:7:101
   |
 7 | fn this_function_name_is_intentionally_long_enough_to_exceed_the_default_one_hundred_character_maximum_width(
   |                                                                                                     ^^^^^^^^^
   |
 
 error[internal]: left behind trailing whitespace
-  --> tests/warning/source/multiple_errors.rs:15:15:46
+  --> tests/warning/source/multiple_errors.rs:15:46
    |
 15 | /// This doc comment has trailing whitespace.   
    |                                              ^^^

--- a/tests/warning/snapshots/trailing_whitespace.snap
+++ b/tests/warning/snapshots/trailing_whitespace.snap
@@ -2,7 +2,7 @@
 source: src/test/mod.rs
 ---
 error[internal]: left behind trailing whitespace
- --> tests/warning/source/trailing_whitespace.rs:1:1:46
+ --> tests/warning/source/trailing_whitespace.rs:1:46
   |
 1 | /// This doc comment has trailing whitespace.   
   |                                              ^^^


### PR DESCRIPTION
I noticed that I was seeing error messages from rustfmt that contained paths ending in `:line:line:column`. The example `:3:3:20` can be found in the snapshot tests in this diff.

This appears to be related to how `annotate_snippets` automatically appends these indicators when annotations are set.

To fix this, I'm only appending `:line` when annotations are not set.