### PR TITLE
Fix trailing whitespace before code block in wrapped doc comments

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -894,6 +894,9 @@ impl<'a> CommentRewrite<'a> {
                 self.result.pop();
             }
             if self.code_block_attr.is_some() && self.is_prev_line_multi_line {
+                if self.result.ends_with(' ') {
+                    self.result.pop();
+                }
                 self.result.push_str(&self.comment_line_separator);
             }
             self.result.push_str(line);


### PR DESCRIPTION
## What this fixes

When a doc comment paragraph gets word-wrapped across multiple lines
(`wrap_comments = true`) and is immediately followed by a fenced code
block (` ``` `), rustfmt was leaving a stray trailing space on the
line right before the code block starts.

## Root cause

In `CommentRewrite::handle_line`, when the previous line was wrapped
into multiple lines, a single space gets pushed to `self.result` for
potential same-line continuation. If the current line turns out to be
the start of a code block, a separate branch then pushes a newline
separator (`comment_line_separator`) right after — but the earlier
space was never removed, leaving it as trailing whitespace right
before the inserted newline.

## Fix

Pop the trailing space (if present) immediately before pushing the
code-block separator, following the same pattern already used
elsewhere in this file (e.g. the existing `.pop()` calls nearby).

## Testing

Verified against the repro in #6695:

Before:
```
error[internal]: left behind trailing whitespace
--> issue_6695.rs:3:3:4
```

After: that error no longer occurs. `cargo test comment::` still
passes (15 passed, 0 failed).

Note: #6695 also reports a second, separate issue (a line-width
overflow caused by `MIN_STRING` in `break_string` rejecting a valid
break point). That one is more involved since it touches shared
wrapping logic used elsewhere in the codebase — I've written up my
findings in a comment on the issue and left it open for discussion
before attempting a fix there.