### PR TITLE
Adjust triagebot label config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -22,6 +22,7 @@ allow-unauthenticated = [
     "UO-*",
     "unstable-language-feature",
     "unstable-option",
+    "X-*",
 ]
 
 # ------------------------------------------------------------------------------

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -13,11 +13,15 @@ allow-unauthenticated = [
     "E-*",
     "F-*",
     "I-*",
-    "S-*",
-    "SO-*",
-    "UO-*",
+    "needs-rfc",
     "needs-triage",
     "regression-*",
+    "S-*",
+    "SO-*",
+    "T-*",
+    "UO-*",
+    "unstable-language-feature",
+    "unstable-option",
 ]
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
* Allow more labels to be changed via `@rustbot label` without needing write access to the repo.
* Match `X-*` for updated formatting stability labels. I renamed the formatting stability labels from `F-*` to `X-*` so that we can steal some `F-*` feature gate labels from `rust-lang/rust`.

---

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.