### PR TITLE
Fix closures.rs indent double-counting for wrapped params with return…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- (Style Edition 2027) Properly format closures with wrapped parameters and an explicit return type instead of leaving the enclosing expression unformatted. Issue: [#7012](https://github.com/rust-lang/rustfmt/issues/7012).
+
 
 ## [1.10.0] 2026-07-21
 

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -351,7 +351,16 @@ fn rewrite_closure_fn_decl(
         prefix.push_str(&ret_str);
     }
     // 1 = space between `|...|` and body.
-    let extra_offset = last_line_width(&prefix) + 1;
+    let last_line = last_line_width(&prefix) + 1;
+    let extra_offset =
+        if prefix.contains('\n') && context.config.style_edition() >= StyleEdition::Edition2027 {
+            // The return type was pushed onto a line of its own, so `last_line_width` measures
+            // from column zero. Callers apply this offset on top of `shape`, so subtract the
+            // width already accounted for by `shape` to avoid counting the indent twice.
+            last_line.saturating_sub(shape.used_width())
+        } else {
+            last_line
+        };
 
     Ok((prefix, extra_offset))
 }

--- a/tests/source/issue_7012_style_edition_2024.rs
+++ b/tests/source/issue_7012_style_edition_2024.rs
@@ -1,0 +1,27 @@
+// rustfmt-style_edition: 2024
+
+fn test() {
+    if outer {
+        if inner {
+            if even_more_inner {
+                let items = page
+                    .into_iter()
+                    .map(
+                        |list_media_response::ListEntry {
+                             cdn,
+                             media_id,
+                             length,
+                         }|
+                         -> Result<_, RequestError<BackupAuthCredentialRejected>> {
+                            Ok(ListMediaItem {
+                                cdn,
+                                media_id,
+                                object_length: length,
+                            })
+                        },
+                    )
+                      .try_collect()?;
+            }
+        }
+    }
+}

--- a/tests/source/issue_7012_style_edition_2027.rs
+++ b/tests/source/issue_7012_style_edition_2027.rs
@@ -1,0 +1,27 @@
+// rustfmt-style_edition: 2027
+
+fn test() {
+    if outer {
+        if inner {
+            if even_more_inner {
+                let items = page
+                    .into_iter()
+                    .map(
+                        |list_media_response::ListEntry {
+                             cdn,
+                             media_id,
+                             length,
+                         }|
+                         -> Result<_, RequestError<BackupAuthCredentialRejected>> {
+                            Ok(ListMediaItem {
+                                cdn,
+                                media_id,
+                                object_length: length,
+                            })
+                        },
+                    )
+                      .try_collect()?;
+            }
+        }
+    }
+}

--- a/tests/target/issue_7012_style_edition_2024.rs
+++ b/tests/target/issue_7012_style_edition_2024.rs
@@ -1,0 +1,27 @@
+// rustfmt-style_edition: 2024
+
+fn test() {
+    if outer {
+        if inner {
+            if even_more_inner {
+                let items = page
+                    .into_iter()
+                    .map(
+                        |list_media_response::ListEntry {
+                             cdn,
+                             media_id,
+                             length,
+                         }|
+                         -> Result<_, RequestError<BackupAuthCredentialRejected>> {
+                            Ok(ListMediaItem {
+                                cdn,
+                                media_id,
+                                object_length: length,
+                            })
+                        },
+                    )
+                      .try_collect()?;
+            }
+        }
+    }
+}

--- a/tests/target/issue_7012_style_edition_2027.rs
+++ b/tests/target/issue_7012_style_edition_2027.rs
@@ -1,0 +1,27 @@
+// rustfmt-style_edition: 2027
+
+fn test() {
+    if outer {
+        if inner {
+            if even_more_inner {
+                let items = page
+                    .into_iter()
+                    .map(
+                        |list_media_response::ListEntry {
+                             cdn,
+                             media_id,
+                             length,
+                         }|
+                         -> Result<_, RequestError<BackupAuthCredentialRejected>> {
+                            Ok(ListMediaItem {
+                                cdn,
+                                media_id,
+                                object_length: length,
+                            })
+                        },
+                    )
+                    .try_collect()?;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes rust-lang/rustfmt#7012: rustfmt gives up formatting a statement when a method-chain argument is a closure whose parameter list wraps onto multiple lines and has an explicit return type, at moderate nesting depth. The reported symptom is that nothing changes and a misindented `.try_collect()?` is left as-is.

## Root cause

In `rewrite_closure_fn_decl` (`src/closures.rs`), when the closure's parameters wrap, the return type is placed on its own line prefixed with `param_offset` indentation. `last_line_width(&prefix)` then returns an absolute column rather than a width. The caller applies this value via `shape.offset_left(extra_offset, span)`, which adds it on top of `shape.indent`, double counting the indent. For the reported code this makes `extra_offset` exceed `shape.width`, the rewrite returns `ExceedsMaxWidth`, and the error propagates up through the closure, the `.map()` call, the chain, and the `let` statement, so rustfmt falls back to emitting the original source untouched.

## Fix

When the prefix wraps, subtract `shape.used_width()` from the computed offset so it is relative to the shape instead of absolute. This is gated behind `style_edition >= Edition2027` because it changes the formatting of closures that already succeed today (a probe closure with a multiline param list and `-> T` return type joins its body onto one line up to 86 chars instead of 78). This follows the same gating precedent as #6835 for issue #6831.

## Testing

- Added `tests/source/issue_7012_style_edition_2024.rs` and matching target, showing the current stable behavior is unchanged (rustfmt still leaves the statement unformatted).
- Added `tests/source/issue_7012_style_edition_2027.rs` and matching target, showing `.try_collect()?` correctly aligned under `style_edition=2027`.
- Verified the new target file is idempotent under `--check`.
- Ran the full `cargo test` suite locally, all system, idempotence, and integration tests pass with no changes to any pre-existing target file.
- Confirmed the new test files are actually exercised by temporarily corrupting the 2027 target and observing a test failure, then restoring it.

## Changelog

Added an entry under `Unreleased > Fixed` noting the style edition 2027 gated fix.
