### PR TITLE
fix: prevent ICE on lifetime-only macro arguments

### DIFF
--- a/src/parse/macros/mod.rs
+++ b/src/parse/macros/mod.rs
@@ -21,6 +21,17 @@ fn build_parser<'a>(context: &RewriteContext<'a>, tokens: TokenStream) -> Parser
     build_stream_parser(context.psess.inner(), tokens)
 }
 
+fn starts_with_ref_lifetime(parser: &Parser<'_>) -> bool {
+    let mut offset = 0;
+    while matches!(
+        parser.look_ahead(offset, |token| token.kind),
+        TokenKind::And | TokenKind::AndAnd
+    ) {
+        offset += 1;
+    }
+    offset > 0 && parser.look_ahead(offset, |token| token.is_lifetime())
+}
+
 fn parse_macro_arg<'a, 'b: 'a>(parser: &'a mut Parser<'b>) -> Option<MacroArg> {
     macro_rules! parse_macro_arg {
         ($macro_arg:ident, $nt_kind:expr, $try_parse:expr, $then:expr) => {
@@ -59,12 +70,14 @@ fn parse_macro_arg<'a, 'b: 'a>(parser: &'a mut Parser<'b>) -> Option<MacroArg> {
         |parser: &mut Parser<'b>| parser.parse_ty(),
         |x: Box<ast::Ty>| Some(x)
     );
-    parse_macro_arg!(
-        Pat,
-        NonterminalKind::Pat(PatParam { inferred: false }),
-        |parser: &mut Parser<'b>| parser.parse_pat_no_top_alt(None, None),
-        |x: ast::Pat| Some(Box::new(x))
-    );
+    if !starts_with_ref_lifetime(parser) {
+        parse_macro_arg!(
+            Pat,
+            NonterminalKind::Pat(PatParam { inferred: false }),
+            |parser: &mut Parser<'b>| parser.parse_pat_no_top_alt(None, None),
+            |x: ast::Pat| Some(Box::new(x))
+        );
+    }
     // `parse_item` returns `Option<Box<ast::Item>>`.
     parse_macro_arg!(
         Item,

--- a/tests/rustfmt/main.rs
+++ b/tests/rustfmt/main.rs
@@ -298,6 +298,7 @@ fn dont_emit_ICE() {
         "tests/target/issue_6082.rs",
         "tests/target/issue_6069.rs",
         "tests/target/issue-6105.rs",
+        "tests/target/issue_7034.rs",
     ];
 
     let panic_re = regex::Regex::new("thread.*panicked").unwrap();

--- a/tests/target/issue_7034.rs
+++ b/tests/target/issue_7034.rs
@@ -1,0 +1,3 @@
+fn foo(a: foo_ty!(&'a (), &'a ));
+fn bar(a: foo_ty!(&'a (), &&'a ));
+fn baz(a: foo_ty!(&'a (), &&&'a ));


### PR DESCRIPTION
Fixes #7034.

### Problem

Malformed macro arguments ending in `&'a` trigger rustc’s pattern parser, which creates an empty suggestion span at EOF and trips a debug assertion. `&&'a` variants are also affected because `&&` is parsed as nested `&` tokens.

### Fix

Skip speculative pattern parsing when a run of `&`/`&&` tokens is followed by a lifetime. Valid types remain unaffected, and rustfmt uses its existing unparseable-macro fallback.

### Testing

Added `&'a`, `&&'a`, and `&&&'a` cases to `dont_emit_ICE`. Full `cargo test` passes.

- [ ] I did not use an LLM to create a change in this PR.
- [x] I used an LLM to create a change in this PR, and I have explained below how it was used.

LLM was used to understand the issue and as an extra reviewer for my code


