### PR TITLE
Follow the same LLM policy as rust-lang/rust

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+- [ ] I did not use an LLM to create a change in this PR.
+- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.
+
+<!--
+Please read our [LLM policy] before opening a PR,
+and check one of the boxes above to indicate whether you've used an LLM.
+If you do not check a box, a reviewer may ask you whether an LLM was involved.
+LLM contributions are not banned, but are held to a higher standard of review and correctness.
+
+[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
+-->

--- a/Contributing.md
+++ b/Contributing.md
@@ -9,6 +9,15 @@ or file new issues specifically to get help.
 All contributors are expected to follow our [Code of
 Conduct](CODE_OF_CONDUCT.md).
 
+
+## LLM policy
+
+rustfmt follows the same [LLM usage policy] as `rust-lang/rust`. Please read it before using LLM
+assistance when participating in `rust-lang/rustfmt`.
+
+[LLM usage policy]: https://forge.rust-lang.org/policies/llm-usage.html
+
+
 ## Test and file issues
 
 It would be really useful to have people use rustfmt on their projects and file


### PR DESCRIPTION
Linking to the same policy established by rust-lang/rust.

I want to make sure the majority of us agree with applying the policy: @rust-lang/rustfmt @rust-lang/rustfmt-contributors.


* `Contributing.md` takes language from https://github.com/rust-lang/mdBook/pull/3195
* PR template takes language from https://github.com/rust-lang/rust/pull/155424

- [ ] @calebcartwright
- [x] @ytmimi 
- [x] @Manishearth
- [x] @fee1-dead
- [x] @camsteffen
- [x] @jieyouxu
- [x] @estebank