### PR TITLE
Fix chain formatting with pre-existing overflow

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -582,7 +582,19 @@ impl Rewrite for Chain {
         formatter.format_last_child(context, shape, child_shape)?;
 
         let result = formatter.join_rewrites(context, child_shape)?;
-        wrap_str(result, context.config.max_width(), shape).max_width_error(shape.width, full_span)
+        let max_width = if context.config.style_edition() >= StyleEdition::Edition2027 {
+            // Keep formatting the chain when a nested expression contains an unavoidable,
+            // pre-existing overflow, but do not allow the rewrite to make it any wider.
+            crate::comment::filter_normal_code(context.snippet(full_span))
+                .lines()
+                .map(utils::unicode_str_width)
+                .max()
+                .unwrap_or(0)
+                .max(context.config.max_width())
+        } else {
+            context.config.max_width()
+        };
+        wrap_str(result, max_width, shape).max_width_error(shape.width, full_span)
     }
 }
 

--- a/tests/source/issue_6977_style_edition_2024.rs
+++ b/tests/source/issue_6977_style_edition_2024.rs
@@ -1,0 +1,11 @@
+// rustfmt-style_edition: 2024
+
+fn main() {
+    some_struct.foo(format!(
+        "{}", if true {
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    } else {
+            ""
+        },
+    ));
+}

--- a/tests/source/issue_6977_style_edition_2027.rs
+++ b/tests/source/issue_6977_style_edition_2027.rs
@@ -1,0 +1,11 @@
+// rustfmt-style_edition: 2027
+
+fn main() {
+    some_struct.foo(format!(
+        "{}", if true {
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    } else {
+            ""
+        },
+    ));
+}

--- a/tests/target/issue_6977_style_edition_2024.rs
+++ b/tests/target/issue_6977_style_edition_2024.rs
@@ -1,0 +1,11 @@
+// rustfmt-style_edition: 2024
+
+fn main() {
+    some_struct.foo(format!(
+        "{}", if true {
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    } else {
+            ""
+        },
+    ));
+}

--- a/tests/target/issue_6977_style_edition_2027.rs
+++ b/tests/target/issue_6977_style_edition_2027.rs
@@ -1,0 +1,12 @@
+// rustfmt-style_edition: 2027
+
+fn main() {
+    some_struct.foo(format!(
+        "{}",
+        if true {
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        } else {
+            ""
+        },
+    ));
+}


### PR DESCRIPTION
## Summary

  Closes #6977.

  A nested expression rewrite could succeed while the final chain width check rejected the entire result because an unchanged string literal already exceeded `max_width`.

  For Style Edition 2027, allow the chain rewrite to retain the widest pre-existing normal-code line without permitting a wider overflow. Style Edition 2024 behavior remains unchanged.

  ## Tests

  Added source/target regression fixtures for Style Editions 2024 and 2027.