### PR TITLE
fix: correct the span used when rewriting `ast::TyKind::FnPtr`

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1132,7 +1132,7 @@ fn rewrite_fn_ptr(
         fn_ptr.decl.inputs.iter(),
         &fn_ptr.decl.output,
         fn_ptr.decl.c_variadic(),
-        span,
+        fn_ptr.decl_span,
         context,
         func_ty_shape,
     )?;

--- a/tests/target/issue_7062.rs
+++ b/tests/target/issue_7062.rs
@@ -1,0 +1,1 @@
+type FnNo = for<#[cfg_attr(FALSE, unknown)] 'a> fn();


### PR DESCRIPTION
Fixes rust-lang/rustfmt#7062

The span for the entire `ast::Ty` contains the generic params, and if those generics contain a `()`, the comment recovery code will accidentally pick those up. Instead limit the rewrite to just the `decl_span`.