### PR TITLE
Split long cargo-fmt invocations on Windows

### DIFF
--- a/src/cargo-fmt/main.rs
+++ b/src/cargo-fmt/main.rs
@@ -6,6 +6,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::env;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, Write};
@@ -165,15 +166,17 @@ fn execute() -> i32 {
     }
 }
 
-fn rustfmt_command() -> Command {
-    let rustfmt = match env::var_os("RUSTFMT") {
+fn rustfmt_path() -> PathBuf {
+    match env::var_os("RUSTFMT") {
         Some(rustfmt) => PathBuf::from(rustfmt),
         None => env::current_exe()
             .expect("current executable path invalid")
             .with_file_name("rustfmt"),
-    };
+    }
+}
 
-    Command::new(rustfmt)
+fn rustfmt_command() -> Command {
+    Command::new(rustfmt_path())
 }
 
 fn convert_message_format_to_rustfmt_args(
@@ -494,6 +497,92 @@ fn add_targets(target_paths: &[cargo_metadata::Target], targets: &mut BTreeSet<T
     }
 }
 
+#[cfg(windows)]
+fn command_line_arg_len(arg: &OsStr) -> usize {
+    use std::os::windows::ffi::OsStrExt;
+
+    let arg = arg.encode_wide().collect::<Vec<_>>();
+    let quoted = arg.is_empty() || arg.iter().any(|&c| c == b' ' as u16 || c == b'\t' as u16);
+    let mut len = arg.len().saturating_add(usize::from(quoted) * 2);
+    let mut backslashes = 0usize;
+
+    for &c in &arg {
+        if c == b'\\' as u16 {
+            backslashes += 1;
+        } else {
+            if c == b'"' as u16 {
+                len = len.saturating_add(backslashes).saturating_add(1);
+            }
+            backslashes = 0;
+        }
+    }
+    if quoted {
+        len = len.saturating_add(backslashes);
+    }
+
+    // Account for the separator before this argument.
+    len.saturating_add(1)
+}
+
+#[cfg(not(windows))]
+fn command_line_arg_len(arg: &OsStr) -> usize {
+    arg.to_string_lossy()
+        .encode_utf16()
+        .count()
+        .saturating_add(1)
+}
+
+#[cfg(windows)]
+fn command_line_program_len(program: &Path) -> usize {
+    use std::os::windows::ffi::OsStrExt;
+
+    // Rust always surrounds argv[0] with quotes on Windows.
+    program.as_os_str().encode_wide().count().saturating_add(2)
+}
+
+#[cfg(not(windows))]
+fn command_line_program_len(program: &Path) -> usize {
+    program
+        .as_os_str()
+        .to_string_lossy()
+        .encode_utf16()
+        .count()
+        .saturating_add(2)
+}
+
+fn rustfmt_file_batches<'a>(
+    rustfmt: &Path,
+    files: &[&'a Path],
+    fixed_args: &[OsString],
+    command_line_limit: usize,
+) -> Vec<Vec<&'a Path>> {
+    let fixed_len = command_line_program_len(rustfmt).saturating_add(
+        fixed_args
+            .iter()
+            .map(|arg| command_line_arg_len(arg))
+            .sum::<usize>(),
+    );
+    let mut batches = vec![];
+    let mut batch = vec![];
+    let mut batch_len = fixed_len;
+
+    for &file in files {
+        let file_len = command_line_arg_len(file.as_os_str());
+        if !batch.is_empty() && batch_len.saturating_add(file_len) > command_line_limit {
+            batches.push(batch);
+            batch = vec![];
+            batch_len = fixed_len;
+        }
+        batch.push(file);
+        batch_len = batch_len.saturating_add(file_len);
+    }
+    if !batch.is_empty() {
+        batches.push(batch);
+    }
+
+    batches
+}
+
 fn run_rustfmt(
     targets: &BTreeSet<Target>,
     fmt_args: &[String],
@@ -511,37 +600,55 @@ fn run_rustfmt(
             h
         });
 
+    #[cfg(windows)]
+    // Windows limits CreateProcess command lines to 32 KiB. Like go fmt, leave
+    // headroom for command-line construction details.
+    const COMMAND_LINE_LIMIT: usize = 30 << 10;
+    #[cfg(not(windows))]
+    const COMMAND_LINE_LIMIT: usize = usize::MAX;
+
+    let rustfmt = rustfmt_path();
     let mut status = vec![];
     for (edition, files) in by_edition {
-        let stdout = if verbosity == Verbosity::Quiet {
-            std::process::Stdio::null()
-        } else {
-            std::process::Stdio::inherit()
-        };
+        let fixed_args = [
+            OsString::from("--edition"),
+            OsString::from(edition.as_str()),
+        ]
+        .into_iter()
+        .chain(fmt_args.iter().map(OsString::from))
+        .collect::<Vec<_>>();
+        let files = files.iter().map(|file| file.as_path()).collect::<Vec<_>>();
 
-        if verbosity == Verbosity::Verbose {
-            print!("rustfmt");
-            print!(" --edition {edition}");
-            fmt_args.iter().for_each(|f| print!(" {}", f));
-            files.iter().for_each(|f| print!(" {}", f.display()));
-            println!();
+        for batch in rustfmt_file_batches(&rustfmt, &files, &fixed_args, COMMAND_LINE_LIMIT) {
+            let stdout = if verbosity == Verbosity::Quiet {
+                std::process::Stdio::null()
+            } else {
+                std::process::Stdio::inherit()
+            };
+
+            if verbosity == Verbosity::Verbose {
+                print!("rustfmt");
+                print!(" --edition {edition}");
+                fmt_args.iter().for_each(|f| print!(" {}", f));
+                batch.iter().for_each(|f| print!(" {}", f.display()));
+                println!();
+            }
+
+            let mut command = Command::new(&rustfmt)
+                .stdout(stdout)
+                .args(batch)
+                .args(&fixed_args)
+                .spawn()
+                .map_err(|e| match e.kind() {
+                    io::ErrorKind::NotFound => io::Error::new(
+                        io::ErrorKind::Other,
+                        "Could not run rustfmt, please make sure it is in your PATH.",
+                    ),
+                    _ => e,
+                })?;
+
+            status.push(command.wait()?);
         }
-
-        let mut command = rustfmt_command()
-            .stdout(stdout)
-            .args(files)
-            .args(["--edition", edition.as_str()])
-            .args(fmt_args)
-            .spawn()
-            .map_err(|e| match e.kind() {
-                io::ErrorKind::NotFound => io::Error::new(
-                    io::ErrorKind::Other,
-                    "Could not run rustfmt, please make sure it is in your PATH.",
-                ),
-                _ => e,
-            })?;
-
-        status.push(command.wait()?);
     }
 
     Ok(status

--- a/src/cargo-fmt/test/mod.rs
+++ b/src/cargo-fmt/test/mod.rs
@@ -139,3 +139,49 @@ fn empty_packages_4() {
             .is_err()
     );
 }
+
+#[test]
+fn rustfmt_files_are_split_at_the_command_line_limit() {
+    let rustfmt = Path::new("rustfmt");
+    let fixed_args = [OsString::from("--edition"), OsString::from("2021")];
+    let files = [
+        Path::new("first.rs"),
+        Path::new("second.rs"),
+        Path::new("third.rs"),
+    ];
+    let two_file_limit = command_line_program_len(rustfmt)
+        + fixed_args
+            .iter()
+            .map(|arg| command_line_arg_len(arg))
+            .sum::<usize>()
+        + files[..2]
+            .iter()
+            .map(|file| command_line_arg_len(file.as_os_str()))
+            .sum::<usize>();
+
+    let batches = rustfmt_file_batches(rustfmt, &files, &fixed_args, two_file_limit);
+
+    assert_eq!(batches, vec![vec![files[0], files[1]], vec![files[2]]]);
+}
+
+#[test]
+fn rustfmt_file_batching_keeps_an_oversized_file() {
+    let rustfmt = Path::new("rustfmt");
+    let files = [Path::new("a-file-that-is-longer-than-the-limit.rs")];
+
+    let batches = rustfmt_file_batches(rustfmt, &files, &[], 1);
+
+    assert_eq!(batches, vec![vec![files[0]]]);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_command_line_length_matches_rust_quoting() {
+    assert_eq!(command_line_arg_len(OsStr::new("plain")), 6);
+    assert_eq!(command_line_arg_len(OsStr::new("")), 3);
+    assert_eq!(command_line_arg_len(OsStr::new("has space")), 12);
+    assert_eq!(command_line_arg_len(OsStr::new(r#"a\"b"#)), 7);
+    assert_eq!(command_line_arg_len(OsStr::new(r#"a \"b"#)), 10);
+    assert_eq!(command_line_arg_len(OsStr::new(r#"a \"#)), 7);
+    assert_eq!(command_line_program_len(Path::new("rustfmt")), 9);
+}

--- a/tests/cargo-fmt/main.rs
+++ b/tests/cargo-fmt/main.rs
@@ -1,6 +1,8 @@
 // Integration tests for cargo-fmt.
 
 use std::env;
+#[cfg(windows)]
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 
@@ -37,6 +39,39 @@ fn cargo_fmt(args: &[&str]) -> (String, String) {
         ),
         Err(e) => panic!("failed to run `{cmd:?} {args:?}`: {e}"),
     }
+}
+
+#[cfg(windows)]
+#[rustfmt_only_ci_test]
+#[test]
+fn cargo_fmt_splits_long_command_lines() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let source_dir = temp_dir.path().join("src");
+    fs::create_dir(&source_dir).unwrap();
+
+    let mut manifest = String::from(
+        "[package]\nname = \"command-line-split-test\"\nversion = \"0.1.0\"\n\
+         edition = \"2021\"\nautobins = false\n",
+    );
+    for index in 0..500 {
+        let file_name = format!("command_line_split_target_with_a_long_name_{index:04}.rs");
+        fs::write(source_dir.join(&file_name), "fn main() {}\n").unwrap();
+        manifest.push_str(&format!(
+            "\n[[bin]]\nname = \"command-line-split-target-{index:04}\"\n\
+             path = \"src/{file_name}\"\n"
+        ));
+    }
+    let manifest_path = temp_dir.path().join("Cargo.toml");
+    fs::write(&manifest_path, manifest).unwrap();
+
+    let (stdout, stderr) = cargo_fmt(&[
+        "--check",
+        "--manifest-path",
+        manifest_path.to_str().unwrap(),
+    ]);
+
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
 }
 
 macro_rules! assert_that {


### PR DESCRIPTION
Addresses #6934.

This is an alternative to the argument-file approach in #7028, following the `go fmt` model discussed in the issue.

## Approach

`cargo-fmt` still groups targets by edition, but on Windows it partitions each edition's files across multiple `rustfmt` processes. Every invocation is kept below a conservative 30 KiB command-line budget, matching Go's headroom below the 32,767 UTF-16 code-unit `CreateProcessW` limit.

The budget includes:

- the rustfmt executable path
- `--edition` and its value
- all user-provided rustfmt options
- Windows quoting and escaping for each file path

Non-Windows behavior remains one rustfmt process per edition. If one file path cannot fit by itself, cargo-fmt still attempts that invocation so the underlying OS error is reported normally.

## Tests

- batching at an artificial command-line boundary
- preserving an unavoidable oversized single-file batch
- Windows quoting/escaping length calculation
- a Windows-only 500-target workspace regression that exceeds one command line and completes via multiple rustfmt processes

Go reference: https://github.com/golang/go/blob/72aa6db7943024b48c4d41c1fbc32b57b9fa036e/src/cmd/go/internal/fmtcmd/fmt.go#L88-L109