### PR TITLE
feature: Allow user's to set the release channel when running the diff check

### DIFF
--- a/.github/workflows/check_diff.yml
+++ b/.github/workflows/check_diff.yml
@@ -32,6 +32,14 @@ on:
       rustfmt_configs:
         description: 'Optional comma separated list of rustfmt config options to pass when running the feature branch'
         required: false
+      release_channel:
+        description: 'Configure which release channel to use when compiling rustfmt'
+        default: stable
+        type: choice
+        options:
+          - stable
+          - beta
+          - nightly
 
 permissions:
   contents: read

--- a/check_diff/src/lib.rs
+++ b/check_diff/src/lib.rs
@@ -79,6 +79,37 @@ impl FromStr for StyleEdition {
     }
 }
 
+/// Configure which release channel to use when compiling rustfmt
+#[derive(Debug, Clone, Copy)]
+pub enum ReleaseChannel {
+    Stable,
+    Beta,
+    Nightly,
+}
+
+impl ReleaseChannel {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Stable => "stable",
+            Self::Beta => "beta",
+            Self::Nightly => "nightly",
+        }
+    }
+}
+
+impl FromStr for ReleaseChannel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "stable" => Ok(Self::Stable),
+            "beta" => Ok(Self::Beta),
+            "nightly" => Ok(Self::Nightly),
+            _ => Err(format!("Invalid release channel {s}")),
+        }
+    }
+}
+
 pub enum FormatCodeError {
     // IO Error when running code formatter
     Io(std::io::Error),
@@ -572,13 +603,16 @@ pub fn build_rustfmt_from_src<T: AsRef<str>>(
     edition: Edition,
     style_edition: StyleEdition,
     config: Option<&[T]>,
+    release_channel: ReleaseChannel,
 ) -> Result<RustfmtRunner, CheckDiffError> {
     // Because we're building standalone binaries we need to set the dynamic library path
     // so each rustfmt binary can find it's runtime dependencies.
     let dynamic_library_path = get_dynamic_library_path(dir)?;
+    let release_channel = release_channel.as_str();
 
-    info!("Building rustfmt from source");
+    info!("Building {} rustfmt from source", release_channel);
     let Ok(_) = Command::new("cargo")
+        .env("CFG_RELEASE_CHANNEL", release_channel)
         .current_dir(dir)
         .args(["build", "-q", "--release", "--bin", "rustfmt"])
         .output()
@@ -611,6 +645,7 @@ pub fn compile_rustfmt<T: AsRef<str>>(
     style_edition: StyleEdition,
     commit_hash: Option<String>,
     config: Option<&[T]>,
+    release_channel: ReleaseChannel,
 ) -> Result<DiffChecker<RustfmtRunner, RustfmtRunner>, CheckDiffError> {
     const RUSTFMT_REPO: &str = "https://github.com/rust-lang/rustfmt.git";
     let checkout_ref = commit_hash.as_ref().unwrap_or(&feature_branch);
@@ -628,6 +663,7 @@ pub fn compile_rustfmt<T: AsRef<str>>(
         edition,
         style_edition,
         config,
+        release_channel,
     )?;
     let should_detach = commit_hash.is_some();
     git_switch(checkout_ref, should_detach)?;
@@ -638,6 +674,7 @@ pub fn compile_rustfmt<T: AsRef<str>>(
         edition,
         style_edition,
         config,
+        release_channel,
     )?;
     info!("SOURCE_BIN {}", source_runner.get_binary_version()?);
     let dynamic_library_path_env_var = dynamic_library_path_env_var_name();

--- a/check_diff/src/main.rs
+++ b/check_diff/src/main.rs
@@ -2,7 +2,8 @@ use std::io::Error;
 use std::process::ExitCode;
 
 use check_diff::{
-    Edition, StyleEdition, check_diff, clone_repositories_for_diff_check, compile_rustfmt,
+    Edition, ReleaseChannel, StyleEdition, check_diff, clone_repositories_for_diff_check,
+    compile_rustfmt,
 };
 use clap::Parser;
 use tempfile::tempdir;
@@ -67,6 +68,8 @@ struct CliInputs {
     // Choosing 16 as the default since that's a common multiple of available CPU cores.
     #[arg(short, long, default_value_t = std::num::NonZeroU8::new(16).unwrap())]
     worker_threads: std::num::NonZeroU8,
+    #[arg(long, default_value = "stable")]
+    release_channel: ReleaseChannel,
 }
 
 fn main() -> Result<ExitCode, Error> {
@@ -85,6 +88,7 @@ fn main() -> Result<ExitCode, Error> {
         args.style_edition,
         args.commit_hash,
         args.rustfmt_config.as_deref(),
+        args.release_channel,
     );
 
     let diff_checker = match compilation_result {


### PR DESCRIPTION
The diff check failed on the latest subtree push (https://github.com/rust-lang/rustfmt/pull/7079) because of `cfg_select!` formatting that was implemented in r-l/r (https://github.com/rust-lang/rust/pull/154202) even though we gated `cfg_select!` formatting on the `nightly` release channel (https://github.com/rust-lang/rust/pull/160998). In theory the diff-check should have succeeded because r-l/rustfmt didn't have its own `cfg_select!` formatting implementation yet.

What I realized is that we're not setting `CFG_RELEASE_CHANNEL` so rustfmt defaults to the `nightly` release channel. with these changes we'll have more control over the release channel and we'll default `CFG_RELEASE_CHANNEL=stable` since the primary goal of the Diff Check is to ensure we're not breaking stable formatting.