### PR TITLE
Don't duplicate separators when there is a comment before and after a list separator

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -617,6 +617,8 @@ pub(crate) fn extract_post_comment(
     separator: &str,
     is_last: bool,
 ) -> Option<String> {
+    use std::borrow::Cow;
+
     let white_space: &[_] = &[' ', '\t'];
 
     // Cleanup post-comment: strip separators and whitespace.
@@ -632,21 +634,41 @@ pub(crate) fn extract_post_comment(
         false
     };
 
-    let post_snippet_trimmed = if post_snippet.starts_with(|c| c == ',' || c == ':') {
-        post_snippet[1..].trim_matches(white_space)
+    let separator_index = post_snippet.find_uncommented(separator);
+
+    let post_snippet_trimmed: Cow<'_, _> = if post_snippet.starts_with(|c| c == ',' || c == ':') {
+        post_snippet[1..].trim_matches(white_space).into()
     } else if let Some(stripped) = post_snippet.strip_prefix(separator) {
-        stripped.trim_matches(white_space)
+        stripped.trim_matches(white_space).into()
     } else if last_inline_comment_ends_with_separator {
         // since we're on the last item it's fine to keep any trailing separators in comments
-        post_snippet.trim_matches(white_space)
+        post_snippet.trim_matches(white_space).into()
     }
     // not comment or over two lines
     else if post_snippet.ends_with(separator)
         && (!post_snippet.trim().starts_with("//") || post_snippet.trim().contains('\n'))
     {
-        post_snippet[..(post_snippet.len() - 1)].trim_matches(white_space)
+        post_snippet[..(post_snippet.len() - 1)]
+            .trim_matches(white_space)
+            .into()
+    }
+    // We have a weird edge case with the last element of the list: A trailing
+    // separator may appear in the middle of our post snippet. This happens when
+    // there is is a comment both before and after the separator. For non-final
+    // elements of the list, the post snippet stops at the separator, but for the
+    // final list item the post snippet contains everything after the item, which
+    // may include a trailing separator between the comments.
+    //
+    // To handle this, we have to rewrite the post snippet to remove the extraneous
+    // separator, otherwise we'll duplicate the sparator when laying out the list.
+    else if is_last && separator_index.is_some() {
+        let separator_index = separator_index.unwrap();
+        let mut snippet_without_separator = String::with_capacity(post_snippet.len());
+        snippet_without_separator.push_str(&post_snippet[..separator_index]);
+        snippet_without_separator.push_str(&post_snippet[separator_index + separator.len()..]);
+        snippet_without_separator.into()
     } else {
-        post_snippet
+        post_snippet.into()
     };
     // FIXME(#3441): post_snippet includes 'const' now
     // it should not include here
@@ -654,7 +676,7 @@ pub(crate) fn extract_post_comment(
     if !post_snippet_trimmed.is_empty()
         && (removed_newline_snippet.starts_with("//") || removed_newline_snippet.starts_with("/*"))
     {
-        Some(post_snippet_trimmed.to_owned())
+        Some(post_snippet_trimmed.into_owned())
     } else {
         None
     }
@@ -699,7 +721,7 @@ pub(crate) fn get_comment_end(
             ),
             // Potential *single* line comment.
             (_, Some(j)) if j > separator_index => j + 1,
-            _ => post_snippet.len(),
+            _ => separator_index + 1,
         }
     } else if let Some(newline_index) = newline_index {
         // Match arms may not have trailing comma. In any case, for match arms,

--- a/tests/source/comments-around-separator.rs
+++ b/tests/source/comments-around-separator.rs
@@ -1,0 +1,23 @@
+fn parameters(
+    first: bool
+    // first line
+    ,
+    /* second pre */
+    second: char /* second */, /* third pre */
+    third: u32 /* third, comment */, /* trailing */
+) {
+}
+
+struct Fields {
+    first: i32 /* first */, /* second pre */
+    second: i32 /* second */, /* third pre */
+    third: i32 /* third, comment */, /* trailing */
+}
+
+fn struct_literal() {
+    let value = Fields {
+        first: 1 /* first */, /* second pre */
+        second: 2 /* second */, /* third pre */
+        third: 3 /* third, comment */, /* trailing */
+    };
+}

--- a/tests/target/comments-around-separator.rs
+++ b/tests/target/comments-around-separator.rs
@@ -1,0 +1,26 @@
+fn parameters(
+    first: bool, // first line
+    /* second pre */
+    second: char, /* second */
+    /* third pre */
+    third: u32, /* third, comment */ /* trailing */
+) {
+}
+
+struct Fields {
+    first: i32, /* first */
+    /* second pre */
+    second: i32, /* second */
+    /* third pre */
+    third: i32, /* third, comment */ /* trailing */
+}
+
+fn struct_literal() {
+    let value = Fields {
+        first: 1, /* first */
+        /* second pre */
+        second: 2, /* second */
+        /* third pre */
+        third: 3, /* third, comment */ /* trailing */
+    };
+}


### PR DESCRIPTION
This PR addresses the following issues:

- Partially addresses https://github.com/rust-lang/rustfmt/issues/6759. This PR handles things like function args and struct fields, but does not cover the case with match arms.
- Fully resolves https://github.com/rust-lang/rustfmt/issues/6797.

This fix relates to the list formatting machinery in `lists.rs`, specifically the way that the post-snippet for a list item is parsed in order to extract comments. In the case where there is a comment both before and after a separator in a list, `get_comment_end` would include the entire gap between the items as the post-snippet of the preceding item. This means that the separator gets included in the post-comment of the preceding item. When `write_list` then lays out the pieces of the list, it prints a separator and then the entire post-comment, which duplicates the separator.

There are two related fixes for this behavior:

- Update `get_comment_end` to split the post-snippet at the separator if there are comments before and after the separator. This means that the comment before the separator becomes the post-comment of the preceding item, and the comment after the separator becomes the pre-comment for the following item.
- Update `extract_post_comment` to handle a separator in the middle of the final item's post-snippet. This is necessary because the new splitting rule in `get_comment_end` doesn't apply the snippet following the final item, since there's no subsequent item to own the comment that follows the separator. To handle this case, we just remove the separator from the post-snippet, which then allows `write_list` to lay out the separator before the post-comment.

I added a test to cover the cases described in https://github.com/rust-lang/rustfmt/issues/6759 and https://github.com/rust-lang/rustfmt/issues/6797.

# LLM Usage Disclosure

- [ ] I did not use an LLM to create a change in this PR.
- [x] **I used an LLM to create a change in this PR, and I have explained below how it was used.**

I used an LLM, specifically gpt-5.6 Sol, as a coding aid while working on this fix:

- The initial changes to `extract_post_comment` were written by LLM and then heavily rewritten by me. The only thing LLM-written that stayed verbatim is the logic for extracting the separator from the post-snippet.