### PR TITLE
Consistently use `--locked` for cargo commands

### DIFF
--- a/.github/workflows/check_diff.yml
+++ b/.github/workflows/check_diff.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Build check_diff binary
       working-directory: ./check_diff
-      run: cargo build --release
+      run: cargo build --release --locked
 
     - name: Run Diff Check
       working-directory: ./check_diff

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,5 +70,5 @@ jobs:
     - name: run integration tests
       env:
         TARGET: x86_64-unknown-linux-gnu
-      run: cargo run --manifest-path ci/Cargo.toml integration ${{ matrix.integration }}
+      run: cargo run --locked --manifest-path ci/Cargo.toml integration ${{ matrix.integration }}
       continue-on-error: ${{ matrix.allow-failure == true }}

--- a/.github/workflows/rustdoc_check.yml
+++ b/.github/workflows/rustdoc_check.yml
@@ -23,4 +23,4 @@ jobs:
     - name: document rustfmt
       env:
         RUSTDOCFLAGS: --document-private-items --enable-index-page --show-type-layout --generate-link-to-definition -Zunstable-options -Dwarnings
-      run: cargo doc -Zskip-rustdoc-fingerprint --no-deps -p rustfmt-nightly -p rustfmt-config_proc_macro
+      run: cargo doc --locked -Zskip-rustdoc-fingerprint --no-deps -p rustfmt-nightly -p rustfmt-config_proc_macro

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
       env:
         RUSTFLAGS: -D warnings
         CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
-      run: cargo run --manifest-path ci/Cargo.toml build-and-test
+      run: cargo run --locked --manifest-path ci/Cargo.toml build-and-test
 
   test-conclusion:
     name: "test conclusion"

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
 
       - name: Build release binaries
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Build archive
         shell: bash

--- a/Contributing.md
+++ b/Contributing.md
@@ -20,7 +20,7 @@ issues where it does something you don't expect.
 Having a strong test suite for a tool like this is essential. It is very easy
 to create regressions. Any tests you can add are very much appreciated.
 
-The tests can be run with `cargo test`. This does a number of things:
+The tests can be run with `cargo test --locked`. This does a number of things:
 * runs the unit tests for a number of internal functions;
 * makes sure that rustfmt run on every file in `./tests/source/` is equal to its
   associated file in `./tests/target/`; this catches

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ language: rust
 before_script:
 - rustup component add rustfmt
 script:
-- cargo build
-- cargo test
+- cargo build --locked
+- cargo test --locked
 - cargo fmt --all -- --check
 ```
 
@@ -144,11 +144,11 @@ for more info.
 
 ## How to build and test
 
-`cargo build` to build.
+`cargo build --locked` to build.
 
-`cargo test` to run all tests.
+`cargo test --locked` to run all tests.
 
-To run rustfmt after this, use `cargo run --bin rustfmt -- filename`. See the
+To run rustfmt after this, use `cargo run --locked --bin rustfmt -- filename`. See the
 notes above on running rustfmt.
 
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,7 @@
 # power comes great responsibility.
 # We deliberately avoid reformatting files with rustfmt comment directives.
 
-cargo build --release
+cargo build --release --locked
 
 target/release/rustfmt src/lib.rs
 target/release/rustfmt src/bin/main.rs

--- a/check_diff/src/lib.rs
+++ b/check_diff/src/lib.rs
@@ -580,7 +580,7 @@ pub fn build_rustfmt_from_src<T: AsRef<str>>(
     info!("Building rustfmt from source");
     let Ok(_) = Command::new("cargo")
         .current_dir(dir)
-        .args(["build", "-q", "--release", "--bin", "rustfmt"])
+        .args(["build", "--locked", "-q", "--release", "--bin", "rustfmt"])
         .output()
     else {
         return Err(CheckDiffError::FailedSourceBuild(

--- a/ci/src/build_and_test.rs
+++ b/ci/src/build_and_test.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 fn run_tests_in_dir(env: &HashMap<&str, &str>, dir: &str) -> Result<(), String> {
     run_command_with_env("cargo", &["build", "--locked"], dir, &env)?;
-    run_command_with_env("cargo", &["test"], dir, &env)
+    run_command_with_env("cargo", &["test", "--locked"], dir, &env)
 }
 
 pub fn runner() -> Result<(), String> {
@@ -39,7 +39,7 @@ pub fn runner() -> Result<(), String> {
             &["build", "--locked"]
         };
     run_command_with_env("cargo", options, ".", &env)?;
-    run_command_with_env("cargo", &["test"], ".", &env)?;
+    run_command_with_env("cargo", &["test", "--locked"], ".", &env)?;
 
     // Build and test config_proc_macro
     run_tests_in_dir(&env, "config_proc_macro")?;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1191,7 +1191,8 @@ fn rustfmt() -> PathBuf {
     assert!(
         me.is_file() || me.with_extension("exe").is_file(),
         "{}",
-        "no rustfmt bin, try running `cargo build` or `cargo build --release` before testing"
+        "no rustfmt bin, try running `cargo build --locked` or `cargo build --locked --release` \
+        before testing"
     );
     me
 }


### PR DESCRIPTION
## Summary

Helps with #7037 but does not **completely** adddress it:

* We still download, build and run the ecosystem integration test repositories **without** `--locked`.

For cases modulo the ecosystem integration tests, use `--locked` consistently -- in CI, bootstrap, docs, test harness, so that we use the exact dependencies checked in via `Cargo.lock` lockfiles instead of floating resolution, where we risk being exposed to fresh supply-chain attacks[^1].

Reminded me to double-check after [yesterday's supply-chain attack](https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/).

[^1]: Obviously this won't help with long-term supply-chain attacks that get into the lockfile, but defense-in-depth etc.
