### PR TITLE
Fix brace placement for multiline control flow

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1009,10 +1009,15 @@ impl<'a> ControlFlow<'a> {
             .config
             .max_width()
             .saturating_sub(constr_shape.used_width() + offset + brace_overhead);
+        let first_line_indent = if context.config.style_edition() >= StyleEdition::Edition2027 {
+            shape.indent.width()
+        } else {
+            shape.used_width()
+        };
         let force_newline_brace = (pat_expr_string.contains('\n')
             || pat_expr_string.len() > one_line_budget)
             && (!last_line_extendable(&pat_expr_string)
-                || last_line_offsetted(shape.used_width(), &pat_expr_string));
+                || last_line_offsetted(first_line_indent, &pat_expr_string));
 
         // Try to format if-else on single line.
         if self.allow_single_line && context.config.single_line_if_else_max_width() > 0 {

--- a/tests/source/issue_7003_style_edition_2024.rs
+++ b/tests/source/issue_7003_style_edition_2024.rs
@@ -1,0 +1,14 @@
+// rustfmt-style_edition: 2024
+
+fn main() {
+    _ = if let Some(term_node) = sema
+        .token_ancestors_with_macros(token.clone())
+        .find(|node| {
+            matches!(
+                node.kind(),
+                BLOCK_EXPR | ARG_LIST | PAREN_EXPR | ARRAY_EXPR | MATCH_EXPR
+            )
+        }) {
+        match term_node.kind() {}
+    };
+}

--- a/tests/source/issue_7003_style_edition_2027.rs
+++ b/tests/source/issue_7003_style_edition_2027.rs
@@ -1,0 +1,14 @@
+// rustfmt-style_edition: 2027
+
+fn main() {
+    _ = if let Some(term_node) = sema
+        .token_ancestors_with_macros(token.clone())
+        .find(|node| {
+            matches!(
+                node.kind(),
+                BLOCK_EXPR | ARG_LIST | PAREN_EXPR | ARRAY_EXPR | MATCH_EXPR
+            )
+        }) {
+        match term_node.kind() {}
+    };
+}

--- a/tests/target/issue_7003_style_edition_2024.rs
+++ b/tests/target/issue_7003_style_edition_2024.rs
@@ -1,0 +1,14 @@
+// rustfmt-style_edition: 2024
+
+fn main() {
+    _ = if let Some(term_node) = sema
+        .token_ancestors_with_macros(token.clone())
+        .find(|node| {
+            matches!(
+                node.kind(),
+                BLOCK_EXPR | ARG_LIST | PAREN_EXPR | ARRAY_EXPR | MATCH_EXPR
+            )
+        }) {
+        match term_node.kind() {}
+    };
+}

--- a/tests/target/issue_7003_style_edition_2027.rs
+++ b/tests/target/issue_7003_style_edition_2027.rs
@@ -1,0 +1,15 @@
+// rustfmt-style_edition: 2027
+
+fn main() {
+    _ = if let Some(term_node) = sema
+        .token_ancestors_with_macros(token.clone())
+        .find(|node| {
+            matches!(
+                node.kind(),
+                BLOCK_EXPR | ARG_LIST | PAREN_EXPR | ARRAY_EXPR | MATCH_EXPR
+            )
+        })
+    {
+        match term_node.kind() {}
+    };
+}


### PR DESCRIPTION
## Summary

  Closes #7003.

  The multiline-condition brace check included the surrounding assignment offset when comparing indentation. This incorrectly kept the opening brace on the condition's final line.

  For Style Edition 2027, compare against the leading indentation of the control-flow expression, matching the Rust Style Guide. Style Edition 2024 behavior remains unchanged.

  ## Tests

  Added source/target regression fixtures for Style Editions 2024 and 2027.