### PR TITLE
fix: Prevent infinite loops when parsing items from `cfg_select!` arms

### DIFF
--- a/src/parse/macros/cfg_select.rs
+++ b/src/parse/macros/cfg_select.rs
@@ -64,7 +64,11 @@ fn parse_items_from_cfg_select_inner<'a>(
                 .parse_item(ForceCollect::No, AllowConstBlockItems::DoesNotMatter)
             {
                 Ok(Some(item_ptr)) => *item_ptr,
-                Ok(None) => continue,
+                Ok(None) => {
+                    // Advance the parser by at least one token to prevent an infinite loop
+                    parser.bump();
+                    continue;
+                }
                 Err(err) => {
                     err.cancel();
                     parser.psess.dcx().reset_err_count();

--- a/tests/source/issue_7088_stable.rs
+++ b/tests/source/issue_7088_stable.rs
@@ -1,0 +1,12 @@
+// rustfmt-stable: true
+
+// cfg_select! doesn't get formatted, but indentation is updated.
+
+#![crate_type = "lib"]
+    cfg_select! {
+        _ => {
+            fn foo(){} {}
+        }
+    }
+
+cfg_select! { _ => {{} {}}}

--- a/tests/source/issue_7088_unstable.rs
+++ b/tests/source/issue_7088_unstable.rs
@@ -1,0 +1,10 @@
+// rustfmt-unstable: true
+
+#![crate_type = "lib"]
+    cfg_select! {
+        _ => {
+            fn foo(){} {}
+        }
+}
+
+cfg_select! { _ => {{} {}}}

--- a/tests/target/issue_7088_stable.rs
+++ b/tests/target/issue_7088_stable.rs
@@ -1,0 +1,12 @@
+// rustfmt-stable: true
+
+// cfg_select! doesn't get formatted, but indentation is updated.
+
+#![crate_type = "lib"]
+cfg_select! {
+    _ => {
+        fn foo(){} {}
+    }
+}
+
+cfg_select! { _ => {{} {}}}

--- a/tests/target/issue_7088_unstable.rs
+++ b/tests/target/issue_7088_unstable.rs
@@ -1,0 +1,16 @@
+// rustfmt-unstable: true
+
+#![crate_type = "lib"]
+cfg_select! {
+    _ => {
+        fn foo() {}
+        {}
+    }
+}
+
+cfg_select! {
+    _ => {
+        {}
+        {}
+    }
+}


### PR DESCRIPTION
Fixes #7088

Before when we failed to parse an item we'd hit an infinite loop because we wouldn't advance the parser. Now we make sure to advance the parser before starting the next loop iteration.

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
-->
