### PR TITLE
Add 2 basic blank_lines_upper_bound tests

### DIFF
--- a/tests/source/configs/blank_lines_upper_bound/1.rs
+++ b/tests/source/configs/blank_lines_upper_bound/1.rs
@@ -1,0 +1,29 @@
+// rustfmt-blank_lines_upper_bound: 1
+
+fn do_stuff()
+
+
+{
+    let i = 0;
+
+
+    i += 1;
+
+
+
+	println!("{i}");
+}
+
+fn foo() {}
+fn bar() {}
+// comment
+fn foobar() {}
+
+
+
+fn foo1() {}
+fn bar1() {}
+
+// comment
+
+fn foobar1() {}

--- a/tests/source/configs/blank_lines_upper_bound/2.rs
+++ b/tests/source/configs/blank_lines_upper_bound/2.rs
@@ -1,0 +1,29 @@
+// rustfmt-blank_lines_upper_bound: 2
+
+fn do_stuff()
+
+
+{
+    let i = 0;
+
+
+    i += 1;
+
+
+
+	println!("{i}");
+}
+
+fn foo() {}
+fn bar() {}
+// comment
+fn foobar() {}
+
+
+
+fn foo1() {}
+fn bar1() {}
+
+// comment
+
+fn foobar1() {}

--- a/tests/target/configs/blank_lines_upper_bound/1.rs
+++ b/tests/target/configs/blank_lines_upper_bound/1.rs
@@ -1,0 +1,21 @@
+// rustfmt-blank_lines_upper_bound: 1
+
+fn do_stuff() {
+    let i = 0;
+
+    i += 1;
+
+    println!("{i}");
+}
+
+fn foo() {}
+fn bar() {}
+// comment
+fn foobar() {}
+
+fn foo1() {}
+fn bar1() {}
+
+// comment
+
+fn foobar1() {}

--- a/tests/target/configs/blank_lines_upper_bound/2.rs
+++ b/tests/target/configs/blank_lines_upper_bound/2.rs
@@ -1,0 +1,24 @@
+// rustfmt-blank_lines_upper_bound: 2
+
+fn do_stuff() {
+    let i = 0;
+
+
+    i += 1;
+
+
+    println!("{i}");
+}
+
+fn foo() {}
+fn bar() {}
+// comment
+fn foobar() {}
+
+
+fn foo1() {}
+fn bar1() {}
+
+// comment
+
+fn foobar1() {}


### PR DESCRIPTION
- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

I'm trying to help out and move towards stabilizing the `blank_lines_upper_bound` and `blank_lines_lower_bound` rustfmt options. Adding some basic tests for `blank_lines_upper_bound` seemed like a good idea (The other one already has a test).

Happy to make any modifications requested, thank you for reviewing my code.