### PR TITLE
fix: formatting macro with braces delimiter

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,7 +38,7 @@ use crate::source_map::SpanUtils;
 use crate::spanned::Spanned;
 use crate::utils::{
     NodeIdExt, filtered_str_fits, indent_next_line, is_empty_line, mk_sp,
-    remove_trailing_white_spaces, rewrite_ident, trim_left_preserve_layout,
+    remove_trailing_white_spaces, rewrite_ident, trim_left_preserve_layout_macros,
 };
 use crate::visitor::FmtVisitor;
 
@@ -136,7 +136,7 @@ fn return_macro_parse_failure_fallback(
         })
         .unwrap_or(false);
     if is_like_block_indent_style {
-        return trim_left_preserve_layout(context.snippet(span), indent, context.config)
+        return trim_left_preserve_layout_macros(context.snippet(span), indent, context.config)
             .macro_error(MacroErrorKind::Unknown, span);
     }
 
@@ -339,10 +339,9 @@ fn rewrite_macro_inner(
         }
         Delimiter::Brace => {
             // For macro invocations with braces, always put a space between
-            // the `macro_name!` and `{ /* macro_body */ }` but skip modifying
-            // anything in between the braces (for now).
+            // the `macro_name!` and `{ /* macro_body */ }`.
             let snippet = context.snippet(mac.span()).trim_start_matches(|c| c != '{');
-            match trim_left_preserve_layout(snippet, shape.indent, context.config) {
+            match trim_left_preserve_layout_macros(snippet, shape.indent, context.config) {
                 Some(macro_body) => Ok(format!("{macro_name} {macro_body}")),
                 None => Ok(format!("{macro_name} {snippet}")),
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -607,33 +607,54 @@ pub(crate) fn remove_trailing_white_spaces(text: &str) -> String {
     buffer
 }
 
-/// Indent each line according to the specified `indent`.
+/// Similar to `[::trim_left_preserve_layout]` but for macros.
+pub(crate) fn trim_left_preserve_layout_macros(
+    orig: &str,
+    indent: Indent,
+    config: &Config,
+) -> Option<String> {
+    let mut lines = LineClasses::new(orig);
+    let (first_line_kind, first_line) = lines.next()?;
+
+    // If a macro delimiter and a string start(`"`) is in the same line, then skip trimming
+    // altogether.
+    if first_line_kind == FullCodeCharKind::StartString {
+        return Some(orig.to_string());
+    }
+
+    let trimmed_lines = trim_left_preserve_layout_lines(lines, indent, config)?;
+    Some(first_line + "\n" + &trimmed_lines)
+}
+
+/// Trim each line based on the minimum indentation of the snippet and
+/// indent line based on `Indent`. First line and lines within a string are skipped
+///
 /// e.g.
 ///
 /// ```rust,compile_fail
-/// foo!{
-/// x,
-/// y,
-/// foo(
-///     a,
-///     b,
-///     c,
-/// ),
-/// }
+/// {
+///         x,
+///         y,
+///         foo(
+///             a,
+///             b,
+///             c,
+///         ),
+///     }
 /// ```
 ///
 /// will become
 ///
 /// ```rust,compile_fail
-/// foo!{
-///     x,
-///     y,
-///     foo(
-///         a,
-///         b,
-///         c,
-///     ),
-/// }
+/// {
+///    x,
+///    y,
+///    foo(
+///        a,
+///        b,
+///        c,
+///    ),
+///}
 /// ```
 pub(crate) fn trim_left_preserve_layout(
     orig: &str,
@@ -641,9 +662,18 @@ pub(crate) fn trim_left_preserve_layout(
     config: &Config,
 ) -> Option<String> {
     let mut lines = LineClasses::new(orig);
-    let first_line = lines.next().map(|(_, s)| s.trim_end().to_owned())?;
-    let mut trimmed_lines = Vec::with_capacity(16);
+    let (_, first_line) = lines.next()?;
 
+    let trimmed_lines = trim_left_preserve_layout_lines(lines, indent, config)?;
+    Some(first_line + "\n" + &trimmed_lines)
+}
+
+pub(crate) fn trim_left_preserve_layout_lines(
+    lines: LineClasses<'_>,
+    indent: Indent,
+    config: &Config,
+) -> Option<String> {
+    let mut trimmed_lines = Vec::with_capacity(16);
     let mut veto_trim = false;
     let min_prefix_space_width = lines
         .filter_map(|(kind, line)| {
@@ -683,24 +713,22 @@ pub(crate) fn trim_left_preserve_layout(
         .min()?;
 
     Some(
-        first_line
-            + "\n"
-            + &trimmed_lines
-                .iter()
-                .map(
-                    |&(trimmed, ref line, prefix_space_width)| match prefix_space_width {
-                        _ if !trimmed => line.to_owned(),
-                        Some(original_indent_width) => {
-                            let new_indent_width = indent.width()
-                                + original_indent_width.saturating_sub(min_prefix_space_width);
-                            let new_indent = Indent::from_width(config, new_indent_width);
-                            format!("{}{}", new_indent.to_string(config), line)
-                        }
-                        None => String::new(),
-                    },
-                )
-                .collect::<Vec<_>>()
-                .join("\n"),
+        trimmed_lines
+            .iter()
+            .map(
+                |&(trimmed, ref line, prefix_space_width)| match prefix_space_width {
+                    _ if !trimmed => line.to_owned(),
+                    Some(original_indent_width) => {
+                        let new_indent_width = indent.width()
+                            + original_indent_width.saturating_sub(min_prefix_space_width);
+                        let new_indent = Indent::from_width(config, new_indent_width);
+                        format!("{}{}", new_indent.to_string(config), line)
+                    }
+                    None => String::new(),
+                },
+            )
+            .collect::<Vec<_>>()
+            .join("\n"),
     )
 }
 

--- a/tests/source/issue_6747.rs
+++ b/tests/source/issue_6747.rs
@@ -1,8 +1,0 @@
-fn main() {
-    println! {"
-                    line 1 \\
-                      line 2 \\
-                      line 3 \\
-                      line 4
-                "};
-}

--- a/tests/source/issue_6747.rs
+++ b/tests/source/issue_6747.rs
@@ -1,0 +1,8 @@
+fn main() {
+    println! {"
+                    line 1 \\
+                      line 2 \\
+                      line 3 \\
+                      line 4
+                "};
+}

--- a/tests/target/issue_6747.rs
+++ b/tests/target/issue_6747.rs
@@ -1,0 +1,8 @@
+fn main() {
+    println! {"
+                    line 1 \\
+                      line 2 \\
+                      line 3 \\
+                      line 4
+                "};
+}


### PR DESCRIPTION
Fixes #6747.

This PR makes it so that `trim_left_preserve_layout` does nothing when the first line contains a string start.

e.g., this will now not be formatted

```rust
macro! {"
...
"};
```

---

I'm not too satisfied with this PR; I think the formatting for macros with braces `{`,`}` needs to be reworked. I'm opening this PR as a starting point for that goal.