### PR TITLE
Preserve comments before semicolon in use statements

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -143,7 +143,13 @@ pub(crate) fn comment_style(orig: &str, normalize_comments: bool) -> CommentStyl
 
 /// Returns true if the last line of the passed string finishes with a block-comment.
 pub(crate) fn is_last_comment_block(s: &str) -> bool {
-    s.trim_end().ends_with("*/")
+    let mut last_non_ws = None;
+    for (kind, c) in CharClasses::new(s.chars()) {
+        if !c.is_whitespace() {
+            last_non_ws = Some((kind, c));
+        }
+    }
+    matches!(last_non_ws, Some((FullCodeCharKind::EndComment, '/')))
 }
 
 /// Combine `prev_str` and `next_str` into a single `String`. `span` may contain
@@ -2145,5 +2151,23 @@ fn main() {
                 "The following line shouldn't be classified as a list item: {line}"
             );
         }
+    }
+
+    #[test]
+    fn test_is_last_comment_block() {
+        assert!(is_last_comment_block("/* block */"));
+        assert!(is_last_comment_block("/* multiline\ncomment */"));
+        assert!(is_last_comment_block("// line\n/* block */"));
+        assert!(is_last_comment_block("/* block */\n   "));
+        assert!(is_last_comment_block("use std; /* block */"));
+
+        assert!(!is_last_comment_block("/* block */ use std;"));
+        assert!(!is_last_comment_block("// line"));
+        assert!(!is_last_comment_block("// comment ending in */"));
+        assert!(!is_last_comment_block("// first\n// second */"));
+        assert!(!is_last_comment_block("/* block */\n// line"));
+        assert!(!is_last_comment_block("\"/* string */\""));
+        assert!(!is_last_comment_block(""));
+        assert!(!is_last_comment_block("   \n  "));
     }
 }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -12,9 +12,6 @@ use rustc_span::{
     symbol::{self, sym},
 };
 
-use crate::comment::{
-    FindUncommented, combine_strs_with_missing_comments, contains_comment, rewrite_missing_comment,
-};
 use crate::config::ImportGranularity;
 use crate::config::lists::*;
 use crate::config::{Edition, IndentStyle, StyleEdition};
@@ -28,6 +25,13 @@ use crate::source_map::SpanUtils;
 use crate::spanned::Spanned;
 use crate::utils::{is_same_visibility, mk_sp, rewrite_ident};
 use crate::visitor::FmtVisitor;
+use crate::{
+    comment::{
+        FindUncommented, combine_strs_with_missing_comments, contains_comment,
+        is_last_comment_block, rewrite_missing_comment,
+    },
+    utils::{first_line_width, last_line_width},
+};
 
 /// Returns a name imported by a `use` declaration.
 /// E.g., returns `Ordering` for `std::cmp::Ordering` and `self` for `std::cmp::self`.
@@ -364,24 +368,53 @@ impl UseTree {
                     .span_to_snippet(mk_sp(lo, context.snippet_provider.end_pos()))
                     .unwrap_or_default();
 
-                if let Some(semi_offset) = snippet.find_uncommented(";") {
-                    let between = &snippet[..semi_offset];
-                    if contains_comment(between) {
-                        let span = mk_sp(lo, lo + BytePos(semi_offset as u32));
-                        let comment = rewrite_missing_comment(span, shape, context)?;
-                        if !comment.is_empty() {
-                            let indent = shape.indent.to_string(context.config);
-                            let one_line = format!("{lhs}; {comment}");
-                            if !comment.contains('\n') && one_line.len() <= shape.width {
-                                return Ok(one_line);
-                            } else {
-                                return Ok(format!("{lhs};\n{indent}{comment}"));
-                            }
-                        }
-                    }
+                let Some(semi_offset) = snippet.find_uncommented(";") else {
+                    return Ok(format!("{lhs};"));
+                };
+
+                let between = &snippet[..semi_offset];
+                if !contains_comment(between) {
+                    return Ok(format!("{lhs};"));
                 }
 
-                Ok(format!("{lhs};"))
+                let span = mk_sp(lo, lo + BytePos(semi_offset as u32));
+                let comment = rewrite_missing_comment(span, shape, context)?;
+                if comment.is_empty() {
+                    return Ok(format!("{lhs};"));
+                }
+
+                let indent = shape.indent.to_string(context.config);
+                let is_block = is_last_comment_block(&comment);
+
+                let prefer_same_line = if let Some(pos) = between.find('/') {
+                    !between[..pos].contains('\n')
+                } else {
+                    !between.contains('\n')
+                };
+
+                let lhs_last_width = if lhs.contains('\n') {
+                    last_line_width(&lhs)
+                } else {
+                    shape.indent.width() + lhs.len()
+                };
+                let semi_len = if is_block && !comment.contains('\n') {
+                    1
+                } else {
+                    0
+                };
+                let one_line_width = lhs_last_width + 1 + first_line_width(&comment) + semi_len;
+
+                let sep = if prefer_same_line && one_line_width <= context.config.max_width() {
+                    " ".to_string()
+                } else {
+                    format!("\n{indent}")
+                };
+
+                if is_block {
+                    Ok(format!("{lhs}{sep}{comment};"))
+                } else {
+                    Ok(format!("{lhs}{sep}{comment}\n{indent};"))
+                }
             })?;
         match self.attrs {
             Some(ref attrs) if !attrs.is_empty() => {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -12,7 +12,9 @@ use rustc_span::{
     symbol::{self, sym},
 };
 
-use crate::comment::combine_strs_with_missing_comments;
+use crate::comment::{
+    FindUncommented, combine_strs_with_missing_comments, contains_comment, rewrite_missing_comment,
+};
 use crate::config::ImportGranularity;
 use crate::config::lists::*;
 use crate::config::{Edition, IndentStyle, StyleEdition};
@@ -346,12 +348,40 @@ impl UseTree {
         });
         let use_str = self
             .rewrite_result(context, shape.offset_left(vis.len(), self.span())?)
-            .map(|s| {
+            .and_then(|s| {
                 if s.is_empty() {
-                    s
-                } else {
-                    format!("{}use {};", vis, s)
+                    return Ok(s);
                 }
+
+                let lhs = format!("{vis}use {s}");
+                if self.span.is_dummy() || self.has_comment() {
+                    return Ok(format!("{lhs};"));
+                }
+
+                let lo = self.span.hi();
+                let snippet = context
+                    .snippet_provider
+                    .span_to_snippet(mk_sp(lo, context.snippet_provider.end_pos()))
+                    .unwrap_or_default();
+
+                if let Some(semi_offset) = snippet.find_uncommented(";") {
+                    let between = &snippet[..semi_offset];
+                    if contains_comment(between) {
+                        let span = mk_sp(lo, lo + BytePos(semi_offset as u32));
+                        let comment = rewrite_missing_comment(span, shape, context)?;
+                        if !comment.is_empty() {
+                            let indent = shape.indent.to_string(context.config);
+                            let one_line = format!("{lhs}; {comment}");
+                            if !comment.contains('\n') && one_line.len() <= shape.width {
+                                return Ok(one_line);
+                            } else {
+                                return Ok(format!("{lhs};\n{indent}{comment}"));
+                            }
+                        }
+                    }
+                }
+
+                Ok(format!("{lhs};"))
             })?;
         match self.attrs {
             Some(ref attrs) if !attrs.is_empty() => {

--- a/tests/source/issue-7051.rs
+++ b/tests/source/issue-7051.rs
@@ -1,0 +1,11 @@
+use std /* goodbye */;
+
+use std // bye
+;
+
+use std /* comment; with semicolon */;
+
+use std /*
+    multiline
+    comment
+*/;

--- a/tests/source/issue-7051.rs
+++ b/tests/source/issue-7051.rs
@@ -9,3 +9,61 @@ use std /*
     multiline
     comment
 */;
+
+use std // some
+// multi-line
+// set of single comments
+;
+
+pub use std /* public import */;
+
+use std::{
+    sync::Arc /* some comment */,
+    thread,
+};
+
+use std /* block comment */ // line comment
+;
+
+use std // line comment
+/* block comment */;
+
+use std // comment ending in */
+;
+
+use std // first
+// second */
+;
+
+use std /* hello aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa */;
+
+use std /* hello aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa */;
+
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+    BinaryHeap,
+    HashMap,
+    HashSet,
+    LinkedList,
+    TryReserveError,
+    VecDeque,
+} /* comment */;
+
+use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicPtr, AtomicUsize, Ordering} /* this comment is long enough to push the line past the 100 column limit */;
+
+mod x {
+    use std // comment
+    ;
+
+    use std /* comment */ ;
+
+    use std // comment
+    // comment
+    ;
+
+    use std /*
+        comment
+        comment
+    */;
+}

--- a/tests/target/issue-7051.rs
+++ b/tests/target/issue-7051.rs
@@ -1,11 +1,61 @@
-use std; /* goodbye */
+use std /* goodbye */;
 
-use std; // bye
+use std // bye
+;
 
-use std; /* comment; with semicolon */
+use std /* comment; with semicolon */;
 
-use std;
-/*
+use std /*
     multiline
     comment
-*/
+*/;
+
+use std // some
+// multi-line
+// set of single comments
+;
+
+pub use std /* public import */;
+
+use std::{sync::Arc /* some comment */, thread};
+
+use std /* block comment */ // line comment
+;
+
+use std // line comment
+/* block comment */;
+
+use std // comment ending in */
+;
+
+use std // first
+// second */
+;
+
+use std /* hello aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa */;
+
+use std
+/* hello aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa */;
+
+use std::collections::{
+    BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, TryReserveError, VecDeque,
+} /* comment */;
+
+use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicPtr, AtomicUsize, Ordering}
+/* this comment is long enough to push the line past the 100 column limit */;
+
+mod x {
+    use std // comment
+    ;
+
+    use std /* comment */;
+
+    use std // comment
+    // comment
+    ;
+
+    use std /*
+        comment
+        comment
+    */;
+}

--- a/tests/target/issue-7051.rs
+++ b/tests/target/issue-7051.rs
@@ -1,0 +1,11 @@
+use std; /* goodbye */
+
+use std; // bye
+
+use std; /* comment; with semicolon */
+
+use std;
+/*
+    multiline
+    comment
+*/


### PR DESCRIPTION
Fixes #7051.

Recovers comments located between the imported path and the terminating semicolon (e.g. `use std /* goodbye */;`) on top-level `use` statements, preventing them from being dropped.

Includes regression tests in `tests/source/issue-7051.rs`.