### PR TITLE
Enable triagebot `issue-links`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -102,3 +102,15 @@ add_labels = ["S-waiting-on-review"]
 # ------------------------------------------------------------------------------
 
 [assign]
+
+# ------------------------------------------------------------------------------
+# Misc
+# ------------------------------------------------------------------------------
+
+# Canonicalize issue numbers to avoid closing the wrong issue
+# when commits are included in subtrees, as well as warning links in commits.
+# Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
+[issue-links]
+# This prevents links from resolving to the wrong repository when the subtree is
+# merged upstream while still allowing issue links in commits.
+check-commits = "uncanonicalized"


### PR DESCRIPTION
Noticed in https://github.com/rust-lang/rustfmt/pull/7095#issuecomment-5517735949, triagebot has a functionality to:

- Automatically canonicalize issue links in PR description, and
- Show a warning message if there are `Fixes #123456` in commit descriptions.

The `Fixes #123456` form triggers github magic comments, which will close the same issue number / PR but on the wrong repo when syncing subtrees.

---

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.
