### PR TITLE
Fix struct `comment_width` off-by-one error

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -21,7 +21,11 @@ pub(crate) struct ListFormatting<'a> {
     separator: &'a str,
     trailing_separator: SeparatorTactic,
     separator_place: SeparatorPlace,
+    // The shape available to a list item, including any width reserved for its separator.
     shape: Shape,
+    // Overrides the item shape for pre-comments. The item shape may reserve space for a separator,
+    // which is not part of a preceding comment.
+    pre_comment_shape: Option<Shape>,
     // Non-expressions, e.g., items, will have a new line at the end of the list.
     // Important for comment styles.
     ends_with_newline: bool,
@@ -42,6 +46,7 @@ impl<'a> ListFormatting<'a> {
             trailing_separator: SeparatorTactic::Never,
             separator_place: SeparatorPlace::Back,
             shape,
+            pre_comment_shape: None,
             ends_with_newline: true,
             preserve_newline: false,
             nested: false,
@@ -67,6 +72,11 @@ impl<'a> ListFormatting<'a> {
 
     pub(crate) fn separator_place(mut self, separator_place: SeparatorPlace) -> Self {
         self.separator_place = separator_place;
+        self
+    }
+
+    pub(crate) fn pre_comment_shape(mut self, pre_comment_shape: Shape) -> Self {
+        self.pre_comment_shape = Some(pre_comment_shape);
         self
     }
 
@@ -366,8 +376,8 @@ where
             // Block style in non-vertical mode.
             let block_mode = tactic == DefinitiveListTactic::Horizontal;
             // Width restriction is only relevant in vertical mode.
-            let comment =
-                rewrite_comment(comment, block_mode, formatting.shape, formatting.config)?;
+            let comment_shape = formatting.pre_comment_shape.unwrap_or(formatting.shape);
+            let comment = rewrite_comment(comment, block_mode, comment_shape, formatting.config)?;
             result.push_str(&comment);
 
             if !inner_item.is_empty() {
@@ -941,6 +951,7 @@ pub(crate) fn struct_lit_formatting<'a>(
         },
         separator_place: SeparatorPlace::Back,
         shape,
+        pre_comment_shape: None,
         ends_with_newline,
         preserve_newline: true,
         nested: false,

--- a/src/vertical.rs
+++ b/src/vertical.rs
@@ -214,6 +214,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
 ) -> Option<String> {
     // 1 = ","
     let item_shape = Shape::indented(offset, context.config).sub_width_opt(1)?;
+    let pre_comment_shape = Shape::indented(offset, context.config);
     let (mut field_prefix_max_width, field_prefix_min_width) =
         struct_field_prefix_max_min_width(context, fields, item_shape);
     let max_diff = field_prefix_max_width.saturating_sub(field_prefix_min_width);
@@ -265,6 +266,7 @@ fn rewrite_aligned_items_inner<T: AlignedItem>(
     let fmt = ListFormatting::new(item_shape, context.config)
         .tactic(tactic)
         .trailing_separator(separator_tactic)
+        .pre_comment_shape(pre_comment_shape)
         .preserve_newline(true);
     write_list(&items, &fmt).ok()
 }

--- a/tests/source/issue_6180.rs
+++ b/tests/source/issue_6180.rs
@@ -1,0 +1,18 @@
+// rustfmt-wrap_comments: true
+// rustfmt-comment_width: 100
+
+pub struct Foo {
+    // This line has 99 characters ...............................................................9
+    pub foo: u8,
+
+    // This line has 100 characters ...............................................................9
+    pub bar: u8,
+
+    // This line has 101 characters ................................................................9
+    pub baz: u8,
+}
+
+pub mod foo {
+    // This line has 100 characters ...............................................................9
+    pub fn foo() {}
+}

--- a/tests/target/configs/struct_field_align_threshold/20.rs
+++ b/tests/target/configs/struct_field_align_threshold/20.rs
@@ -321,8 +321,8 @@ fn main() {
 
     A {
         // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
-        // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
-        // hendrerit. Donec et mollis dolor.
+        // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit.
+        // Donec et mollis dolor.
         first:  item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
         // Nam tincidunt congue enim, ut porta lorem lacinia consectetur.

--- a/tests/target/issue_6180.rs
+++ b/tests/target/issue_6180.rs
@@ -1,0 +1,19 @@
+// rustfmt-wrap_comments: true
+// rustfmt-comment_width: 100
+
+pub struct Foo {
+    // This line has 99 characters ...............................................................9
+    pub foo: u8,
+
+    // This line has 100 characters ...............................................................9
+    pub bar: u8,
+
+    // This line has 101 characters
+    // ................................................................9
+    pub baz: u8,
+}
+
+pub mod foo {
+    // This line has 100 characters ...............................................................9
+    pub fn foo() {}
+}


### PR DESCRIPTION
Fixes #6180.

## The bug

The bug originates here, in `rewrite_aligned_items_inner`: https://github.com/rust-lang/rustfmt/blob/7852ca33e12e116dfb1e42ee27a95b763c5e96a1/src/vertical.rs#L216

Note the use of `sub_width_opt(1)`, which reserves space for the item separator (e.g., a comma).

That declared `item_shape` is used to construct a `ListFormatting` struct, which is used in a call to `write_list`: https://github.com/rust-lang/rustfmt/blob/7852ca33e12e116dfb1e42ee27a95b763c5e96a1/src/vertical.rs#L265-L269

Note that `item_shape` populates the `shape` field of the `ListFormatting` struct via `ListFormatting::new`: https://github.com/rust-lang/rustfmt/blob/7852ca33e12e116dfb1e42ee27a95b763c5e96a1/src/lists.rs#L38-L51

Within the body of `write_list`, there is this code: https://github.com/rust-lang/rustfmt/blob/7852ca33e12e116dfb1e42ee27a95b763c5e96a1/src/lists.rs#L369-L370

But recall that `formatting.shape = item_shape`, which already (and incorrectly for a comment) has space reserved for the separator, hence, the off-by-one error.

## The fix

The fix is to add an additional, optional field, `pre_comment_shape`, to `ListFormatting`. This additional field does not reserve space for the separator, and thus avoids the off-by-one error.

In particular, the call to `rewrite_comment` in `write_list` now looks like this:
```rust
            let comment_shape = formatting.pre_comment_shape.unwrap_or(formatting.shape);
            let comment = rewrite_comment(comment, block_mode, comment_shape, formatting.config)?;
```

The field is optional because not all code paths that construct a `ListFormatting` use it. Specifically, `pre_comment_shape` is set in `rewrite_aligned_items_inner`, but it is not set at any of `ListFormatting::new`'s other call sites.

## Tests

A test case was added to resemble the one in #6180. However, it was modified to obtain 99-, 100-, and 101-column boundary coverage.

Also, one other existing test case had to be modified, as it suffered from the same bug. Specifically, this code: https://github.com/rust-lang/rustfmt/blob/7852ca33e12e116dfb1e42ee27a95b763c5e96a1/tests/target/configs/struct_field_align_threshold/20.rs#L323-L325
was reflowed like this:
```rust
        // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
        // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit.
        // Donec et mollis dolor.
```

## What this PR does not do

This PR's test case uses a `comment_width` equal to the default `max_width` (i.e., 100).

By doing so, this PR does not attempt to establish a policy for when `comment_width < max_width`, for example.

This choice was intentional, as I consider such policy decisions out of scope for this PR.

## LLM disclosure

Codex was used to diagnose the bug and implement the fix, including comments I asked it to add to the code; however, all such comments look reasonable to me.

This PR description was written entirely by me (@smoelius).