### PR TITLE
Use caret (^) as the default required_version comparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- The unstable `required_version` configuration option now defaults to a caret (`^`) semver requirement instead of an exact match when no comparator is given, matching how Cargo treats dependency version requirements. Use the explicit `=` operator (e.g. `required_version = "=1.2.3"`) to opt back into exact matching [#6729](https://github.com/rust-lang/rustfmt/issues/6729)
+
 
 ## [1.10.0] 2026-07-21
 

--- a/Configurations.md
+++ b/Configurations.md
@@ -2469,7 +2469,13 @@ specific version of rustfmt is used in your CI, use this option.
   requirement, matching how Cargo treats dependency version requirements.
 - **Stable**: No (tracking issue: [#3386](https://github.com/rust-lang/rustfmt/issues/3386))
 
-#### Default matching (new minor or patch versions):
+#### New minor or patch versions (default behavior):
+
+```toml
+required_version="^1.0.0"
+```
+
+This is the default behavior, so that is equivalent to:
 
 ```toml
 required_version="1.0.0"

--- a/Configurations.md
+++ b/Configurations.md
@@ -2465,12 +2465,20 @@ specific version of rustfmt is used in your CI, use this option.
 
 - **Default value**: `CARGO_PKG_VERSION`
 - **Possible values**: `semver` compliant values, such as defined on [semver.org](https://semver.org/).
+  A value with no comparator, such as `"1.0.0"`, defaults to a caret (`^`)
+  requirement, matching how Cargo treats dependency version requirements.
 - **Stable**: No (tracking issue: [#3386](https://github.com/rust-lang/rustfmt/issues/3386))
+
+#### Default matching (new minor or patch versions):
+
+```toml
+required_version="1.0.0"
+```
 
 #### Match on exact version:
 
 ```toml
-required_version="1.0.0"
+required_version="=1.0.0"
 ```
 
 #### Higher or equal to:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -242,7 +242,11 @@ impl PartialConfig {
 }
 
 fn check_semver_version(range_requirement: &str, actual: &str) -> bool {
-    let mut version_req = match semver::VersionReq::parse(range_requirement) {
+    // A bare version (no comparator prefix) is left as `semver`'s own default,
+    // which is a caret requirement, matching how Cargo treats dependency version
+    // requirements. Callers who want the old exact-match behavior can opt in
+    // explicitly with the `=` operator, e.g. `required_version = "=1.2.3"`.
+    let version_req = match semver::VersionReq::parse(range_requirement) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: failed to parse required version {range_requirement:?}: {e}");
@@ -256,24 +260,6 @@ fn check_semver_version(range_requirement: &str, actual: &str) -> bool {
             return false;
         }
     };
-
-    range_requirement
-        .split(',')
-        .enumerate()
-        .for_each(|(i, label)| {
-            // the label refers to the current comparator
-            let Some(comparator) = version_req.comparators.get_mut(i) else {
-                return;
-            };
-
-            // semver crate handles "1.0.0" as "^1.0.0", and we want to treat it as "=1.0.0"
-            // because of this, we need to iterate over the comparators, and change each one
-            // that has "default caret operator" to an exact operator
-            // this condition overrides the "default caret operator" of semver create.
-            if !label.starts_with('^') && comparator.op == semver::Op::Caret {
-                comparator.op = semver::Op::Exact;
-            }
-        });
 
     version_req.matches(&actual_version)
 }
@@ -1552,13 +1538,27 @@ make_backup = false
         use super::*;
 
         #[test]
-        fn test_exact_version_match() {
+        fn test_default_caret_match() {
+            // A bare version (no operator) defaults to a caret requirement,
+            // matching how Cargo treats dependency version requirements.
             assert!(check_semver_version("1.0.0", "1.0.0"));
-            assert!(!check_semver_version("1.0.0", "1.1.0"));
-            assert!(!check_semver_version("1.0.0", "1.0.1"));
+            assert!(check_semver_version("1.0.0", "1.1.0"));
+            assert!(check_semver_version("1.0.0", "1.0.1"));
             assert!(!check_semver_version("1.0.0", "2.1.0"));
             assert!(!check_semver_version("1.0.0", "0.1.0"));
             assert!(!check_semver_version("1.0.0", "0.0.1"));
+        }
+
+        #[test]
+        fn test_explicit_exact_match() {
+            // The old exact-match default is still available by opting in
+            // with the `=` operator.
+            assert!(check_semver_version("=1.0.0", "1.0.0"));
+            assert!(!check_semver_version("=1.0.0", "1.1.0"));
+            assert!(!check_semver_version("=1.0.0", "1.0.1"));
+            assert!(!check_semver_version("=1.0.0", "2.1.0"));
+            assert!(!check_semver_version("=1.0.0", "0.1.0"));
+            assert!(!check_semver_version("=1.0.0", "0.0.1"));
         }
 
         #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -244,8 +244,7 @@ impl PartialConfig {
 fn check_semver_version(range_requirement: &str, actual: &str) -> bool {
     // A bare version (no comparator prefix) is left as `semver`'s own default,
     // which is a caret requirement, matching how Cargo treats dependency version
-    // requirements. Callers who want the old exact-match behavior can opt in
-    // explicitly with the `=` operator, e.g. `required_version = "=1.2.3"`.
+    // requirements.
     let version_req = match semver::VersionReq::parse(range_requirement) {
         Ok(r) => r,
         Err(e) => {
@@ -1551,8 +1550,6 @@ make_backup = false
 
         #[test]
         fn test_explicit_exact_match() {
-            // The old exact-match default is still available by opting in
-            // with the `=` operator.
             assert!(check_semver_version("=1.0.0", "1.0.0"));
             assert!(!check_semver_version("=1.0.0", "1.1.0"));
             assert!(!check_semver_version("=1.0.0", "1.0.1"));


### PR DESCRIPTION
Closes #6729

## Summary

`required_version` currently treats a bare version (no comparator prefix) as
an exact match, overriding the `semver` crate's own default of a caret
requirement. As discussed in #6729, this diverges from how Cargo treats
dependency version requirements with no operator, where a bare version like
`"1.2.3"` is equivalent to `"^1.2.3"`.

This removes the override in `check_semver_version` so a bare version behaves
like `^version`, matching Cargo's convention. The old exact-match behavior is
still available by opting in explicitly with `=`, e.g.
`required_version = "=1.2.3"`.

- `src/config/mod.rs`: remove the per-comparator override that forced a bare
  (no-prefix) comparator from `semver`'s own default (`Op::Caret`) back to
  `Op::Exact`.
- `Configurations.md`: documents the new default, adds an explicit "Match on
  exact version" example using `=`, and notes the caret-default in the
  Possible values bullet.
- `CHANGELOG.md`: adds a `Changed` entry under `[Unreleased]` referencing
  #6729.

## Test plan

- `cargo test --lib required_version` — all 19 existing tests pass unchanged;
  none of them depended on the old exact-only default (they all either use
  the current version as its own requirement, an explicit operator, or a
  requirement whose major/minor already differs enough that caret vs. exact
  makes no difference).
- `cargo test --lib check_semver_version` — 27 tests pass, including two new
  ones: `test_default_caret_match` (renamed from `test_exact_version_match`,
  with the two assertions that change under the new default flipped) and
  `test_explicit_exact_match` (covers the opt-in `=` exact-match path).
- `cargo test --lib` (full suite, binary built first): `235 passed; 0 failed`.