### PR TITLE
Fix skip range miscalculation

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -799,7 +799,7 @@ fn check_files(files: Vec<PathBuf>, opt_config: &Option<PathBuf>) -> (Vec<Format
 
         debug!("Testing '{}'...", file_name.display());
 
-        match idempotent_check(&file_name, opt_config) {
+        match idempotent_check(&file_name, opt_config, &sig_comments) {
             Ok(ref report) if report.has_warnings() => {
                 print!("{}", FormatReportFormatterBuilder::new(report).build());
                 fails += 1;
@@ -846,6 +846,10 @@ fn print_mismatches<T: Fn(u32) -> String>(
 
 fn read_config(filename: &Path) -> Config {
     let sig_comments = read_significant_comments(filename);
+    config_from_comments(filename, &sig_comments)
+}
+
+fn config_from_comments(filename: &Path, sig_comments: &HashMap<String, String>) -> Config {
     let (edition, style_edition, version) = get_editions_from_comments(&sig_comments);
     // Look for a config file. If there is a 'config' property in the significant comments, use
     // that. Otherwise, if there are no significant comments at all, look for a config file with
@@ -866,7 +870,7 @@ fn read_config(filename: &Path) -> Config {
         )
     };
 
-    for (key, val) in &sig_comments {
+    for (key, val) in sig_comments {
         if key != "target" && key != "config" && key != "unstable" {
             config.override_value(key, val);
         }
@@ -910,14 +914,14 @@ fn get_editions_from_comments(
 fn idempotent_check(
     filename: &PathBuf,
     opt_config: &Option<PathBuf>,
+    sig_comments: &HashMap<String, String>,
 ) -> Result<FormatReport, IdempotentCheckError> {
-    let sig_comments = read_significant_comments(filename);
     let config = if let Some(ref config_file_path) = opt_config {
-        let (edition, style_edition, version) = get_editions_from_comments(&sig_comments);
+        let (edition, style_edition, version) = get_editions_from_comments(sig_comments);
         Config::from_toml_path(config_file_path, edition, style_edition, version)
             .expect("`rustfmt.toml` not found")
     } else {
-        read_config(filename)
+        config_from_comments(filename, sig_comments)
     };
     let (parsing_errors, source_file, format_report) = format_file(filename, config);
     if parsing_errors {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -808,7 +808,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
         // So here we need to take a minimum between the two.
         let lo = std::cmp::min(attrs_end + 1, first_line);
         self.push_rewrite_inner(item_span, None);
-        let hi = self.line_number + 1;
+        let hi = self.psess.line_of_byte_pos(item_span.hi());
         self.skipped_range.borrow_mut().push((lo, hi));
     }
 

--- a/tests/target/skip_with_overflow.rs
+++ b/tests/target/skip_with_overflow.rs
@@ -1,0 +1,22 @@
+// rustfmt-error_on_line_overflow: true
+// rustfmt-error_on_unformatted: true
+// rustfmt-max_width: 100
+
+// This is a regression test for a bug where when calculating
+// the end of a skip range when use a FmtVisitor's 'line_number' which was _assumed_ to be relative
+// to the entire file, but when nesting a visitor inside another would be _relative_ to the start of
+// that block
+
+fn foo() {
+    let _ = || {
+        // the bug: we'd mark the region (lo=16, hi=10) as skipped
+        // the lo value is correct, but the hi value is the offset of the line after the end of the
+        // 'if' block relative to the start of the '|| {' block
+        #[rustfmt::skip]
+        if true {
+            println!(
+                "this is a very long string, it goes over max_width. This is just padding to push it over"
+            );
+        }
+    };
+}


### PR DESCRIPTION
As well as a bit of code tidying

- Idempotent test: avoid redundant file reads

    We read the 'significant comments' in `check_files`, so just pass it
    down rather than re-reading the test file.

- Fix skip range miscalculated on nested blocks

    Fix a bug in `FmtVisitor::push_skipped_with_span` that assumed
    `line_number` was always absolute (within a given file) and instead set
    the end of the range to be the end of the span with the skip attribute.

    Found while investigating issue #6954 (but this commit doesn't address
    that issue).