### PR TITLE
fix: reject inline emit_mode in check mode

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -622,6 +622,9 @@ impl GetOptsOptions {
             .collect::<Result<HashMap<_, _>, _>>()?;
 
         options.check = matches.opt_present("check");
+        if options.check && options.inline_config.contains_key("emit_mode") {
+            return Err(format_err!("Invalid to use `emit_mode` and `--check`"));
+        }
         if let Some(ref emit_str) = matches.opt_str("emit") {
             if options.check {
                 return Err(format_err!("Invalid to use `--emit` and `--check`"));

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -1,7 +1,7 @@
 //! Integration tests for rustfmt.
 
 use std::env;
-use std::fs::{File, remove_file};
+use std::fs::{File, read_to_string, remove_file, write};
 use std::path::Path;
 use std::process::Command;
 
@@ -378,4 +378,26 @@ fn rustfmt_allow_not_a_dir_errors() {
     // Should pass without any errors
     assert_eq!(stdout, "");
     assert_eq!(stderr, "");
+}
+
+#[test]
+fn check_rejects_emit_mode_from_inline_config() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let source_path = temp_dir.path().join("source.rs");
+    let source = "fn main(){println!(\"hello\");}\n";
+    write(&source_path, source).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rustfmt"))
+        .args([
+            "--check",
+            "--config",
+            "emit_mode=files",
+            source_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("emit_mode"));
+    assert_eq!(read_to_string(source_path).unwrap(), source);
 }


### PR DESCRIPTION
## Summary
- reject inline `emit_mode` overrides when `--check` is active
- add an integration regression proving `emit_mode=files` cannot rewrite the checked file

Fixes #6999

## Validation
- `rustup run 1.97.1 cargo fmt --all -- --check`
- `cargo test --test rustfmt check_rejects_emit_mode_from_inline_config`

The focused test confirms exit code 1, an error mentioning `emit_mode`, and unchanged source contents.