### PR TITLE
fix: Use `ident` span when recovering comments in non-shorthand `PatField`

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -479,7 +479,7 @@ impl Rewrite for PatField {
                 context,
                 &attrs_str,
                 &pat_and_id_str,
-                mk_sp(hi_pos, self.pat.span.lo()),
+                mk_sp(hi_pos, self.ident.span.lo()),
                 combine_shape,
                 false,
             )

--- a/tests/target/issue_6984_style_edition_2024.rs
+++ b/tests/target/issue_6984_style_edition_2024.rs
@@ -1,0 +1,13 @@
+// rustfmt-style_edition: 2024
+
+fn main() {
+    let Demo {
+        #[cfg(feature = "diagnostics")]
+            // comment between attribute and field
+            field_name_baz: _,
+
+        #[cfg(feature = "diagnostics")]
+        // comment between attribute and shorthand field
+        field_name_bar,
+    } = value;
+}

--- a/tests/target/issue_6984_style_edition_2027.rs
+++ b/tests/target/issue_6984_style_edition_2027.rs
@@ -1,0 +1,13 @@
+// rustfmt-style_edition: 2027
+
+fn main() {
+    let Demo {
+        #[cfg(feature = "diagnostics")]
+        // comment between attribute and field
+        field_name_baz: _,
+
+        #[cfg(feature = "diagnostics")]
+        // comment between attribute and shorthand field
+        field_name_bar,
+    } = value;
+}


### PR DESCRIPTION
Fixes #6984

Using the `pat` span wasn't correct because it contained the field identifier, which caused code duplication when recovering comments between the attribute and the pattern struct field.