### PR TITLE
Replace archived actions/upload-release-asset with gh CLI

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -68,11 +68,6 @@ jobs:
 
       - name: Upload Release Asset
         if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
-          asset_content_type: application/octet-stream
+        run: gh release upload "${{ github.event.release.tag_name }}" "${{ env.ASSET }}"


### PR DESCRIPTION
actions/upload-release-asset has been archived for a while now, so this swaps it in CI for the gh CLI directly. The runner already ships gh, and the uploaded asset name stays the same as before.
This is part of a wider effort to remove archived actions across rust-lang repos, tracked in rust-lang/crabwatch#49.
