### PR TITLE
Fix ICE on `for await` loops with separated keyword tokens

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1033,7 +1033,7 @@ impl<'a> ControlFlow<'a> {
         };
 
         // 1 = space after keyword.
-        let offset = keyword.len() + label_string.len() + 1;
+        let offset = last_line_width(&keyword) + label_string.len() + 1;
 
         let pat_expr_string = match self.cond {
             Some(cond) => self.rewrite_pat_expr(context, cond, constr_shape, offset)?,
@@ -1106,7 +1106,7 @@ impl<'a> ControlFlow<'a> {
             last_line_width(&pat_expr_string)
         } else {
             // 2 = spaces after keyword and condition.
-            label_string.len() + keyword.len() + pat_expr_string.len() + 2
+            label_string.len() + last_line_width(&keyword) + pat_expr_string.len() + 2
         };
 
         Ok((

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -990,8 +990,50 @@ impl<'a> ControlFlow<'a> {
         };
 
         let label_string = rewrite_label(context, self.label);
+
+        // Do not include the label in the span.
+        let lo = self
+            .label
+            .map_or(self.span.lo(), |label| label.ident.span.hi());
+
+        // `for await` is spelled with two tokens, and the source is free to
+        // separate them with any whitespace or comments. Locate each token in
+        // turn rather than searching for the rendered keyword, and keep
+        // whatever sits in the gap.
+        let (keyword, after_kwd) = if self.keyword == "for await" {
+            let after_for = context
+                .snippet_provider
+                .span_after(mk_sp(lo, self.span.hi()), "for");
+            let before_await = context
+                .snippet_provider
+                .opt_span_before(mk_sp(after_for, self.span.hi()), "await")
+                .unknown_error()?;
+            let after_await = context
+                .snippet_provider
+                .opt_span_after(mk_sp(after_for, self.span.hi()), "await")
+                .unknown_error()?;
+
+            // "for" + whatever is in the gap + "await"
+            let kwd = combine_strs_with_missing_comments(
+                context,
+                "for",
+                "await",
+                mk_sp(after_for, before_await),
+                shape,
+                true,
+            )?;
+            (kwd, after_await)
+        } else {
+            (
+                self.keyword.to_owned(),
+                context
+                    .snippet_provider
+                    .span_after(mk_sp(lo, self.span.hi()), self.keyword.trim()),
+            )
+        };
+
         // 1 = space after keyword.
-        let offset = self.keyword.len() + label_string.len() + 1;
+        let offset = keyword.len() + label_string.len() + 1;
 
         let pat_expr_string = match self.cond {
             Some(cond) => self.rewrite_pat_expr(context, cond, constr_shape, offset)?,
@@ -1032,14 +1074,8 @@ impl<'a> ControlFlow<'a> {
         };
 
         // `for event in event`
-        // Do not include label in the span.
-        let lo = self
-            .label
-            .map_or(self.span.lo(), |label| label.ident.span.hi());
         let between_kwd_cond = mk_sp(
-            context
-                .snippet_provider
-                .span_after(mk_sp(lo, self.span.hi()), self.keyword.trim()),
+            after_kwd,
             if self.pat.is_none() {
                 cond_span.lo()
             } else if self.matcher.is_empty() {
@@ -1070,14 +1106,14 @@ impl<'a> ControlFlow<'a> {
             last_line_width(&pat_expr_string)
         } else {
             // 2 = spaces after keyword and condition.
-            label_string.len() + self.keyword.len() + pat_expr_string.len() + 2
+            label_string.len() + keyword.len() + pat_expr_string.len() + 2
         };
 
         Ok((
             format!(
                 "{}{}{}{}{}",
                 label_string,
-                self.keyword,
+                keyword,
                 between_kwd_cond_comment.as_ref().map_or(
                     if pat_expr_string.is_empty() || pat_expr_string.starts_with('\n') {
                         ""

--- a/tests/source/issue-7054.rs
+++ b/tests/source/issue-7054.rs
@@ -1,0 +1,72 @@
+// rustfmt-edition: 2024
+
+// `for await` is spelled with two tokens, so the source may separate them with
+// arbitrary whitespace or comments. rustfmt must not search for the rendered
+// keyword `for await` as a single literal string.
+
+#![feature(async_iterator, async_for_loop)]
+
+async fn for_await_canonical(iter: Iter) {
+    for await i in iter {}
+}
+
+async fn for_await_extra_spaces(iter: Iter) {
+    for   await i in iter {}
+}
+
+async fn for_await_newline(iter: Iter) {
+    for
+        await i in iter {}
+}
+
+async fn for_await_comment_between_keywords(iter: Iter) {
+    for /* between for and await */ await i in iter {}
+}
+
+async fn for_await_comment_after_keyword(iter: Iter) {
+    for await /* between await and pat */ i in iter {}
+}
+
+async fn for_await_comment_both_gaps(iter: Iter) {
+    for /* first gap */ await /* second gap */ i in iter {}
+}
+
+async fn for_await_labeled(iter: Iter) {
+    'outer: for   await i in iter {}
+}
+
+async fn for_await_body(iter: Iter) {
+    for await i in iter {
+        do_something(i);
+    }
+}
+
+// Single-token keywords must be unaffected by the change.
+
+fn plain_for(iter: Iter) {
+    for   i in iter {}
+    for /* comment */ i in iter {}
+    'outer: for i in iter {}
+}
+
+fn plain_while(cond: bool) {
+    while   cond {}
+    while /* comment */ cond {}
+    'outer: while cond {}
+}
+
+fn plain_while_let(opt: Opt) {
+    while   let Some(x) = opt {}
+    while /* comment */ let Some(x) = opt {}
+}
+
+fn plain_loop() {
+    loop {}
+    'outer: loop {}
+}
+
+fn plain_if(cond: bool) {
+    if   cond {}
+    if /* comment */ cond {}
+    if   let Some(x) = opt {}
+}

--- a/tests/source/issue-7054.rs
+++ b/tests/source/issue-7054.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: 2024
+// rustfmt-edition: 2018
 
 // `for await` is spelled with two tokens, so the source may separate them with
 // arbitrary whitespace or comments. rustfmt must not search for the rendered
@@ -31,9 +31,81 @@ async fn for_await_comment_both_gaps(iter: Iter) {
     for /* first gap */ await /* second gap */ i in iter {}
 }
 
+async fn for_multi_line_comment_await(iter: Iter) {
+    for /* some
+ * multi-line
+ * comment */ await
+    i in iter {}
+}
+
+async fn for_comment_await_comment_(iter: Iter) {
+    for /* some
+ * multi-line
+ * comment */ await
+/* some
+ * multi-line
+ * comment */
+    i in iter {}
+}
+
+async fn for_await_comment_with_long_iterator(iter: Iter) {
+    for /* some
+ * multi-line
+ * comment */ await
+    i in some_really_long_iterator_expression(alpha, beta, gamma, delta) {}
+}
+
+async fn for_await_comment_exceeding_line_budget(iter: Iter) {
+    for /* some
+ * multi-line
+ * comment
+ * that keeps
+ * going on
+ * and on
+ * past ninety
+ * six bytes */
+ await
+    i in iter {}
+}
+
+async fn for_await_line_comment_between_keywords(iter: Iter) {
+    for // between for and await
+    await i in iter {}
+}
+
+async fn for_await_multiple_line_comments_between_keywords_with_spaces(iter: Iter) {
+    for      // first line
+    // second line
+    await i in iter {}
+}
+
+async fn for_await_line_comment_after_keyword(iter: Iter) {
+    for await // between await and pat
+    i in iter {}
+}
+
+async fn for_await_line_comments_both_gaps(iter: Iter) {
+    for // first gap
+    await // second gap
+    i in iter {}
+}
+
 async fn for_await_labeled(iter: Iter) {
     'outer: for   await i in iter {}
 }
+
+async fn for_await_labeled(iter: Iter) {
+    'outer: for   // line comment
+    await i in iter {}
+}
+
+async fn for_await_labeled_multi_line_comment(iter: Iter) {
+    'outer: for /* some
+ * multi-line
+ * comment */ await
+    i in iter {}
+}
+
 
 async fn for_await_body(iter: Iter) {
     for await i in iter {
@@ -46,18 +118,24 @@ async fn for_await_body(iter: Iter) {
 fn plain_for(iter: Iter) {
     for   i in iter {}
     for /* comment */ i in iter {}
+    for // line comment
+    i in iter {}
     'outer: for i in iter {}
 }
 
 fn plain_while(cond: bool) {
     while   cond {}
     while /* comment */ cond {}
+    while // line comment
+    cond {}
     'outer: while cond {}
 }
 
 fn plain_while_let(opt: Opt) {
     while   let Some(x) = opt {}
     while /* comment */ let Some(x) = opt {}
+    while // line comment
+    let Some(x) = opt {}
 }
 
 fn plain_loop() {
@@ -68,5 +146,8 @@ fn plain_loop() {
 fn plain_if(cond: bool) {
     if   cond {}
     if /* comment */ cond {}
+    if // line comment
+    cond {}
     if   let Some(x) = opt {}
 }
+

--- a/tests/target/issue-7054.rs
+++ b/tests/target/issue-7054.rs
@@ -1,0 +1,83 @@
+// rustfmt-edition: 2024
+
+// `for await` is spelled with two tokens, so the source may separate them with
+// arbitrary whitespace or comments. rustfmt must not search for the rendered
+// keyword `for await` as a single literal string.
+
+#![feature(async_iterator, async_for_loop)]
+
+async fn for_await_canonical(iter: Iter) {
+    for await i in iter {}
+}
+
+async fn for_await_extra_spaces(iter: Iter) {
+    for await i in iter {}
+}
+
+async fn for_await_newline(iter: Iter) {
+    for await i in iter {}
+}
+
+async fn for_await_comment_between_keywords(iter: Iter) {
+    for /* between for and await */ await i in iter {}
+}
+
+async fn for_await_comment_after_keyword(iter: Iter) {
+    for await
+    /* between await and pat */
+    i in iter {}
+}
+
+async fn for_await_comment_both_gaps(iter: Iter) {
+    for /* first gap */ await
+    /* second gap */
+    i in iter {}
+}
+
+async fn for_await_labeled(iter: Iter) {
+    'outer: for await i in iter {}
+}
+
+async fn for_await_body(iter: Iter) {
+    for await i in iter {
+        do_something(i);
+    }
+}
+
+// Single-token keywords must be unaffected by the change.
+
+fn plain_for(iter: Iter) {
+    for i in iter {}
+    for
+    /* comment */
+    i in iter {}
+    'outer: for i in iter {}
+}
+
+fn plain_while(cond: bool) {
+    while cond {}
+    while
+    /* comment */
+    cond {}
+    'outer: while cond {}
+}
+
+fn plain_while_let(opt: Opt) {
+    while let Some(x) = opt {}
+    while
+    /* comment */
+    let Some(x) = opt {}
+}
+
+fn plain_loop() {
+    loop {}
+    'outer: loop {}
+}
+
+fn plain_if(cond: bool) {
+    if cond {}
+    if
+    /* comment */
+    cond {}
+    if let Some(x) = opt {}
+}

--- a/tests/target/issue-7054.rs
+++ b/tests/target/issue-7054.rs
@@ -1,4 +1,4 @@
-// rustfmt-edition: 2024
+// rustfmt-edition: 2018
 
 // `for await` is spelled with two tokens, so the source may separate them with
 // arbitrary whitespace or comments. rustfmt must not search for the rendered
@@ -34,8 +34,81 @@ async fn for_await_comment_both_gaps(iter: Iter) {
     i in iter {}
 }
 
+async fn for_multi_line_comment_await(iter: Iter) {
+    for /* some
+     * multi-line
+     * comment */
+    await i in iter {}
+}
+
+async fn for_comment_await_comment_(iter: Iter) {
+    for /* some
+     * multi-line
+     * comment */
+    await
+    /* some
+     * multi-line
+     * comment */
+    i in iter {}
+}
+
+async fn for_await_comment_with_long_iterator(iter: Iter) {
+    for /* some
+     * multi-line
+     * comment */
+    await i in some_really_long_iterator_expression(alpha, beta, gamma, delta) {}
+}
+
+async fn for_await_comment_exceeding_line_budget(iter: Iter) {
+    for /* some
+     * multi-line
+     * comment
+     * that keeps
+     * going on
+     * and on
+     * past ninety
+     * six bytes */
+    await i in iter {}
+}
+
+async fn for_await_line_comment_between_keywords(iter: Iter) {
+    for // between for and await
+    await i in iter {}
+}
+
+async fn for_await_multiple_line_comments_between_keywords_with_spaces(iter: Iter) {
+    for // first line
+    // second line
+    await i in iter {}
+}
+
+async fn for_await_line_comment_after_keyword(iter: Iter) {
+    for await
+    // between await and pat
+    i in iter {}
+}
+
+async fn for_await_line_comments_both_gaps(iter: Iter) {
+    for // first gap
+    await
+    // second gap
+    i in iter {}
+}
+
 async fn for_await_labeled(iter: Iter) {
     'outer: for await i in iter {}
+}
+
+async fn for_await_labeled(iter: Iter) {
+    'outer: for // line comment
+    await i in iter {}
+}
+
+async fn for_await_labeled_multi_line_comment(iter: Iter) {
+    'outer: for /* some
+     * multi-line
+     * comment */
+    await i in iter {}
 }
 
 async fn for_await_body(iter: Iter) {
@@ -51,6 +124,9 @@ fn plain_for(iter: Iter) {
     for
     /* comment */
     i in iter {}
+    for
+    // line comment
+    i in iter {}
     'outer: for i in iter {}
 }
 
@@ -59,6 +135,9 @@ fn plain_while(cond: bool) {
     while
     /* comment */
     cond {}
+    while
+    // line comment
+    cond {}
     'outer: while cond {}
 }
 
@@ -66,6 +145,9 @@ fn plain_while_let(opt: Opt) {
     while let Some(x) = opt {}
     while
     /* comment */
+    let Some(x) = opt {}
+    while
+    // line comment
     let Some(x) = opt {}
 }
 
@@ -78,6 +160,9 @@ fn plain_if(cond: bool) {
     if cond {}
     if
     /* comment */
+    cond {}
+    if
+    // line comment
     cond {}
     if let Some(x) = opt {}
 }


### PR DESCRIPTION
Issue : we are searching source for single string literal `for await`, but source have more than one space between these tokens. Any source that separated tokens with more than one space, new line, or a comment failed the search because `span_after` panicked


Fix: locate `for` and `await` as independent token then combine them with `combine_strs_with_missing_comments` by preserving any comment between them, like how `mut` and `ref` handled in patterns.rs. the lookup uses `opt_span_after` so a miss results in unformatted output instead of an ICE

Fixes #7054 