### PR TITLE
Fix non-idempotent indentation of consecutive block comments

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -245,7 +245,9 @@ impl<'a> FmtVisitor<'a> {
             .rev()
             .find(|rev_c| ![' ', '\t'].contains(rev_c));
 
-        let fix_indent = last_char.map_or(true, |rev_c| ['{', '\n'].contains(&rev_c));
+        let starts_output_line = !self.buffer.is_empty() && self.buffer.ends_with('\n');
+        let fix_indent =
+            starts_output_line || last_char.map_or(true, |rev_c| ['{', '\n'].contains(&rev_c));
         let mut on_same_line = false;
 
         let comment_indent = if fix_indent {

--- a/tests/source/issue-7019.rs
+++ b/tests/source/issue-7019.rs
@@ -1,0 +1,36 @@
+fn two() -> usize {
+    /*A*/ /*B*/
+    1 + 2
+}
+
+fn three() -> usize {
+    /*A*/ /*B*/ /*C*/
+    1 + 2
+}
+
+fn nested() -> usize {
+    {
+        {
+            /*A*/ /*B*/ /*C*/
+            1 + 2
+        }
+    }
+}
+
+fn between_statements() -> usize {
+    let a = 1;
+    /*A*/ /*B*/
+    let b = 2;
+    a + b
+}
+
+fn trailing_inline() -> usize {
+    let a = 1; /*trailing*/
+    a
+}
+
+fn already_canonical() -> usize {
+    /*A*/
+    /*B*/
+    1 + 2
+}

--- a/tests/target/issue-7019.rs
+++ b/tests/target/issue-7019.rs
@@ -1,0 +1,42 @@
+fn two() -> usize {
+    /*A*/
+    /*B*/
+    1 + 2
+}
+
+fn three() -> usize {
+    /*A*/
+    /*B*/
+    /*C*/
+    1 + 2
+}
+
+fn nested() -> usize {
+    {
+        {
+            /*A*/
+            /*B*/
+            /*C*/
+            1 + 2
+        }
+    }
+}
+
+fn between_statements() -> usize {
+    let a = 1;
+    /*A*/
+    /*B*/
+    let b = 2;
+    a + b
+}
+
+fn trailing_inline() -> usize {
+    let a = 1; /*trailing*/
+    a
+}
+
+fn already_canonical() -> usize {
+    /*A*/
+    /*B*/
+    1 + 2
+}


### PR DESCRIPTION
## Context

`process_comment` determined indentation only from the original source. For `/*A*/ /*B*/`, formatting the first comment added a newline, but the second was still treated as inline and indented by one space, requiring another pass to converge.

The fix also checks whether the output buffer ends with a newline. If so, the comment receives `self.block_indent`. Genuine trailing comments and already-canonical output remain unchanged, so no style-edition gate is needed.

## Tests

Added source and target regression tests covering consecutive comments, nested blocks, comments between statements, trailing comments, and canonical input.

Closes rust-lang/rustfmt#7019

- [ ] I did not use an LLM to create a change in this PR.
- [x] I used an LLM to create a change in this PR, and I have explained below how it was used.

Used an LLM to better understand the code surrounding the changes and the issue. Changes made by me