### PR TITLE
chore: fix lint `cargo::manual_readme`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "rustfmt-nightly"
 version = "1.10.0"
 description = "Tool to find and fix Rust formatting issues"
 repository = "https://github.com/rust-lang/rustfmt"
-readme = "README.md"
 license = "Apache-2.0 OR MIT"
 build = "build.rs"
 categories = ["development-tools"]


### PR DESCRIPTION
```
warning: explicit `package.readme` can be inferred
 --> src/tools/rustfmt/Cargo.toml:6:1
  |
6 | readme = "README.md"
  | ^^^^^^^^^^^^^^^^^^^^
  |
  = note: `cargo::manual_readme` is set to `warn` by default
help: consider removing `package.readme`
warning: `rustfmt-nightly` (manifest) generated 1 warning
```

See
<https://triage.rust-lang.org/gha-logs/rust-lang/rust/98030530980#L2026-08-26T03:05:00.5387201Z-L2026-08-26T03:05:00.5388957Z>

This was discovered in https://github.com/rust-lang/rust/pull/161789