### PR TITLE
Inconsistent formatting of doc comments in macros

### DIFF
--- a/src/parse/macros/mod.rs
+++ b/src/parse/macros/mod.rs
@@ -25,7 +25,9 @@ fn parse_macro_arg<'a, 'b: 'a>(parser: &'a mut Parser<'b>) -> Option<MacroArg> {
     macro_rules! parse_macro_arg {
         ($macro_arg:ident, $nt_kind:expr, $try_parse:expr, $then:expr) => {
             let mut cloned_parser = (*parser).clone();
-            if Parser::nonterminal_may_begin_with($nt_kind, &cloned_parser.token) {
+            if Parser::nonterminal_may_begin_with($nt_kind, &cloned_parser.token)
+                || matches!(cloned_parser.token.kind, TokenKind::DocComment(..))
+            {
                 match $try_parse(&mut cloned_parser) {
                     Ok(x) => {
                         if parser.psess.dcx().has_errors().is_some() {

--- a/tests/source/issue_7036.rs
+++ b/tests/source/issue_7036.rs
@@ -1,21 +1,157 @@
 // Doc comments inside macro calls should not prevent formatting.
+//
+// Each comment form below is tested three ways: on its own, after an
+// attribute, and before an attribute.
 
 foo!(
-    /// Doc
+    // Only a comment
     A,
       B,
 );
 
 foo!(
     #[doc = ""]
-    /// Doc
+    // Only a comment
     A,
       B,
 );
 
 foo!(
-    /// Doc
+    // Only a comment
     #[doc = ""]
+    A,
+      B,
+);
+
+
+foo!(
+    /// Outer line doc (exactly 3 slashes)
+    A,
+      B,
+);
+
+foo!(
+    #[doc = ""]
+    /// Outer line doc (exactly 3 slashes)
+    A,
+      B,
+);
+
+foo!(
+    /// Outer line doc (exactly 3 slashes)
+    #[doc = ""]
+    A,
+      B,
+);
+
+
+foo!(
+    //// Only a comment
+    A,
+      B,
+);
+
+foo!(
+    #[doc = ""]
+    //// Only a comment
+    A,
+      B,
+);
+
+foo!(
+    //// Only a comment
+    #[doc = ""]
+    A,
+      B,
+);
+
+
+foo!(
+    /* Only a comment */
+    A,
+      B,
+);
+
+foo!(
+    #[doc = ""]
+    /* Only a comment */
+    A,
+      B,
+);
+
+foo!(
+    /* Only a comment */
+    #[doc = ""]
+    A,
+      B,
+);
+
+
+foo!(
+    /** Outer block doc (exactly 2 asterisks) */
+    A,
+      B,
+);
+
+foo!(
+    #[doc = ""]
+    /** Outer block doc (exactly 2 asterisks) */
+    A,
+      B,
+);
+
+foo!(
+    /** Outer block doc (exactly 2 asterisks) */
+    #[doc = ""]
+    A,
+      B,
+);
+
+
+foo!(
+    /*** Only a comment */
+    A,
+      B,
+);
+
+foo!(
+    #[doc = ""]
+    /*** Only a comment */
+    A,
+      B,
+);
+
+foo!(
+    /*** Only a comment */
+    #[doc = ""]
+    A,
+      B,
+);
+
+
+// Inner doc comments cannot attach to a macro argument, so these are left
+// unformatted on purpose.
+
+foo!(
+    //! Inner line doc
+    A,
+      B,
+);
+
+foo!(
+    //!! Still an inner line doc (but with a bang at the beginning)
+    A,
+      B,
+);
+
+foo!(
+    /*! Inner block doc */
+    A,
+      B,
+);
+
+foo!(
+    /*!! Still an inner block doc (but with a bang at the beginning) */
     A,
       B,
 );

--- a/tests/source/issue_7036.rs
+++ b/tests/source/issue_7036.rs
@@ -1,0 +1,21 @@
+// Doc comments inside macro calls should not prevent formatting.
+
+foo!(
+    /// Doc
+    A,
+      B,
+);
+
+foo!(
+    #[doc = ""]
+    /// Doc
+    A,
+      B,
+);
+
+foo!(
+    /// Doc
+    #[doc = ""]
+    A,
+      B,
+);

--- a/tests/target/issue_7036.rs
+++ b/tests/target/issue_7036.rs
@@ -1,21 +1,141 @@
 // Doc comments inside macro calls should not prevent formatting.
+//
+// Each comment form below is tested three ways: on its own, after an
+// attribute, and before an attribute.
 
 foo!(
-    /// Doc
+    // Only a comment
+    A, B,
+);
+
+foo!(
+    #[doc = ""]
+    // Only a comment
+    A,
+    B,
+);
+
+foo!(
+    // Only a comment
+    #[doc = ""]
+    A,
+    B,
+);
+
+foo!(
+    /// Outer line doc (exactly 3 slashes)
     A,
     B,
 );
 
 foo!(
     #[doc = ""]
-    /// Doc
+    /// Outer line doc (exactly 3 slashes)
     A,
     B,
 );
 
 foo!(
-    /// Doc
+    /// Outer line doc (exactly 3 slashes)
     #[doc = ""]
     A,
     B,
+);
+
+foo!(
+    //// Only a comment
+    A, B,
+);
+
+foo!(
+    #[doc = ""]
+    //// Only a comment
+    A,
+    B,
+);
+
+foo!(
+    //// Only a comment
+    #[doc = ""]
+    A,
+    B,
+);
+
+foo!(/* Only a comment */ A, B,);
+
+foo!(
+    #[doc = ""]
+    /* Only a comment */
+    A,
+    B,
+);
+
+foo!(
+    /* Only a comment */
+    #[doc = ""]
+    A,
+    B,
+);
+
+foo!(
+    /** Outer block doc (exactly 2 asterisks) */
+    A,
+    B,
+);
+
+foo!(
+    #[doc = ""]
+    /** Outer block doc (exactly 2 asterisks) */
+    A,
+    B,
+);
+
+foo!(
+    /** Outer block doc (exactly 2 asterisks) */
+    #[doc = ""]
+    A,
+    B,
+);
+
+foo!(/*** Only a comment */ A, B,);
+
+foo!(
+    #[doc = ""]
+    /*** Only a comment */
+    A,
+    B,
+);
+
+foo!(
+    /*** Only a comment */
+    #[doc = ""]
+    A,
+    B,
+);
+
+// Inner doc comments cannot attach to a macro argument, so these are left
+// unformatted on purpose.
+
+foo!(
+    //! Inner line doc
+    A,
+      B,
+);
+
+foo!(
+    //!! Still an inner line doc (but with a bang at the beginning)
+    A,
+      B,
+);
+
+foo!(
+    /*! Inner block doc */
+    A,
+      B,
+);
+
+foo!(
+    /*!! Still an inner block doc (but with a bang at the beginning) */
+    A,
+      B,
 );

--- a/tests/target/issue_7036.rs
+++ b/tests/target/issue_7036.rs
@@ -1,0 +1,21 @@
+// Doc comments inside macro calls should not prevent formatting.
+
+foo!(
+    /// Doc
+    A,
+    B,
+);
+
+foo!(
+    #[doc = ""]
+    /// Doc
+    A,
+    B,
+);
+
+foo!(
+    /// Doc
+    #[doc = ""]
+    A,
+    B,
+);


### PR DESCRIPTION
Unlike `//` comments, which the lexer discards, doc comments `///` survive in the token stream as `DocComment` tokens.
`Parser::nonterminal_may_begin_with` reports that such a token cannot begin an expression, so rustfmt never attempted to parse the argument as one and fell back to emitting the macro call verbatim.

`matches!(cloned_parser.token.kind, TokenKind::DocComment(..))` Added this in check as well that allowed doc comments through. The parser already handles them as outer attributes, which is why the equivalent `#[doc = ""]` form formatted correctly.

Fixes #7036 
