### PR TITLE
Remove repeated `--style-edition` option

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -137,12 +137,6 @@ fn make_opts() -> Options {
     );
     opts.optopt(
         "",
-        "style-edition",
-        "The edition of the Style Guide (unstable).",
-        "[2015|2018|2021|2024]",
-    );
-    opts.optopt(
-        "",
         "color",
         "Use colored output (if supported)",
         "[always|never|auto]",

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -140,8 +140,6 @@ fn rustfmt_usage_text() {
                             input file path
             --edition [2015|2018|2021|2024]
                             Rust edition to use
-            --style-edition [2015|2018|2021|2024]
-                            The edition of the Style Guide (unstable).
             --color [always|never|auto]
                             Use colored output (if supported)
             --print-config [default|minimal|current] PATH
@@ -190,8 +188,6 @@ fn rustfmt_nightly_usage_text() {
                             input file path
             --edition [2015|2018|2021|2024]
                             Rust edition to use
-            --style-edition [2015|2018|2021|2024]
-                            The edition of the Style Guide (unstable).
             --color [always|never|auto]
                             Use colored output (if supported)
             --print-config [default|minimal|current] PATH


### PR DESCRIPTION
Due to a quirk of history, there were two version of this flag. The flag used to be nested under `is_nightly` but then separately:

* f649c4c1771db3f9a6e4edeabde69978d2c0a340: move it to the main options, with `(unstable)`
* 840eb96e1614182cc6fad779c49d5311791debfa: moved it to the main options, without `(unstable)`

Those two commits were part of subtree pushes, so the two commits were likely made at roughly the same time on different subtrees.

There should be no functional change here, the flags were identical, so no distinction was ever made when matching on them with `matches.opt_str("style-edition")`

Fixes: #7046