### PR TITLE
Fix issue 7061

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -186,6 +186,9 @@ pub(crate) fn format_expr(
                     // not the `ast::Block` node we're about to rewrite. To prevent dropping inner
                     // attributes call `rewrite_block` directly.
                     // See https://github.com/rust-lang/rustfmt/issues/6158
+
+                    // Shrink the shape by `"const ".len()` before rewriting the block
+                    let shape = shape.offset_left(6, expr.span)?;
                     rewrite_block(block, Some(&expr.attrs), opt_label, context, shape)?
                 }
                 _ => anon_const.rewrite_result(context, shape)?,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -186,9 +186,12 @@ pub(crate) fn format_expr(
                     // not the `ast::Block` node we're about to rewrite. To prevent dropping inner
                     // attributes call `rewrite_block` directly.
                     // See https://github.com/rust-lang/rustfmt/issues/6158
-
-                    // Shrink the shape by `"const ".len()` before rewriting the block
-                    let shape = shape.offset_left(6, expr.span)?;
+                    let shape = if context.config.style_edition() >= StyleEdition::Edition2027 {
+                        // Shrink the shape by `"const ".len()` before rewriting the block
+                        shape.offset_left(6, expr.span)?
+                    } else {
+                        shape
+                    };
                     rewrite_block(block, Some(&expr.attrs), opt_label, context, shape)?
                 }
                 _ => anon_const.rewrite_result(context, shape)?,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,7 @@ use rustc_ast::ast::{
     self, Attribute, ImplRestriction, MetaItem, MetaItemInner, MetaItemKind, MutRestriction,
     NodeId, Path, RestrictionKind, Visibility, VisibilityKind,
 };
+use rustc_ast::visit;
 use rustc_ast_pretty::pprust;
 use rustc_span::{BytePos, LocalExpnId, Span, Symbol, SyntaxContext, sym, symbol};
 use unicode_width::UnicodeWidthStr;
@@ -344,6 +345,33 @@ pub(crate) fn semicolon_for_expr(context: &RewriteContext<'_>, expr: &ast::Expr)
     }
 }
 
+/// Does this `loop` evaluate to something other than `()`?
+///
+/// `loop { break v }` evaluates to `v`, so the trailing semicolon is what
+/// discards that value. Removing it leaves a bare expression statement,
+/// which rustc requires to be `()`
+fn loop_breaks_with_value(expr: &ast::Expr) -> bool {
+    struct BreakWithValue(bool);
+
+    impl<'ast> visit::Visitor<'ast> for BreakWithValue {
+        fn visit_expr(&mut self, ex: &'ast ast::Expr) {
+            match ex.kind {
+                ast::ExprKind::Break(_, Some(_)) => self.0 = true,
+                _ => {
+                    visit::walk_expr(self, ex);
+                }
+            }
+        }
+    }
+
+    let ast::ExprKind::Loop(ref block, ..) = expr.kind else {
+        return false;
+    };
+    let mut finder = BreakWithValue(false);
+    visit::walk_block(&mut finder, block);
+    finder.0
+}
+
 #[inline]
 pub(crate) fn semicolon_for_stmt(
     context: &RewriteContext<'_>,
@@ -352,14 +380,13 @@ pub(crate) fn semicolon_for_stmt(
 ) -> bool {
     match stmt.kind {
         ast::StmtKind::Semi(ref expr) => match expr.kind {
-            ast::ExprKind::While(..) | ast::ExprKind::Loop(..) | ast::ExprKind::ForLoop { .. } => {
-                false
-            }
+            ast::ExprKind::While(..) | ast::ExprKind::ForLoop { .. } => false,
             ast::ExprKind::Break(..) | ast::ExprKind::Continue(..) | ast::ExprKind::Ret(..) => {
                 // The only time we can skip the semi-colon is if the config option is set to false
                 // **and** this is the last expr (even though any following exprs are unreachable)
                 context.config.trailing_semicolon() || !is_last_expr
             }
+            ast::ExprKind::Loop(..) => loop_breaks_with_value(expr),
             _ => true,
         },
         ast::StmtKind::Expr(..) => false,

--- a/tests/source/issue-7055.rs
+++ b/tests/source/issue-7055.rs
@@ -1,0 +1,27 @@
+struct S;
+
+impl S {
+    const fn new(_: &str) -> Self {
+        S
+    }
+
+    fn go(&self) {}
+}
+
+fn main() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn second_issue() {
+    const {
+        S::new( 
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}

--- a/tests/source/issue-7055.rs
+++ b/tests/source/issue-7055.rs
@@ -1,3 +1,5 @@
+// rustfmt-style_edition: 2027
+
 struct S;
 
 impl S {

--- a/tests/source/issue-7055.rs
+++ b/tests/source/issue-7055.rs
@@ -19,7 +19,7 @@ fn main() {
     .go();
 }
 
-fn second_issue() {
+fn removes_trailing_whitespace() {
     const {
         S::new( 
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/tests/source/issue-7061.rs
+++ b/tests/source/issue-7061.rs
@@ -1,0 +1,7 @@
+unsafe fn foo()  ->  i32  {  42  }
+
+fn  main  ()  {
+        'label:  loop  {
+                break  'label  unsafe  {  foo()  }
+        };
+}

--- a/tests/target/issue-7055.rs
+++ b/tests/target/issue-7055.rs
@@ -17,7 +17,7 @@ fn main() {
     .go();
 }
 
-fn second_issue() {
+fn removes_trailing_whitespace() {
     const {
         S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     }

--- a/tests/target/issue-7055.rs
+++ b/tests/target/issue-7055.rs
@@ -1,0 +1,23 @@
+struct S;
+
+impl S {
+    const fn new(_: &str) -> Self {
+        S
+    }
+
+    fn go(&self) {}
+}
+
+fn main() {
+    const {
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    }
+    .go();
+}
+
+fn second_issue() {
+    const {
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    }
+    .go();
+}

--- a/tests/target/issue-7055.rs
+++ b/tests/target/issue-7055.rs
@@ -1,3 +1,5 @@
+// rustfmt-style_edition: 2027
+
 struct S;
 
 impl S {

--- a/tests/target/issue-7061.rs
+++ b/tests/target/issue-7061.rs
@@ -1,0 +1,9 @@
+unsafe fn foo() -> i32 {
+    42
+}
+
+fn main() {
+    'label: loop {
+        break 'label unsafe { foo() };
+    };
+}


### PR DESCRIPTION
issue : `semicolon_for_stmt` grouped `loop` with `for`,  `while` and discarded trailing semicolon. This is correct for `for` and `while` as they evaluate to `()` but `loop` can evaluate to some value. so when `loop { break v } ` has the type of `v` and semicolon discarded then it becomes a bare expression statement, which rustc requires to be `()` . that's why we got compilation error.

Fix: check the loop body, if it breaks with value then keep the trailing semicolon else remove it as before.