### PR TITLE
ci tests rustfmt, but rustfmt doesn't test ci

### DIFF
--- a/check_diff/tests/check_diff.rs
+++ b/check_diff/tests/check_diff.rs
@@ -1,6 +1,6 @@
 use check_diff::{
-    CheckDiffError, DiffChecker, CodeFormatter, FormatCodeError, Repository,
-    RustFmtFileFinder, check_diff,
+    CheckDiffError, CodeFormatter, DiffChecker, FormatCodeError, Repository, RustFmtFileFinder,
+    check_diff,
 };
 use std::fs::File;
 use tempfile::Builder;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -504,6 +504,9 @@ fn self_tests() {
         for file in search_files {
             files.push(file);
         }
+
+        let mut tests_files = get_test_files(&PathBuf::from(external_crate).join("tests"), false);
+        files.append(&mut tests_files);
     }
     files.push(PathBuf::from("src/lib.rs"));
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -505,7 +505,7 @@ fn self_tests() {
             files.push(file);
         }
 
-        let mut tests_files = get_test_files(&PathBuf::from(external_crate).join("tests"), false);
+        let mut tests_files = get_test_files(&PathBuf::from(external_crate).join("tests"), true);
         files.append(&mut tests_files);
     }
     files.push(PathBuf::from("src/lib.rs"));

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -486,7 +486,7 @@ fn self_tests() {
         files.push(path);
     }
     // for crates that need to be included but lies outside src
-    let external_crates = vec!["check_diff", "config_proc_macro"];
+    let external_crates = vec!["check_diff", "config_proc_macro", "ci"];
     for external_crate in external_crates {
         let mut path = PathBuf::from(external_crate);
         path.push("src");


### PR DESCRIPTION
```
Mismatch at ci/src/common.rs:12:
     })
 }
 
-pub                                fn run_command_with_env<I, S>(
+pub fn run_command_with_env<I, S>(
     bin: &str,
     args: I,
     current_dir: &str,
```


@ytmimi your suggestion works. Confirmed: before adding "ci" to external_crates, self_tests passed even with pub                                fn run_command_with_env<I, S>( in ci/src/common.rs. After the change it fails with a mismatch on that line.

fixes : #7039 