### PR TITLE
Shrink the const block shape by the width of the `const ` keyword

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -180,6 +180,14 @@ pub(crate) fn format_expr(
             .unknown_error()
             .and_then(|control_flow| control_flow.rewrite_result(context, shape)),
         ast::ExprKind::ConstBlock(ref anon_const) => {
+            // 6 = "const ". The keyword sits on the first line of the rewrite, so the
+            // block has that many fewer columns to work with. Gated because widening
+            // the block by six columns is stable formatting on earlier style editions.
+            let shape = if context.config.style_edition() >= StyleEdition::Edition2027 {
+                shape.offset_left_opt(6).unwrap_or(shape)
+            } else {
+                shape
+            };
             let rewrite = match anon_const.value.kind {
                 ast::ExprKind::Block(ref block, opt_label) => {
                     // Inner attributes are associated with the `ast::ExprKind::ConstBlock` node,

--- a/tests/source/issue_7055_narrow_max_width.rs
+++ b/tests/source/issue_7055_narrow_max_width.rs
@@ -1,0 +1,21 @@
+// rustfmt-style_edition: 2027
+// rustfmt-max_width: 30
+// rustfmt-error_on_line_overflow: false
+
+// Fewer than six columns of
+// budget left: still format
+// it, do not bail out and
+// emit it verbatim.
+fn deep() {
+    if a {
+        if b {
+            if c {
+                if d {
+                    if e {
+                        let q = const {   1 + 2   };
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/source/issue_7055_style_edition_2021.rs
+++ b/tests/source/issue_7055_style_edition_2021.rs
@@ -1,0 +1,74 @@
+// rustfmt-style_edition: 2021
+// rustfmt-max_width: 100
+// rustfmt-error_on_line_overflow: false
+
+struct S;
+
+impl S {
+    const fn new(_: &str) -> Self {
+        S
+    }
+
+    fn go(&self) {}
+}
+
+// The reported symptom. As the receiver of a method call the block was rewritten at
+// the full width, the `const ` prefix pushed the result past `max_width`, the chain
+// rejected it, and the whole expression was silently left unformatted.
+fn receiver_74() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn receiver_77() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn receiver_80() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+// Not a method receiver, so the over-wide rewrite was accepted and emitted. This is
+// the stable formatting the gate protects: on style editions below 2027 these keep
+// producing a line past `max_width`.
+fn statement_74() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+fn statement_77() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+fn statement_80() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+// The `const ` budget applies to a nested block too.
+fn nested() {
+    let _ = const {
+        const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  }
+    };
+}
+
+// Inner attributes belong to the `ConstBlock` node, not the `Block`, so they take the
+// `rewrite_block` path directly. Guard that the shape change leaves them alone.
+fn inner_attrs() {
+    let _ = const {
+        #![allow(unused)]
+        S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )
+    };
+}

--- a/tests/source/issue_7055_style_edition_2024.rs
+++ b/tests/source/issue_7055_style_edition_2024.rs
@@ -1,0 +1,74 @@
+// rustfmt-style_edition: 2024
+// rustfmt-max_width: 100
+// rustfmt-error_on_line_overflow: false
+
+struct S;
+
+impl S {
+    const fn new(_: &str) -> Self {
+        S
+    }
+
+    fn go(&self) {}
+}
+
+// The reported symptom. As the receiver of a method call the block was rewritten at
+// the full width, the `const ` prefix pushed the result past `max_width`, the chain
+// rejected it, and the whole expression was silently left unformatted.
+fn receiver_74() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn receiver_77() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn receiver_80() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+// Not a method receiver, so the over-wide rewrite was accepted and emitted. This is
+// the stable formatting the gate protects: on style editions below 2027 these keep
+// producing a line past `max_width`.
+fn statement_74() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+fn statement_77() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+fn statement_80() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+// The `const ` budget applies to a nested block too.
+fn nested() {
+    let _ = const {
+        const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  }
+    };
+}
+
+// Inner attributes belong to the `ConstBlock` node, not the `Block`, so they take the
+// `rewrite_block` path directly. Guard that the shape change leaves them alone.
+fn inner_attrs() {
+    let _ = const {
+        #![allow(unused)]
+        S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )
+    };
+}

--- a/tests/source/issue_7055_style_edition_2027.rs
+++ b/tests/source/issue_7055_style_edition_2027.rs
@@ -1,0 +1,74 @@
+// rustfmt-style_edition: 2027
+// rustfmt-max_width: 100
+// rustfmt-error_on_line_overflow: false
+
+struct S;
+
+impl S {
+    const fn new(_: &str) -> Self {
+        S
+    }
+
+    fn go(&self) {}
+}
+
+// The reported symptom. As the receiver of a method call the block was rewritten at
+// the full width, the `const ` prefix pushed the result past `max_width`, the chain
+// rejected it, and the whole expression was silently left unformatted.
+fn receiver_74() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn receiver_77() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn receiver_80() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+// Not a method receiver, so the over-wide rewrite was accepted and emitted. This is
+// the stable formatting the gate protects: on style editions below 2027 these keep
+// producing a line past `max_width`.
+fn statement_74() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+fn statement_77() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+fn statement_80() {
+    const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  } ;
+}
+
+// The `const ` budget applies to a nested block too.
+fn nested() {
+    let _ = const {
+        const {  S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )  }
+    };
+}
+
+// Inner attributes belong to the `ConstBlock` node, not the `Block`, so they take the
+// `rewrite_block` path directly. Guard that the shape change leaves them alone.
+fn inner_attrs() {
+    let _ = const {
+        #![allow(unused)]
+        S::new( "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" )
+    };
+}

--- a/tests/target/issue_7055_narrow_max_width.rs
+++ b/tests/target/issue_7055_narrow_max_width.rs
@@ -1,0 +1,23 @@
+// rustfmt-style_edition: 2027
+// rustfmt-max_width: 30
+// rustfmt-error_on_line_overflow: false
+
+// Fewer than six columns of
+// budget left: still format
+// it, do not bail out and
+// emit it verbatim.
+fn deep() {
+    if a {
+        if b {
+            if c {
+                if d {
+                    if e {
+                        let q = const {
+                            1 + 2
+                        };
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/target/issue_7055_style_edition_2021.rs
+++ b/tests/target/issue_7055_style_edition_2021.rs
@@ -1,0 +1,70 @@
+// rustfmt-style_edition: 2021
+// rustfmt-max_width: 100
+// rustfmt-error_on_line_overflow: false
+
+struct S;
+
+impl S {
+    const fn new(_: &str) -> Self {
+        S
+    }
+
+    fn go(&self) {}
+}
+
+// The reported symptom. As the receiver of a method call the block was rewritten at
+// the full width, the `const ` prefix pushed the result past `max_width`, the chain
+// rejected it, and the whole expression was silently left unformatted.
+fn receiver_74() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+        .go();
+}
+
+fn receiver_77() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn receiver_80() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+// Not a method receiver, so the over-wide rewrite was accepted and emitted. This is
+// the stable formatting the gate protects: on style editions below 2027 these keep
+// producing a line past `max_width`.
+fn statement_74() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") };
+}
+
+fn statement_77() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") };
+}
+
+fn statement_80() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") };
+}
+
+// The `const ` budget applies to a nested block too.
+fn nested() {
+    let _ = const {
+        const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+    };
+}
+
+// Inner attributes belong to the `ConstBlock` node, not the `Block`, so they take the
+// `rewrite_block` path directly. Guard that the shape change leaves them alone.
+fn inner_attrs() {
+    let _ = const {
+        #![allow(unused)]
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    };
+}

--- a/tests/target/issue_7055_style_edition_2024.rs
+++ b/tests/target/issue_7055_style_edition_2024.rs
@@ -1,0 +1,70 @@
+// rustfmt-style_edition: 2024
+// rustfmt-max_width: 100
+// rustfmt-error_on_line_overflow: false
+
+struct S;
+
+impl S {
+    const fn new(_: &str) -> Self {
+        S
+    }
+
+    fn go(&self) {}
+}
+
+// The reported symptom. As the receiver of a method call the block was rewritten at
+// the full width, the `const ` prefix pushed the result past `max_width`, the chain
+// rejected it, and the whole expression was silently left unformatted.
+fn receiver_74() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+        .go();
+}
+
+fn receiver_77() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+fn receiver_80() {
+    const {
+        S::new(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+    }
+    .go();
+}
+
+// Not a method receiver, so the over-wide rewrite was accepted and emitted. This is
+// the stable formatting the gate protects: on style editions below 2027 these keep
+// producing a line past `max_width`.
+fn statement_74() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") };
+}
+
+fn statement_77() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") };
+}
+
+fn statement_80() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") };
+}
+
+// The `const ` budget applies to a nested block too.
+fn nested() {
+    let _ = const {
+        const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+    };
+}
+
+// Inner attributes belong to the `ConstBlock` node, not the `Block`, so they take the
+// `rewrite_block` path directly. Guard that the shape change leaves them alone.
+fn inner_attrs() {
+    let _ = const {
+        #![allow(unused)]
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    };
+}

--- a/tests/target/issue_7055_style_edition_2027.rs
+++ b/tests/target/issue_7055_style_edition_2027.rs
@@ -1,0 +1,70 @@
+// rustfmt-style_edition: 2027
+// rustfmt-max_width: 100
+// rustfmt-error_on_line_overflow: false
+
+struct S;
+
+impl S {
+    const fn new(_: &str) -> Self {
+        S
+    }
+
+    fn go(&self) {}
+}
+
+// The reported symptom. As the receiver of a method call the block was rewritten at
+// the full width, the `const ` prefix pushed the result past `max_width`, the chain
+// rejected it, and the whole expression was silently left unformatted.
+fn receiver_74() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+        .go();
+}
+
+fn receiver_77() {
+    const {
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    }
+    .go();
+}
+
+fn receiver_80() {
+    const {
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    }
+    .go();
+}
+
+// Not a method receiver, so the over-wide rewrite was accepted and emitted. This is
+// the stable formatting the gate protects: on style editions below 2027 these keep
+// producing a line past `max_width`.
+fn statement_74() {
+    const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") };
+}
+
+fn statement_77() {
+    const {
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    };
+}
+
+fn statement_80() {
+    const {
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    };
+}
+
+// The `const ` budget applies to a nested block too.
+fn nested() {
+    let _ = const {
+        const { S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") }
+    };
+}
+
+// Inner attributes belong to the `ConstBlock` node, not the `Block`, so they take the
+// `rewrite_block` path directly. Guard that the shape change leaves them alone.
+fn inner_attrs() {
+    let _ = const {
+        #![allow(unused)]
+        S::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    };
+}


### PR DESCRIPTION
Fixes #7055.

## What

`format_expr`'s `ConstBlock` arm calls `rewrite_block` with the full `shape` and then prepends the literal `const `, so the block is laid out with six more columns than it actually has. This shrinks the shape by those six columns first.

`unsafe { ... }` and a plain `{ ... }` are unaffected today because their prefix is built inside `rewrite_block_inner`, where `rewrite_single_line_block` already does `shape.offset_left(last_line_width(prefix))`.

`offset_left_opt(..).unwrap_or(shape)` rather than `offset_left(..)?`: a block body's indentation is fixed by the enclosing indent, so there is no alternative layout to fall back to, and erroring on a narrow shape would only discard the formatting of the whole statement. Same idiom as `src/items.rs:2677`.

## Why it is gated

The issue reports the method-receiver case, where the over-wide rewrite is rejected by the chain and the expression is silently emitted verbatim. But outside a chain the same over-wide rewrite is accepted, so at the default `max_width` of 100 rustfmt today normalises

```rust
    const {  S::new( "<77 a's>" )  } ;
```

into a 102 column line, idempotently. That is stable formatting, so the change is gated behind `style_edition=2027`, following bdab101 ("Check if function return type fits before rewriting", #6831).

One consequence worth flagging: gating means the reported symptom stays broken on style editions 2015 through 2024. If you would rather have it ungated on the grounds that the receiver case emits nothing at all today, I am happy to drop the gate and the 2021/2024 test pairs.

## Tests

- `issue_7055_style_edition_{2021,2024,2027}.rs`, source and target. 2021 and 2024 are byte-identical to each other and to pre-fix output. 2027 covers the reported receiver case, the boundary case just below it that must not change, the bare statement case that motivates the gate, a nested `const` block, and a block with inner attributes (#6158).
- `issue_7055_narrow_max_width.rs`, a `const` block with fewer than six columns of budget at `max_width=30`, guarding against bailing out and emitting verbatim.

`cargo test` is green: 234 system tests, no existing target file changed, and rustfmt still bootstraps on its own source.
