### PR TITLE
fix: keep comments inside restricted visibility parens

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,23 +51,6 @@ pub(crate) fn is_same_visibility(a: &Visibility, b: &Visibility) -> bool {
     }
 }
 
-/// Trims trailing whitespace from every line, not just the end of the input.
-/// Snippets copied from the source can span lines, and rustfmt rejects
-/// trailing whitespace in its own output.
-fn trim_lines_end(snippet: &str) -> Cow<'_, str> {
-    if snippet.lines().any(|line| line.ends_with([' ', '\t'])) {
-        Cow::from(
-            snippet
-                .lines()
-                .map(str::trim_end)
-                .collect::<Vec<_>>()
-                .join("\n"),
-        )
-    } else {
-        Cow::from(snippet.trim_end())
-    }
-}
-
 // Uses Cow to avoid allocating in the common cases.
 pub(crate) fn format_visibility(
     context: &RewriteContext<'_>,
@@ -77,13 +60,11 @@ pub(crate) fn format_visibility(
         VisibilityKind::Public => Cow::from("pub "),
         VisibilityKind::Inherited => Cow::from(""),
         VisibilityKind::Restricted { ref path, .. } => {
-            // A comment can sit anywhere inside the parens, e.g.
-            // `pub(crate /* why */)`. The path on its own cannot round-trip
-            // one, so fall back to the source when a comment is present.
-            if let Some(snippet) = context.snippet_provider.span_to_snippet(vis.span) {
-                if contains_comment(snippet) {
-                    return Cow::from(format!("{} ", trim_lines_end(snippet)));
-                }
+            // FIXME: we should properly handle comments here, but for now
+            // return the span unchanged.
+            let snippet = context.snippet(vis.span);
+            if contains_comment(snippet) {
+                return Cow::from(format!("{snippet} "));
             }
 
             let Path { ref segments, .. } = **path;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,9 @@ use rustc_ast_pretty::pprust;
 use rustc_span::{BytePos, LocalExpnId, Span, Symbol, SyntaxContext, sym, symbol};
 use unicode_width::UnicodeWidthStr;
 
-use crate::comment::{CharClasses, FullCodeCharKind, LineClasses, filter_normal_code};
+use crate::comment::{
+    CharClasses, FullCodeCharKind, LineClasses, contains_comment, filter_normal_code,
+};
 use crate::config::{Config, StyleEdition};
 use crate::rewrite::RewriteContext;
 use crate::shape::{Indent, Shape};
@@ -49,6 +51,23 @@ pub(crate) fn is_same_visibility(a: &Visibility, b: &Visibility) -> bool {
     }
 }
 
+/// Trims trailing whitespace from every line, not just the end of the input.
+/// Snippets copied from the source can span lines, and rustfmt rejects
+/// trailing whitespace in its own output.
+fn trim_lines_end(snippet: &str) -> Cow<'_, str> {
+    if snippet.lines().any(|line| line.ends_with([' ', '\t'])) {
+        Cow::from(
+            snippet
+                .lines()
+                .map(str::trim_end)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    } else {
+        Cow::from(snippet.trim_end())
+    }
+}
+
 // Uses Cow to avoid allocating in the common cases.
 pub(crate) fn format_visibility(
     context: &RewriteContext<'_>,
@@ -58,6 +77,15 @@ pub(crate) fn format_visibility(
         VisibilityKind::Public => Cow::from("pub "),
         VisibilityKind::Inherited => Cow::from(""),
         VisibilityKind::Restricted { ref path, .. } => {
+            // A comment can sit anywhere inside the parens, e.g.
+            // `pub(crate /* why */)`. The path on its own cannot round-trip
+            // one, so fall back to the source when a comment is present.
+            if let Some(snippet) = context.snippet_provider.span_to_snippet(vis.span) {
+                if contains_comment(snippet) {
+                    return Cow::from(format!("{} ", trim_lines_end(snippet)));
+                }
+            }
+
             let Path { ref segments, .. } = **path;
             let mut segments_iter = segments.iter().map(|seg| rewrite_ident(context, seg.ident));
             if path.is_global() {

--- a/tests/source/issue-6669.rs
+++ b/tests/source/issue-6669.rs
@@ -3,29 +3,58 @@
 
 pub(crate /* important comment */) fn a() {}
 
+pub(crate // important comment
+) fn a_line() {}
+
 pub(in /* which */ foo::bar) fn b() {}
+
+pub(in // which
+    foo::bar) fn b_line() {}
 
 pub(super /* up */) fn c() {}
 
+pub(super // up
+) fn c_line() {}
+
 pub(self /* here */) fn d() {}
 
+pub(self // here
+) fn d_line() {}
+
 pub(/* leading */ crate) fn e() {}
+
+pub(// leading
+    crate) fn e_line() {}
 
 pub(crate) fn no_comment() {}
 
 pub(crate /* mod */) mod m {}
 
+pub(crate // mod
+) mod m_line {}
+
 pub(crate /* use */) use std::io;
+
+pub(crate // use
+) use std::fmt;
 
 struct S {
     pub(crate /* field */) field: u32,
+
+    pub(crate // field
+    ) field_line: u32,
 }
 
-// Multi-line comments are kept as-is too.
+// Comments that span more than one line are kept as-is too.
 pub(crate /* multi
    line */) fn multi_line_block() {}
 
-pub(crate //  line
-) fn line_comment() {}
+pub(crate // multi
+    // line
+) fn multi_line_single() {}
 
 pub(in /* one */ foo::bar /* two */) fn two_comments() {}
+
+pub(in foo::bar // one
+    // two
+) fn two_comments_line() {}

--- a/tests/source/issue-6669.rs
+++ b/tests/source/issue-6669.rs
@@ -21,9 +21,11 @@ struct S {
     pub(crate /* field */) field: u32,
 }
 
-// Trailing whitespace inside the parens must not reach the output.
-pub(crate /* block */   
-   ) fn trailing_ws() {}
+// Multi-line comments are kept as-is too.
+pub(crate /* multi
+   line */) fn multi_line_block() {}
 
-pub(crate //  line   
+pub(crate //  line
 ) fn line_comment() {}
+
+pub(in /* one */ foo::bar /* two */) fn two_comments() {}

--- a/tests/source/issue-6669.rs
+++ b/tests/source/issue-6669.rs
@@ -1,0 +1,29 @@
+// A comment inside the parens of a restricted visibility must survive
+// formatting. The path alone cannot round-trip it.
+
+pub(crate /* important comment */) fn a() {}
+
+pub(in /* which */ foo::bar) fn b() {}
+
+pub(super /* up */) fn c() {}
+
+pub(self /* here */) fn d() {}
+
+pub(/* leading */ crate) fn e() {}
+
+pub(crate) fn no_comment() {}
+
+pub(crate /* mod */) mod m {}
+
+pub(crate /* use */) use std::io;
+
+struct S {
+    pub(crate /* field */) field: u32,
+}
+
+// Trailing whitespace inside the parens must not reach the output.
+pub(crate /* block */   
+   ) fn trailing_ws() {}
+
+pub(crate //  line   
+) fn line_comment() {}

--- a/tests/target/issue-6669.rs
+++ b/tests/target/issue-6669.rs
@@ -3,31 +3,66 @@
 
 pub(crate /* important comment */) fn a() {}
 
+pub(crate // important comment
+) fn a_line() {
+}
+
 pub(in /* which */ foo::bar) fn b() {}
+
+pub(in // which
+    foo::bar) fn b_line() {
+}
 
 pub(super /* up */) fn c() {}
 
+pub(super // up
+) fn c_line() {
+}
+
 pub(self /* here */) fn d() {}
 
+pub(self // here
+) fn d_line() {
+}
+
 pub(/* leading */ crate) fn e() {}
+
+pub(// leading
+    crate) fn e_line() {
+}
 
 pub(crate) fn no_comment() {}
 
 pub(crate /* mod */) mod m {}
 
+pub(crate // mod
+) mod m_line {}
+
 pub(crate /* use */) use std::io;
+
+pub(crate // use
+) use std::fmt;
 
 struct S {
     pub(crate /* field */) field: u32,
+
+    pub(crate // field
+    ) field_line: u32,
 }
 
-// Multi-line comments are kept as-is too.
+// Comments that span more than one line are kept as-is too.
 pub(crate /* multi
    line */) fn multi_line_block() {
 }
 
-pub(crate //  line
-) fn line_comment() {
+pub(crate // multi
+    // line
+) fn multi_line_single() {
 }
 
 pub(in /* one */ foo::bar /* two */) fn two_comments() {}
+
+pub(in foo::bar // one
+    // two
+) fn two_comments_line() {
+}

--- a/tests/target/issue-6669.rs
+++ b/tests/target/issue-6669.rs
@@ -1,0 +1,31 @@
+// A comment inside the parens of a restricted visibility must survive
+// formatting. The path alone cannot round-trip it.
+
+pub(crate /* important comment */) fn a() {}
+
+pub(in /* which */ foo::bar) fn b() {}
+
+pub(super /* up */) fn c() {}
+
+pub(self /* here */) fn d() {}
+
+pub(/* leading */ crate) fn e() {}
+
+pub(crate) fn no_comment() {}
+
+pub(crate /* mod */) mod m {}
+
+pub(crate /* use */) use std::io;
+
+struct S {
+    pub(crate /* field */) field: u32,
+}
+
+// Trailing whitespace inside the parens must not reach the output.
+pub(crate /* block */
+   ) fn trailing_ws() {
+}
+
+pub(crate //  line
+) fn line_comment() {
+}

--- a/tests/target/issue-6669.rs
+++ b/tests/target/issue-6669.rs
@@ -21,11 +21,13 @@ struct S {
     pub(crate /* field */) field: u32,
 }
 
-// Trailing whitespace inside the parens must not reach the output.
-pub(crate /* block */
-   ) fn trailing_ws() {
+// Multi-line comments are kept as-is too.
+pub(crate /* multi
+   line */) fn multi_line_block() {
 }
 
 pub(crate //  line
 ) fn line_comment() {
 }
+
+pub(in /* one */ foo::bar /* two */) fn two_comments() {}


### PR DESCRIPTION
- [ ] I did not use an LLM to create a change in this PR.
- [x] I used an LLM to create a change in this PR, and I have explained below how it was used.

LLM disclosure: I used Claude to investigate the cause and draft the patch. The
direction, the scope calls and the review responses are mine, and I verified the
result myself: full `cargo test`, confirmed both new tests fail with the fix
reverted, checked rustfmt still formats its own source cleanly, and reproduced
the trait case below on `main` to confirm this PR does not introduce it. I am
responsible for every line.

---

Fixes rust-lang/rustfmt#6669

`format_visibility` rebuilds `pub(path)` from the AST path, so a comment inside the parens has nowhere to go and gets dropped. `pub(crate /* important comment */) fn add() {}` came out as `pub(crate) fn add() {}`.

Per the review this no longer tries to format the visibility at all when a comment is present. It returns the source span unchanged with a FIXME so we can handle it properly later.

Worth calling out: trailing whitespace inside the parens now reaches the output and rustfmt reports it, so the user removes it themselves rather than rustfmt quietly fixing it. That is deliberate.

Tests in `tests/source|target/issue-6669.rs` cover `crate`, `in path`, `super`, `self`, a leading comment, a comment free case, `mod`, `use`, a struct field, a multi line block comment, a line comment, and two comments in one visibility. They fail with the change to `src/utils.rs` reverted. `cargo test` is green.

Two things I left alone. `format_restriction` has the same bug for `pub mut(crate /* c */)`, but rust-lang/rustfmt#6834 is already reworking that function. And a comment in the visibility of a trait produces invalid code, which happens on main too. It comes from the no where clause branch in `src/items.rs` treating any `/` in the item as the start of a comment, so it wants its own fix. Happy to file that separately.
