### PR TITLE
Add args-file support for large Windows workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ regex = "1.7"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"
 term = "1.1"
+tempfile = "3.23.0"
 thiserror = "1.0.40"
 toml = "1.1"
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
@@ -62,7 +63,6 @@ rustfmt-config_proc_macro = { version = "0.3", path = "config_proc_macro" }
 semver = "1.0.21"
 
 [dev-dependencies]
-tempfile = "3.23.0"
 insta = { version = "1.48.0", features = ["filters"] }
 
 # Rustc dependencies are loaded from the sysroot, Cargo doesn't know about them.

--- a/README.md
+++ b/README.md
@@ -85,10 +85,8 @@ The easiest way to run rustfmt against a project is with `cargo fmt`. `cargo fmt
 single-crate projects and [cargo workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html).
 Please see `cargo fmt --help` for usage information.
 
-Rustfmt can read command-line arguments from a response file using `@path`. The response file must
-be UTF-8 encoded and contain one argument per line. Response files are expanded once, so an
-argument beginning with `@` inside a response file is treated literally. On the command line, use
-`@@` to pass a literal argument beginning with `@`.
+Rustfmt can read command-line arguments from a file using `--args-file <path>`. Argument files must
+be UTF-8 encoded and contain one argument per line.
 
 You can specify the path to your own `rustfmt` binary for cargo to use by setting the`RUSTFMT` 
 environment variable. This was added in v1.4.22, so you must have this version or newer to leverage this feature (`cargo fmt --version`)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ The easiest way to run rustfmt against a project is with `cargo fmt`. `cargo fmt
 single-crate projects and [cargo workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html).
 Please see `cargo fmt --help` for usage information.
 
+Rustfmt can read command-line arguments from a response file using `@path`. The response file must
+be UTF-8 encoded and contain one argument per line. Response files are expanded once, so an
+argument beginning with `@` inside a response file is treated literally. On the command line, use
+`@@` to pass a literal argument beginning with `@`.
+
 You can specify the path to your own `rustfmt` binary for cargo to use by setting the`RUSTFMT` 
 environment variable. This was added in v1.4.22, so you must have this version or newer to leverage this feature (`cargo fmt --version`)
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::EnvFilter;
 
 use std::collections::HashMap;
 use std::env;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, Read, Write, stdout};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -222,7 +222,8 @@ fn is_nightly() -> bool {
 
 // Returned i32 is an exit code
 fn execute(opts: &Options) -> Result<i32> {
-    let matches = opts.parse(env::args().skip(1))?;
+    let args = expand_response_files(env::args().skip(1))?;
+    let matches = opts.parse(args)?;
     let options = GetOptsOptions::from_matches(&matches)?;
 
     match determine_operation(&matches)? {
@@ -273,6 +274,22 @@ fn execute(opts: &Options) -> Result<i32> {
             minimal_config_path,
         } => format(files, minimal_config_path, &options),
     }
+}
+
+fn expand_response_files(args: impl IntoIterator<Item = String>) -> Result<Vec<String>> {
+    let mut expanded = Vec::new();
+    for arg in args {
+        if let Some(arg) = arg.strip_prefix("@@") {
+            expanded.push(format!("@{arg}"));
+        } else if let Some(path) = arg.strip_prefix('@') {
+            let contents = fs::read_to_string(path)
+                .map_err(|e| format_err!("failed to load argument file `{path}`: {e}"))?;
+            expanded.extend(contents.lines().map(str::to_owned));
+        } else {
+            expanded.push(arg);
+        }
+    }
+    Ok(expanded)
 }
 
 fn format_string(input: String, options: GetOptsOptions) -> Result<i32> {
@@ -807,9 +824,39 @@ fn emit_mode_from_emit_str(emit_str: &str) -> Result<EmitMode> {
 mod test {
     use super::*;
     use rustfmt_config_proc_macro::nightly_only_test;
+    use tempfile::NamedTempFile;
 
     fn get_config<O: CliOptions>(path: Option<&Path>, options: Option<O>) -> Config {
         load_config(path, options).unwrap().0
+    }
+
+    #[test]
+    fn response_files_are_expanded_once() {
+        let mut response_file = NamedTempFile::new().unwrap();
+        writeln!(
+            response_file,
+            "--edition\r\n2021\r\n\r\n@nested-response-file"
+        )
+        .unwrap();
+
+        let args = expand_response_files([format!("@{}", response_file.path().display())]).unwrap();
+        assert_eq!(args, ["--edition", "2021", "", "@nested-response-file"]);
+    }
+
+    #[test]
+    fn doubled_at_sign_escapes_response_file_expansion() {
+        let args = expand_response_files(["@@source.rs".to_owned()]).unwrap();
+        assert_eq!(args, ["@source.rs"]);
+    }
+
+    #[test]
+    fn missing_response_file_is_an_error() {
+        let error = expand_response_files(["@missing-response-file".to_owned()]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .starts_with("failed to load argument file `missing-response-file`:")
+        );
     }
 
     #[nightly_only_test]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -328,6 +328,7 @@ fn expand_args_files_inner(
             }
             let contents = fs::read_to_string(&path)
                 .map_err(|e| format_err!("failed to load argument file `{path}`: {e}"))?;
+            let contents = contents.strip_prefix('\u{feff}').unwrap_or(&contents);
             expanded.extend(expand_args_files_inner(
                 contents.lines().map(str::to_owned),
                 depth + 1,
@@ -902,6 +903,19 @@ mod test {
 
         let args =
             expand_args_files([format!("--args-file={}", args_file.path().display())]).unwrap();
+        assert_eq!(args, ["--check"]);
+    }
+
+    #[test]
+    fn args_file_accepts_utf8_bom() {
+        let mut args_file = NamedTempFile::new().unwrap();
+        args_file.write_all(b"\xEF\xBB\xBF--check\n").unwrap();
+
+        let args = expand_args_files([
+            "--args-file".to_owned(),
+            args_file.path().display().to_string(),
+        ])
+        .unwrap();
         assert_eq!(args, ["--check"]);
     }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -173,6 +173,12 @@ fn make_opts() -> Options {
         "The edition of the Style Guide.",
         "[2015|2018|2021|2024]",
     );
+    opts.optmulti(
+        "",
+        "args-file",
+        "Read command-line arguments from a UTF-8 file, one argument per line",
+        "PATH",
+    );
 
     if is_nightly {
         opts.optflag(
@@ -222,7 +228,7 @@ fn is_nightly() -> bool {
 
 // Returned i32 is an exit code
 fn execute(opts: &Options) -> Result<i32> {
-    let args = expand_response_files(env::args().skip(1))?;
+    let args = expand_args_files(env::args().skip(1))?;
     let matches = opts.parse(args)?;
     let options = GetOptsOptions::from_matches(&matches)?;
 
@@ -276,15 +282,61 @@ fn execute(opts: &Options) -> Result<i32> {
     }
 }
 
-fn expand_response_files(args: impl IntoIterator<Item = String>) -> Result<Vec<String>> {
+fn expand_args_files(args: impl IntoIterator<Item = String>) -> Result<Vec<String>> {
+    let mut options_enabled = true;
+    expand_args_files_inner(args, 0, &mut options_enabled)
+}
+
+fn expand_args_files_inner(
+    args: impl IntoIterator<Item = String>,
+    depth: usize,
+    options_enabled: &mut bool,
+) -> Result<Vec<String>> {
+    const MAX_ARGS_FILE_DEPTH: usize = 16;
+    if depth > MAX_ARGS_FILE_DEPTH {
+        return Err(format_err!(
+            "argument files cannot be nested more than {MAX_ARGS_FILE_DEPTH} levels"
+        ));
+    }
+
     let mut expanded = Vec::new();
-    for arg in args {
-        if let Some(arg) = arg.strip_prefix("@@") {
-            expanded.push(format!("@{arg}"));
-        } else if let Some(path) = arg.strip_prefix('@') {
-            let contents = fs::read_to_string(path)
+    let mut args = args.into_iter();
+    while let Some(arg) = args.next() {
+        if !*options_enabled {
+            expanded.push(arg);
+            expanded.extend(args);
+            break;
+        }
+        if arg == "--" {
+            *options_enabled = false;
+            expanded.push(arg);
+            expanded.extend(args);
+            break;
+        }
+        let path = if arg == "--args-file" {
+            Some(
+                args.next()
+                    .ok_or_else(|| format_err!("`--args-file` requires a path"))?,
+            )
+        } else {
+            arg.strip_prefix("--args-file=").map(str::to_owned)
+        };
+
+        if let Some(path) = path {
+            if path.is_empty() {
+                return Err(format_err!("`--args-file` requires a path"));
+            }
+            let contents = fs::read_to_string(&path)
                 .map_err(|e| format_err!("failed to load argument file `{path}`: {e}"))?;
-            expanded.extend(contents.lines().map(str::to_owned));
+            expanded.extend(expand_args_files_inner(
+                contents.lines().map(str::to_owned),
+                depth + 1,
+                options_enabled,
+            )?);
+            if !*options_enabled {
+                expanded.extend(args);
+                break;
+            }
         } else {
             expanded.push(arg);
         }
@@ -831,31 +883,62 @@ mod test {
     }
 
     #[test]
-    fn response_files_are_expanded_once() {
-        let mut response_file = NamedTempFile::new().unwrap();
-        writeln!(
-            response_file,
-            "--edition\r\n2021\r\n\r\n@nested-response-file"
-        )
+    fn args_files_are_expanded() {
+        let mut args_file = NamedTempFile::new().unwrap();
+        writeln!(args_file, "--edition\r\n2021\r\n\r\n@ordinary-source-file").unwrap();
+
+        let args = expand_args_files([
+            "--args-file".to_owned(),
+            args_file.path().display().to_string(),
+        ])
         .unwrap();
-
-        let args = expand_response_files([format!("@{}", response_file.path().display())]).unwrap();
-        assert_eq!(args, ["--edition", "2021", "", "@nested-response-file"]);
+        assert_eq!(args, ["--edition", "2021", "", "@ordinary-source-file"]);
     }
 
     #[test]
-    fn doubled_at_sign_escapes_response_file_expansion() {
-        let args = expand_response_files(["@@source.rs".to_owned()]).unwrap();
-        assert_eq!(args, ["@source.rs"]);
+    fn args_file_equals_syntax_is_supported() {
+        let mut args_file = NamedTempFile::new().unwrap();
+        writeln!(args_file, "--check").unwrap();
+
+        let args =
+            expand_args_files([format!("--args-file={}", args_file.path().display())]).unwrap();
+        assert_eq!(args, ["--check"]);
     }
 
     #[test]
-    fn missing_response_file_is_an_error() {
-        let error = expand_response_files(["@missing-response-file".to_owned()]).unwrap_err();
+    fn args_file_after_option_terminator_is_a_file_name() {
+        let args = expand_args_files([
+            "--".to_owned(),
+            "--args-file".to_owned(),
+            "source.rs".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(args, ["--", "--args-file", "source.rs"]);
+    }
+
+    #[test]
+    fn option_terminator_in_args_file_stops_outer_expansion() {
+        let mut args_file = NamedTempFile::new().unwrap();
+        writeln!(args_file, "--").unwrap();
+
+        let args = expand_args_files([
+            "--args-file".to_owned(),
+            args_file.path().display().to_string(),
+            "--args-file".to_owned(),
+            "source.rs".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(args, ["--", "--args-file", "source.rs"]);
+    }
+
+    #[test]
+    fn missing_args_file_is_an_error() {
+        let error = expand_args_files(["--args-file".to_owned(), "missing-args-file".to_owned()])
+            .unwrap_err();
         assert!(
             error
                 .to_string()
-                .starts_with("failed to load argument file `missing-response-file`:")
+                .starts_with("failed to load argument file `missing-args-file`:")
         );
     }
 

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -503,25 +503,86 @@ fn add_targets(target_paths: &[cargo_metadata::Target], targets: &mut BTreeSet<T
     }
 }
 
-fn expand_response_file_args(args: &[OsString]) -> Result<Vec<OsString>, io::Error> {
+fn expand_args_file_args(args: &[OsString]) -> Result<Vec<OsString>, io::Error> {
+    let mut options_enabled = true;
+    expand_args_file_args_inner(args, 0, &mut options_enabled)
+}
+
+fn expand_args_file_args_inner(
+    args: &[OsString],
+    depth: usize,
+    options_enabled: &mut bool,
+) -> Result<Vec<OsString>, io::Error> {
+    const MAX_ARGS_FILE_DEPTH: usize = 16;
+    if depth > MAX_ARGS_FILE_DEPTH {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("argument files cannot be nested more than {MAX_ARGS_FILE_DEPTH} levels"),
+        ));
+    }
+
     let mut expanded = Vec::new();
-    for arg in args {
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        if !*options_enabled {
+            expanded.push(arg.clone());
+            expanded.extend(args.cloned());
+            break;
+        }
         let arg = arg.to_str().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "rustfmt response-file arguments must be valid UTF-8",
+                "rustfmt argument-file arguments must be valid UTF-8",
             )
         })?;
-        if let Some(arg) = arg.strip_prefix("@@") {
-            expanded.push(OsString::from(format!("@{arg}")));
-        } else if let Some(path) = arg.strip_prefix('@') {
-            let contents = fs::read_to_string(path).map_err(|e| {
+        if arg == "--" {
+            *options_enabled = false;
+            expanded.push(OsString::from(arg));
+            expanded.extend(args.cloned());
+            break;
+        }
+        let path = if arg == "--args-file" {
+            Some(
+                args.next()
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidInput, "`--args-file` requires a path")
+                    })?
+                    .to_str()
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "argument-file paths must be valid UTF-8",
+                        )
+                    })?
+                    .to_owned(),
+            )
+        } else {
+            arg.strip_prefix("--args-file=").map(str::to_owned)
+        };
+
+        if let Some(path) = path {
+            if path.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "`--args-file` requires a path",
+                ));
+            }
+            let contents = fs::read_to_string(&path).map_err(|e| {
                 io::Error::new(
                     e.kind(),
                     format!("failed to load argument file `{path}`: {e}"),
                 )
             })?;
-            expanded.extend(contents.lines().map(OsString::from));
+            let nested = contents.lines().map(OsString::from).collect::<Vec<_>>();
+            expanded.extend(expand_args_file_args_inner(
+                &nested,
+                depth + 1,
+                options_enabled,
+            )?);
+            if !*options_enabled {
+                expanded.extend(args.cloned());
+                break;
+            }
         } else {
             expanded.push(OsString::from(arg));
         }
@@ -529,25 +590,25 @@ fn expand_response_file_args(args: &[OsString]) -> Result<Vec<OsString>, io::Err
     Ok(expanded)
 }
 
-fn write_response_file(args: &[OsString]) -> Result<NamedTempFile, io::Error> {
-    let mut response_file = NamedTempFile::new()?;
-    for arg in expand_response_file_args(args)? {
+fn write_args_file(args: &[OsString]) -> Result<NamedTempFile, io::Error> {
+    let mut args_file = NamedTempFile::new()?;
+    for arg in expand_args_file_args(args)? {
         let arg = arg.to_str().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "rustfmt response-file arguments must be valid UTF-8",
+                "rustfmt argument-file arguments must be valid UTF-8",
             )
         })?;
         if arg.contains('\n') || arg.contains('\r') {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "rustfmt response-file arguments cannot contain newlines",
+                "rustfmt argument-file arguments cannot contain newlines",
             ));
         }
-        writeln!(response_file, "{arg}")?;
+        writeln!(args_file, "{arg}")?;
     }
-    response_file.flush()?;
-    Ok(response_file)
+    args_file.flush()?;
+    Ok(args_file)
 }
 
 #[cfg(windows)]
@@ -582,7 +643,7 @@ fn command_line_program_len(program: &Path) -> usize {
 }
 
 #[cfg(windows)]
-fn should_use_response_file(program: &Path, args: &[OsString]) -> bool {
+fn should_use_args_file(program: &Path, args: &[OsString]) -> bool {
     const WINDOWS_COMMAND_LINE_LIMIT: usize = 32_767;
 
     let command_line_len = command_line_program_len(program).saturating_add(
@@ -594,7 +655,7 @@ fn should_use_response_file(program: &Path, args: &[OsString]) -> bool {
 }
 
 #[cfg(not(windows))]
-fn should_use_response_file(_program: &Path, _args: &[OsString]) -> bool {
+fn should_use_args_file(_program: &Path, _args: &[OsString]) -> bool {
     false
 }
 
@@ -642,16 +703,14 @@ fn run_rustfmt(
         ]);
         args.extend(fmt_args.iter().map(OsString::from));
 
-        let response_file = should_use_response_file(&rustfmt, &args)
-            .then(|| write_response_file(&args))
+        let args_file = should_use_args_file(&rustfmt, &args)
+            .then(|| write_args_file(&args))
             .transpose()?;
 
         let mut command = Command::new(rustfmt);
         command.stdout(stdout);
-        if let Some(response_file) = response_file.as_ref() {
-            let mut response_arg = OsString::from("@");
-            response_arg.push(response_file.path());
-            command.arg(response_arg);
+        if let Some(args_file) = args_file.as_ref() {
+            command.arg("--args-file").arg(args_file.path());
         } else {
             command.args(&args);
         }

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -573,6 +573,7 @@ fn expand_args_file_args_inner(
                     format!("failed to load argument file `{path}`: {e}"),
                 )
             })?;
+            let contents = contents.strip_prefix('\u{feff}').unwrap_or(&contents);
             let nested = contents.lines().map(OsString::from).collect::<Vec<_>>();
             expanded.extend(expand_args_file_args_inner(
                 &nested,

--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -6,6 +6,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
+use std::ffi::OsString;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
@@ -15,6 +16,12 @@ use std::str;
 
 use cargo_metadata::Edition;
 use clap::{CommandFactory, Parser};
+use tempfile::NamedTempFile;
+
+#[cfg(windows)]
+use std::ffi::OsStr;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
 
 #[path = "test/mod.rs"]
 #[cfg(test)]
@@ -165,15 +172,17 @@ fn execute() -> i32 {
     }
 }
 
-fn rustfmt_command() -> Command {
-    let rustfmt = match env::var_os("RUSTFMT") {
+fn rustfmt_path() -> PathBuf {
+    match env::var_os("RUSTFMT") {
         Some(rustfmt) => PathBuf::from(rustfmt),
         None => env::current_exe()
             .expect("current executable path invalid")
             .with_file_name("rustfmt"),
-    };
+    }
+}
 
-    Command::new(rustfmt)
+fn rustfmt_command() -> Command {
+    Command::new(rustfmt_path())
 }
 
 fn convert_message_format_to_rustfmt_args(
@@ -494,6 +503,101 @@ fn add_targets(target_paths: &[cargo_metadata::Target], targets: &mut BTreeSet<T
     }
 }
 
+fn expand_response_file_args(args: &[OsString]) -> Result<Vec<OsString>, io::Error> {
+    let mut expanded = Vec::new();
+    for arg in args {
+        let arg = arg.to_str().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "rustfmt response-file arguments must be valid UTF-8",
+            )
+        })?;
+        if let Some(arg) = arg.strip_prefix("@@") {
+            expanded.push(OsString::from(format!("@{arg}")));
+        } else if let Some(path) = arg.strip_prefix('@') {
+            let contents = fs::read_to_string(path).map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!("failed to load argument file `{path}`: {e}"),
+                )
+            })?;
+            expanded.extend(contents.lines().map(OsString::from));
+        } else {
+            expanded.push(OsString::from(arg));
+        }
+    }
+    Ok(expanded)
+}
+
+fn write_response_file(args: &[OsString]) -> Result<NamedTempFile, io::Error> {
+    let mut response_file = NamedTempFile::new()?;
+    for arg in expand_response_file_args(args)? {
+        let arg = arg.to_str().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "rustfmt response-file arguments must be valid UTF-8",
+            )
+        })?;
+        if arg.contains('\n') || arg.contains('\r') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "rustfmt response-file arguments cannot contain newlines",
+            ));
+        }
+        writeln!(response_file, "{arg}")?;
+    }
+    response_file.flush()?;
+    Ok(response_file)
+}
+
+#[cfg(windows)]
+fn command_line_arg_len(arg: &OsStr) -> usize {
+    let arg = arg.encode_wide().collect::<Vec<_>>();
+    let quoted = arg.is_empty() || arg.iter().any(|&c| c == b' ' as u16 || c == b'\t' as u16);
+    let mut len = arg.len().saturating_add(usize::from(quoted) * 2);
+    let mut backslashes = 0usize;
+
+    for &c in &arg {
+        if c == b'\\' as u16 {
+            backslashes += 1;
+        } else {
+            if c == b'"' as u16 {
+                len = len.saturating_add(backslashes).saturating_add(1);
+            }
+            backslashes = 0;
+        }
+    }
+    if quoted {
+        len = len.saturating_add(backslashes);
+    }
+
+    // Account for the separator before this argument.
+    len.saturating_add(1)
+}
+
+#[cfg(windows)]
+fn command_line_program_len(program: &Path) -> usize {
+    // Rust always surrounds argv[0] with quotes on Windows.
+    program.as_os_str().encode_wide().count().saturating_add(2)
+}
+
+#[cfg(windows)]
+fn should_use_response_file(program: &Path, args: &[OsString]) -> bool {
+    const WINDOWS_COMMAND_LINE_LIMIT: usize = 32_767;
+
+    let command_line_len = command_line_program_len(program).saturating_add(
+        args.iter()
+            .map(|arg| command_line_arg_len(arg))
+            .sum::<usize>(),
+    );
+    command_line_len >= WINDOWS_COMMAND_LINE_LIMIT
+}
+
+#[cfg(not(windows))]
+fn should_use_response_file(_program: &Path, _args: &[OsString]) -> bool {
+    false
+}
+
 fn run_rustfmt(
     targets: &BTreeSet<Target>,
     fmt_args: &[String],
@@ -527,19 +631,38 @@ fn run_rustfmt(
             println!();
         }
 
-        let mut command = rustfmt_command()
-            .stdout(stdout)
-            .args(files)
-            .args(["--edition", edition.as_str()])
-            .args(fmt_args)
-            .spawn()
-            .map_err(|e| match e.kind() {
-                io::ErrorKind::NotFound => io::Error::new(
-                    io::ErrorKind::Other,
-                    "Could not run rustfmt, please make sure it is in your PATH.",
-                ),
-                _ => e,
-            })?;
+        let rustfmt = rustfmt_path();
+        let mut args = files
+            .iter()
+            .map(|file| file.as_os_str().to_owned())
+            .collect::<Vec<_>>();
+        args.extend([
+            OsString::from("--edition"),
+            OsString::from(edition.as_str()),
+        ]);
+        args.extend(fmt_args.iter().map(OsString::from));
+
+        let response_file = should_use_response_file(&rustfmt, &args)
+            .then(|| write_response_file(&args))
+            .transpose()?;
+
+        let mut command = Command::new(rustfmt);
+        command.stdout(stdout);
+        if let Some(response_file) = response_file.as_ref() {
+            let mut response_arg = OsString::from("@");
+            response_arg.push(response_file.path());
+            command.arg(response_arg);
+        } else {
+            command.args(&args);
+        }
+
+        let mut command = command.spawn().map_err(|e| match e.kind() {
+            io::ErrorKind::NotFound => io::Error::new(
+                io::ErrorKind::Other,
+                "Could not run rustfmt, please make sure it is in your PATH.",
+            ),
+            _ => e,
+        })?;
 
         status.push(command.wait()?);
     }

--- a/src/cargo-fmt/test/mod.rs
+++ b/src/cargo-fmt/test/mod.rs
@@ -134,6 +134,21 @@ fn argument_file_arguments_are_expanded() {
 }
 
 #[test]
+fn argument_file_accepts_utf8_bom() {
+    use std::io::Write;
+
+    let mut args_file = tempfile::NamedTempFile::new().unwrap();
+    args_file.write_all(b"\xEF\xBB\xBF--check\n").unwrap();
+
+    let args = expand_args_file_args(&[
+        OsString::from("--args-file"),
+        args_file.path().as_os_str().to_owned(),
+    ])
+    .unwrap();
+    assert_eq!(args, ["--check"]);
+}
+
+#[test]
 fn argument_file_terminator_stops_outer_expansion() {
     use std::io::Write;
 

--- a/src/cargo-fmt/test/mod.rs
+++ b/src/cargo-fmt/test/mod.rs
@@ -119,18 +119,35 @@ fn windows_command_line_length_matches_rust_quoting() {
 }
 
 #[test]
-fn response_file_arguments_are_expanded_once() {
+fn argument_file_arguments_are_expanded() {
     use std::io::Write;
 
-    let mut response_file = tempfile::NamedTempFile::new().unwrap();
-    writeln!(response_file, "--check\r\n@nested-response-file").unwrap();
+    let mut args_file = tempfile::NamedTempFile::new().unwrap();
+    writeln!(args_file, "--check\r\n@ordinary-source-file").unwrap();
 
-    let args = expand_response_file_args(&[
-        OsString::from(format!("@{}", response_file.path().display())),
-        OsString::from("@@literal"),
+    let args = expand_args_file_args(&[
+        OsString::from("--args-file"),
+        args_file.path().as_os_str().to_owned(),
     ])
     .unwrap();
-    assert_eq!(args, ["--check", "@nested-response-file", "@literal"]);
+    assert_eq!(args, ["--check", "@ordinary-source-file"]);
+}
+
+#[test]
+fn argument_file_terminator_stops_outer_expansion() {
+    use std::io::Write;
+
+    let mut args_file = tempfile::NamedTempFile::new().unwrap();
+    writeln!(args_file, "--").unwrap();
+
+    let args = expand_args_file_args(&[
+        OsString::from("--args-file"),
+        args_file.path().as_os_str().to_owned(),
+        OsString::from("--args-file"),
+        OsString::from("source.rs"),
+    ])
+    .unwrap();
+    assert_eq!(args, ["--", "--args-file", "source.rs"]);
 }
 
 #[test]

--- a/src/cargo-fmt/test/mod.rs
+++ b/src/cargo-fmt/test/mod.rs
@@ -104,6 +104,35 @@ fn multiple_packages_grouped() {
     assert_eq!(4, o.packages.len());
 }
 
+#[cfg(windows)]
+#[test]
+fn windows_command_line_length_matches_rust_quoting() {
+    use std::ffi::OsStr;
+
+    assert_eq!(command_line_arg_len(OsStr::new("plain")), 6);
+    assert_eq!(command_line_arg_len(OsStr::new("")), 3);
+    assert_eq!(command_line_arg_len(OsStr::new("has space")), 12);
+    assert_eq!(command_line_arg_len(OsStr::new(r#"a\"b"#)), 7);
+    assert_eq!(command_line_arg_len(OsStr::new(r#"a \"b"#)), 10);
+    assert_eq!(command_line_arg_len(OsStr::new(r#"a \"#)), 7);
+    assert_eq!(command_line_program_len(Path::new("rustfmt")), 9);
+}
+
+#[test]
+fn response_file_arguments_are_expanded_once() {
+    use std::io::Write;
+
+    let mut response_file = tempfile::NamedTempFile::new().unwrap();
+    writeln!(response_file, "--check\r\n@nested-response-file").unwrap();
+
+    let args = expand_response_file_args(&[
+        OsString::from(format!("@{}", response_file.path().display())),
+        OsString::from("@@literal"),
+    ])
+    .unwrap();
+    assert_eq!(args, ["--check", "@nested-response-file", "@literal"]);
+}
+
 #[test]
 fn empty_packages_1() {
     assert!(

--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -63,7 +63,7 @@ fn cargo_fmt_uses_args_file_for_long_command_lines() {
     let manifest_path = temp_dir.path().join("Cargo.toml");
     fs::write(&manifest_path, manifest).unwrap();
     let args_file = temp_dir.path().join("rustfmt.args");
-    fs::write(&args_file, "--check\n").unwrap();
+    fs::write(&args_file, b"\xEF\xBB\xBF--check\n").unwrap();
 
     let (stdout, stderr) = cargo_fmt(&[
         "--manifest-path",

--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -1,6 +1,8 @@
 // Integration tests for cargo-fmt.
 
 use std::env;
+#[cfg(windows)]
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -37,6 +39,41 @@ fn cargo_fmt(args: &[&str]) -> (String, String) {
         ),
         Err(e) => panic!("failed to run `{cmd:?} {args:?}`: {e}"),
     }
+}
+
+#[cfg(windows)]
+#[rustfmt_only_ci_test]
+#[test]
+fn cargo_fmt_uses_response_file_for_long_command_lines() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let source_dir = temp_dir.path().join("src");
+    fs::create_dir(&source_dir).unwrap();
+
+    let mut manifest = String::from(
+        "[package]\nname = \"response-file-test\"\nversion = \"0.1.0\"\n\
+         edition = \"2021\"\nautobins = false\n",
+    );
+    for index in 0..500 {
+        let file_name = format!("response_file_target_with_a_long_name_{index:04}.rs");
+        fs::write(source_dir.join(&file_name), "fn main() {}\n").unwrap();
+        manifest.push_str(&format!(
+            "\n[[bin]]\nname = \"response-file-target-{index:04}\"\npath = \"src/{file_name}\"\n"
+        ));
+    }
+    let manifest_path = temp_dir.path().join("Cargo.toml");
+    fs::write(&manifest_path, manifest).unwrap();
+    let response_file = temp_dir.path().join("rustfmt.args");
+    fs::write(&response_file, "--check\n").unwrap();
+    let response_arg = format!("@{}", response_file.display());
+
+    let (stdout, stderr) = cargo_fmt(&[
+        "--manifest-path",
+        manifest_path.to_str().unwrap(),
+        "--",
+        &response_arg,
+    ]);
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
 }
 
 macro_rules! assert_that {

--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -44,33 +44,33 @@ fn cargo_fmt(args: &[&str]) -> (String, String) {
 #[cfg(windows)]
 #[rustfmt_only_ci_test]
 #[test]
-fn cargo_fmt_uses_response_file_for_long_command_lines() {
+fn cargo_fmt_uses_args_file_for_long_command_lines() {
     let temp_dir = tempfile::tempdir().unwrap();
     let source_dir = temp_dir.path().join("src");
     fs::create_dir(&source_dir).unwrap();
 
     let mut manifest = String::from(
-        "[package]\nname = \"response-file-test\"\nversion = \"0.1.0\"\n\
+        "[package]\nname = \"args-file-test\"\nversion = \"0.1.0\"\n\
          edition = \"2021\"\nautobins = false\n",
     );
     for index in 0..500 {
-        let file_name = format!("response_file_target_with_a_long_name_{index:04}.rs");
+        let file_name = format!("args_file_target_with_a_long_name_{index:04}.rs");
         fs::write(source_dir.join(&file_name), "fn main() {}\n").unwrap();
         manifest.push_str(&format!(
-            "\n[[bin]]\nname = \"response-file-target-{index:04}\"\npath = \"src/{file_name}\"\n"
+            "\n[[bin]]\nname = \"args-file-target-{index:04}\"\npath = \"src/{file_name}\"\n"
         ));
     }
     let manifest_path = temp_dir.path().join("Cargo.toml");
     fs::write(&manifest_path, manifest).unwrap();
-    let response_file = temp_dir.path().join("rustfmt.args");
-    fs::write(&response_file, "--check\n").unwrap();
-    let response_arg = format!("@{}", response_file.display());
+    let args_file = temp_dir.path().join("rustfmt.args");
+    fs::write(&args_file, "--check\n").unwrap();
 
     let (stdout, stderr) = cargo_fmt(&[
         "--manifest-path",
         manifest_path.to_str().unwrap(),
         "--",
-        &response_arg,
+        "--args-file",
+        args_file.to_str().unwrap(),
     ]);
     assert_eq!(stdout, "");
     assert_eq!(stderr, "");

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -1,7 +1,8 @@
 //! Integration tests for rustfmt.
 
 use std::env;
-use std::fs::{File, remove_file};
+use std::fs::{self, File, remove_file};
+use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 
@@ -39,6 +40,49 @@ fn rustfmt_with_extra(
 
 fn rustfmt(args: &[&str]) -> (String, String) {
     rustfmt_with_extra(args, None, &[])
+}
+
+#[test]
+fn response_file() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let source = temp_dir.path().join("response file.rs");
+    fs::write(&source, "fn main () {}\n").unwrap();
+
+    let mut response_file = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        response_file,
+        "--quiet\r\n--emit\r\nstdout\r\n--edition\r\n2021\r\n{}\r\n",
+        source.display()
+    )
+    .unwrap();
+
+    let response_arg = format!("@{}", response_file.path().display());
+    let (stdout, stderr) = rustfmt(&[&response_arg]);
+    assert_eq!(stdout, "fn main() {}\n");
+    assert_eq!(stderr, "");
+}
+
+#[test]
+fn missing_response_file() {
+    let (stdout, stderr) = rustfmt(&["@missing-rustfmt-response-file"]);
+    assert!(
+        stdout.contains("failed to load argument file `missing-rustfmt-response-file`:")
+            || stderr.contains("failed to load argument file `missing-rustfmt-response-file`:")
+    );
+}
+
+#[test]
+fn doubled_at_sign_formats_a_literal_at_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    fs::write(temp_dir.path().join("@source.rs"), "fn main () {}\n").unwrap();
+
+    let (stdout, stderr) = rustfmt_with_extra(
+        &["--quiet", "--emit", "stdout", "@@source.rs"],
+        temp_dir.path().to_str(),
+        &[],
+    );
+    assert_eq!(stdout, "fn main() {}\n");
+    assert_eq!(stderr, "");
 }
 
 macro_rules! assert_that {

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -49,6 +49,7 @@ fn args_file() {
     fs::write(&source, "fn main () {}\n").unwrap();
 
     let mut args_file = tempfile::NamedTempFile::new().unwrap();
+    args_file.write_all(b"\xEF\xBB\xBF").unwrap();
     write!(
         args_file,
         "--quiet\r\n--emit\r\nstdout\r\n--edition\r\n2021\r\n{}\r\n",

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -43,41 +43,40 @@ fn rustfmt(args: &[&str]) -> (String, String) {
 }
 
 #[test]
-fn response_file() {
+fn args_file() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let source = temp_dir.path().join("response file.rs");
+    let source = temp_dir.path().join("args file.rs");
     fs::write(&source, "fn main () {}\n").unwrap();
 
-    let mut response_file = tempfile::NamedTempFile::new().unwrap();
+    let mut args_file = tempfile::NamedTempFile::new().unwrap();
     write!(
-        response_file,
+        args_file,
         "--quiet\r\n--emit\r\nstdout\r\n--edition\r\n2021\r\n{}\r\n",
         source.display()
     )
     .unwrap();
 
-    let response_arg = format!("@{}", response_file.path().display());
-    let (stdout, stderr) = rustfmt(&[&response_arg]);
+    let (stdout, stderr) = rustfmt(&["--args-file", args_file.path().to_str().unwrap()]);
     assert_eq!(stdout, "fn main() {}\n");
     assert_eq!(stderr, "");
 }
 
 #[test]
-fn missing_response_file() {
-    let (stdout, stderr) = rustfmt(&["@missing-rustfmt-response-file"]);
+fn missing_args_file() {
+    let (stdout, stderr) = rustfmt(&["--args-file", "missing-rustfmt-args-file"]);
     assert!(
-        stdout.contains("failed to load argument file `missing-rustfmt-response-file`:")
-            || stderr.contains("failed to load argument file `missing-rustfmt-response-file`:")
+        stdout.contains("failed to load argument file `missing-rustfmt-args-file`:")
+            || stderr.contains("failed to load argument file `missing-rustfmt-args-file`:")
     );
 }
 
 #[test]
-fn doubled_at_sign_formats_a_literal_at_path() {
+fn at_sign_path_remains_an_ordinary_file_name() {
     let temp_dir = tempfile::tempdir().unwrap();
     fs::write(temp_dir.path().join("@source.rs"), "fn main () {}\n").unwrap();
 
     let (stdout, stderr) = rustfmt_with_extra(
-        &["--quiet", "--emit", "stdout", "@@source.rs"],
+        &["--quiet", "--emit", "stdout", "@source.rs"],
         temp_dir.path().to_str(),
         &[],
     );
@@ -203,6 +202,9 @@ fn rustfmt_usage_text() {
                             priority over .rustfmt.toml
             --style-edition [2015|2018|2021|2024]
                             The edition of the Style Guide.
+            --args-file PATH
+                            Read command-line arguments from a UTF-8 file, one
+                            argument per line
         -v, --verbose       Print verbose output
         -q, --quiet         Print less output
         -V, --version       Show version information
@@ -253,6 +255,9 @@ fn rustfmt_nightly_usage_text() {
                             priority over .rustfmt.toml
             --style-edition [2015|2018|2021|2024]
                             The edition of the Style Guide.
+            --args-file PATH
+                            Read command-line arguments from a UTF-8 file, one
+                            argument per line
             --unstable-features 
                             Enables unstable features. Only available on nightly
                             channel.


### PR DESCRIPTION
Fixes #6934.

This implements the explicit argument-file option suggested in https://github.com/rust-lang/rustfmt/issues/6934#issuecomment-5256785465 and replaces the closed #7027 approach.

## Problem

`cargo-fmt` passes every target path for an edition directly to one `rustfmt` process. Windows limits the complete `CreateProcessW` command line to 32,767 UTF-16 code units, so large workspaces fail with OS error 206 before rustfmt starts.

## Solution

Rustfmt gains an explicit argument-file option:

```
rustfmt --args-file <path>
rustfmt --args-file=<path>
```

Argument files are UTF-8 with one argument per line. They may be nested up to 16 levels, and `--` terminates option and argument-file expansion globally. Ordinary filenames beginning with `@` retain their existing meaning; no existing positional syntax is reinterpreted.

On Windows, `cargo-fmt` calculates the command-line length using Rust's Windows quoting rules. Only when an invocation would reach 32,767 UTF-16 code units does it write the complete rustfmt argument vector to a temporary file and invoke `rustfmt --args-file <temporary-path>`.

Keeping one rustfmt process per edition preserves existing session, ordering, JSON, and checkstyle behavior. User-provided `--args-file` options are expanded before cargo-fmt creates its transport file, so behavior remains identical below and above the Windows threshold.

## Compatibility

- `@source.rs` remains an ordinary source filename.
- Non-Windows behavior is unchanged.
- Windows commands below the OS limit continue to use direct arguments.
- Argument-file paths and contents must be valid UTF-8, consistent with rustfmt's existing Unicode CLI.
- Embedded newlines are rejected because the format is one argument per line.
- The temporary file remains alive until rustfmt exits.

## Tests

- Separated and `=` syntax, CRLF, blank arguments, missing files, nesting, and global `--` termination.
- An ordinary source filename beginning with `@`.
- Windows command-line quoting and exact length calculation.
- A generated 500-target Windows workspace exceeding the limit.
- User-provided argument files across the cargo-fmt threshold.
- The original #6934 918-target reproducer.